### PR TITLE
Improve Sample Sheet handling and error detection WIP

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -775,8 +775,12 @@ class AutoProcess:
                                                         custom_sample_sheet)
             os.remove(tmp_run_info)
         print "Corrected bases mask: %s" % bases_mask
-        # Generate and print predicted outputs
+        # Generate and print predicted outputs and warnings
         print samplesheet_utils.predict_outputs(sample_sheet=sample_sheet)
+        samplesheet_utils.warn_close_names(sample_sheet=sample_sheet)
+        if samplesheet_utils.has_invalid_characters(custom_sample_sheet):
+            logging.warning("Sample sheet file contains invalid characters "
+                            "(non-printing ASCII or non-ASCII)")
         # Store the parameters
         self.params['data_dir'] = data_dir
         self.params['analysis_dir'] = self.analysis_dir

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -266,6 +266,20 @@ class AutoProcess:
                 # Unable to get missing data items
                 logging.warning("Unable to set missing instrument metadata")
 
+    def edit_samplesheet(self,editor='vi'):
+        """
+        Bring up SampleSheet in an editor
+        """
+        # Fetch the sample sheet
+        sample_sheet_file = self.params.sample_sheet
+        if sample_sheet_file is None:
+            logging.error("No sample sheet file to edit")
+            return
+        editor = editor.split(' ')
+        edit_cmd = applications.Command(editor[0],*editor[1:])
+        edit_cmd.add_args(sample_sheet_file)
+        edit_cmd.run_subprocess()
+
     def init_readme(self):
         """
         Create a new README file

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -31,6 +31,7 @@ import applications
 import utils
 import simple_scheduler
 import bcl2fastq_utils
+import samplesheet_utils
 import settings
 from .exceptions import MissingParameterFileException
 from auto_process_ngs import get_version
@@ -774,18 +775,8 @@ class AutoProcess:
                                                         custom_sample_sheet)
             os.remove(tmp_run_info)
         print "Corrected bases mask: %s" % bases_mask
-        # Print the predicted ouputs
-        projects = sample_sheet.predict_output()
-        print "Predicted output from sample sheet:"
-        print "Project\tSample\tFastq"
-        for project in projects:
-            project_name = project[8:]
-            sample_names = []
-            for sample in projects[project]:
-                sample_name = sample[7:]
-                for fastq_base in projects[project][sample]:
-                    print "%s\t%s\t%s" % (project_name,sample_name,fastq_base)
-                sample_names.append(sample_name)
+        # Generate and print predicted outputs
+        print samplesheet_utils.predict_outputs(sample_sheet=sample_sheet)
         # Store the parameters
         self.params['data_dir'] = data_dir
         self.params['analysis_dir'] = self.analysis_dir

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -266,7 +266,7 @@ class AutoProcess:
                 # Unable to get missing data items
                 logging.warning("Unable to set missing instrument metadata")
 
-    def edit_samplesheet(self,editor='vi'):
+    def edit_samplesheet(self):
         """
         Bring up SampleSheet in an editor
         """
@@ -275,10 +275,7 @@ class AutoProcess:
         if sample_sheet_file is None:
             logging.error("No sample sheet file to edit")
             return
-        editor = editor.split(' ')
-        edit_cmd = applications.Command(editor[0],*editor[1:])
-        edit_cmd.add_args(sample_sheet_file)
-        edit_cmd.run_subprocess()
+        utils.edit_file(sample_sheet_file)
 
     def init_readme(self):
         """
@@ -294,17 +291,14 @@ class AutoProcess:
         else:
             logging.warning("'%s' already exists" % self.readme_file)
 
-    def edit_readme(self,editor='vi'):
+    def edit_readme(self):
         """
         Bring up README in an editor
         """
         if self.readme_file is None:
             logging.error("No README file to edit")
             return
-        editor = editor.split(' ')
-        edit_cmd = applications.Command(editor[0],*editor[1:])
-        edit_cmd.add_args(self.readme_file)
-        edit_cmd.run_subprocess()
+        utils.edit_file(sample_sheet_file)
 
     def load_illumina_data(self,unaligned_dir=None):
         # Load and return an IlluminaData object

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -276,6 +276,9 @@ class AutoProcess:
             logging.error("No sample sheet file to edit")
             return
         utils.edit_file(sample_sheet_file)
