### PR TITLE
Add utility to reassign barcodes in FASTQ file

### DIFF
--- a/auto_process_ngs/fastq_utils.py
+++ b/auto_process_ngs/fastq_utils.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+#
+#     fastq_utils.py: utility functions for operating on fastq files
+#     Copyright (C) University of Manchester 2016 Peter Briggs
+#
+########################################################################
+#
+# fastq_utils.py
+#
+#########################################################################
+
+"""
+fastq_utils.py
+
+Utility functions for operating on Fastq files:
+
+- assign_barcodes_single_end: extract and assign inline barcodes
+
+"""
+
+#######################################################################
+# Imports
+#######################################################################
+
+import gzip
+from bcftbx.FASTQFile import FastqIterator
+
+#######################################################################
+# Functions
+#######################################################################
+
+def assign_barcodes_single_end(fastq_in,fastq_out,n=5):
+    """
+    Extract inline barcodes and assign to Fastq read headers
+
+    """
+    if fastq_out.endswith('.gz'):
+        fp = gzip.GzipFile(filename=fastq_out,mode='wb')
+    else:
+        fp = open(fastq_out,'w')
+    print "Processing reads from %s" % fastq_in
+    nread = 0
+    for read in FastqIterator(fastq_in):
+        # Extract new barcode sequence
+        barcode = read.sequence[:n]
+        # Truncate sequence and quality accordingly
+        sequence = read.sequence[n:]
+        quality = read.quality[n:]
+        # Assign new values and write to output
+        read.seqid.index_sequence = barcode
+        read.sequence = sequence
+        read.quality = quality
+        fp.write("%s\n" % read)
+        nread += 1
+    print "Finished (%d reads processed)" % nread

--- a/auto_process_ngs/fastq_utils.py
+++ b/auto_process_ngs/fastq_utils.py
@@ -33,6 +33,23 @@ def assign_barcodes_single_end(fastq_in,fastq_out,n=5):
     """
     Extract inline barcodes and assign to Fastq read headers
 
+    Strips the first n bases from each read of the input
+    FASTQ file and assigns it to the index sequence for that
+    read in the output file.
+
+    If the supplied output file name ends with '.gz' then it
+    will be gzipped.
+
+    Arguments:
+      fastq_in (str): input FASTQ file (can be gzipped)
+      fastq_out (str): output FASTQ file (will be gzipped if
+        ending with '.gz')
+      n (integer): number of bases to extract and assign as
+        index sequence (default: 5)
+
+    Returns:
+      Integer: number of reads processed.
+
     """
     if fastq_out.endswith('.gz'):
         fp = gzip.GzipFile(filename=fastq_out,mode='wb')
@@ -53,3 +70,4 @@ def assign_barcodes_single_end(fastq_in,fastq_out,n=5):
         fp.write("%s\n" % read)
         nread += 1
     print "Finished (%d reads processed)" % nread
+    return nread

--- a/auto_process_ngs/test/test_fastq_utils.py
+++ b/auto_process_ngs/test/test_fastq_utils.py
@@ -71,7 +71,8 @@ class TestAssignBarcodesSingleEnd(unittest.TestCase):
     def test_assign_barcodes_single_end(self):
         """assign_barcodes_single_end: extract barcodes from first 5 bases
         """
-        assign_barcodes_single_end(self.fastq_in,
-                                   self.fastq_out)
+        nreads = assign_barcodes_single_end(self.fastq_in,
+                                            self.fastq_out)
+        self.assertEqual(nreads,5)
         self.assertEqual(open(self.fastq_out,'r').read(),
                          fastq_r1_out)

