### PR TITLE
Execute rsync operations via scheduler/job runners

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1577,7 +1577,7 @@ class AutoProcess:
         if runner is not None:
             runner = fetch_runner(runner)
         else:
-            runner = fetch_runner(self.settings.general.default_runner)
+            runner = self.settings.general.default_runner
         runner.set_log_dir(self.log_dir)
         # Schedule the jobs needed to do counting
         sched = simple_scheduler.SimpleScheduler(

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -2096,7 +2096,7 @@ class AutoProcess:
 
     def copy_to_archive(self,archive_dir=None,platform=None,year=None,dry_run=False,
                         chmod=None,group=None,include_bcl2fastq=False,
-                        read_only_fastqs=True,force=False):
+                        read_only_fastqs=True,force=False,runner=None):
         """Copy the analysis directory and contents to an archive area
 
         Copies the contents of the analysis directory to an archive
@@ -2144,6 +2144,8 @@ class AutoProcess:
             permissions.
           force: if True then do archiving even if key metadata items
             are not set; otherwise abort archiving operation.
+          runner: (optional) specify a non-default job runner to use
+            for primary data rsync
 
         Returns:
           UNIX-style integer returncode: 0 = successful termination,
@@ -2196,45 +2198,61 @@ class AutoProcess:
             excludes.append('--exclude=%s' % self.params.unaligned_dir)
         # Log dir
         self.set_log_dir(self.get_log_subdir('archive'))
+        # Set up runner
+        if runner is not None:
+            runner = fetch_runner(runner)
+        else:
+            runner = self.settings.general.default_runner
+        runner.set_log_dir(self.log_dir)
+        # Setup a scheduler for multiple rsync jobs
+        sched = simple_scheduler.SimpleScheduler(
+            runner=runner,
+            max_concurrent=self.settings.general.max_concurrent_jobs)
+        sched.start()
         # If making fastqs read-only then transfer them separately
         if read_only_fastqs:
-            try:
-                rsync_fastqs = applications.general.rsync(self.analysis_dir,archive_dir,
-                                                          prune_empty_dirs=True,
-                                                          dry_run=dry_run,
-                                                          chmod='ugo-w',
-                                                          extra_options=('--include=*/',
-                                                                         '--include=fastqs/**',
-                                                                         '--exclude=*',))
-                print "Running %s" % rsync_fastqs
-                status = rsync_fastqs.run_subprocess(
-                    log=self.log_path('rsync.archive_fastqs.log'))
-            except Exception, ex:
-                logging.error("Exception rsyncing fastqs to archive: %s" % ex)
-                status = -1
-            if status != 0:
-                logging.error("Failed to rsync fastqs to archive (returned status %d)" %
-                              status)
-            # Exclude from main rsync
+            rsync_fastqs = applications.general.rsync(self.analysis_dir,
+                                                      archive_dir,
+                                                      prune_empty_dirs=True,
+                                                      dry_run=dry_run,
+                                                      chmod='ugo-w',
+                                                      extra_options=(
+                                                          '--include=*/',
+                                                          '--include=fastqs/**',
+                                                          '--exclude=*',))
+            print "Running %s" % rsync_fastqs
+            rsync_fastqs_job = sched.submit(rsync_fastqs,
+                                            name="rsync.archive_fastqs")
+            # Exclude fastqs from main rsync
             excludes.append('--exclude=fastqs')
-            # Set returncode
-            retval = status if status != 0 else retval
-        # Run the rsync command
-        try:
-            rsync = applications.general.rsync(self.analysis_dir,archive_dir,
-                                               prune_empty_dirs=True,
-                                               dry_run=dry_run,
-                                               chmod=chmod,
-                                               extra_options=excludes)
-            print "Running %s" % rsync
-            status = rsync.run_subprocess(log=self.log_path('rsync.archive.log'))
-        except Exception, ex:
-            logging.error("Exception rsyncing to archive: %s" % ex)
-            status = -1
-        if status != 0:
-            logging.error("Failed to rsync to archive (returned status %d)" % status)
+        else:
+            rsync_fastqs_job = None
+        # Main rsync command
+        rsync = applications.general.rsync(self.analysis_dir,archive_dir,
+                                           prune_empty_dirs=True,
+                                           dry_run=dry_run,
+                                           chmod=chmod,
+                                           extra_options=excludes)
+        print "Running %s" % rsync
+        rsync_job = sched.submit(rsync,name="rsync.archive")
+        # Wait for scheduler to complete
+        sched.wait()
+        sched.stop()
+        # Check exit status on job(s)
+        if rsync_fastqs_job:
+            exit_code = rsync_fastqs_job.exit_code
+            print "rsync of FASTQs completed: exit code %s" % exit_code
+            if exit_code != 0:
+                logging.error("Failed to copy FASTQs to archive location "
+                              "(non-zero exit code returned)")
+        else:
+            exit_code = 0
+        print "rsync of data completed: exit code %s" % rsync_job.exit_code
+        if rsync_job.exit_code != 0:
+            logging.error("Failed to copy data to archive location "
+                          "(non-zero exit code returned)")
         # Set returncode
-        retval = status if status != 0 else retval
+        retval = exit_code if exit_code != 0 else rsync_job.exit_code
         # Set the group (local copies only)
         if group is not None:
             user,server,dirn = utils.split_user_host_dir(archive_dir)

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -101,8 +101,11 @@ class Settings:
             config.read(os.path.join(get_config_dir(),'settings.ini.sample'))
         # General parameters
         self.add_section('general')
-        self.general['default_runner'] = config.get('general','default_runner',
-                                                    'SimpleJobRunner')
+        default_runner = config.get('general','default_runner',
+                                    'SimpleJobRunner')
+        self.general['default_runner'] = config.getrunner('general',
+                                                          'default_runner',
+                                                          'SimpleJobRunner')
         self.general['max_concurrent_jobs'] = config.getint('general',
                                                             'max_concurrent_jobs',12)
         # modulefiles
@@ -141,7 +144,7 @@ class Settings:
         self.add_section('runners')
         for name in ('bcl2fastq','qc','stats',):
             self.runners[name] = config.getrunner('runners',name,
-                                                  self.general.default_runner)
+                                                  default_runner)
         # Information for archiving analyses
         # dirn should be a directory in the form [[user@]host:]path]
         self.add_section('archive')

--- a/auto_process_ngs/simple_scheduler.py
+++ b/auto_process_ngs/simple_scheduler.py
@@ -647,6 +647,15 @@ class SchedulerJob(Job):
         # Check if job is running
         return self.isRunning()
 
+    @property
+    def exit_code(self):
+        """Return exit code from job
+
+        Wrapper for the 'exit_status' property provided by the
+        'Job' superclass.
+        """
+        return self.exit_status
+
     def start(self):
         """Start the job running
 

--- a/auto_process_ngs/test/test_settings.py
+++ b/auto_process_ngs/test/test_settings.py
@@ -17,7 +17,7 @@ class TestSettings(unittest.TestCase):
                         "Missing sample file %s" % sample_settings_file)
         s = Settings(sample_settings_file)
         # General settings
-        self.assertEqual(s.general.default_runner,'SimpleJobRunner')
+        self.assertTrue(isinstance(s.general.default_runner,SimpleJobRunner))
         self.assertEqual(s.general.max_concurrent_jobs,12)
         self.assertEqual(s.modulefiles.make_fastqs,None)
         self.assertEqual(s.modulefiles.run_qc,None)


### PR DESCRIPTION
PR which reimplements the `rsync` operations in `make_fastqs` (used for acquiring the primary data) and `archive` (used for copying the processed data to the archive location) to wrap them in job runners and then use the scheduler classes to execute them.