+        # Check updated sample sheet and issue warnings
+        if samplesheet_utils.check_and_warn(sample_sheet_file=sample_sheet_file):
+            logging.error("Sample sheet may have problems, see warnings above")
 
     def init_readme(self):
         """
@@ -785,17 +788,7 @@ class AutoProcess:
         print "Corrected bases mask: %s" % bases_mask
         # Generate and print predicted outputs and warnings
         print samplesheet_utils.predict_outputs(sample_sheet=sample_sheet)
-        if samplesheet_utils.close_project_names(sample_sheet=sample_sheet):
-            logging.warning("Some projects have similar names: check for typos")
-        if samplesheet_utils.samples_with_multiple_barcodes(sample_sheet=sample_sheet):
-            logging.warning("Some samples have more than one barcode assigned")
-        if samplesheet_utils.samples_in_multiple_projects(sample_sheet=sample_sheet):
-            logging.warning("Some samples appear in more than one project")
-        if samplesheet_utils.has_invalid_characters(custom_sample_sheet):
-            logging.warning("Sample sheet file contains invalid characters "
-                            "(non-printing ASCII or non-ASCII)")
-        if samplesheet_utils.has_invalid_lines(sample_sheet=sample_sheet):
-            logging.warning("Sample sheet has one or more invalid lines")
+        samplesheet_utils.check_and_warn(sample_sheet=sample_sheet)
         # Store the parameters
         self.params['data_dir'] = data_dir
         self.params['analysis_dir'] = self.analysis_dir

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -785,10 +785,17 @@ class AutoProcess:
         print "Corrected bases mask: %s" % bases_mask
         # Generate and print predicted outputs and warnings
         print samplesheet_utils.predict_outputs(sample_sheet=sample_sheet)
-        samplesheet_utils.warn_close_names(sample_sheet=sample_sheet)
+        if samplesheet_utils.close_project_names(sample_sheet=sample_sheet):
+            logging.warning("Some projects have similar names: check for typos")
+        if samplesheet_utils.samples_with_multiple_barcodes(sample_sheet=sample_sheet):
+            logging.warning("Some samples have more than one barcode assigned")
+        if samplesheet_utils.samples_in_multiple_projects(sample_sheet=sample_sheet):
+            logging.warning("Some samples appear in more than one project")
         if samplesheet_utils.has_invalid_characters(custom_sample_sheet):
             logging.warning("Sample sheet file contains invalid characters "
                             "(non-printing ASCII or non-ASCII)")
+        if samplesheet_utils.has_invalid_lines(sample_sheet=sample_sheet):
+            logging.warning("Sample sheet has one or more invalid lines")
         # Store the parameters
         self.params['data_dir'] = data_dir
         self.params['analysis_dir'] = self.analysis_dir

--- a/auto_process_ngs/samplesheet_utils.py
+++ b/auto_process_ngs/samplesheet_utils.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+#     samplesheet_utils.py: utility functions for handling samplesheet files
+#     Copyright (C) University of Manchester 2016 Peter Briggs
+#
+########################################################################
+#
+# samplesheet_utils.py
+#
+#########################################################################
+
+"""
+samplesheet_utils.py
+
+Utility functions for handling SampleSheet files:
+
+- predict_outputs: generate expected outputs in human-readable form
+
+"""
+
+#######################################################################
+# Imports
+#######################################################################
+
+from bcftbx.IlluminaData import SampleSheet
+from bcftbx.IlluminaData import SampleSheetPredictor
+
+#######################################################################
+# Functions
+#######################################################################
+
+def predict_outputs(sample_sheet=None,sample_sheet_file=None):
+    """
+    Generate expected sample sheet output in human-readable form
+
+    Arguments:
+      sample_sheet (SampleSheet): if supplied then must be a
+        populated ``SampleSheet`` instance (if ``None`` then
+        data will be loaded from file specified by
+        ``sample_sheet_file``)
+      sample_sheet_file (str): if ``sample_sheet`` is ``None``
+        then read data from the file specified by this argument
+
+    Returns:
+      String: text describing the expected projects, sample names,
+        indices, barcodes and lanes.
+
+    """
+    prediction = []
+    if sample_sheet is None:
+        sample_sheet = SampleSheet(sample_sheet_file)
+    predictor = SampleSheetPredictor(sample_sheet=sample_sheet)
+    title = "Predicted projects:"
+    prediction.append("%s\n%s" % (title,('='*len(title))))
+    for project_name in predictor.project_names:
+        prediction.append("- %s" % project_name)
+    for project_name in predictor.project_names:
+        project = predictor.get_project(project_name)
+        title = "%s (%d samples)" % (project_name,
+                                     len(project.sample_ids))
+        prediction.append("\n%s\n%s" % (title,('-'*len(title))))
+        for sample_id in project.sample_ids:
+            sample = project.get_sample(sample_id)
+            for barcode in sample.barcode_seqs:
+                lanes = sample.lanes(barcode)
+                if lanes:
+                    lanes = "L%s" % (','.join([str(l)
+                                               for l in lanes]))
+                else:
+                    lanes = "L*"
+                line = [sample_id,
+                        "S%d" % sample.s_index,
+                        barcode,
+                        lanes]
+                prediction.append("%s" % '\t'.join([str(i) for i in line]))
+    return '\n'.join(prediction)

--- a/auto_process_ngs/samplesheet_utils.py
+++ b/auto_process_ngs/samplesheet_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-#     samplesheet_utils.py: utility functions for handling samplesheet files
+#     samplesheet_utils.py: utilities for handling samplesheet files
 #     Copyright (C) University of Manchester 2016 Peter Briggs
 #
 ########################################################################
@@ -12,9 +12,11 @@
 """
 samplesheet_utils.py
 
-Utility functions for handling SampleSheet files:
+Utilities for handling SampleSheet files:
 
 - predict_outputs: generate expected outputs in human-readable form
+- get_close_names: return closely matching names from a list
+- has_invalid_characters: check if a file contains invalid characters
 
 """
 
@@ -22,6 +24,8 @@ Utility functions for handling SampleSheet files:
 # Imports
 #######################################################################
 
+import logging
+import difflib
 from bcftbx.IlluminaData import SampleSheet
 from bcftbx.IlluminaData import SampleSheetPredictor
 
@@ -46,18 +50,29 @@ def predict_outputs(sample_sheet=None,sample_sheet_file=None):
         indices, barcodes and lanes.
 
     """
-    prediction = []
+    # Set up predictor instance
     if sample_sheet is None:
         sample_sheet = SampleSheet(sample_sheet_file)
     predictor = SampleSheetPredictor(sample_sheet=sample_sheet)
+    # Do checks
+    close_names = get_close_names(predictor.project_names)
+    # Generate prediction report
+    prediction = []
     title = "Predicted projects:"
     prediction.append("%s\n%s" % (title,('='*len(title))))
     for project_name in predictor.project_names:
-        prediction.append("- %s" % project_name)
+        if project_name in close_names:
+            warning_flag = " *"
+        else:
+            warning_flag = ""
+        prediction.append("- %s%s" % (project_name,
+                                      warning_flag))
     for project_name in predictor.project_names:
         project = predictor.get_project(project_name)
-        title = "%s (%d samples)" % (project_name,
-                                     len(project.sample_ids))
+        title = "%s (%d sample%s)" % (project_name,
+                                      len(project.sample_ids),
+                                      ('s' if len(project.sample_ids) != 1
+                                       else ''))
         prediction.append("\n%s\n%s" % (title,('-'*len(title))))
         for sample_id in project.sample_ids:
             sample = project.get_sample(sample_id)
@@ -74,3 +89,80 @@ def predict_outputs(sample_sheet=None,sample_sheet_file=None):
                         lanes]
                 prediction.append("%s" % '\t'.join([str(i) for i in line]))
     return '\n'.join(prediction)