--- a/auto_process_ngs/test/test_fastq_utils.py
+++ b/auto_process_ngs/test/test_fastq_utils.py
@@ -1,0 +1,77 @@
+#######################################################################
+# Tests for fastq_utils.py module
+#######################################################################
+
+import unittest
+import os
+import tempfile
+import shutil
+from auto_process_ngs.fastq_utils import *
+
+fastq_r1 = """@MISEQ:34:000000000-A7PHP:1:1101:12552:1774 1:N:0:TAAGGCGA
+TTTACAACTAGCTTCTCTTTTTCTT
++
+>AA?131@C1FCGGGG1BFFGF1F3
+@MISEQ:34:000000000-A7PHP:1:1101:16449:1793 1:N:0:TAAGGCGA
+TCCCCAGTCTCAGCCCTACTCCACT
++
+11>>>11CDFFFBCGGG1AFE11AB
+@MISEQ:34:000000000-A7PHP:1:1101:15171:1796 1:N:0:GCCTTACC
+CCACCACGCCTGGCTAATTTTTTTT
++
+1>1>>AAAAAFAGGGGBFGGGGGG0
+@MISEQ:34:000000000-A7PHP:1:1101:18777:1797 1:N:0:TAAGNNNA
+CAGCAATATACACTTCACTCTGCAT
++
+111>>1FBFFFFGGGGCBGEG3A3D
+@MISEQ:34:000000000-A7PHP:1:1101:18622:1812 1:N:0:TAAGGCGA
+GATAAAGACAGAGTCTTAATTAAAC
++
+11>1>11DFFCFFDGGGB3BF313A
+"""
+
+fastq_r1_out = """@MISEQ:34:000000000-A7PHP:1:1101:12552:1774 1:N:0:TTTAC
+AACTAGCTTCTCTTTTTCTT
++
+31@C1FCGGGG1BFFGF1F3
+@MISEQ:34:000000000-A7PHP:1:1101:16449:1793 1:N:0:TCCCC
+AGTCTCAGCCCTACTCCACT
++
+11CDFFFBCGGG1AFE11AB
+@MISEQ:34:000000000-A7PHP:1:1101:15171:1796 1:N:0:CCACC
+ACGCCTGGCTAATTTTTTTT
++
+AAAAAFAGGGGBFGGGGGG0
+@MISEQ:34:000000000-A7PHP:1:1101:18777:1797 1:N:0:CAGCA
+ATATACACTTCACTCTGCAT
++
+1FBFFFFGGGGCBGEG3A3D
+@MISEQ:34:000000000-A7PHP:1:1101:18622:1812 1:N:0:GATAA
+AGACAGAGTCTTAATTAAAC
++
+11DFFCFFDGGGB3BF313A
+"""
+
+
+class TestAssignBarcodesSingleEnd(unittest.TestCase):
+    """Tests for the assign_barcodes_single_end function
+    """
+    def setUp(self):
+        # Temporary working dir
+        self.wd = tempfile.mkdtemp(suffix='.test_split_single_end')
+        # Test file
+        self.fastq_in = os.path.join(self.wd,'test.fq')
+        open(self.fastq_in,'w').write(fastq_r1)
+        # Output file
+        self.fastq_out = os.path.join(self.wd,'out.fq')
+    def tearDown(self):
+        # Remove temporary working dir
+        if os.path.isdir(self.wd):
+            shutil.rmtree(self.wd)
+    def test_assign_barcodes_single_end(self):
+        """assign_barcodes_single_end: extract barcodes from first 5 bases
+        """
+        assign_barcodes_single_end(self.fastq_in,
+                                   self.fastq_out)
+        self.assertEqual(open(self.fastq_out,'r').read(),
+                         fastq_r1_out)

