### PR TITLE
Add 'import_project' command

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -2046,7 +2046,8 @@ class AutoProcess:
         print "Year    : %s" % year
         # Determine which directories to exclude
         excludes = ['--exclude=primary_data',
-                    '--exclude=save.*']
+                    '--exclude=save.*',
+                    '--exclude=tmp.*']
         if not include_bcl2fastq:
             # Determine whether bcl2fastq dir should be included implicitly
             # because there are links from the analysis directories
@@ -2797,6 +2798,53 @@ class AutoProcess:
             report.append('\t'.join(project_line))
         report = '\n'.join(report)
         return report
+
+    def import_project(self,project_dir):
+        """
+        Import a project directory into this analysis directory
+
+        Arguments:
+          project_dir (str): path to project directory to be
+            imported
+
+        """
+        # Check that target directory exists
+        project_dir = os.path.abspath(project_dir)
+        # Check that project doesn't already exist
+        project_name = os.path.basename(project_dir)
+        project = utils.AnalysisProject(project_name,
+                                        os.path.join(self.analysis_dir,
+                                                     project_name))
+        if project.exists:
+            raise Exception("Project called '%s' already exists" %
+                            project_name)
+        # Load target as a project
+        project = utils.AnalysisProject(project_name,project_dir)
+        # Rsync the project directory
+        print "Importing project directory contents"
+        try:
+            rsync = applications.general.rsync(project_dir,
+                                               self.analysis_dir)
+            print "Running %s" % rsync
+            status = rsync.run_subprocess(log=self.log_path('import_project.rsync.log'))
+        except Exception as ex:
+            logging.error("Exception importing project: %s" % ex)
+            raise ex
+        if status != 0:
+            raise Exception("Failed to import project from %s (status %s)" %
+                            (project_dir,status))
+        # Update the projects.info metadata file
+        print "Updating projects.info file with imported project"
+        project_metadata = self.load_illumina_data()
+        project_metadata.add_project(project.name,sample_names)
+        sample_names = [s.name for s in project.samples]
+        project_metadata.add_project(project_name,
+                                     sample_names,
+                                     user=project.info.user,
+                                     library_type=project.info.library_type,
+                                     organism=project.info.organism,
+                                     PI=project.info.PI,
+                                     comments=project.info.comments)
 
     def check_metadata(self,items):
         """

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -2835,8 +2835,7 @@ class AutoProcess:
                             (project_dir,status))
         # Update the projects.info metadata file
         print "Updating projects.info file with imported project"
-        project_metadata = self.load_illumina_data()
-        project_metadata.add_project(project.name,sample_names)
+        project_metadata = self.load_project_metadata()
         sample_names = [s.name for s in project.samples]
         project_metadata.add_project(project_name,
                                      sample_names,
@@ -2845,6 +2844,11 @@ class AutoProcess:
                                      organism=project.info.organism,
                                      PI=project.info.PI,
                                      comments=project.info.comments)
+        project_metadata.save()
+        # Report
+        print "Projects now in metadata file:"
+        for p in project_metadata:
+            print "- %s" % p['Project']
 
     def check_metadata(self,items):
         """

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -140,6 +140,14 @@ class MockAnalysisDir(MockIlluminaData):
         # Add top-level logs directory
         os.mkdir(os.path.join(self.dirn,'logs'))
         # Add project dirs
+        projects_info = open(os.path.join(self.dirn,'projects.info'),'w')
+        projects_info.write('#%s\n' % '\t'.join(('Project',
+                                                 'Samples',
+                                                 'User',
+                                                 'Library',
+                                                 'Organism',
+                                                 'PI',
+                                                 'Comments')))
         for project in self.projects:
             if project.startswith("Undetermined"):
                 project_name = 'undetermined'
@@ -149,10 +157,21 @@ class MockAnalysisDir(MockIlluminaData):
             # Add fastqs
             fqs_dir = os.path.join(self.dirn,project_name,'fastqs')
             os.mkdir(fqs_dir)
+            sample_names = []
             for sample in self.samples_in_project(project):
+                sample_names.append(sample)
                 for fq in self.fastqs_in_sample(project,sample):
                     with open(os.path.join(fqs_dir,fq),'w') as fp:
                         fp.write('')