+
+def warn_close_names(sample_sheet=None,sample_sheet_file=None):
+    """
+    Issue a warning for each set of closely matching project names
+
+    Arguments:
+      sample_sheet (SampleSheet): if supplied then must be a
+        populated ``SampleSheet`` instance (if ``None`` then
+        data will be loaded from file specified by
+        ``sample_sheet_file``)
+      sample_sheet_file (str): if ``sample_sheet`` is ``None``
+        then read data from the file specified by this argument
+
+    Returns:
+      Boolean: True if there is at least one pair of closely
+        matching project names, False if not.
+
+    """
+    # Set up predictor instance
+    if sample_sheet is None:
+        sample_sheet = SampleSheet(sample_sheet_file)
+    predictor = SampleSheetPredictor(sample_sheet=sample_sheet)
+    # Look for close names
+    close_names = get_close_names(predictor.project_names)
+    for name in close_names:
+        logging.warning("Project '%s': similar to %d others (%s)" %
+                        (name,
+                         len(close_names[name]),
+                         ','.join(close_names[name])))
+    # Return status indicates whether or not there were
+    # closely matching names
+    if close_names:
+        return True
+    else:
+        return False
+
+def get_close_names(names):
+    """
+    Given a list of names, find pairs which are similar
+
+    Returns:
+      Dictionary: keys are names which have at least one close
+        match; the values for each key are lists with the
+        close matches.
+
+    """
+    close_names = {}
+    for i,name in enumerate(names[:-1]):
+        matches = difflib.get_close_matches(name,names[i+1:])
+        if len(matches):
+            #print "*** %s: matches %s ***" % (name,matches)
+            close_names[name] = matches
+            for name1 in matches:
+                if name1 not in close_names:
+                    close_names[name1] = []
+                close_names[name1].append(name)
+    return close_names
+
+def has_invalid_characters(filen):
+    """
+    Check if text file contains any 'invalid' characters
+
+    In this context a character is 'invalid' if:
+    - it is non-ASCII (decimal code > 127), or
+    - it is a non-printing ASCII character (code < 32)
+
+    Returns:
+      Boolean: True if file contains at least one invalid
+        character, False if all characters are valid.
+
+    """
+    with open(filen,'r') as fp:
+        for line in fp:
+            for c in line.replace('\n','').replace('\t',''):
+                if ord(c) > 127 or ord(c) < 32:
+                    return True
+    return False

--- a/auto_process_ngs/samplesheet_utils.py
+++ b/auto_process_ngs/samplesheet_utils.py
@@ -90,41 +90,6 @@ def predict_outputs(sample_sheet=None,sample_sheet_file=None):
                 prediction.append("%s" % '\t'.join([str(i) for i in line]))
     return '\n'.join(prediction)
 
-def warn_close_names(sample_sheet=None,sample_sheet_file=None):
-    """
-    Issue a warning for each set of closely matching project names
-
-    Arguments:
-      sample_sheet (SampleSheet): if supplied then must be a
-        populated ``SampleSheet`` instance (if ``None`` then
-        data will be loaded from file specified by
-        ``sample_sheet_file``)
-      sample_sheet_file (str): if ``sample_sheet`` is ``None``
-        then read data from the file specified by this argument
-
-    Returns:
-      Boolean: True if there is at least one pair of closely
-        matching project names, False if not.
-
-    """
-    # Set up predictor instance
-    if sample_sheet is None:
-        sample_sheet = SampleSheet(sample_sheet_file)
-    predictor = SampleSheetPredictor(sample_sheet=sample_sheet)
-    # Look for close names
-    close_names = get_close_names(predictor.project_names)
-    for name in close_names:
-        logging.warning("Project '%s': similar to %d others (%s)" %
-                        (name,
-                         len(close_names[name]),
-                         ','.join(close_names[name])))
-    # Return status indicates whether or not there were
-    # closely matching names
-    if close_names:
-        return True
-    else:
-        return False
-
 def close_project_names(sample_sheet=None,sample_sheet_file=None):
     """
     Return list of closely-matching project names in samplesheet

--- a/auto_process_ngs/samplesheet_utils.py
+++ b/auto_process_ngs/samplesheet_utils.py
@@ -172,10 +172,26 @@ class SampleSheetLinter(SampleSheetPredictor):
             required data) in the sample sheet.
 
         """
+        # Convience variables
+        sample_id = self._sample_sheet.sample_id_column
+        sample_name = self._sample_sheet.sample_name_column
+        sample_project = self._sample_sheet.sample_project_column
+        # Look at first line to see which items have been provided
+        line = self._sample_sheet.data[0]
+        has_sample_id = line[sample_id] != ''
+        has_sample_name = (sample_name is not None) and \
+                          (line[sample_name] != '')
+        has_project = line[sample_project] != ''
         # Look for invalid data lines
         invalid_lines = []
         for line in self._sample_sheet.data:
             if self._sample_sheet.has_lanes and line['Lane'] == '':
+                invalid_lines.append(line)
+            elif has_sample_id and line[sample_id] == '':
+                invalid_lines.append(line)
+            elif has_sample_name and line[sample_name] == '':
+                invalid_lines.append(line)
+            elif has_project and line[sample_project] == '':
                 invalid_lines.append(line)
         return invalid_lines
 

--- a/auto_process_ngs/samplesheet_utils.py
+++ b/auto_process_ngs/samplesheet_utils.py
@@ -14,12 +14,13 @@ samplesheet_utils.py
 
 Utilities for handling SampleSheet files:
 
+- SampleSheetLinter: core class which provides methods for checking
+  sample sheet contents for potential problems
 - predict_outputs: generate expected outputs in human-readable form
 - check_and_warn: check sample sheet for problems and issue warnings
-- close_project_names: check if sample sheet projects look similar
-- samples_with_multiple_barcodes: check for samples with multiple barcodes
-- samples_in_multiple_projects: check for samples assigned to multiple projects
-- has_invalid_lines: check for invalid sample sheet lines
+
+Helper functions:
+
 - has_invalid_characters: check if a file contains invalid characters
 - get_close_names: return closely matching names from a list
 
@@ -33,6 +34,165 @@ import logging
 import difflib
 from bcftbx.IlluminaData import SampleSheet
 from bcftbx.IlluminaData import SampleSheetPredictor