--- a/bin/assign_barcodes.py
+++ b/bin/assign_barcodes.py
@@ -12,98 +12,7 @@ headers.
 
 """
 import optparse
-import gzip
-from bcftbx.FASTQFile import FastqIterator
-
-def assign_barcodes_single_end(fastq_in,fastq_out,n=5):
-    """
-    """
-    if fastq_out.endswith('.gz'):
-        fp = gzip.GzipFile(filename=fastq_out,mode='wb')
-    else:
-        fp = open(fastq_out,'w')
-    print "Processing reads from %s" % fastq_in
-    nread = 0
-    for read in FastqIterator(fastq_in):
-        # Extract new barcode sequence
-        barcode = read.sequence[:n]
-        # Truncate sequence and quality accordingly
-        sequence = read.sequence[n:]
-        quality = read.quality[n:]
-        # Assign new values and write to output
-        read.seqid.index_sequence = barcode
-        read.sequence = sequence
-        read.quality = quality
-        fp.write("%s\n" % read)
-        nread += 1
-    print "Finished (%d reads processed)" % nread
-
-fastq_r1 = """@MISEQ:34:000000000-A7PHP:1:1101:12552:1774 1:N:0:TAAGGCGA
-TTTACAACTAGCTTCTCTTTTTCTT
-+
->AA?131@C1FCGGGG1BFFGF1F3
-@MISEQ:34:000000000-A7PHP:1:1101:16449:1793 1:N:0:TAAGGCGA
-TCCCCAGTCTCAGCCCTACTCCACT
-+
-11>>>11CDFFFBCGGG1AFE11AB
-@MISEQ:34:000000000-A7PHP:1:1101:15171:1796 1:N:0:GCCTTACC
-CCACCACGCCTGGCTAATTTTTTTT
-+
-1>1>>AAAAAFAGGGGBFGGGGGG0
-@MISEQ:34:000000000-A7PHP:1:1101:18777:1797 1:N:0:TAAGNNNA
-CAGCAATATACACTTCACTCTGCAT
-+
-111>>1FBFFFFGGGGCBGEG3A3D
-@MISEQ:34:000000000-A7PHP:1:1101:18622:1812 1:N:0:TAAGGCGA
-GATAAAGACAGAGTCTTAATTAAAC
-+
-11>1>11DFFCFFDGGGB3BF313A
-"""
-
-fastq_r1_out = """@MISEQ:34:000000000-A7PHP:1:1101:12552:1774 1:N:0:TTTAC
-AACTAGCTTCTCTTTTTCTT
-+
-31@C1FCGGGG1BFFGF1F3
-@MISEQ:34:000000000-A7PHP:1:1101:16449:1793 1:N:0:TCCCC
-AGTCTCAGCCCTACTCCACT
-+
-11CDFFFBCGGG1AFE11AB
-@MISEQ:34:000000000-A7PHP:1:1101:15171:1796 1:N:0:CCACC
-ACGCCTGGCTAATTTTTTTT
-+
-AAAAAFAGGGGBFGGGGGG0
-@MISEQ:34:000000000-A7PHP:1:1101:18777:1797 1:N:0:CAGCA
-ATATACACTTCACTCTGCAT
-+
-1FBFFFFGGGGCBGEG3A3D
-@MISEQ:34:000000000-A7PHP:1:1101:18622:1812 1:N:0:GATAA
-AGACAGAGTCTTAATTAAAC
-+
-11DFFCFFDGGGB3BF313A
-"""
-
-import unittest
-import os
-import tempfile
-import shutil
-class TestAssignBarcodesSingleEnd(unittest.TestCase):
-    def setUp(self):
-        # Temporary working dir
-        self.wd = tempfile.mkdtemp(suffix='.test_split_single_end')
-        # Test file
-        self.fastq_in = os.path.join(self.wd,'test.fq')
-        open(self.fastq_in,'w').write(fastq_r1)
-        # Output file
-        self.fastq_out = os.path.join(self.wd,'out.fq')
-    def tearDown(self):
-        # Remove temporary working dir
-        if os.path.isdir(self.wd):
-            shutil.rmtree(self.wd)
-    def test_assign_barcodes_single_end(self):
-        assign_barcodes_single_end(self.fastq_in,
-                                   self.fastq_out)
-        self.assertEqual(open(self.fastq_out,'r').read(),
-                         fastq_r1_out)
+from auto_process_ngs.fastq_utils import assign_barcodes_single_end
 
 if __name__ == '__main__':
     p = optparse.OptionParser(usage="%prog [OPTIONS] INPUT.fq OUTPUT.fq",
@@ -119,7 +28,3 @@ if __name__ == '__main__':
     if len(args) != 2:
         p.error('Need to specify input and output files')
     assign_barcodes_single_end(args[0],args[1],opts.n)
-
-
-        
-        

--- a/bin/assign_barcodes.py
+++ b/bin/assign_barcodes.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+#
+#     assign_barcodes.py: assign barcodes to read headers in fastqs
+#     Copyright (C) University of Manchester 2016 Peter Briggs
+#
+"""
+assign_barcodes.py
+
+Utility to extract arbitrary sequence fragments from reads in FASTQ
+format files and assign these to the index sequence in the read
+headers.
+
+"""
+import optparse
+import gzip
+from bcftbx.FASTQFile import FastqIterator
+
+def assign_barcodes_single_end(fastq_in,fastq_out,n=5):
+    """
+    """
+    if fastq_out.endswith('.gz'):
+        fp = gzip.GzipFile(filename=fastq_out,mode='wb')
+    else:
+        fp = open(fastq_out,'w')
+    print "Processing reads from %s" % fastq_in
+    nread = 0
+    for read in FastqIterator(fastq_in):
+        # Extract new barcode sequence
+        barcode = read.sequence[:n]
+        # Truncate sequence and quality accordingly
+        sequence = read.sequence[n:]
+        quality = read.quality[n:]
+        # Assign new values and write to output
+        read.seqid.index_sequence = barcode
+        read.sequence = sequence
+        read.quality = quality
+        fp.write("%s\n" % read)
+        nread += 1
+    print "Finished (%d reads processed)" % nread
+
+fastq_r1 = """@MISEQ:34:000000000-A7PHP:1:1101:12552:1774 1:N:0:TAAGGCGA
+TTTACAACTAGCTTCTCTTTTTCTT
++
+>AA?131@C1FCGGGG1BFFGF1F3
+@MISEQ:34:000000000-A7PHP:1:1101:16449:1793 1:N:0:TAAGGCGA
+TCCCCAGTCTCAGCCCTACTCCACT
++
+11>>>11CDFFFBCGGG1AFE11AB
+@MISEQ:34:000000000-A7PHP:1:1101:15171:1796 1:N:0:GCCTTACC
+CCACCACGCCTGGCTAATTTTTTTT
++
+1>1>>AAAAAFAGGGGBFGGGGGG0
+@MISEQ:34:000000000-A7PHP:1:1101:18777:1797 1:N:0:TAAGNNNA
+CAGCAATATACACTTCACTCTGCAT
++
+111>>1FBFFFFGGGGCBGEG3A3D
+@MISEQ:34:000000000-A7PHP:1:1101:18622:1812 1:N:0:TAAGGCGA
+GATAAAGACAGAGTCTTAATTAAAC
++
+11>1>11DFFCFFDGGGB3BF313A
+"""
+
+fastq_r1_out = """@MISEQ:34:000000000-A7PHP:1:1101:12552:1774 1:N:0:TTTAC
+AACTAGCTTCTCTTTTTCTT
++
+31@C1FCGGGG1BFFGF1F3
+@MISEQ:34:000000000-A7PHP:1:1101:16449:1793 1:N:0:TCCCC
+AGTCTCAGCCCTACTCCACT
++
+11CDFFFBCGGG1AFE11AB
+@MISEQ:34:000000000-A7PHP:1:1101:15171:1796 1:N:0:CCACC
+ACGCCTGGCTAATTTTTTTT
++
+AAAAAFAGGGGBFGGGGGG0
+@MISEQ:34:000000000-A7PHP:1:1101:18777:1797 1:N:0:CAGCA
+ATATACACTTCACTCTGCAT
++
+1FBFFFFGGGGCBGEG3A3D
+@MISEQ:34:000000000-A7PHP:1:1101:18622:1812 1:N:0:GATAA
+AGACAGAGTCTTAATTAAAC
++
+11DFFCFFDGGGB3BF313A
+"""
+
+import unittest
+import os
+import tempfile
+import shutil
+class TestAssignBarcodesSingleEnd(unittest.TestCase):
+    def setUp(self):
+        # Temporary working dir
+        self.wd = tempfile.mkdtemp(suffix='.test_split_single_end')
+        # Test file
+        self.fastq_in = os.path.join(self.wd,'test.fq')
+        open(self.fastq_in,'w').write(fastq_r1)
+        # Output file
+        self.fastq_out = os.path.join(self.wd,'out.fq')
+    def tearDown(self):
+        # Remove temporary working dir
+        if os.path.isdir(self.wd):
+            shutil.rmtree(self.wd)
+    def test_assign_barcodes_single_end(self):
+        assign_barcodes_single_end(self.fastq_in,
+                                   self.fastq_out)
+        self.assertEqual(open(self.fastq_out,'r').read(),
+                         fastq_r1_out)
+
+if __name__ == '__main__':
+    p = optparse.OptionParser(usage="%prog [OPTIONS] INPUT.fq OUTPUT.fq",
+                              description="Extract arbitrary sequence "
+                              "fragments from reads in INPUT.fq FASTQ "
+                              "file and assign these as the index "
+                              "(barcode) sequences in the read headers "
+                              "in OUTPUT.fq.")
+    p.add_option('-n',action='store',dest='n',type='int',default=5,
+                 help="remove first N bases from each read and assign "
+                 "these as barcode index sequence (default: 5)")
+    opts,args = p.parse_args()
+    if len(args) != 2:
+        p.error('Need to specify input and output files')
+    assign_barcodes_single_end(args[0],args[1],opts.n)
+
+
+        
+        

--- a/docs/source/problems.rst
+++ b/docs/source/problems.rst
@@ -5,6 +5,13 @@ There are a variety of relatively common problem situations that can be
 encountered; these are outline below along with suggested protocols to
 use to solve them.
 
+ * :ref:`problem-missing-sample-sheet`
+ * :ref:`problem-split-processing`
+ * :ref:`problem-incomplete-run`
+ * :ref:`problem-incorrect-barcodes`
+ * :ref:`problem-skip-demultiplexing`
+ * :ref:`problem-handling-inline-barcodes`
+
 .. _problem-missing-sample-sheet:
 
 Missing Sample Sheet
@@ -193,8 +200,7 @@ Skip demultiplexing in ``make_fastqs`` stage
 
 .. warning::
 
-    This section is still under development and might be inaccurate or even
-    completely wrong!
+    This section is still under development
 
 The demultiplexing can be skipped in one of two ways.
 
@@ -229,3 +235,35 @@ Using this approach should put all the reads into the "undetermined" project;
 however this way the index sequences should still have been captured in the read
 headers.
 
+.. _problem-handling-inline-barcodes:
+
+Handling inline barcodes
+************************
+
+.. warning::
+
+    This section is still under development.
+
+In this situation the barcode index sequences are part of each read (e.g.
+the first five bases of the first read), so ``bcl2fastq``'s standard
+demultiplexing process can't be used.
+
+In this case the following procedure can be used:
+
+ * **Perform ``bcl`` to ``fastq`` conversion without demultiplexing**:
+   put all the reads into a single fastq file by following the approach
+   outlined in :ref:`problem-skip-demultiplexing` to avoid assigning
+   index sequences to each read.
+
+ * **Extract and assign inline barcodes**: use the ``assign_barcodes.py``
+   utility to extract the barcode sequences from each read from the fastq
+   file produced by the previous step and assign these to the read header,
+   for example::
+
+       assign_barcodes.py -n 5 all_S1_R1_001.fastq.gz all_barcoded_S1_R1_001.fastq.gz
+
+ * **Split into separate fastq files by barcode sequence**: use the
+   ``barcode_splitter.py`` utility to assign reads to individual fastqs,
+   for example::
+
+       barcode_splitter.py -b ATACC -b TCTAG -b GCAGC all_barcoded_S1_R1_001.fastq.gz

--- a/docs/source/problems.rst
+++ b/docs/source/problems.rst
@@ -244,6 +244,10 @@ Handling inline barcodes
 
     This section is still under development.
 
+.. warning::
+
+    Currently this is only implemented for **single-ended FASTQs**
+
 In this situation the barcode index sequences are part of each read (e.g.
 the first five bases of the first read), so ``bcl2fastq``'s standard
 demultiplexing process can't be used.


### PR DESCRIPTION
PR to add a utility to assign barcode sequences in a FASTQ file by extracting leading bases from each read.