### PR TITLE
Fix duplicated sample/fastq combinations causing error in 'run_qc'

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -2063,7 +2063,8 @@ class AutoProcess:
                                                 log_dir=log_dir)
                         # Create and submit a QC job
                         fastq = os.path.join(project.dirn,'fastqs',fq)
-                        label = "illumina_qc.%s" % str(utils.AnalysisFastq(fq))
+                        label = "illumina_qc.%s.%s" % \
+                                (project.name,str(utils.AnalysisFastq(fq)))
                         qc_cmd = applications.Command('illumina_qc.sh',fastq)
                         if ungzip_fastqs:
                             qc_cmd.add_args('--ungzip-fastqs')


### PR DESCRIPTION
PR to fix issue #36, where QC fails if there are duplicated sample and fastq names in two or more projects.

The PR fixes the issue by adding the project name to the job name, in principle making the job name unique.