+
+#######################################################################
+# Classes
+#######################################################################
+
+class SampleSheetLinter(SampleSheetPredictor):
+    """
+    Class for checking sample sheets for problems
+
+    Provides the following methods for checking different aspects
+    of a sample sheet:
+
+    - close_project_names: check if sample sheet projects look similar
+    - samples_with_multiple_barcodes: check for samples with multiple
+      barcodes
+    - samples_in_multiple_projects: check for samples assigned to
+      multiple projects
+    - has_invalid_lines: check for invalid sample sheet lines
+    - has_invalid_characters: check if sample sheet contains invalid
+      characters
+
+    Example usage:
+
+    Initialise linter:
+    >>> linter = SampleSheetLinter(sample_sheet_file="SampleSheet.txt")
+
+    Get closely-matching names:
+    >>> linter.close_project_names()
+    ...
+
+    """
+    def __init__(self,sample_sheet=None,sample_sheet_file=None,fp=None):
+        """
+        Create a new SampleSheetLinter instance
+
+        Arguments:
+          sample_sheet (SampleSheet): a SampleSheet instance to use
+            for prediction (if None then must provide a file via
+            the `sample_sheet_file` argument; if both are provided
+            then `sample_sheet` takes precedence)
+          sample_sheet_file (str): path to a sample sheet file, if
+            `sample_sheet` argument is None
+          fp (File): File-like object opened for reading; if this
+            is not None then the SampleSheet object will be populated
+            from this in preference to `sample_sheet`
+
+        """
+        # Initialise
+        self._fp = fp
+        self._sample_sheet_file = sample_sheet_file
+        self._sample_sheet = sample_sheet
+        if self._fp is None:
+            if self._sample_sheet is None:
+                self._sample_sheet = SampleSheet(sample_sheet_file)
+        else:
+            self._sample_sheet = SampleSheet(fp=self._fp)
+        SampleSheetPredictor.__init__(self,
+                                      sample_sheet=self._sample_sheet)
+
+
+    def walk(self):
+        """
+        Traverse the list of projects and samples
+
+        Generator that yields tuples consisting of
+        (SampleSheetProject,SampleSheetSample) pairs
+        
+        Yields:
+          Tuple: SampleSheetProject, SampleSheetSample pair
+
+        """
+        for project in [self.get_project(name)
+                        for name in self.project_names]:
+            for sample in [project.get_sample(idx)
+                           for idx in project.sample_ids]:
+                yield (project,sample)
+        
+    def close_project_names(self):
+        """
+        Return list of closely-matching project names
+
+        Returns:
+          Dictionary: keys are project names which have at least one
+            close match; the values for each key are lists with the
+            project names which are close matches.
+
+        """
+        return get_close_names(self.project_names)
+
+    def samples_with_multiple_barcodes(self):
+        """
+        Return list of samples which have multiple associated barcodes
+
+        Returns:
+          Dictionary: keys are sample IDs which have more than one
+          associated barcode; the values for each key are lists of
+          the associated barcodes.
+
+        """
+        # Look for samples with multiple barcodes
+        multiple_barcodes = {}
+        for project,sample in self.walk():
+            if len(sample.barcode_seqs) > 1:
+                multiple_barcodes[sample.sample_id] = \
+                    [s for s in sample.barcode_seqs]
+        return multiple_barcodes
+
+    def samples_in_multiple_projects(self):
+        """
+        Return list of samples which are in multiple projects
+
+        Returns:
+          Dictionary: dictionary with sample IDs which appear in
+            multiple projects as keys; the associated values are
+            lists with the project names.
+
+        """
+        # Look for samples with multiple projects
+        samples = {}
+        for project,sample in self.walk():
+            if sample.sample_id not in samples:
+                samples[sample.sample_id] = []
+            samples[sample.sample_id].append(project.name)
+        multiple_projects = {}
+        for sample in samples:
+            if len(samples[sample]) > 1:
+                multiple_projects[sample] = samples[sample]
+        return multiple_projects
+
+    def has_invalid_lines(self):
+        """
+        Return list of samplesheet lines which are invalid
+
+        Returns:
+          List: list of lines which are invalid (i.e. missing
+            required data) in the sample sheet.
+
+        """
+        # Look for invalid data lines
+        invalid_lines = []
+        for line in self._sample_sheet.data:
+            if self._sample_sheet.has_lanes and line['Lane'] == '':
+                invalid_lines.append(line)
+        return invalid_lines
+
+    def has_invalid_characters(self):
+        """
+        Check if text file contains any 'invalid' characters
+
+        In this context a character is 'invalid' if:
+        - it is non-ASCII (decimal code > 127), or
+        - it is a non-printing ASCII character (code < 32)
+
+        Returns:
+          Boolean: True if file contains at least one invalid
+            character, False if all characters are valid.
+
+        """
+        return has_invalid_characters(text=self._sample_sheet.show())
 
 #######################################################################
 # Functions
@@ -55,25 +215,24 @@ def predict_outputs(sample_sheet=None,sample_sheet_file=None):
         indices, barcodes and lanes.
 
     """
-    # Set up predictor instance
-    if sample_sheet is None:
-        sample_sheet = SampleSheet(sample_sheet_file)
-    predictor = SampleSheetPredictor(sample_sheet=sample_sheet)
+    # Set up linter
+    linter = SampleSheetLinter(sample_sheet=sample_sheet,
+                               sample_sheet_file=sample_sheet_file)
     # Do checks
-    close_names = get_close_names(predictor.project_names)
+    close_names = linter.close_project_names()
     # Generate prediction report
     prediction = []
     title = "Predicted projects:"
     prediction.append("%s\n%s" % (title,('='*len(title))))
-    for project_name in predictor.project_names:
+    for project_name in linter.project_names:
         if project_name in close_names:
             warning_flag = " *"
         else:
             warning_flag = ""
         prediction.append("- %s%s" % (project_name,
                                       warning_flag))
-    for project_name in predictor.project_names:
-        project = predictor.get_project(project_name)
+    for project_name in linter.project_names:
+        project = linter.get_project(project_name)
         title = "%s (%d sample%s)" % (project_name,
                                       len(project.sample_ids),
                                       ('s' if len(project.sample_ids) != 1
@@ -119,151 +278,28 @@ def check_and_warn(sample_sheet=None,sample_sheet_file=None):
       Boolean: True if problems were identified, False otherwise.
 
     """
-    # Acquire sample sheet instance
-    if sample_sheet is None:
-        sample_sheet = SampleSheet(sample_sheet_file)
+    # Acquire sample sheet linter instance
+    linter = SampleSheetLinter(sample_sheet=sample_sheet,
+                               sample_sheet_file=sample_sheet_file)
     # Do checks
     warnings = False
-    if close_project_names(sample_sheet=sample_sheet):
+    if linter.close_project_names():
         logging.warning("Some projects have similar names: check for typos")
         warnings = True
-    if samples_with_multiple_barcodes(sample_sheet=sample_sheet):
+    if linter.samples_with_multiple_barcodes():
         logging.warning("Some samples have more than one barcode assigned")
         warnings = True