+            # Add line to projects.info
+            if project_name != 'undetermined':
+                projects_info.write('%s\n' % '\t'.join((project,
+                                                        ','.join(sample_names),
+                                                        '.',
+                                                        '.',
+                                                        '.',
+                                                        '.',
+                                                        '.')))
             # Add (empty) README.info
             open(os.path.join(self.dirn,
                               project_name,

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -132,6 +132,18 @@ class MockAnalysisDir(MockIlluminaData):
                     fp.write("%s\t%s\n" % (item,self.metadata[item]))
             else:
                 fp.write('')
+        # Add auto_process.info file
+        with open(os.path.join(self.dirn,'auto_process.info'),'w') as fp:
+            fp.write("analysis_dir\t%s\n" % os.path.basename(self.dirn))
+            fp.write("bases_mask\ty76,I8,I8,y76\n")
+            fp.write("data_dir\t/mnt/data/%s\n" % self.run_name)
+            fp.write("per_lane_stats_file\tper_lane_statistics.info\n")
+            fp.write("primary_data_dir\t%s/primary_data/%s\n" % (self.dirn,
+                                                                 self.run_name))
+            fp.write("project_metadata\tprojects.info\n")
+            fp.write("sample_sheet\t%s/custom_SampleSheet.csv\n" % self.dirn)
+            fp.write("stats_file\tstatistics.info\n")
+            fp.write("unaligned_dir\tbcl2fastq\n")
         # Add top-level README file
         if self.readme is not None:
             open(os.path.join(self.dirn,'README'),'w').write(self.readme)
@@ -229,4 +241,3 @@ class MockAnalysisDirFactory(object):
         mad.add_fastq_batch('CDE','CDE3','CDE3_GCCAAT',lanes=lanes)
         mad.add_fastq_batch('CDE','CDE4','CDE4_AGTCAA',lanes=lanes)
         return mad
-

--- a/auto_process_ngs/test/test_auto_processor.py
+++ b/auto_process_ngs/test/test_auto_processor.py
@@ -145,3 +145,10 @@ Comments\t1% PhiX spike in
         self.assertTrue('NewProj' in [p.name
                                       for p in ap.get_analysis_projects_from_dirs()])
         self.assertTrue(os.path.exists(os.path.join(ap.analysis_dir,'NewProj')))
+        # Verify via fresh AutoProcess object
+        ap2 = AutoProcess(mockdir.dirn)
+        self.assertTrue('NewProj' in [p.name
+                                      for p in ap2.get_analysis_projects()])
+        self.assertTrue('NewProj' in [p.name
+                                      for p in ap2.get_analysis_projects_from_dirs()])
+        self.assertTrue(os.path.exists(os.path.join(ap2.analysis_dir,'NewProj')))

--- a/auto_process_ngs/test/test_auto_processor.py
+++ b/auto_process_ngs/test/test_auto_processor.py
@@ -114,21 +114,6 @@ class TestAutoProcessImportProject(unittest.TestCase):
             'miseq',
             top_dir=self.dirn)
         mockdir.create()
-        open(os.path.join(mockdir.dirn,'auto_process.info'),'w').write(
-            """analysis_dir\t%s
-bases_mask\ty76,I8,I8,y76
-data_dir\t/mnt/data/%s
-per_lane_stats_file\tper_lane_statistics.info
-primary_data_dir\t%s/primary_data/%s
-project_metadata\tprojects.info
-sample_sheet\t%s/custom_SampleSheet.csv
-stats_file\tstatistics.info
-unaligned_dir\tbcl2fastq
-"""
-            % (mockdir.dirn,
-               os.path.basename(mockdir.dirn[:-9]),
-               mockdir.dirn,os.path.basename(mockdir.dirn[:-9]),
-               mockdir.dirn))
         # Make a mock project
         project_dir = os.path.join(self.dirn,'NewProj')
         os.mkdir(project_dir)

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -44,6 +44,7 @@ Additional commands are available:
     analyse_barcodes
     merge_fastq_dirs
     update_fastq_stats
+    import_project
     readme
 
 but these are not part of the standard workflow - they are used for
@@ -546,6 +547,15 @@ def add_merge_fastq_dirs_command(cmdparser):
     add_dry_run_option(p)
     add_debug_option(p)
 
+def add_import_project_command(cmdparser):
+    """Create a parser for the 'import_project' command
+    """
+    p = cmdparser.add_command('import_project',help="Import a project directory",
+                              usage="%prog import_project [OPTIONS] [ANALYSIS_DIR] PROJECT_DIR",
+                              description="Copy a project directory PROJECT_DIR into "
+                              "ANALYSIS_DIR.")
+    add_debug_option(p)
+
 def add_update_fastq_stats_command(cmdparser):
     """Create a parser for the 'update_fastq_stats' command
     """
@@ -595,6 +605,7 @@ if __name__ == "__main__":
     add_clone_command(p)
     add_analyse_barcodes_command(p)
     add_merge_fastq_dirs_command(p)
+    add_import_project_command(p)
     add_update_fastq_stats_command(p)
     
     # Process remaining command line
@@ -678,6 +689,16 @@ if __name__ == "__main__":
             sys.exit(1)
         d = AutoProcess(args[0],allow_save_params=False)
         d.clone(args[1],copy_fastqs=options.copy_fastqs)
+    elif cmd == 'import_project':
+        if len(args) == 0 or len(args) > 2:
+            sys.stderr.write("Need to supply a project directory to import\n")
+            sys.exit(1)
+        if len(args) == 2:
+            analysis_dir = args[0]
+        else:
+            analysis_dir = os.getcwd()
+        d = AutoProcess(analysis_dir)
+        d.import_project(args[-1])
     else:
         # For other options check if an analysis
         # directory was specified
@@ -685,8 +706,8 @@ if __name__ == "__main__":
             analysis_dir = args[0]
         else:
             analysis_dir = os.getcwd()
-        # Turn off allow save for 'params' and 'metadata' commands
-        if cmd == 'params' or cmd == 'metadata':
+        # Turn off allow save for specific commands
+        if cmd in ('params','metadata','report'):
             allow_save = False
         # Run the specified stage
         d = AutoProcess(analysis_dir,allow_save_params=allow_save)


### PR DESCRIPTION
PR adds an `import_project` command which pulls a project directory from an external location into the current auto-process analysis directory, e.g.

    auto_process.py import_project /path/to/NewProject