-    if samples_in_multiple_projects(sample_sheet=sample_sheet):
+    if linter.samples_in_multiple_projects():
         logging.warning("Some samples appear in more than one project")
         warnings = True
-    if has_invalid_characters(text=sample_sheet.show()):
+    if linter.has_invalid_characters():
         logging.warning("Sample sheet file contains invalid characters "
                         "(non-printing ASCII or non-ASCII)")
         warnings = True
-    if has_invalid_lines(sample_sheet=sample_sheet):
+    if linter.has_invalid_lines():
         logging.warning("Sample sheet has one or more invalid lines")
         warnings = True
     return warnings
-
-def close_project_names(sample_sheet=None,sample_sheet_file=None):
-    """
-    Return list of closely-matching project names in samplesheet
-
-    Arguments:
-      sample_sheet (SampleSheet): if supplied then must be a
-        populated ``SampleSheet`` instance (if ``None`` then
-        data will be loaded from file specified by
-        ``sample_sheet_file``)
-      sample_sheet_file (str): if ``sample_sheet`` is ``None``
-        then read data from the file specified by this argument
-
-    Returns:
-      Dictionary: keys are project names which have at least one
-        close match; the values for each key are lists with the
-        project names which are close matches.
-
-    """
-    # Set up predictor instance
-    if sample_sheet is None:
-        sample_sheet = SampleSheet(sample_sheet_file)
-    predictor = SampleSheetPredictor(sample_sheet=sample_sheet)
-    # Return close names
-    return get_close_names(predictor.project_names)
-
-def samples_with_multiple_barcodes(sample_sheet=None,sample_sheet_file=None):
-    """
-    Return list of samples which have multiple associated barcodes
-
-    Arguments:
-      sample_sheet (SampleSheet): if supplied then must be a
-        populated ``SampleSheet`` instance (if ``None`` then
-        data will be loaded from file specified by
-        ``sample_sheet_file``)
-      sample_sheet_file (str): if ``sample_sheet`` is ``None``
-        then read data from the file specified by this argument
-
-    Returns:
-      Dictionary: keys are sample IDs which have more than one
-        associated barcode; the values for each key are lists of
-        the associated barcodes.
-
-    """
-    # Set up predictor instance
-    if sample_sheet is None:
-        sample_sheet = SampleSheet(sample_sheet_file)
-    predictor = SampleSheetPredictor(sample_sheet=sample_sheet)
-    logging.debug(predict_outputs(sample_sheet=sample_sheet))
-    # Look for samples with multiple barcodes
-    multiple_barcodes = {}
-    for project in [predictor.get_project(name)
-                    for name in predictor.project_names]:
-        for sample in [project.get_sample(idx)
-                       for idx in project.sample_ids]:
-            if len(sample.barcode_seqs) > 1:
-                multiple_barcodes[sample.sample_id] = \
-                            [s for s in sample.barcode_seqs]
-    return multiple_barcodes
-
-def samples_in_multiple_projects(sample_sheet=None,
-                                 sample_sheet_file=None):
-    """
-    Return list of samples which are in multiple projects
-
-    Arguments:
-      sample_sheet (SampleSheet): if supplied then must be a
-        populated ``SampleSheet`` instance (if ``None`` then
-        data will be loaded from file specified by
-        ``sample_sheet_file``)
-      sample_sheet_file (str): if ``sample_sheet`` is ``None``
-        then read data from the file specified by this argument
-
-    Returns:
-      Dictionary: dictionary with sample IDs which appear in
-        multiple projects as keys; the associated values are
-        lists with the project names.
-
-    """
-    # Set up predictor instance
-    if sample_sheet is None:
-        sample_sheet = SampleSheet(sample_sheet_file)
-    predictor = SampleSheetPredictor(sample_sheet=sample_sheet)
-    # Look for samples with multiple projects
-    samples = {}
-    for project in [predictor.get_project(name)
-                    for name in predictor.project_names]:
-        for sample in [project.get_sample(name)
-                       for name in project.sample_ids]:
-            if sample.sample_id not in samples:
-                samples[sample.sample_id] = []
-            samples[sample.sample_id].append(project.name)
-    multiple_projects = {}
-    for sample in samples:
-        if len(samples[sample]) > 1:
-            multiple_projects[sample] = samples[sample]
-    return multiple_projects
-
-def has_invalid_lines(sample_sheet=None,sample_sheet_file=None):
-    """
-    Return list of samplesheet lines which are invalid
-
-    Arguments:
-      sample_sheet (SampleSheet): if supplied then must be a
-        populated ``SampleSheet`` instance (if ``None`` then
-        data will be loaded from file specified by
-        ``sample_sheet_file``)
-      sample_sheet_file (str): if ``sample_sheet`` is ``None``
-        then read data from the file specified by this argument
-
-    Returns:
-      List: list of lines which are invalid (i.e. missing
-        required data) in the sample sheet.
-
-    """
-    # Look for invalid data lines
-    if sample_sheet is None:
-        sample_sheet = SampleSheet(sample_sheet_file)
-    invalid_lines = []
-    for line in sample_sheet.data:
-        if sample_sheet.has_lanes and line['Lane'] == '':
-            invalid_lines.append(line)
-    return invalid_lines
 
 def has_invalid_characters(filen=None,text=None):
     """

--- a/auto_process_ngs/samplesheet_utils.py
+++ b/auto_process_ngs/samplesheet_utils.py
@@ -15,8 +15,13 @@ samplesheet_utils.py
 Utilities for handling SampleSheet files:
 
 - predict_outputs: generate expected outputs in human-readable form
-- get_close_names: return closely matching names from a list
+- check_and_warn: check sample sheet for problems and issue warnings
+- close_project_names: check if sample sheet projects look similar
+- samples_with_multiple_barcodes: check for samples with multiple barcodes
+- samples_in_multiple_projects: check for samples assigned to multiple projects
+- has_invalid_lines: check for invalid sample sheet lines
 - has_invalid_characters: check if a file contains invalid characters
+- get_close_names: return closely matching names from a list
 
 """
 

--- a/auto_process_ngs/test/test_samplesheet_utils.py
+++ b/auto_process_ngs/test/test_samplesheet_utils.py
@@ -1,0 +1,66 @@
+#######################################################################
+# Tests for samplesheet_utils.py module
+#######################################################################
+
+import os
+import unittest
+import tempfile
+import shutil
+import codecs
+from auto_process_ngs.samplesheet_utils import get_close_names
+from auto_process_ngs.samplesheet_utils import has_invalid_characters
+
+class TestCloseNamesFunction(unittest.TestCase):
+    def test_close_names(self):
+        """get_close_names: check function returns expected results
+        """
+        self.assertEqual(get_close_names(("Andrew Bloggs",
+                                          "Carl Dewey",
+                                          "Filipe Greer",)),{})
+        self.assertEqual(get_close_names(("Andrew Blogs",
+                                          "Andrew Bloggs",
+                                          "Carl Dewey",
+                                          "Filipe Greer",)),
+                         { "Andrew Bloggs": ["Andrew Blogs"],
+                           "Andrew Blogs": ["Andrew Bloggs"] })
+
+class TestHasInvalidCharacters(unittest.TestCase):
+    def setUp(self):
+        self.wd = tempfile.mkdtemp()
+    def tearDown(self):
+        if os.path.isdir(self.wd):
+            shutil.rmtree(self.wd)
+    def test_file_with_non_printing_ascii_character(self):
+        """has_invalid_characters: detects non-printing ASCII character
+        """
+        non_printing_ascii_file = os.path.join(self.wd,
+                                               "test.nonprintingascii")
+        with open(non_printing_ascii_file,'wb') as fp:
+            fp.write(u"""This file contains:
+a non-printing ASCII ctrl-S character here\x13
+""")
+        self.assertTrue(has_invalid_characters(non_printing_ascii_file))
+    def test_file_with_non_ascii_character(self):
+        """has_invalid_characters: detects non-ASCII character
+        """
+        non_ascii_file = os.path.join(self.wd,"test.nonascii")
+        with codecs.open(non_ascii_file,'wb',encoding='utf-8') as fp:
+            fp.write(u"""This file contains:
+a non-ASCII character here\x80
+""")
+        self.assertTrue(has_invalid_characters(non_ascii_file))
+    def test_file_with_valid_characters(self):
+        """has_invalid_characters: works for valid file
+        """
+        valid_file = os.path.join(self.wd,"test.valid")
+        with open(valid_file,'wb') as fp:
+            fp.write(u"""This file contains valid characters:
+- ABCDEFGHIJKLMNOPQRSTUVWXYZ
+- abcdefghijklmnopqrstuvwxyz
+- 01234567890
+- !"$%^&*()_-+=\|/:;'@#~`?
+- {}[]
+- \t\n
+""")
+        self.assertFalse(has_invalid_characters(valid_file))
+        

--- a/auto_process_ngs/test/test_samplesheet_utils.py
+++ b/auto_process_ngs/test/test_samplesheet_utils.py
@@ -147,7 +147,7 @@ class TestHasInvalidCharacters(unittest.TestCase):
         if os.path.isdir(self.wd):
             shutil.rmtree(self.wd)
     def test_file_with_non_printing_ascii_character(self):
-        """has_invalid_characters: detects non-printing ASCII character
+        """has_invalid_characters: detects non-printing ASCII character in file
         """
         non_printing_ascii_file = os.path.join(self.wd,
                                                "test.nonprintingascii")
@@ -156,8 +156,14 @@ class TestHasInvalidCharacters(unittest.TestCase):
 a non-printing ASCII ctrl-S character here\x13
 """)
         self.assertTrue(has_invalid_characters(non_printing_ascii_file))
+    def test_text_with_non_printing_ascii_character(self):
+        """has_invalid_characters: detects non-printing ASCII character in text
+        """
+        self.assertTrue(has_invalid_characters(text=u"""This file contains:
+a non-printing ASCII ctrl-S character here\x13
+"""))
     def test_file_with_non_ascii_character(self):
-        """has_invalid_characters: detects non-ASCII character
+        """has_invalid_characters: detects non-ASCII character in file
         """
         non_ascii_file = os.path.join(self.wd,"test.nonascii")
         with codecs.open(non_ascii_file,'wb',encoding='utf-8') as fp:
@@ -165,6 +171,12 @@ a non-printing ASCII ctrl-S character here\x13
 a non-ASCII character here\x80
 """)
         self.assertTrue(has_invalid_characters(non_ascii_file))
+    def test_text_with_non_ascii_character(self):
+        """has_invalid_characters: detects non-ASCII character in text
+        """
+        self.assertTrue(has_invalid_characters(text=u"""This text contains:
+a non-ASCII character here\x80
+"""))
     def test_file_with_valid_characters(self):
         """has_invalid_characters: works for valid file
         """
@@ -179,6 +191,17 @@ a non-ASCII character here\x80
 - \t\n
 """)
         self.assertFalse(has_invalid_characters(valid_file))
+    def test_text_with_valid_characters(self):
+        """has_invalid_characters: works for valid text
+        """
+        self.assertFalse(has_invalid_characters(text=u"""This file contains valid characters:
+- ABCDEFGHIJKLMNOPQRSTUVWXYZ
+- abcdefghijklmnopqrstuvwxyz
+- 01234567890
+- !"$%^&*()_-+=\|/:;'@#~`?
+- {}[]
+- \t\n
+"""))
 
 class TestCloseNamesFunction(unittest.TestCase):
     def test_close_names(self):

--- a/auto_process_ngs/test/test_samplesheet_utils.py
+++ b/auto_process_ngs/test/test_samplesheet_utils.py
@@ -9,10 +9,7 @@ import shutil
 import codecs
 import cStringIO
 from bcftbx.IlluminaData import SampleSheet
-from auto_process_ngs.samplesheet_utils import close_project_names
-from auto_process_ngs.samplesheet_utils import samples_in_multiple_projects
-from auto_process_ngs.samplesheet_utils import samples_with_multiple_barcodes
-from auto_process_ngs.samplesheet_utils import has_invalid_lines
+from auto_process_ngs.samplesheet_utils import SampleSheetLinter
 from auto_process_ngs.samplesheet_utils import has_invalid_characters
 from auto_process_ngs.samplesheet_utils import get_close_names
 
@@ -43,9 +40,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
 2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 """
-        iem = SampleSheet(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=cStringIO.StringIO(
             self.sample_sheet_no_close_project_names))
-        self.assertEqual(close_project_names(sample_sheet=iem),{})
+        self.assertEqual(linter.close_project_names(),{})
     def test_sample_sheet_with_close_project_names(self):
         self.sample_sheet_close_project_names = """[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
@@ -54,9 +51,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
 2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 """
-        iem = SampleSheet(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=cStringIO.StringIO(
             self.sample_sheet_close_project_names))
-        self.assertEqual(close_project_names(sample_sheet=iem),
+        self.assertEqual(linter.close_project_names(),
                          { 'Andrew_Bloggs': ['Andrew_Blogs'],
                            'Andrew_Blogs': ['Andrew_Bloggs'] })
 
@@ -70,9 +67,9 @@ Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,ind
 2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
 2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 """
-        iem = SampleSheet(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=cStringIO.StringIO(
             self.sample_sheet_no_samples_in_multiple_projects))
-        self.assertEqual(samples_in_multiple_projects(sample_sheet=iem),{})
+        self.assertEqual(linter.samples_in_multiple_projects(),{})
     def test_sample_sheet_with_samples_in_multiple_projects(self):
         self.sample_sheet_samples_in_multiple_projects = """[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
@@ -82,9 +79,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
 2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 """
-        iem = SampleSheet(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=cStringIO.StringIO(
             self.sample_sheet_samples_in_multiple_projects))
-        self.assertEqual(samples_in_multiple_projects(sample_sheet=iem),
+        self.assertEqual(linter.samples_in_multiple_projects(),
                          { 'AB1': ['Andrew_Bloggs1','Andrew_Bloggs2'] })
 
 class TestSamplesWithMultipleBarcodes(unittest.TestCase):
@@ -97,9 +94,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
 2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 """
-        iem = SampleSheet(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=cStringIO.StringIO(
             self.sample_sheet_without_multiple_barcodes))
-        self.assertEqual(samples_with_multiple_barcodes(sample_sheet=iem),{})
+        self.assertEqual(linter.samples_with_multiple_barcodes(),{})
     def test_sample_sheet_with_multiple_barcodes(self):
         self.sample_sheet_with_multiple_barcodes = """[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
@@ -109,12 +106,12 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
 2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 """
-        iem = SampleSheet(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=cStringIO.StringIO(
             self.sample_sheet_with_multiple_barcodes))
-        self.assertEqual(samples_with_multiple_barcodes(sample_sheet=iem),
+        self.assertEqual(linter.samples_with_multiple_barcodes(),
                          { 'AB1': ['CGATGTAT-TCTTTCCC','CTGTAGTA-TCTTTCCC'] })
 
-class TestHasInvalidLines(unittest.TestCase):
+class TestLinterHasInvalidLines(unittest.TestCase):
     def test_sample_sheet_without_invalid_lines(self):
         self.sample_sheet_without_invalid_lines = """[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
@@ -123,9 +120,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
 2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 """
-        iem = SampleSheet(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=cStringIO.StringIO(
             self.sample_sheet_without_invalid_lines))
-        self.assertFalse(has_invalid_lines(sample_sheet=iem))
+        self.assertFalse(linter.has_invalid_lines())
     def test_sample_sheet_with_invalid_lines_no_lane(self):
         self.sample_sheet_with_invalid_lines = """[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
@@ -136,11 +133,35 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 ,,,,,,,,,Filipe_Greer,
 ,,,,,,,,,Filipe_Greer,
 """
-        iem = SampleSheet(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=cStringIO.StringIO(
             self.sample_sheet_with_invalid_lines))
-        self.assertTrue(has_invalid_lines(sample_sheet=iem))
+        self.assertTrue(linter.has_invalid_lines())
 
-class TestHasInvalidCharacters(unittest.TestCase):
+class TestLinterHasInvalidCharacters(unittest.TestCase):
+    def test_sample_sheet_with_non_printing_ascii_character(self):
+        self.sample_sheet_with_non_printing_ascii_characters = """[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,\x13
+1,AB2,AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
+2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
+2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
+"""
+        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+            self.sample_sheet_with_non_printing_ascii_characters))
+        self.assertTrue(linter.has_invalid_characters())
+    def test_sample_sheet_with_valid_characters(self):
+        self.sample_sheet_with_valid_characters = """[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
+1,AB2,AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
+2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
+2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
+"""
+        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+            self.sample_sheet_with_valid_characters))
+        self.assertFalse(linter.has_invalid_characters())
+
+class TestHasInvalidCharactersFunction(unittest.TestCase):
     def setUp(self):
         self.wd = tempfile.mkdtemp()
     def tearDown(self):

--- a/auto_process_ngs/test/test_samplesheet_utils.py
+++ b/auto_process_ngs/test/test_samplesheet_utils.py
@@ -123,7 +123,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         linter = SampleSheetLinter(fp=cStringIO.StringIO(
             self.sample_sheet_without_invalid_lines))
         self.assertFalse(linter.has_invalid_lines())
-    def test_sample_sheet_with_invalid_lines_no_lane(self):
+    def test_sample_sheet_with_invalid_lines_missing_lane(self):
         self.sample_sheet_with_invalid_lines = """[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
 1,AB1,AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
@@ -135,6 +135,19 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 """
         linter = SampleSheetLinter(fp=cStringIO.StringIO(
             self.sample_sheet_with_invalid_lines))
+        self.assertTrue(linter.has_invalid_lines())
+    def test_sample_sheet_with_invalid_lines_no_lane(self):
+        self.sample_sheet_with_invalid_lines_no_lane = """[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+AB1,AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
+AB2,AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
+CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
+FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
+,,,,,,,,Filipe_Greer,
+,,,,,,,,Filipe_Greer,
+"""
+        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+            self.sample_sheet_with_invalid_lines_no_lane))
         self.assertTrue(linter.has_invalid_lines())
 
 class TestLinterHasInvalidCharacters(unittest.TestCase):

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     utils: utility classes & funcs for auto_process_mgs module
-#     Copyright (C) University of Manchester 2013-2014 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2016 Peter Briggs
 #
 ########################################################################
 #
@@ -24,10 +24,12 @@ tree at some point.
 # Imports
 #######################################################################
 
+import sys
 import os
 import fnmatch
 import logging
 import zipfile
+import pydoc
 import applications
 import bcftbx.IlluminaData as IlluminaData
 import bcftbx.TabFile as TabFile
@@ -1482,3 +1484,27 @@ def write_script_file(script_file,contents,append=False,shell=None):
             fp.write("#!%s\n" % shell)
         fp.write("%s\n" % contents)
     os.chmod(script_file,0775)
+
+def paginate_output(text):
+    """
+    Send text to stdout with pagination
+
+    Arguments:
+      text (str): text to be printed using pagination
+
+    """
+    # If stdout is a terminal
+    if os.isatty(sys.stdout.fileno()):
+        # Acquire a pager command
+        try:
+            pager = os.environ["PAGER"]
+        except KeyError:
+            pager = None
+        # Output the prediction with paging
+        if pager is not None:
+            pydoc.pipepager(text,cmd=pager)
+        else:
+            pydoc.pager(text)
+    else:
+        # Stdout not a terminal
+        print text

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -18,6 +18,27 @@ Utility classes and functions to support auto_process_ngs module.
 Ultimately these should be relocated in the main 'genomics' code
 tree at some point.
 
+Classes:
+
+- AnalysisFastq:
+- AnalysisDir:
+- AnalysisProject:
+- AnalysisSample:
+- MetadataDict:
+- AnalysisDirParameters:
+- AnalysisDirMetadata:
+- AnalysisProjectInfo:
+- ProjectMetadataFile:
+- ZipArchive:
+
+Functions:
+
+- bases_mask_is_paired_end:
+- split_user_host_dir:
+- pretty_print_rows:
+- write_script_file:
+- paginate:
+
 """
 
 #######################################################################
@@ -1485,9 +1506,20 @@ def write_script_file(script_file,contents,append=False,shell=None):
         fp.write("%s\n" % contents)
     os.chmod(script_file,0775)
 
-def paginate_output(text):
+def paginate(text):
     """
     Send text to stdout with pagination
+
+    If the function detects that the stdout is an interactive
+    terminal then the supplied text will be piped via a
+    paginator command.
+
+    The pager command will be the default for ``pydoc``, but
+    can be over-ridden by the ``PAGER`` environment variable.
+
+    If stdout is not a terminal (for example if it's being
+    set to a file, or piped to another command) then the
+    pagination is skipped.
 
     Arguments:
       text (str): text to be printed using pagination

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -37,6 +37,7 @@ Functions:
 - split_user_host_dir:
 - pretty_print_rows:
 - write_script_file:
+- edit_file:
 - paginate:
 
 """
@@ -1505,6 +1506,31 @@ def write_script_file(script_file,contents,append=False,shell=None):
             fp.write("#!%s\n" % shell)
         fp.write("%s\n" % contents)
     os.chmod(script_file,0775)
+
+def edit_file(filen,editor="vi"):
+    """
+    Send a file to an editor
+
+    Arguments:
+      filen (str): path to the file to be edited
+      editor (str): optional, editor command to be used
+        (will be overriden by user's EDITOR environment
+        variable even if set). Defaults to 'vi'.
+
+    """
+    # Acquire an editor command
+    try:
+        editor = os.environ["EDITOR"]
+    except KeyError:
+        pass
+    if editor is None:
+        logging.critical("No editor specified!")
+        return
+    # Build command line to run the editor
+    editor = str(editor).split(' ')
+    edit_cmd = applications.Command(editor[0],*editor[1:])
+    edit_cmd.add_args(filen)
+    edit_cmd.run_subprocess()
 
 def paginate(text):
     """

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -41,6 +41,7 @@ settings and project metadata:
 Additional commands are available:
 
     clone
+    samplesheet
     analyse_barcodes
     merge_fastq_dirs
     update_fastq_stats
@@ -75,6 +76,8 @@ import auto_process_ngs
 import auto_process_ngs.settings
 import auto_process_ngs.envmod as envmod
 from auto_process_ngs.auto_processor import AutoProcess
+from auto_process_ngs.samplesheet_utils import predict_outputs
+from auto_process_ngs.utils import paginate
 
 __version__ = auto_process_ngs.get_version()
 __settings = auto_process_ngs.settings.Settings()
@@ -169,6 +172,17 @@ def add_metadata_command(cmdparser):
                  help="Automatically update metadata items where possible "
                  "(e.g. for older analyses which have old or missing metadata "
                  "files)")
+    add_debug_option(p)
+
+def add_samplesheet_command(cmdparser):
+    """Create a parser for the 'samplesheet' command
+    """
+    p = cmdparser.add_command('samplesheet',help="Sample sheet manipulation",
+                              usage="%prog samplesheet [OPTIONS] [ANALYSIS_DIR]",
+                              description="Query and manipulate sample sheets")
+    p.add_option('-e','--edit',action='store_true',dest='edit',default=False,
+                 help="bring up sample sheet file in an editor to make "
+                 "changes manually")
     add_debug_option(p)
 
 def add_make_fastqs_command(cmdparser):
@@ -622,6 +636,7 @@ if __name__ == "__main__":
     add_setup_command(p)
     add_params_command(p)
     add_metadata_command(p)
+    add_samplesheet_command(p)
     add_make_fastqs_command(p)
     add_setup_analysis_dirs_command(p)
     add_run_qc_command(p)
@@ -805,6 +820,15 @@ if __name__ == "__main__":
                                fastq_screen_subset=options.subset,
                                runner=options.runner)
             sys.exit(retcode)
+        elif cmd == 'samplesheet':
+            # Sample sheet operations
+            if options.edit:
+                # Manually edit the sample sheet
+                d.edit_samplesheet()
+            else:
+                # Predict the outputs
+                paginate(predict_outputs(
+                    sample_sheet_file=d.params.sample_sheet))
         elif cmd == 'params':
             # Update the project-specific parameters
             if options.key_value is not None:


### PR DESCRIPTION
This PR is a WIP for improving the handling of sample sheets within autoprocessor.

It aims to address the following issues:

- #14 (check project names for potential typos)
- #19 (improve prediction of sample sheet outputs)
- #35 (detect non-ASCII characters in sample sheets)
- #37 (check for duplicated sample ids in different projects)

Additionally we would like to handle:

- Identifying samples with multiple associated barcodes
- Detect "bad" trailing lines (e.g. output from Excel but without any actual data)

Finally it also implements a new `samplesheet` command which provides the following functionality:

- view predicted samplesheet outputs (with warnings) (when invoked without arguments)
- bring up samplesheet in an editor for manual editing (`-e`/`--edit`) option

This PR will supersede PR #30 which aimed to cover similar ground.