### PR TITLE
WIP update fastq_statistics.py to produce per-lane stats for all formats

### DIFF
--- a/auto_process_ngs/stats.py
+++ b/auto_process_ngs/stats.py
@@ -162,6 +162,13 @@ class FastqStatistics:
         """
         return [("L%d" % l) for l in self._lanes]
 
+    @property
+    def raw(self):
+        """
+        Return the 'raw' statistics TabFile instance
+        """
+        return self._stats
+
     def report_full_stats(self,out_file=None):
         """
         Report all statistics gathered for all FASTQs

--- a/auto_process_ngs/stats.py
+++ b/auto_process_ngs/stats.py
@@ -176,7 +176,7 @@ class FastqStatistics:
         """
         return self._stats
 
-    def report_full_stats(self,out_file=None):
+    def report_full_stats(self,out_file=None,fp=None):
         """
         Report all statistics gathered for all FASTQs
 
@@ -184,18 +184,24 @@ class FastqStatistics:
 
         Arguments:
           out_file (str): name of file to write report
-            to (defaults to stdout)
+            to (used if 'fp' is not supplied)
+          fp (File): File-like object open for writing
+            (defaults to stdout if 'out_file' also not
+            supplied)
         """
         # Determine output stream
-        if out_file is None:
-            fp = sys.stdout
+        if fp is None:
+            if out_file is None:
+                fpp = sys.stdout
+            else:
+                fpp = open(out_file,'w')
         else:
-            fp = open(out_file,'w')
+            fpp = fp
         # Report
-        self._stats.write(fp=fp,include_header=True)
+        self._stats.write(fp=fpp,include_header=True)
         # Close file
-        if out_file is not None:
-            fp.close()
+        if fp is None and out_file is not None:
+            fpp.close()
 
     def report_basic_stats(self,out_file=None,fp=None):
         """

--- a/auto_process_ngs/stats.py
+++ b/auto_process_ngs/stats.py
@@ -273,19 +273,25 @@ class FastqStatistics:
         if out_file is not None:
             fp.close()
 
-    def report_per_lane_summary_stats(self,out_file=None):
+    def report_per_lane_summary_stats(self,out_file=None,fp=None):
         """
         Report summary of total and unassigned reads per-lane
 
         Arguments:
           out_file (str): name of file to write report
-            to (defaults to stdout)
+            to (used if 'fp' is not supplied)
+          fp (File): File-like object open for writing
+            (defaults to stdout if 'out_file' also not
+            supplied)
         """
         # Determine output stream
-        if out_file is None:
-            fp = sys.stdout
+        if fp is None:
+            if out_file is None:
+                fpp = sys.stdout
+            else:
+                fpp = open(out_file,'w')
         else:
-            fp = open(out_file,'w')
+            fpp = fp
         # Set up TabFile to hold the data collected
         per_lane_stats = TabFile(column_names=('Lane',
                                                'Total reads',
@@ -323,10 +329,10 @@ class FastqStatistics:
                                         "%.2f" % percent_assigned,
                                         "%.2f" % percent_unassigned))
         # Write to file
-        per_lane_stats.write(fp=fp,include_header=True)
+        per_lane_stats.write(fp=fpp,include_header=True)
         # Close file
-        if out_file is not None:
-            fp.close()
+        if fp is None and out_file is not None:
+            fpp.close()
 
 class FastqStats:
     """Container for storing data about a FASTQ file

--- a/auto_process_ngs/stats.py
+++ b/auto_process_ngs/stats.py
@@ -166,7 +166,7 @@ class FastqStatistics:
         """
         return [("L%d" % l) for l in self._lanes]
 
-    def report_full_stats(self,out_file):
+    def report_full_stats(self,out_file=None):
         """
         Report all statistics gathered for all FASTQs
 
@@ -187,7 +187,7 @@ class FastqStatistics:
         if out_file is not None:
             fp.close()
 
-    def report_basic_stats(self,out_file):
+    def report_basic_stats(self,out_file=None):
         """
         Report the 'basic' statistics
 
@@ -261,7 +261,7 @@ class FastqStatistics:
         if out_file is not None:
             fp.close()
 
-    def report_per_lane_summary_stats(self,out_file):
+    def report_per_lane_summary_stats(self,out_file=None):
         """
         Report summary of total and unassigned reads per-lane
 
@@ -278,7 +278,9 @@ class FastqStatistics:
         per_lane_stats = TabFile(column_names=('Lane',
                                                'Total reads',
                                                'Assigned reads',
-                                               'Unassigned reads'))
+                                               'Unassigned reads',
+                                               '%assigned',
+                                               '%unassigned'))
         assigned = {}
         unassigned = {}
         # Count assigned and unassigned (= undetermined) reads
@@ -300,10 +302,14 @@ class FastqStatistics:
             assigned_reads = assigned[lane]
             unassigned_reads = unassigned[lane]
             total_reads = assigned_reads + unassigned_reads
+            percent_assigned = float(assigned_reads)/float(total_reads)*100.0
+            percent_unassigned = float(unassigned_reads)/float(total_reads)*100.0
             per_lane_stats.append(data=("Lane %d" % lane_number,
                                         total_reads,
                                         assigned_reads,
-                                        unassigned_reads))
+                                        unassigned_reads,
+                                        "%.2f" % percent_assigned,
+                                        "%.2f" % percent_unassigned))
         # Write to file
         per_lane_stats.write(fp=fp,include_header=True)
         # Close file

--- a/auto_process_ngs/stats.py
+++ b/auto_process_ngs/stats.py
@@ -227,6 +227,15 @@ class FastqStatistics:
         Reports the number of reads for each sample in each
         lane plus the total reads for each lane.
 
+        Example output:
+
+        Lane 1
+        Total reads = 182851745
+        - KatyDobbs/KD-K1      79888058        43.7%
+        - KatyDobbs/KD-K3      97854292        53.5%
+        - Undetermined_indices/lane1       5109395 2.8%
+        ...
+
         Arguments:
           out_file (str): name of file to write report
             to (defaults to stdout)
@@ -519,72 +528,3 @@ def collect_fastq_data(fqstats):
                                   bcf_utils.format_file_size(fqs.fsize))
     print "- %s: took %f.2s" % (fastq_name,(end_time-start_time))
     return fqs
-
-def report_per_lane_stats(stats_file,out_file=None):
-    """
-    Write per-lane statistics
-
-    Analyse the 'statistics.info' format file from fastq_stats.py
-    and summarise the number of reads per sample in each lane (and
-    the percentage of reads that represents in the lane).
-
-    Example output:
-
-    Lane 1
-    Total reads = 182851745
-    - KatharineDibb/KD-K1	79888058	43.7%
-    - KatharineDibb/KD-K3	97854292	53.5%
-    - Undetermined_indices/lane1	5109395	2.8%
-    ...
-
-    Arguments:
-      stats_file (str): path of input file with per-file
-        statistics
-      out_file (str): optional path to output file; if None then
-        statistics will be written to stdout.
-
-    """
-    # Read in data
-    stats = TabFile(stats_file,first_line_is_header=True)
-    data = dict()
-    for line in stats:
-        # Collect sample name, lane etc
-        fq = IlluminaFastq(line['Fastq'])
-        if fq.read_number != 1:
-            # Only interested in R1 reads
-            continue
-        lane = fq.lane_number
-        sample = "%s/%s" % (line['Project'],line['Sample'])
-        nreads = line['Nreads']
-        # Update information in dict
-        if lane not in data:
-            data[lane] = dict()
-        try:
-            data[lane][sample] += nreads
-        except KeyError:
-            data[lane][sample] = nreads
-    # Get list of lanes
-    lanes = [int(x) for x in data.keys()]
-    lanes.sort()
-    # Determine output stream
-    if out_file is None:
-        fp = sys.stdout
-    else:
-        fp = open(out_file,'w')
-    # Report
-    for lane in lanes:
-        fp.write("\nLane %d\n" % lane)
-        samples = data[lane].keys()
-        samples.sort()
-        total_reads = sum([data[lane][x] for x in samples])
-        fp.write("Total reads = %d\n" % total_reads)
-        for sample in samples:
-            nreads = float(data[lane][sample])
-            if total_reads > 0:
-                fp.write("- %s\t%d\t%.1f%%\n" % (sample,nreads,
-                                                 nreads/total_reads*100.0))
-            else:
-                fp.write("- %s\t%d\tn/a\n" % (sample,nreads))
-    # Close file
-    if out_file is not None:
-        fp.close()

--- a/auto_process_ngs/stats.py
+++ b/auto_process_ngs/stats.py
@@ -63,7 +63,7 @@ class FastqStatistics:
         Arguments:
           illumina_data: populated IlluminaData object describing the
             run.
-          n_processors: number of processors to use (if 1>1 then uses
+          n_processors: number of processors to use (if >1 then uses
             the multiprocessing library to run the statistics gathering
             using multiple cores).
         """

--- a/auto_process_ngs/stats.py
+++ b/auto_process_ngs/stats.py
@@ -35,6 +35,10 @@ import bcftbx.utils as bcf_utils
 from bcftbx.IlluminaData import IlluminaFastq
 from bcftbx.TabFile import TabFile
 
+# Initialise logging
+import logging
+logger = logging.getLogger(__name__)
+
 #######################################################################
 # Classes
 #######################################################################
@@ -119,21 +123,24 @@ class FastqStatistics:
         # columns for each
         lanes = set()
         for fastq in results_r1:
-            print "%s: %s" % (fastq.name,fastq.lanes)
+            logger.debug("-- %s: lanes %s" %
+                         (fastq.name,
+                          ','.join([str(l) for l in fastq.lanes])))
             for lane in fastq.lanes:
                 lanes.add(lane)
         self._lanes = sorted(list(lanes))
-        print "Lanes: %s" % self._lanes
+        logger.debug("Lanes found: %s" %
+                     ','.join([str(l) for l in self._lanes]))
         for lane in self._lanes:
             self._stats.appendColumn("L%s" % lane)
         # Copy reads per lane from R1 FASTQs into R2
         for r2_fastq in results_r2:
             # Get corresponding R1 name
-            print "-- Fastq R2: %s" % r2_fastq.name
+            logger.debug("-- Fastq R2: %s" % r2_fastq.name)
             r1_fastq_name = IlluminaFastq(r2_fastq.name)
             r1_fastq_name.read_number = 1
             r1_fastq_name = str(r1_fastq_name)
-            print "--       R1: %s" % r1_fastq_name
+            logger.debug("--    -> R1: %s" % r1_fastq_name)
             # Locate corresponding data
             r1_fastq = filter(lambda f: f.name.startswith(r1_fastq_name),
                               results_r1)[0]
@@ -551,5 +558,5 @@ def collect_fastq_data(fqstats):
     print "- %s: %d reads, %s" % (fastq_name,
                                   fqs.nreads,
                                   bcf_utils.format_file_size(fqs.fsize))
-    print "- %s: took %f.2s" % (fastq_name,(end_time-start_time))
+    print "- %s: took %.2fs" % (fastq_name,(end_time-start_time))
     return fqs

--- a/auto_process_ngs/stats.py
+++ b/auto_process_ngs/stats.py
@@ -154,10 +154,6 @@ class FastqStatistics:
                 except:
                     data.append('')
             self._stats.append(data=data)
-        # Write raw stats data
-        self._stats.write("statistics_all.info",include_header=True)
-        # Return the data
-        return self._stats
 
     @property
     def lane_names(self):

--- a/auto_process_ngs/stats.py
+++ b/auto_process_ngs/stats.py
@@ -227,7 +227,7 @@ class FastqStatistics:
         if out_file is not None:
             fp.close()
 
-    def report_per_lane_sample_stats(self,out_file=None):
+    def report_per_lane_sample_stats(self,out_file=None,fp=None):
         """
         Report of reads per sample in each lane
 
@@ -245,13 +245,19 @@ class FastqStatistics:
 
         Arguments:
           out_file (str): name of file to write report
-            to (defaults to stdout)
+            to (used if 'fp' is not supplied)
+          fp (File): File-like object open for writing
+            (defaults to stdout if 'out_file' also not
+            supplied)
         """
         # Determine output stream
-        if out_file is None:
-            fp = sys.stdout
+        if fp is None:
+            if out_file is None:
+                fpp = sys.stdout
+            else:
+                fpp = open(out_file,'w')
         else:
-            fp = open(out_file,'w')
+            fpp = fp
         # Report
         lanes = self.lane_names
         for lane in lanes:
@@ -260,18 +266,18 @@ class FastqStatistics:
                              x['Read_number'] == 1 and bool(x[lane]),
                              self._stats)
             total_reads = sum([s[lane] for s in samples])
-            fp.write("\nLane %d\n" % lane_number)
-            fp.write("Total reads = %d\n" % total_reads)
+            fpp.write("\nLane %d\n" % lane_number)
+            fpp.write("Total reads = %d\n" % total_reads)
             for sample in samples:
                 sample_name = "%s/%s" % (sample['Project'],
                                          sample['Sample'])
                 nreads = float(sample[lane])
-                fp.write("- %s\t%d\t%.1f%%\n" % (sample_name,
-                                                 nreads,
-                                                 nreads/total_reads*100.0))
+                fpp.write("- %s\t%d\t%.1f%%\n" % (sample_name,
+                                                  nreads,
+                                                  nreads/total_reads*100.0))
         # Close file
-        if out_file is not None:
-            fp.close()
+        if fp is None and out_file is not None:
+            fpp.close()
 
     def report_per_lane_summary_stats(self,out_file=None,fp=None):
         """

--- a/auto_process_ngs/stats.py
+++ b/auto_process_ngs/stats.py
@@ -1,17 +1,139 @@
 #!/usr/bin/env python
 #
 #     stats.py: utilities for generating run-related statistics
-#     Copyright (C) University of Manchester 2016 Peter Briggs
+#     Copyright (C) University of Manchester 2016-17 Peter Briggs
 #
 #########################################################################
+
+"""
+stats.py
+
+Classes and functions for collecting and reporting statistics for
+a run:
+
+- FastqReadCounter: implements various methods for counting reads
+  in FASTQ files
+
+"""
 
 #######################################################################
 # Imports
 #######################################################################
 
 import sys
+import subprocess
 import bcftbx.TabFile as tf
+import bcftbx.FASTQFile as FASTQFile
 from bcftbx.IlluminaData import IlluminaFastq
+
+#######################################################################
+# Classes
+#######################################################################
+
+class FastqReadCounter:
+    """
+    Implements various methods for counting reads in FASTQ file
+
+    The methods are:
+
+    - simple: a wrapper for the FASTQFile.nreads() function
+    - fastqiterator: counts reads using FASTQFile.FastqIterator
+    - zcat_wc: runs 'zcat | wc -l' in the shell
+    - reads_per_lane: counts reads by lane using FastqIterator
+
+    """
+    @staticmethod
+    def simple(fastq=None,fp=None):
+        """
+        Return number of reads in a FASTQ file
+
+        Uses the FASTQFile.nreads function to do the counting.
+
+        Arguments:
+          fastq: fastq(.gz) file
+          fp: open file descriptor for fastq file
+
+        Returns:
+          Number of reads
+
+        """
+        return FASTQFile.nreads(fastq=fastq,fp=fp)
+    @staticmethod
+    def fastqiterator(fastq=None,fp=None):
+        """
+        Return number of reads in a FASTQ file
+
+        Uses the FASTQFile.FastqIterator class to do the
+        counting.
+
+        Arguments:
+          fastq: fastq(.gz) file
+          fp: open file descriptor for fastq file
+
+        Returns:
+          Number of reads
+
+        """
+        nreads = 0
+        for r in FASTQFile.FastqIterator(fastq_file=fastq,fp=fp):
+            nreads += 1
+        return nreads
+    @staticmethod
+    def zcat_wc(fastq=None,fp=None):
+        """
+        Return number of reads in a FASTQ file
+
+        Uses a system call to run 'zcat FASTQ | wc -l' to do
+        the counting (or just 'wc -l' if not a gzipped FASTQ).
+
+        Note that this can only operate on fastq files (not
+        on streams provided via the 'fp' argument; this will
+        raise an exception).
+
+        Arguments:
+          fastq: fastq(.gz) file
+          fp: open file descriptor for fastq file
+
+        Returns:
+          Number of reads
+
+        """
+        if fastq is None:
+            raise Exception("zcat_wc: can only operate on a file")
+        if fastq.endswith(".gz"):
+            cmd = "zcat %s | wc -l" % fastq
+        else:
+            cmd = "wc -l %s | cut -d' ' -f1" % fastq
+        output = subprocess.check_output(cmd,shell=True)
+        try:
+            return int(output)/4
+        except Exception,ex:
+            raise Exception("zcat_wc returned: %s" % output)
+    @staticmethod
+    def reads_per_lane(fastq=None,fp=None):
+        """
+        Return counts of reads in each lane of FASTQ file
+
+        Uses the FASTQFile.FastqIterator class to do the
+        counting, with counts split by lane.
+
+        Arguments:
+          fastq: fastq(.gz) file
+          fp: open file descriptor for fastq file
+
+        Returns:
+          Dictionary where keys are lane numbers (as integers)
+            and values are number of reads in that lane.
+
+        """
+        nreads = {}
+        for r in FASTQFile.FastqIterator(fastq_file=fastq,fp=fp):
+            lane = int(r.seqid.flowcell_lane)
+            try:
+                nreads[lane] += 1
+            except KeyError:
+                nreads[lane] = 1
+        return nreads
 
 #######################################################################
 # Functions

--- a/auto_process_ngs/stats.py
+++ b/auto_process_ngs/stats.py
@@ -190,7 +190,7 @@ class FastqStatistics:
         if out_file is not None:
             fp.close()
 
-    def report_basic_stats(self,out_file=None):
+    def report_basic_stats(self,out_file=None,fp=None):
         """
         Report the 'basic' statistics
 
@@ -205,13 +205,19 @@ class FastqStatistics:
 
         Arguments:
           out_file (str): name of file to write report
-            to (defaults to stdout)
+            to (used if 'fp' is not supplied)
+          fp (File): File-like object open for writing
+            (defaults to stdout if 'out_file' also not
+            supplied)
         """
         # Determine output stream
-        if out_file is None:
-            fp = sys.stdout
+        if fp is None:
+            if out_file is None:
+                fpp = sys.stdout
+            else:
+                fpp = open(out_file,'w')
         else:
-            fp = open(out_file,'w')
+            fpp = fp
         # Report
         stats = TabFile(column_names=('Project',
                                       'Sample',
@@ -222,10 +228,10 @@ class FastqStatistics:
         for line in self._stats:
             data = [line[c] for c in stats.header()]
             stats.append(data=data)
-        stats.write(fp=fp,include_header=True)
+        stats.write(fp=fpp,include_header=True)
         # Close file
-        if out_file is not None:
-            fp.close()
+        if fp is None and out_file is not None:
+            fpp.close()
 
     def report_per_lane_sample_stats(self,out_file=None,fp=None):
         """

--- a/auto_process_ngs/test/test_stats.py
+++ b/auto_process_ngs/test/test_stats.py
@@ -316,6 +316,39 @@ class TestFastqStatisticsCasava(unittest.TestCase):
                     self.assertEqual(line[lane],'')
             self.assertEqual(line['Read_number'],
                              IlluminaFastq(expctd[2]).read_number)
+    def test_report_per_lane_sample_stats(self):
+        fp = cStringIO.StringIO()
+        self._setup_casava()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        fqstatistics.report_per_lane_sample_stats(fp=fp)
+        self.assertEqual(fp.getvalue(),"""
+Lane 1
+Total reads = 10
+- AB/AB1	3	30.0%
+- AB/AB2	5	50.0%
+- Undetermined_indices/lane1	2	20.0%
+
+Lane 2
+Total reads = 6
+- AB/AB1	2	33.3%
+- AB/AB2	3	50.0%
+- Undetermined_indices/lane2	1	16.7%
+
+Lane 3
+Total reads = 19
+- CDE/CDE3	7	36.8%
+- CDE/CDE4	8	42.1%
+- Undetermined_indices/lane3	4	21.1%
+
+Lane 4
+Total reads = 11
+- CDE/CDE3	2	18.2%
+- CDE/CDE4	6	54.5%
+- Undetermined_indices/lane4	3	27.3%
+""")
     def test_report_per_lane_summary_stats(self):
         fp = cStringIO.StringIO()
         self._setup_casava()
@@ -460,6 +493,39 @@ class TestFastqStatisticsBcl2fastq2(unittest.TestCase):
                     self.assertEqual(line[lane],'')
             self.assertEqual(line['Read_number'],
                              IlluminaFastq(expctd[2]).read_number)
+    def test_report_per_lane_sample_stats(self):
+        fp = cStringIO.StringIO()
+        self._setup_bcl2fastq2()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        fqstatistics.report_per_lane_sample_stats(fp=fp)
+        self.assertEqual(fp.getvalue(),"""
+Lane 1
+Total reads = 10
+- AB/AB1	3	30.0%
+- AB/AB2	5	50.0%
+- Undetermined_indices/lane1	2	20.0%
+
+Lane 2
+Total reads = 6
+- AB/AB1	2	33.3%
+- AB/AB2	3	50.0%
+- Undetermined_indices/lane2	1	16.7%
+
+Lane 3
+Total reads = 19
+- CDE/CDE3	7	36.8%
+- CDE/CDE4	8	42.1%
+- Undetermined_indices/lane3	4	21.1%
+
+Lane 4
+Total reads = 11
+- CDE/CDE3	2	18.2%
+- CDE/CDE4	6	54.5%
+- Undetermined_indices/lane4	3	27.3%
+""")
     def test_report_per_lane_summary_stats(self):
         fp = cStringIO.StringIO()
         self._setup_bcl2fastq2()
@@ -587,6 +653,39 @@ class TestFastqStatisticsBcl2fastq2NoLaneSplitting(unittest.TestCase):
                     self.assertEqual(line[lane],'')
             self.assertEqual(line['Read_number'],
                              IlluminaFastq(expctd[2]).read_number)
+    def test_report_per_lane_sample_stats(self):
+        fp = cStringIO.StringIO()
+        self._setup_bcl2fastq2_no_lane_splitting()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        fqstatistics.report_per_lane_sample_stats(fp=fp)
+        self.assertEqual(fp.getvalue(),"""
+Lane 1
+Total reads = 10
+- AB/AB1	3	30.0%
+- AB/AB2	5	50.0%
+- Undetermined_indices/undetermined	2	20.0%
+
+Lane 2
+Total reads = 6
+- AB/AB1	2	33.3%
+- AB/AB2	3	50.0%
+- Undetermined_indices/undetermined	1	16.7%
+
+Lane 3
+Total reads = 19
+- CDE/CDE3	7	36.8%
+- CDE/CDE4	8	42.1%
+- Undetermined_indices/undetermined	4	21.1%
+
+Lane 4
+Total reads = 11
+- CDE/CDE3	2	18.2%
+- CDE/CDE4	6	54.5%
+- Undetermined_indices/undetermined	3	27.3%
+""")
     def test_report_per_lane_summary_stats(self):
         fp = cStringIO.StringIO()
         self._setup_bcl2fastq2_no_lane_splitting()

--- a/auto_process_ngs/test/test_stats.py
+++ b/auto_process_ngs/test/test_stats.py
@@ -1,0 +1,191 @@
+#######################################################################
+# Tests for stats.py module
+#######################################################################
+
+import os
+import unittest
+import tempfile
+import shutil
+import gzip
+from auto_process_ngs.stats import FastqReadCounter
+
+# FastqReadCounter
+fastq_data = """@MISEQ:34:000000000-A7PHP:1:1101:12552:1774 1:N:0:TAAGGCGA
+TTTACAACTAGCTTCTCTTTTTCTT
++
+>AA?131@C1FCGGGG1BFFGF1F3
+@MISEQ:34:000000000-A7PHP:1:1101:16449:1793 1:N:0:TAAGGCGA
+TCCCCAGTCTCAGCCCTACTCCACT
++
+11>>>11CDFFFBCGGG1AFE11AB
+@MISEQ:34:000000000-A7PHP:1:1101:15171:1796 1:N:0:GCCTTACC
+CCACCACGCCTGGCTAATTTTTTTT
++
+1>1>>AAAAAFAGGGGBFGGGGGG0
+@MISEQ:34:000000000-A7PHP:1:1101:18777:1797 1:N:0:TAAGNNNA
+CAGCAATATACACTTCACTCTGCAT
++
+111>>1FBFFFFGGGGCBGEG3A3D
+@MISEQ:34:000000000-A7PHP:1:1101:18622:1812 1:N:0:TAAGGCGA
+GATAAAGACAGAGTCTTAATTAAAC
++
+11>1>11DFFCFFDGGGB3BF313A
+"""
+fastq_multi_lane_data = """@NB500968:10:H57NTAFXX:1:11101:4210:1091 1:N:0:CGGCAGAA
+CTCCAGTTCTGAGTAACTTCAAGGG
++
+AAAAAEEEEEEEEE6/EEEA//EE/
+@NB500968:10:H57NTAFXX:1:11101:21113:1097 1:N:0:AGGCAGAA
+CCCACACACCTATGTTTATTGCAGC
++
+AAAAAEEEEEEEEEEEEEEEEEEEE
+@NB500968:10:H57NTAFXX:1:11101:20639:1107 1:N:0:AGGCAGAA
+GGATGATGGACCCGGAGCACATAAA
++
+AAAAAEEEEEEEEEEEEEEEEEEEE
+@NB500968:10:H57NTAFXX:1:11101:11994:1111 1:N:0:AGGCAGAA
+GATTGTATGTCTCAAGAGATGCAGG
++
+AAAAAEEEEEEEEEEEEEEEEEEEE
+@NB500968:10:H57NTAFXX:2:11101:16822:1113 1:N:0:AGGCAGAA
+TAAGGTGGAGTGGGTTTGGGGCTAG
++
+6AAAAAEEEEEEEEAEEEEEEEAEE
+@NB500968:10:H57NTAFXX:3:11101:7366:1119 1:N:0:AGGCAGAA
+CCCCTCACCTGTGCTTTCTCGTCCT
++
+AAAAAEAEEEEEEEEEEEEEEEEEE
+@NB500968:10:H57NTAFXX:3:11101:2547:1129 1:N:0:AGGAAGAA
+AGACTGAGCCGAATTGGTAAATAGT
++
+AAAAAE/EEE/EEEE6/AAEEEAEE
+@NB500968:10:H57NTAFXX:4:11101:12127:1131 1:N:0:AGGCAGAA
+GCCCCAACTGTCTGGCGGGGAGGAC
++
+AAAAAEEEEEEEEEEEEEEEEEEEE
+@NB500968:10:H57NTAFXX:4:11101:11578:1134 1:N:0:AGGCAGAA
+CACATCTACAACGTTATCGTCACAG
++
+AAAAAEAEE/EEAEEEEEAEE/EEE
+@NB500968:10:H57NTAFXX:4:11101:2817:1161 1:N:0:AGGCAGAA
+GACCAACCCTGGGGTTAGTATAGCT
++
+A/AAAEEEEEEEEEEE<EEEEEEEA
+@NB500968:10:H57NTAFXX:1:11101:18892:1167 1:N:0:AGGCAGAA
+CTTCTGTGGAACGAGGGTTTATTTT
++
+AAAAAEEEEEEEEEEEEEEEEEEEE
+@NB500968:10:H57NTAFXX:4:11101:14759:1191 1:N:0:AGGCAGAA
+CTTATACACATCTCCGAGCCCACGA
++
+AAAAAEEEEEEEEEEEEEEEE/EE/
+"""
+class TestFastqReadCounter(unittest.TestCase):
+    def setUp(self):
+        # Temporary working dir (if needed)
+        self.wd = None
+
+    def _make_working_dir(self):
+        if self.wd is None:
+            self.wd = tempfile.mkdtemp(suffix='.test_FastqReadCounter')
+
+    def _make_fastq(self,name,contents):
+        # Create a FASTQ file under the working directory
+        # called "name" and populated with "contents"
+        # Working directory will be created if not already
+        # set up
+        # If "name" ends with ".gz" then "contents" will be
+        # gzipped
+        # Returns the path to the file
+        self._make_working_dir()
+        filen = os.path.join(self.wd,name)
+        if filen.endswith(".gz"):
+            with gzip.GzipFile(filen,'wb') as fp:
+                fp.write(contents)
+        else:
+            with open(filen,'w') as fp:
+                fp.write(contents)
+        return filen
+
+    def tearDown(self):
+        # Remove temporary working dir
+        if self.wd is not None and os.path.isdir(self.wd):
+            shutil.rmtree(self.wd)
+
+    def test_simple(self):
+        readcounter = FastqReadCounter.simple
+        fq = self._make_fastq("test_S1_L001_R1_001.fastq",
+                              fastq_data)
+        self.assertEqual(readcounter(fq),5)
+        fq = self._make_fastq("test_S2_R1_001.fastq",
+                              fastq_multi_lane_data)
+        self.assertEqual(readcounter(fq),12)
+
+    def test_simple_gz(self):
+        readcounter = FastqReadCounter.simple
+        fq = self._make_fastq("test_S1_L001_R1_001.fastq.gz",
+                              fastq_data)
+        self.assertEqual(readcounter(fq),5)
+        fq = self._make_fastq("test_S2_R1_001.fastq.gz",
+                              fastq_multi_lane_data)
+        self.assertEqual(readcounter(fq),12)
+
+    def test_fastqiterator(self):
+        readcounter = FastqReadCounter.fastqiterator
+        fq = self._make_fastq("test_S1_L001_R1_001.fastq",
+                              fastq_data)
+        self.assertEqual(readcounter(fq),5)
+        fq = self._make_fastq("test_S2_R1_001.fastq",
+                              fastq_multi_lane_data)
+        self.assertEqual(readcounter(fq),12)
+
+    def test_fastqiterator_gz(self):
+        readcounter = FastqReadCounter.fastqiterator
+        fq = self._make_fastq("test_S1_L001_R1_001.fastq.gz",
+                              fastq_data)
+        self.assertEqual(readcounter(fq),5)
+        fq = self._make_fastq("test_S2_R1_001.fastq.gz",
+                              fastq_multi_lane_data)
+        self.assertEqual(readcounter(fq),12)
+
+    def test_zcat_wc(self):
+        readcounter = FastqReadCounter.zcat_wc
+        fq = self._make_fastq("test_S1_L001_R1_001.fastq",
+                              fastq_data)
+        self.assertEqual(readcounter(fq),5)
+        fq = self._make_fastq("test_S2_R1_001.fastq",
+                              fastq_multi_lane_data)
+        self.assertEqual(readcounter(fq),12)
+
+    def test_zcat_wc_gz(self):
+        readcounter = FastqReadCounter.zcat_wc
+        fq = self._make_fastq("test_S1_L001_R1_001.fastq.gz",
+                              fastq_data)
+        self.assertEqual(readcounter(fq),5)
+        fq = self._make_fastq("test_S2_R1_001.fastq.gz",
+                              fastq_multi_lane_data)
+        self.assertEqual(readcounter(fq),12)
+
+    def test_reads_per_lane(self):
+        readcounter = FastqReadCounter.reads_per_lane
+        fq = self._make_fastq("test_S1_L001_R1_001.fastq",
+                              fastq_data)
+        self.assertEqual(readcounter(fq),{ 1: 5 })
+        fq = self._make_fastq("test_S2_R1_001.fastq",
+                              fastq_multi_lane_data)
+        self.assertEqual(readcounter(fq),{ 1: 5,
+                                           2: 1,
+                                           3: 2,
+                                           4: 4 })
+
+    def test_reads_per_lane_gz(self):
+        readcounter = FastqReadCounter.reads_per_lane
+        fq = self._make_fastq("test_S1_L001_R1_001.fastq.gz",
+                              fastq_data)
+        self.assertEqual(readcounter(fq),{ 1: 5 })
+        fq = self._make_fastq("test_S2_R1_001.fastq.gz",
+                              fastq_multi_lane_data)
+        self.assertEqual(readcounter(fq),{ 1: 5,
+                                           2: 1,
+                                           3: 2,
+                                           4: 4 })

--- a/auto_process_ngs/test/test_stats.py
+++ b/auto_process_ngs/test/test_stats.py
@@ -7,6 +7,10 @@ import unittest
 import tempfile
 import shutil
 import gzip
+from bcftbx.mock import MockIlluminaData
+from bcftbx.IlluminaData import IlluminaFastq
+from bcftbx.IlluminaData import IlluminaData
+from auto_process_ngs.stats import FastqStatistics
 from auto_process_ngs.stats import FastqStats
 from auto_process_ngs.stats import FastqReadCounter
 from auto_process_ngs.stats import collect_fastq_data
@@ -108,6 +112,398 @@ CTTATACACATCTCCGAGCCCACGA
 +
 AAAAAEEEEEEEEEEEEEEEE/EE/
 """
+
+# Mock classes
+class AugmentedMockIlluminaData(MockIlluminaData):
+    def __init__(self,name,package,**kws):
+        MockIlluminaData.__init__(self,name,package,**kws)
+    def populate_fastq(self,path,nreads,lane=None,append=False):
+        # Extract read number from name
+        read_number = IlluminaFastq(path).read_number
+        # Extract lane from name, if not explicitly specified
+        if lane is None:
+            lane = IlluminaFastq(path).lane_number
+            if lane is None:
+                raise Exception("Couldn't get lane from FASTQ name: %s" %
+                                path)
+        # Create or append fake reads to a FASTQ file
+        fastq = os.path.join(self.unaligned_dir,path)
+        if append:
+            mode = 'ab'
+        else:
+            mode = 'wb'
+        # Write the required number of reads to the file
+        with gzip.GzipFile(fastq,mode) as fq:
+            if read_number == 1:
+                r = """@HISEQ:1:000000000-A2Y1L:%s:1101:19264:2433 1:N:0:AGATCGC
+AGATAGCCGA
++
+?????BBB@B
+""" % lane
+            else:
+                r = """@HISEQ:1:000000000-A2Y1L:%s:1101:19264:2433 2:N:0:AGATCGC
+GCCGATATGC
++
+??A??ABBDD
+""" % lane
+            for i in xrange(nreads):
+                fq.write(r)
+
+# FastqStatistics
+class TestFastqStatistics(unittest.TestCase):
+    def setUp(self):
+        # Create a temp working dir
+        self.dirn = tempfile.mkdtemp(suffix='TestFastqStats')
+    def tearDown(self):
+        # Remove the temporary test directory
+        #shutil.rmtree(self.dirn)
+        pass
+    def _setup_casava(self):
+        # Create a mock casava dir structure
+        mock_data = AugmentedMockIlluminaData(
+            '151125_S00879_0001_000000000-ABCDE1_analysis',
+            'casava',
+            unaligned_dir='bcl2fastq',
+            paired_end=True,
+            top_dir=self.dirn)
+        mock_data.add_fastq_batch('AB','AB1','AB1_GCCAAT',lanes=[1,2])
+        mock_data.add_fastq_batch('AB','AB2','AB2_AGTCAA',lanes=[1,2])
+        mock_data.add_fastq_batch('CDE','CDE3','CDE3_GCCAAT',lanes=[3,4])
+        mock_data.add_fastq_batch('CDE','CDE4','CDE4_AGTCAA',lanes=[3,4])
+        mock_data.add_undetermined(lanes=(1,2,3,4))
+        # Create on disk
+        mock_data.create()
+        # Populate the FASTQs with 'fake' reads
+        reads = {
+            "AB": {
+                "AB1": { 1:3, 2:2 },
+                "AB2": { 1:5, 2:3 },
+            },
+            "CDE": {
+                "CDE3": { 3:7, 4:2 },
+                "CDE4": { 3:8, 4:6 },
+            },
+            "Undetermined_indices": {
+                "lane1": { 1: 2 },
+                "lane2": { 2: 1 },
+                "lane3": { 3: 4 },
+                "lane4": { 4: 3 },
+            },
+        }
+        barcodes = {
+            "AB1": "GCCAAT",
+            "AB2": "AGTCAA",
+            "CDE3": "GCCAAT",
+            "CDE4": "AGTCAA"
+        }
+        for project in reads:
+            for sample in reads[project]:
+                for lane in reads[project][sample]:
+                    for read_number in (1,2):
+                        try:
+                            barcode = barcodes[sample]
+                        except KeyError:
+                            barcode = "Undetermined"
+                        nreads = reads[project][sample][lane]
+                        if project != "Undetermined_indices":
+                            project_name = "Project_%s" % project
+                        else:
+                            project_name = project
+                        sample_name = "Sample_%s" % sample
+                        fastq = os.path.join(
+                            project_name,sample_name,
+                            "%s_%s_L%03d_R%d_001.fastq.gz" %
+                            (sample,barcode,lane,read_number))
+                        mock_data.populate_fastq(fastq,nreads)
+        # Store the location of the mock data
+        self.illumina_data = mock_data.dirn
+    def _setup_bcl2fastq2(self):
+        # Create a mock bcl2fastq dir structure
+        mock_data = AugmentedMockIlluminaData(
+            '151125_S00879_0001_000000000-ABCDE1_analysis',
+            'bcl2fastq2',
+            unaligned_dir='bcl2fastq',
+            paired_end=True,
+            no_lane_splitting=False,
+            top_dir=self.dirn)
+        mock_data.add_fastq_batch('AB','AB1','AB1_S1',lanes=[1,2])
+        mock_data.add_fastq_batch('AB','AB2','AB2_S2',lanes=[1,2])
+        mock_data.add_fastq_batch('CDE','CDE3','CDE3_S3',lanes=[3,4])
+        mock_data.add_fastq_batch('CDE','CDE4','CDE4_S4',lanes=[3,4])
+        mock_data.add_undetermined(lanes=(1,2,3,4))
+        # Create on disk
+        mock_data.create()
+        # Populate the FASTQs with 'fake' reads
+        reads = {
+            "AB": {
+                "AB1": { 1:3, 2:2 },
+                "AB2": { 1:5, 2:3 },
+            },
+            "CDE": {
+                "CDE3": { 3:7, 4:2 },
+                "CDE4": { 3:8, 4:6 },
+            },
+            "Undetermined_indices": {
+                "Undetermined": { 1: 2, 2: 1, 3: 4, 4: 3 },
+            },
+        }
+        s_indices = {
+            "AB1": "S1",
+            "AB2": "S2",
+            "CDE3": "S3",
+            "CDE4": "S4"
+        }
+        for project in reads:
+            for sample in reads[project]:
+                for lane in reads[project][sample]:
+                    for read_number in (1,2):
+                        try:
+                            s_index = s_indices[sample]
+                        except KeyError:
+                            s_index = "S0"
+                        nreads = reads[project][sample][lane]
+                        if project != "Undetermined_indices":
+                            project_name = project
+                        else:
+                            project_name = ""
+                        fastq = os.path.join(
+                            project_name,
+                            "%s_%s_L%03d_R%d_001.fastq.gz" %
+                            (sample,s_index,lane,read_number))
+                        mock_data.populate_fastq(fastq,nreads)
+        # Store the location of the mock data
+        self.illumina_data = mock_data.dirn
+    def _setup_bcl2fastq2_no_lane_splitting(self):
+        # Create mock bcl2fastq2 dir structure with no lane splitting
+        mock_data = AugmentedMockIlluminaData(
+            '151125_S00879_0001_000000000-ABCDE1_analysis',
+            'bcl2fastq2',
+            unaligned_dir='bcl2fastq',
+            paired_end=True,
+            no_lane_splitting=True,
+            top_dir=self.dirn)
+        mock_data.add_fastq_batch('AB','AB1','AB1_S1',lanes=[1,2])
+        mock_data.add_fastq_batch('AB','AB2','AB2_S2',lanes=[1,2])
+        mock_data.add_fastq_batch('CDE','CDE3','CDE3_S3',lanes=[3,4])
+        mock_data.add_fastq_batch('CDE','CDE4','CDE4_S4',lanes=[3,4])
+        mock_data.add_undetermined(lanes=(1,2,3,4))
+        # Create on disk
+        mock_data.create()
+        # Populate the FASTQs with 'fake' reads
+        reads = {
+            "AB": {
+                "AB1": { 1:3, 2:2 },
+                "AB2": { 1:5, 2:3 },
+            },
+            "CDE": {
+                "CDE3": { 3:7, 4:2 },
+                "CDE4": { 3:8, 4:6 },
+            },
+            "Undetermined_indices": {
+                "Undetermined": { 1: 2, 2: 1, 3: 4, 4: 3 },
+            },
+        }
+        s_indices = {
+            "AB1": "S1",
+            "AB2": "S2",
+            "CDE3": "S3",
+            "CDE4": "S4"
+        }
+        for project in reads:
+            for sample in reads[project]:
+                for lane in reads[project][sample]:
+                    for read_number in (1,2):
+                        try:
+                            s_index = s_indices[sample]
+                        except KeyError:
+                            s_index = "S0"
+                        nreads = reads[project][sample][lane]
+                        if project != "Undetermined_indices":
+                            project_name = project
+                        else:
+                            project_name = ""
+                        fastq = os.path.join(
+                            project_name,
+                            "%s_%s_R%d_001.fastq.gz" %
+                            (sample,s_index,read_number))
+                        mock_data.populate_fastq(fastq,nreads,lane=lane,
+                                                 append=True)
+        # Store the location of the mock data
+        self.illumina_data = mock_data.dirn
+    def test_fastqstatistics_casava(self):
+        self._setup_casava()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        self.assertEqual(fqstatistics.lane_names,
+                         ['L1','L2','L3','L4'])
+        self.assertEqual(fqstatistics.raw.header(),
+                         ['Project',
+                          'Sample',
+                          'Fastq',
+                          'Size',
+                          'Nreads',
+                          'Paired_end',
+                          'Read_number',
+                          'L1','L2','L3','L4'])
+        self.assertEqual(len(fqstatistics.raw),24)
+        expected = [
+            ['AB','AB1','AB1_GCCAAT_L001_R1_001.fastq.gz',3,{'L1':3}],
+            ['AB','AB1','AB1_GCCAAT_L001_R2_001.fastq.gz',3,{'L1':3}],
+            ['AB','AB1','AB1_GCCAAT_L002_R1_001.fastq.gz',2,{'L2':2}],
+            ['AB','AB1','AB1_GCCAAT_L002_R2_001.fastq.gz',2,{'L2':2}],
+            ['AB','AB2','AB2_AGTCAA_L001_R1_001.fastq.gz',5,{'L1':5}],
+            ['AB','AB2','AB2_AGTCAA_L001_R2_001.fastq.gz',5,{'L1':5}],
+            ['AB','AB2','AB2_AGTCAA_L002_R1_001.fastq.gz',3,{'L2':3}],
+            ['AB','AB2','AB2_AGTCAA_L002_R2_001.fastq.gz',3,{'L2':3}],
+            ['CDE','CDE3','CDE3_GCCAAT_L003_R1_001.fastq.gz',7,{'L3':7}],
+            ['CDE','CDE3','CDE3_GCCAAT_L003_R2_001.fastq.gz',7,{'L3':7}],
+            ['CDE','CDE3','CDE3_GCCAAT_L004_R1_001.fastq.gz',2,{'L4':2}],
+            ['CDE','CDE3','CDE3_GCCAAT_L004_R2_001.fastq.gz',2,{'L4':2}],
+            ['CDE','CDE4','CDE4_AGTCAA_L003_R1_001.fastq.gz',8,{'L3':8}],
+            ['CDE','CDE4','CDE4_AGTCAA_L003_R2_001.fastq.gz',8,{'L3':8}],
+            ['CDE','CDE4','CDE4_AGTCAA_L004_R1_001.fastq.gz',6,{'L4':6}],
+            ['CDE','CDE4','CDE4_AGTCAA_L004_R2_001.fastq.gz',6,{'L4':6}],
+            ['Undetermined_indices','lane1',
+             'lane1_Undetermined_L001_R1_001.fastq.gz',2,{'L1':2}],
+            ['Undetermined_indices','lane1',
+             'lane1_Undetermined_L001_R2_001.fastq.gz',2,{'L1':2}],
+            ['Undetermined_indices','lane2',
+             'lane2_Undetermined_L002_R1_001.fastq.gz',1,{'L2':1}],
+            ['Undetermined_indices','lane2',
+             'lane2_Undetermined_L002_R2_001.fastq.gz',1,{'L2':1}],
+            ['Undetermined_indices','lane3',
+             'lane3_Undetermined_L003_R1_001.fastq.gz',4,{'L3':4}],
+            ['Undetermined_indices','lane3',
+             'lane3_Undetermined_L003_R2_001.fastq.gz',4,{'L3':4}],
+            ['Undetermined_indices','lane4',
+             'lane4_Undetermined_L004_R1_001.fastq.gz',3,{'L4':3}],
+            ['Undetermined_indices','lane4',
+             'lane4_Undetermined_L004_R2_001.fastq.gz',3,{'L4':3}],
+        ]
+        for line,expctd in zip(fqstatistics.raw,expected):
+            self.assertEqual(line['Project'],expctd[0])
+            self.assertEqual(line['Sample'],expctd[1])
+            self.assertEqual(line['Fastq'],expctd[2])
+            self.assertEqual(line['Nreads'],expctd[3])
+            for lane in ('L1','L2','L3','L4'):
+                if lane in expctd[4]:
+                    self.assertEqual(line[lane],expctd[4][lane])
+                else:
+                    self.assertEqual(line[lane],'')
+            self.assertEqual(line['Read_number'],
+                             IlluminaFastq(expctd[2]).read_number)
+    def test_fastqstatistics_bcl2fastq2(self):
+        self._setup_bcl2fastq2()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        self.assertEqual(fqstatistics.lane_names,
+                         ['L1','L2','L3','L4'])
+        self.assertEqual(fqstatistics.raw.header(),
+                         ['Project',
+                          'Sample',
+                          'Fastq',
+                          'Size',
+                          'Nreads',
+                          'Paired_end',
+                          'Read_number',
+                          'L1','L2','L3','L4'])
+        self.assertEqual(len(fqstatistics.raw),24)
+        expected = [
+            ['AB','AB1','AB1_S1_L001_R1_001.fastq.gz',3,{'L1':3}],
+            ['AB','AB1','AB1_S1_L001_R2_001.fastq.gz',3,{'L1':3}],
+            ['AB','AB1','AB1_S1_L002_R1_001.fastq.gz',2,{'L2':2}],
+            ['AB','AB1','AB1_S1_L002_R2_001.fastq.gz',2,{'L2':2}],
+            ['AB','AB2','AB2_S2_L001_R1_001.fastq.gz',5,{'L1':5}],
+            ['AB','AB2','AB2_S2_L001_R2_001.fastq.gz',5,{'L1':5}],
+            ['AB','AB2','AB2_S2_L002_R1_001.fastq.gz',3,{'L2':3}],
+            ['AB','AB2','AB2_S2_L002_R2_001.fastq.gz',3,{'L2':3}],
+            ['CDE','CDE3','CDE3_S3_L003_R1_001.fastq.gz',7,{'L3':7}],
+            ['CDE','CDE3','CDE3_S3_L003_R2_001.fastq.gz',7,{'L3':7}],
+            ['CDE','CDE3','CDE3_S3_L004_R1_001.fastq.gz',2,{'L4':2}],
+            ['CDE','CDE3','CDE3_S3_L004_R2_001.fastq.gz',2,{'L4':2}],
+            ['CDE','CDE4','CDE4_S4_L003_R1_001.fastq.gz',8,{'L3':8}],
+            ['CDE','CDE4','CDE4_S4_L003_R2_001.fastq.gz',8,{'L3':8}],
+            ['CDE','CDE4','CDE4_S4_L004_R1_001.fastq.gz',6,{'L4':6}],
+            ['CDE','CDE4','CDE4_S4_L004_R2_001.fastq.gz',6,{'L4':6}],
+            ['Undetermined_indices','lane1',
+             'Undetermined_S0_L001_R1_001.fastq.gz',2,{'L1':2}],
+            ['Undetermined_indices','lane1',
+             'Undetermined_S0_L001_R2_001.fastq.gz',2,{'L1':2}],
+            ['Undetermined_indices','lane2',
+             'Undetermined_S0_L002_R1_001.fastq.gz',1,{'L2':1}],
+            ['Undetermined_indices','lane2',
+             'Undetermined_S0_L002_R2_001.fastq.gz',1,{'L2':1}],
+            ['Undetermined_indices','lane3',
+             'Undetermined_S0_L003_R1_001.fastq.gz',4,{'L3':4}],
+            ['Undetermined_indices','lane3',
+             'Undetermined_S0_L003_R2_001.fastq.gz',4,{'L3':4}],
+            ['Undetermined_indices','lane4',
+             'Undetermined_S0_L004_R1_001.fastq.gz',3,{'L4':3}],
+            ['Undetermined_indices','lane4',
+             'Undetermined_S0_L004_R2_001.fastq.gz',3,{'L4':3}],
+        ]
+        for line,expctd in zip(fqstatistics.raw,expected):
+            self.assertEqual(line['Project'],expctd[0])
+            self.assertEqual(line['Sample'],expctd[1])
+            self.assertEqual(line['Fastq'],expctd[2])
+            self.assertEqual(line['Nreads'],expctd[3])
+            for lane in ('L1','L2','L3','L4'):
+                if lane in expctd[4]:
+                    self.assertEqual(line[lane],expctd[4][lane])
+                else:
+                    self.assertEqual(line[lane],'')
+            self.assertEqual(line['Read_number'],
+                             IlluminaFastq(expctd[2]).read_number)
+    def test_fastqstatistics_bcl2fastq2_no_lane_splitting(self):
+        self._setup_bcl2fastq2_no_lane_splitting()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        self.assertEqual(fqstatistics.lane_names,
+                         ['L1','L2','L3','L4'])
+        self.assertEqual(fqstatistics.raw.header(),
+                         ['Project',
+                          'Sample',
+                          'Fastq',
+                          'Size',
+                          'Nreads',
+                          'Paired_end',
+                          'Read_number',
+                          'L1','L2','L3','L4'])
+        self.assertEqual(len(fqstatistics.raw),10)
+        expected = [
+            ['AB','AB1','AB1_S1_R1_001.fastq.gz',5,{'L1':3,'L2':2}],
+            ['AB','AB1','AB1_S1_R2_001.fastq.gz',5,{'L1':3,'L2':2}],
+            ['AB','AB2','AB2_S2_R1_001.fastq.gz',8,{'L1':5,'L2':3}],
+            ['AB','AB2','AB2_S2_R2_001.fastq.gz',8,{'L1':5,'L2':3}],
+            ['CDE','CDE3','CDE3_S3_R1_001.fastq.gz',9,{'L3':7,'L4':2}],
+            ['CDE','CDE3','CDE3_S3_R2_001.fastq.gz',9,{'L3':7,'L4':2}],
+            ['CDE','CDE4','CDE4_S4_R1_001.fastq.gz',14,{'L3':8,'L4':6}],
+            ['CDE','CDE4','CDE4_S4_R2_001.fastq.gz',14,{'L3':8,'L4':6}],
+            ['Undetermined_indices','undetermined',
+             'Undetermined_S0_R1_001.fastq.gz',10,
+             {'L1':2,'L2':1,'L3':4,'L4':3}],
+            ['Undetermined_indices','undetermined',
+             'Undetermined_S0_R2_001.fastq.gz',10,
+             {'L1':2,'L2':1,'L3':4,'L4':3}],
+        ]
+        for line,expctd in zip(fqstatistics.raw,expected):
+            self.assertEqual(line['Project'],expctd[0])
+            self.assertEqual(line['Sample'],expctd[1])
+            self.assertEqual(line['Fastq'],expctd[2])
+            self.assertEqual(line['Nreads'],expctd[3])
+            for lane in ('L1','L2','L3','L4'):
+                if lane in expctd[4]:
+                    self.assertEqual(line[lane],expctd[4][lane])
+                else:
+                    self.assertEqual(line[lane],'')
+            self.assertEqual(line['Read_number'],
+                             IlluminaFastq(expctd[2]).read_number)
 
 # FastqStats
 class TestFastqStats(unittest.TestCase):

--- a/auto_process_ngs/test/test_stats.py
+++ b/auto_process_ngs/test/test_stats.py
@@ -7,9 +7,11 @@ import unittest
 import tempfile
 import shutil
 import gzip
+from auto_process_ngs.stats import FastqStats
 from auto_process_ngs.stats import FastqReadCounter
+from auto_process_ngs.stats import collect_fastq_data
 
-# FastqReadCounter
+# Test data
 fastq_data = """@MISEQ:34:000000000-A7PHP:1:1101:12552:1774 1:N:0:TAAGGCGA
 TTTACAACTAGCTTCTCTTTTTCTT
 +
@@ -30,6 +32,32 @@ CAGCAATATACACTTCACTCTGCAT
 GATAAAGACAGAGTCTTAATTAAAC
 +
 11>1>11DFFCFFDGGGB3BF313A
+"""
+fastq_r1_data = """@HISEQ:1:000000000-A2Y1L:1:1101:19264:2433 1:N:0:AGATCGC
+AGATAGCCGA
++
+?????BBB@B
+@HISEQ:1:000000000-A2Y1L:1:1101:18667:2435 1:N:0:AGATCGC
+ATATATTCAT
++
+?????BBBDD
+@HISEQ:1:000000000-A2Y1L:1:1101:17523:2436 1:N:0:AGATCGC
+CATCACTACC
++
+?<,<?BBBBB
+"""
+fastq_r2_data = """@HISEQ:1:000000000-A2Y1L:1:1101:19264:2433 2:N:0:AGATCGC
+GCCGATATGC
++
+??A??ABBDD
+@HISEQ:1:000000000-A2Y1L:1:1101:18667:2435 2:N:0:AGATCGC
+GATGACATCA
++
+?????BBBDD
+@HISEQ:1:000000000-A2Y1L:1:1101:17523:2436 2:N:0:AGATCGC
+GAATATAGAA
++
+??AAABBBDD
 """
 fastq_multi_lane_data = """@NB500968:10:H57NTAFXX:1:11101:4210:1091 1:N:0:CGGCAGAA
 CTCCAGTTCTGAGTAACTTCAAGGG
@@ -80,6 +108,38 @@ CTTATACACATCTCCGAGCCCACGA
 +
 AAAAAEEEEEEEEEEEEEEEE/EE/
 """
+
+# FastqStats
+class TestFastqStats(unittest.TestCase):
+    def test_fastqstats_r1(self):
+        fqs = FastqStats(
+            "/data/fastqs/test_S1_L001_R1_001.fastq",
+            "Proj","test")
+        self.assertEqual(fqs.fastq,"/data/fastqs/test_S1_L001_R1_001.fastq")
+        self.assertEqual(fqs.project,"Proj")
+        self.assertEqual(fqs.sample,"test")
+        self.assertEqual(fqs.name,"test_S1_L001_R1_001.fastq")
+        self.assertEqual(fqs.lanes,[])
+        self.assertEqual(fqs.read_number,1)
+        self.assertEqual(fqs.nreads,None)
+        self.assertEqual(fqs.fsize,None)
+        self.assertEqual(fqs.reads_by_lane,{})
+
+    def test_fastqstats_r2(self):
+        fqs = FastqStats(
+            "/data/fastqs/test_S1_L001_R2_001.fastq",
+            "Proj","test")
+        self.assertEqual(fqs.fastq,"/data/fastqs/test_S1_L001_R2_001.fastq")
+        self.assertEqual(fqs.project,"Proj")
+        self.assertEqual(fqs.sample,"test")
+        self.assertEqual(fqs.name,"test_S1_L001_R2_001.fastq")
+        self.assertEqual(fqs.lanes,[])
+        self.assertEqual(fqs.read_number,2)
+        self.assertEqual(fqs.nreads,None)
+        self.assertEqual(fqs.fsize,None)
+        self.assertEqual(fqs.reads_by_lane,{})
+
+# FastqReadCounter
 class TestFastqReadCounter(unittest.TestCase):
     def setUp(self):
         # Temporary working dir (if needed)
@@ -189,3 +249,114 @@ class TestFastqReadCounter(unittest.TestCase):
                                            2: 1,
                                            3: 2,
                                            4: 4 })
+
+# collect_fastq_data
+class TestCollectFastqData(unittest.TestCase):
+    def setUp(self):
+        # Temporary working dir (if needed)
+        self.wd = None
+
+    def _make_working_dir(self):
+        if self.wd is None:
+            self.wd = tempfile.mkdtemp(suffix='.test_collect_fastq_data')
+
+    def _make_fastq(self,name,contents):
+        # Create a FASTQ file under the working directory
+        # called "name" and populated with "contents"
+        # Working directory will be created if not already
+        # set up
+        # If "name" ends with ".gz" then "contents" will be
+        # gzipped
+        # Returns the path to the file
+        self._make_working_dir()
+        filen = os.path.join(self.wd,name)
+        if filen.endswith(".gz"):
+            with gzip.GzipFile(filen,'wb') as fp:
+                fp.write(contents)
+        else:
+            with open(filen,'w') as fp:
+                fp.write(contents)
+        return filen
+
+    def tearDown(self):
+        # Remove temporary working dir
+        if self.wd is not None and os.path.isdir(self.wd):
+            shutil.rmtree(self.wd)
+
+    def test_collect_fastq_data_r1_lane_in_name(self):
+        fastq = self._make_fastq("test_S1_L001_R1_001.fastq",
+                                 fastq_r1_data)
+        fqs = FastqStats(fastq,"Proj","test")
+        self.assertEqual(fqs.fastq,fastq)
+        collect_fastq_data(fqs)
+        self.assertEqual(fqs.project,"Proj")
+        self.assertEqual(fqs.sample,"test")
+        self.assertEqual(fqs.name,"test_S1_L001_R1_001.fastq")
+        self.assertEqual(fqs.lanes,[1])
+        self.assertEqual(fqs.read_number,1)
+        self.assertEqual(fqs.nreads,3)
+        self.assertEqual(fqs.fsize,os.path.getsize(fastq))
+        self.assertEqual(fqs.reads_by_lane,{1: 3})
+
+    def test_collect_fastq_data_r1_no_lane_in_name(self):
+        fastq = self._make_fastq("test_S1_R1_001.fastq",
+                                 fastq_r1_data)
+        fqs = FastqStats(fastq,"Proj","test")
+        self.assertEqual(fqs.fastq,fastq)
+        collect_fastq_data(fqs)
+        self.assertEqual(fqs.project,"Proj")
+        self.assertEqual(fqs.sample,"test")
+        self.assertEqual(fqs.name,"test_S1_R1_001.fastq")
+        self.assertEqual(fqs.lanes,[1])
+        self.assertEqual(fqs.read_number,1)
+        self.assertEqual(fqs.nreads,3)
+        self.assertEqual(fqs.fsize,os.path.getsize(fastq))
+        self.assertEqual(fqs.reads_by_lane,{1: 3})
+
+    def test_collect_fastq_data_r2_lane_in_name(self):
+        fastq = self._make_fastq("test_S1_L001_R2_001.fastq",
+                                 fastq_r2_data)
+        fqs = FastqStats(fastq,"Proj","test")
+        self.assertEqual(fqs.fastq,fastq)
+        collect_fastq_data(fqs)
+        self.assertEqual(fqs.project,"Proj")
+        self.assertEqual(fqs.sample,"test")
+        self.assertEqual(fqs.name,"test_S1_L001_R2_001.fastq")
+        self.assertEqual(fqs.lanes,[])
+        self.assertEqual(fqs.read_number,2)
+        self.assertEqual(fqs.nreads,3)
+        self.assertEqual(fqs.fsize,os.path.getsize(fastq))
+        self.assertEqual(fqs.reads_by_lane,{})
+
+    def test_collect_fastq_data_r2_no_lane_in_name(self):
+        fastq = self._make_fastq("test_S1_R2_001.fastq",
+                                 fastq_r2_data)
+        fqs = FastqStats(fastq,"Proj","test")
+        self.assertEqual(fqs.fastq,fastq)
+        collect_fastq_data(fqs)
+        self.assertEqual(fqs.project,"Proj")
+        self.assertEqual(fqs.sample,"test")
+        self.assertEqual(fqs.name,"test_S1_R2_001.fastq")
+        self.assertEqual(fqs.lanes,[])
+        self.assertEqual(fqs.read_number,2)
+        self.assertEqual(fqs.nreads,3)
+        self.assertEqual(fqs.fsize,os.path.getsize(fastq))
+        self.assertEqual(fqs.reads_by_lane,{})
+
+    def test_collect_fastq_data_multi_lanes(self):
+        fastq = self._make_fastq("test_S1_R1_001.fastq",
+                                 fastq_multi_lane_data)
+        fqs = FastqStats(fastq,"Proj","test")
+        self.assertEqual(fqs.fastq,fastq)
+        collect_fastq_data(fqs)
+        self.assertEqual(fqs.project,"Proj")
+        self.assertEqual(fqs.sample,"test")
+        self.assertEqual(fqs.name,"test_S1_R1_001.fastq")
+        self.assertEqual(fqs.lanes,[1,2,3,4])
+        self.assertEqual(fqs.read_number,1)
+        self.assertEqual(fqs.nreads,12)
+        self.assertEqual(fqs.fsize,os.path.getsize(fastq))
+        self.assertEqual(fqs.reads_by_lane,{ 1: 5,
+                                             2: 1,
+                                             3: 2,
+                                             4: 4 })

--- a/auto_process_ngs/test/test_stats.py
+++ b/auto_process_ngs/test/test_stats.py
@@ -7,6 +7,7 @@ import unittest
 import tempfile
 import shutil
 import gzip
+import cStringIO
 from bcftbx.mock import MockIlluminaData
 from bcftbx.IlluminaData import IlluminaFastq
 from bcftbx.IlluminaData import IlluminaData
@@ -315,6 +316,20 @@ class TestFastqStatisticsCasava(unittest.TestCase):
                     self.assertEqual(line[lane],'')
             self.assertEqual(line['Read_number'],
                              IlluminaFastq(expctd[2]).read_number)
+    def test_report_per_lane_summary_stats(self):
+        fp = cStringIO.StringIO()
+        self._setup_casava()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        fqstatistics.report_per_lane_summary_stats(fp=fp)
+        self.assertEqual(fp.getvalue(),"""#Lane	Total reads	Assigned reads	Unassigned reads	%assigned	%unassigned
+Lane 1	10	8	2	80.0	20.0
+Lane 2	6	5	1	83.33	16.67
+Lane 3	19	15	4	78.95	21.05
+Lane 4	11	8	3	72.73	27.27
+""")
 
 class TestFastqStatisticsBcl2fastq2(unittest.TestCase):
     def setUp(self):
@@ -445,6 +460,20 @@ class TestFastqStatisticsBcl2fastq2(unittest.TestCase):
                     self.assertEqual(line[lane],'')
             self.assertEqual(line['Read_number'],
                              IlluminaFastq(expctd[2]).read_number)
+    def test_report_per_lane_summary_stats(self):
+        fp = cStringIO.StringIO()
+        self._setup_bcl2fastq2()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        fqstatistics.report_per_lane_summary_stats(fp=fp)
+        self.assertEqual(fp.getvalue(),"""#Lane	Total reads	Assigned reads	Unassigned reads	%assigned	%unassigned
+Lane 1	10	8	2	80.0	20.0
+Lane 2	6	5	1	83.33	16.67
+Lane 3	19	15	4	78.95	21.05
+Lane 4	11	8	3	72.73	27.27
+""")
 
 class TestFastqStatisticsBcl2fastq2NoLaneSplitting(unittest.TestCase):
     def setUp(self):
@@ -558,6 +587,20 @@ class TestFastqStatisticsBcl2fastq2NoLaneSplitting(unittest.TestCase):
                     self.assertEqual(line[lane],'')
             self.assertEqual(line['Read_number'],
                              IlluminaFastq(expctd[2]).read_number)
+    def test_report_per_lane_summary_stats(self):
+        fp = cStringIO.StringIO()
+        self._setup_bcl2fastq2_no_lane_splitting()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        fqstatistics.report_per_lane_summary_stats(fp=fp)
+        self.assertEqual(fp.getvalue(),"""#Lane	Total reads	Assigned reads	Unassigned reads	%assigned	%unassigned
+Lane 1	10	8	2	80.0	20.0
+Lane 2	6	5	1	83.33	16.67
+Lane 3	19	15	4	78.95	21.05
+Lane 4	11	8	3	72.73	27.27
+""")
 
 # FastqStats
 class TestFastqStats(unittest.TestCase):

--- a/auto_process_ngs/test/test_stats.py
+++ b/auto_process_ngs/test/test_stats.py
@@ -225,7 +225,7 @@ class TestFastqStatisticsCasava(unittest.TestCase):
         ]
     def tearDown(self):
         # Remove the temporary test directory
-        #shutil.rmtree(self.dirn)
+        shutil.rmtree(self.dirn)
         pass
     def _setup_casava(self):
         # Create a mock casava dir structure
@@ -425,7 +425,7 @@ class TestFastqStatisticsBcl2fastq2(unittest.TestCase):
         ]
     def tearDown(self):
         # Remove the temporary test directory
-        #shutil.rmtree(self.dirn)
+        shutil.rmtree(self.dirn)
         pass
     def _setup_bcl2fastq2(self):
         # Create a mock bcl2fastq dir structure
@@ -514,6 +514,7 @@ class TestFastqStatisticsBcl2fastq2(unittest.TestCase):
                     self.assertEqual(line[lane],'')
             self.assertEqual(line['Read_number'],
                              IlluminaFastq(expctd[2]).read_number)
+            self.assertEqual(line['Paired_end'],'Y')
     def test_report_basic_stats(self):
         fp = cStringIO.StringIO()
         self._setup_bcl2fastq2()
@@ -532,6 +533,185 @@ class TestFastqStatisticsBcl2fastq2(unittest.TestCase):
             self.assertEqual(line[2],expctd[2]) # Fastq
             self.assertEqual(int(line[4]),expctd[3]) # Nreads
             self.assertEqual(line[5],'Y') # Paired_end
+    def test_report_per_lane_sample_stats(self):
+        fp = cStringIO.StringIO()
+        self._setup_bcl2fastq2()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        fqstatistics.report_per_lane_sample_stats(fp=fp)
+        self.assertEqual(fp.getvalue(),"""
+Lane 1
+Total reads = 10
+- AB/AB1	3	30.0%
+- AB/AB2	5	50.0%
+- Undetermined_indices/lane1	2	20.0%
+
+Lane 2
+Total reads = 6
+- AB/AB1	2	33.3%
+- AB/AB2	3	50.0%
+- Undetermined_indices/lane2	1	16.7%
+
+Lane 3
+Total reads = 19
+- CDE/CDE3	7	36.8%
+- CDE/CDE4	8	42.1%
+- Undetermined_indices/lane3	4	21.1%
+
+Lane 4
+Total reads = 11
+- CDE/CDE3	2	18.2%
+- CDE/CDE4	6	54.5%
+- Undetermined_indices/lane4	3	27.3%
+""")
+    def test_report_per_lane_summary_stats(self):
+        fp = cStringIO.StringIO()
+        self._setup_bcl2fastq2()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        fqstatistics.report_per_lane_summary_stats(fp=fp)
+        self.assertEqual(fp.getvalue(),"""#Lane	Total reads	Assigned reads	Unassigned reads	%assigned	%unassigned
+Lane 1	10	8	2	80.0	20.0
+Lane 2	6	5	1	83.33	16.67
+Lane 3	19	15	4	78.95	21.05
+Lane 4	11	8	3	72.73	27.27
+""")
+
+class TestFastqStatisticsBcl2fastq2SingleEnd(unittest.TestCase):
+    def setUp(self):
+        # Create a temp working dir
+        self.dirn = tempfile.mkdtemp(suffix='TestFastqStats')
+        # Expected data
+        self.expected = [
+            ['AB','AB1','AB1_S1_L001_R1_001.fastq.gz',3,{'L1':3}],
+            ['AB','AB1','AB1_S1_L002_R1_001.fastq.gz',2,{'L2':2}],
+            ['AB','AB2','AB2_S2_L001_R1_001.fastq.gz',5,{'L1':5}],
+            ['AB','AB2','AB2_S2_L002_R1_001.fastq.gz',3,{'L2':3}],
+            ['CDE','CDE3','CDE3_S3_L003_R1_001.fastq.gz',7,{'L3':7}],
+            ['CDE','CDE3','CDE3_S3_L004_R1_001.fastq.gz',2,{'L4':2}],
+            ['CDE','CDE4','CDE4_S4_L003_R1_001.fastq.gz',8,{'L3':8}],
+            ['CDE','CDE4','CDE4_S4_L004_R1_001.fastq.gz',6,{'L4':6}],
+            ['Undetermined_indices','lane1',
+             'Undetermined_S0_L001_R1_001.fastq.gz',2,{'L1':2}],
+            ['Undetermined_indices','lane2',
+             'Undetermined_S0_L002_R1_001.fastq.gz',1,{'L2':1}],
+            ['Undetermined_indices','lane3',
+             'Undetermined_S0_L003_R1_001.fastq.gz',4,{'L3':4}],
+            ['Undetermined_indices','lane4',
+             'Undetermined_S0_L004_R1_001.fastq.gz',3,{'L4':3}],
+        ]
+    def tearDown(self):
+        # Remove the temporary test directory
+        shutil.rmtree(self.dirn)
+        pass
+    def _setup_bcl2fastq2(self):
+        # Create a mock bcl2fastq dir structure
+        mock_data = AugmentedMockIlluminaData(
+            '151125_S00879_0001_000000000-ABCDE1_analysis',
+            'bcl2fastq2',
+            unaligned_dir='bcl2fastq',
+            paired_end=False,
+            no_lane_splitting=False,
+            top_dir=self.dirn)
+        mock_data.add_fastq_batch('AB','AB1','AB1_S1',lanes=[1,2])
+        mock_data.add_fastq_batch('AB','AB2','AB2_S2',lanes=[1,2])
+        mock_data.add_fastq_batch('CDE','CDE3','CDE3_S3',lanes=[3,4])
+        mock_data.add_fastq_batch('CDE','CDE4','CDE4_S4',lanes=[3,4])
+        mock_data.add_undetermined(lanes=(1,2,3,4))
+        # Create on disk
+        mock_data.create()
+        # Populate the FASTQs with 'fake' reads
+        reads = {
+            "AB": {
+                "AB1": { 1:3, 2:2 },
+                "AB2": { 1:5, 2:3 },
+            },
+            "CDE": {
+                "CDE3": { 3:7, 4:2 },
+                "CDE4": { 3:8, 4:6 },
+            },
+            "Undetermined_indices": {
+                "Undetermined": { 1: 2, 2: 1, 3: 4, 4: 3 },
+            },
+        }
+        s_indices = {
+            "AB1": "S1",
+            "AB2": "S2",
+            "CDE3": "S3",
+            "CDE4": "S4"
+        }
+        for project in reads:
+            for sample in reads[project]:
+                for lane in reads[project][sample]:
+                    try:
+                        s_index = s_indices[sample]
+                    except KeyError:
+                        s_index = "S0"
+                    nreads = reads[project][sample][lane]
+                    if project != "Undetermined_indices":
+                        project_name = project
+                    else:
+                        project_name = ""
+                    fastq = os.path.join(
+                        project_name,
+                        "%s_%s_L%03d_R1_001.fastq.gz" %
+                        (sample,s_index,lane))
+                    mock_data.populate_fastq(fastq,nreads)
+        # Store the location of the mock data
+        self.illumina_data = mock_data.dirn
+    def test_fastqstatistics_bcl2fastq2(self):
+        self._setup_bcl2fastq2()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        self.assertEqual(fqstatistics.lane_names,
+                         ['L1','L2','L3','L4'])
+        # Check "raw" stored data
+        self.assertEqual(fqstatistics.raw.header(),
+                         ['Project',
+                          'Sample',
+                          'Fastq',
+                          'Size',
+                          'Nreads',
+                          'Paired_end',
+                          'Read_number',
+                          'L1','L2','L3','L4'])
+        self.assertEqual(len(fqstatistics.raw),12)
+        for line,expctd in zip(fqstatistics.raw,self.expected):
+            self.assertEqual(line['Project'],expctd[0])
+            self.assertEqual(line['Sample'],expctd[1])
+            self.assertEqual(line['Fastq'],expctd[2])
+            self.assertEqual(line['Nreads'],expctd[3])
+            for lane in ('L1','L2','L3','L4'):
+                if lane in expctd[4]:
+                    self.assertEqual(line[lane],expctd[4][lane])
+                else:
+                    self.assertEqual(line[lane],'')
+            self.assertEqual(line['Read_number'],1)
+            self.assertEqual(line['Paired_end'],'N')
+    def test_report_basic_stats(self):
+        fp = cStringIO.StringIO()
+        self._setup_bcl2fastq2()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        fqstatistics.report_basic_stats(fp=fp)
+        stats = fp.getvalue().strip('\n').split('\n')
+        self.assertEqual(len(stats),13)
+        self.assertEqual(stats[0],"#Project	Sample	Fastq	Size	Nreads	Paired_end")
+        for line,expctd in zip(stats[1:],self.expected):
+            line = line.split('\t')
+            self.assertEqual(line[0],expctd[0]) # Project
+            self.assertEqual(line[1],expctd[1]) # Sample
+            self.assertEqual(line[2],expctd[2]) # Fastq
+            self.assertEqual(int(line[4]),expctd[3]) # Nreads
+            self.assertEqual(line[5],'N') # Paired_end
     def test_report_per_lane_sample_stats(self):
         fp = cStringIO.StringIO()
         self._setup_bcl2fastq2()
@@ -603,7 +783,7 @@ class TestFastqStatisticsBcl2fastq2NoLaneSplitting(unittest.TestCase):
         ]
     def tearDown(self):
         # Remove the temporary test directory
-        #shutil.rmtree(self.dirn)
+        shutil.rmtree(self.dirn)
         pass
     def _setup_bcl2fastq2_no_lane_splitting(self):
         # Create mock bcl2fastq2 dir structure with no lane splitting
@@ -693,6 +873,7 @@ class TestFastqStatisticsBcl2fastq2NoLaneSplitting(unittest.TestCase):
                     self.assertEqual(line[lane],'')
             self.assertEqual(line['Read_number'],
                              IlluminaFastq(expctd[2]).read_number)
+            self.assertEqual(line['Paired_end'],'Y')
     def test_report_basic_stats(self):
         fp = cStringIO.StringIO()
         self._setup_bcl2fastq2_no_lane_splitting()

--- a/auto_process_ngs/test/test_stats.py
+++ b/auto_process_ngs/test/test_stats.py
@@ -188,6 +188,41 @@ class TestFastqStatisticsCasava(unittest.TestCase):
     def setUp(self):
         # Create a temp working dir
         self.dirn = tempfile.mkdtemp(suffix='TestFastqStats')
+        # Expected data
+        self.expected = [
+            ['AB','AB1','AB1_GCCAAT_L001_R1_001.fastq.gz',3,{'L1':3}],
+            ['AB','AB1','AB1_GCCAAT_L001_R2_001.fastq.gz',3,{'L1':3}],
+            ['AB','AB1','AB1_GCCAAT_L002_R1_001.fastq.gz',2,{'L2':2}],
+            ['AB','AB1','AB1_GCCAAT_L002_R2_001.fastq.gz',2,{'L2':2}],
+            ['AB','AB2','AB2_AGTCAA_L001_R1_001.fastq.gz',5,{'L1':5}],
+            ['AB','AB2','AB2_AGTCAA_L001_R2_001.fastq.gz',5,{'L1':5}],
+            ['AB','AB2','AB2_AGTCAA_L002_R1_001.fastq.gz',3,{'L2':3}],
+            ['AB','AB2','AB2_AGTCAA_L002_R2_001.fastq.gz',3,{'L2':3}],
+            ['CDE','CDE3','CDE3_GCCAAT_L003_R1_001.fastq.gz',7,{'L3':7}],
+            ['CDE','CDE3','CDE3_GCCAAT_L003_R2_001.fastq.gz',7,{'L3':7}],
+            ['CDE','CDE3','CDE3_GCCAAT_L004_R1_001.fastq.gz',2,{'L4':2}],
+            ['CDE','CDE3','CDE3_GCCAAT_L004_R2_001.fastq.gz',2,{'L4':2}],
+            ['CDE','CDE4','CDE4_AGTCAA_L003_R1_001.fastq.gz',8,{'L3':8}],
+            ['CDE','CDE4','CDE4_AGTCAA_L003_R2_001.fastq.gz',8,{'L3':8}],
+            ['CDE','CDE4','CDE4_AGTCAA_L004_R1_001.fastq.gz',6,{'L4':6}],
+            ['CDE','CDE4','CDE4_AGTCAA_L004_R2_001.fastq.gz',6,{'L4':6}],
+            ['Undetermined_indices','lane1',
+             'lane1_Undetermined_L001_R1_001.fastq.gz',2,{'L1':2}],
+            ['Undetermined_indices','lane1',
+             'lane1_Undetermined_L001_R2_001.fastq.gz',2,{'L1':2}],
+            ['Undetermined_indices','lane2',
+             'lane2_Undetermined_L002_R1_001.fastq.gz',1,{'L2':1}],
+            ['Undetermined_indices','lane2',
+             'lane2_Undetermined_L002_R2_001.fastq.gz',1,{'L2':1}],
+            ['Undetermined_indices','lane3',
+             'lane3_Undetermined_L003_R1_001.fastq.gz',4,{'L3':4}],
+            ['Undetermined_indices','lane3',
+             'lane3_Undetermined_L003_R2_001.fastq.gz',4,{'L3':4}],
+            ['Undetermined_indices','lane4',
+             'lane4_Undetermined_L004_R1_001.fastq.gz',3,{'L4':3}],
+            ['Undetermined_indices','lane4',
+             'lane4_Undetermined_L004_R2_001.fastq.gz',3,{'L4':3}],
+        ]
     def tearDown(self):
         # Remove the temporary test directory
         #shutil.rmtree(self.dirn)
@@ -270,41 +305,7 @@ class TestFastqStatisticsCasava(unittest.TestCase):
                           'Read_number',
                           'L1','L2','L3','L4'])
         self.assertEqual(len(fqstatistics.raw),24)
-        expected = [
-            ['AB','AB1','AB1_GCCAAT_L001_R1_001.fastq.gz',3,{'L1':3}],
-            ['AB','AB1','AB1_GCCAAT_L001_R2_001.fastq.gz',3,{'L1':3}],
-            ['AB','AB1','AB1_GCCAAT_L002_R1_001.fastq.gz',2,{'L2':2}],
-            ['AB','AB1','AB1_GCCAAT_L002_R2_001.fastq.gz',2,{'L2':2}],
-            ['AB','AB2','AB2_AGTCAA_L001_R1_001.fastq.gz',5,{'L1':5}],
-            ['AB','AB2','AB2_AGTCAA_L001_R2_001.fastq.gz',5,{'L1':5}],
-            ['AB','AB2','AB2_AGTCAA_L002_R1_001.fastq.gz',3,{'L2':3}],
-            ['AB','AB2','AB2_AGTCAA_L002_R2_001.fastq.gz',3,{'L2':3}],
-            ['CDE','CDE3','CDE3_GCCAAT_L003_R1_001.fastq.gz',7,{'L3':7}],
-            ['CDE','CDE3','CDE3_GCCAAT_L003_R2_001.fastq.gz',7,{'L3':7}],
-            ['CDE','CDE3','CDE3_GCCAAT_L004_R1_001.fastq.gz',2,{'L4':2}],
-            ['CDE','CDE3','CDE3_GCCAAT_L004_R2_001.fastq.gz',2,{'L4':2}],
-            ['CDE','CDE4','CDE4_AGTCAA_L003_R1_001.fastq.gz',8,{'L3':8}],
-            ['CDE','CDE4','CDE4_AGTCAA_L003_R2_001.fastq.gz',8,{'L3':8}],
-            ['CDE','CDE4','CDE4_AGTCAA_L004_R1_001.fastq.gz',6,{'L4':6}],
-            ['CDE','CDE4','CDE4_AGTCAA_L004_R2_001.fastq.gz',6,{'L4':6}],
-            ['Undetermined_indices','lane1',
-             'lane1_Undetermined_L001_R1_001.fastq.gz',2,{'L1':2}],
-            ['Undetermined_indices','lane1',
-             'lane1_Undetermined_L001_R2_001.fastq.gz',2,{'L1':2}],
-            ['Undetermined_indices','lane2',
-             'lane2_Undetermined_L002_R1_001.fastq.gz',1,{'L2':1}],
-            ['Undetermined_indices','lane2',
-             'lane2_Undetermined_L002_R2_001.fastq.gz',1,{'L2':1}],
-            ['Undetermined_indices','lane3',
-             'lane3_Undetermined_L003_R1_001.fastq.gz',4,{'L3':4}],
-            ['Undetermined_indices','lane3',
-             'lane3_Undetermined_L003_R2_001.fastq.gz',4,{'L3':4}],
-            ['Undetermined_indices','lane4',
-             'lane4_Undetermined_L004_R1_001.fastq.gz',3,{'L4':3}],
-            ['Undetermined_indices','lane4',
-             'lane4_Undetermined_L004_R2_001.fastq.gz',3,{'L4':3}],
-        ]
-        for line,expctd in zip(fqstatistics.raw,expected):
+        for line,expctd in zip(fqstatistics.raw,self.expected):
             self.assertEqual(line['Project'],expctd[0])
             self.assertEqual(line['Sample'],expctd[1])
             self.assertEqual(line['Fastq'],expctd[2])
@@ -316,6 +317,25 @@ class TestFastqStatisticsCasava(unittest.TestCase):
                     self.assertEqual(line[lane],'')
             self.assertEqual(line['Read_number'],
                              IlluminaFastq(expctd[2]).read_number)
+            self.assertEqual(line['Paired_end'],'Y')
+    def test_report_basic_stats(self):
+        fp = cStringIO.StringIO()
+        self._setup_casava()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        fqstatistics.report_basic_stats(fp=fp)
+        stats = fp.getvalue().strip('\n').split('\n')
+        self.assertEqual(len(stats),25)
+        self.assertEqual(stats[0],"#Project	Sample	Fastq	Size	Nreads	Paired_end")
+        for line,expctd in zip(stats[1:],self.expected):
+            line = line.split('\t')
+            self.assertEqual(line[0],expctd[0]) # Project
+            self.assertEqual(line[1],expctd[1]) # Sample
+            self.assertEqual(line[2],expctd[2]) # Fastq
+            self.assertEqual(int(line[4]),expctd[3]) # Nreads
+            self.assertEqual(line[5],'Y') # Paired_end
     def test_report_per_lane_sample_stats(self):
         fp = cStringIO.StringIO()
         self._setup_casava()
@@ -368,6 +388,41 @@ class TestFastqStatisticsBcl2fastq2(unittest.TestCase):
     def setUp(self):
         # Create a temp working dir
         self.dirn = tempfile.mkdtemp(suffix='TestFastqStats')
+        # Expected data
+        self.expected = [
+            ['AB','AB1','AB1_S1_L001_R1_001.fastq.gz',3,{'L1':3}],
+            ['AB','AB1','AB1_S1_L001_R2_001.fastq.gz',3,{'L1':3}],
+            ['AB','AB1','AB1_S1_L002_R1_001.fastq.gz',2,{'L2':2}],
+            ['AB','AB1','AB1_S1_L002_R2_001.fastq.gz',2,{'L2':2}],
+            ['AB','AB2','AB2_S2_L001_R1_001.fastq.gz',5,{'L1':5}],
+            ['AB','AB2','AB2_S2_L001_R2_001.fastq.gz',5,{'L1':5}],
+            ['AB','AB2','AB2_S2_L002_R1_001.fastq.gz',3,{'L2':3}],
+            ['AB','AB2','AB2_S2_L002_R2_001.fastq.gz',3,{'L2':3}],
+            ['CDE','CDE3','CDE3_S3_L003_R1_001.fastq.gz',7,{'L3':7}],
+            ['CDE','CDE3','CDE3_S3_L003_R2_001.fastq.gz',7,{'L3':7}],
+            ['CDE','CDE3','CDE3_S3_L004_R1_001.fastq.gz',2,{'L4':2}],
+            ['CDE','CDE3','CDE3_S3_L004_R2_001.fastq.gz',2,{'L4':2}],
+            ['CDE','CDE4','CDE4_S4_L003_R1_001.fastq.gz',8,{'L3':8}],
+            ['CDE','CDE4','CDE4_S4_L003_R2_001.fastq.gz',8,{'L3':8}],
+            ['CDE','CDE4','CDE4_S4_L004_R1_001.fastq.gz',6,{'L4':6}],
+            ['CDE','CDE4','CDE4_S4_L004_R2_001.fastq.gz',6,{'L4':6}],
+            ['Undetermined_indices','lane1',
+             'Undetermined_S0_L001_R1_001.fastq.gz',2,{'L1':2}],
+            ['Undetermined_indices','lane1',
+             'Undetermined_S0_L001_R2_001.fastq.gz',2,{'L1':2}],
+            ['Undetermined_indices','lane2',
+             'Undetermined_S0_L002_R1_001.fastq.gz',1,{'L2':1}],
+            ['Undetermined_indices','lane2',
+             'Undetermined_S0_L002_R2_001.fastq.gz',1,{'L2':1}],
+            ['Undetermined_indices','lane3',
+             'Undetermined_S0_L003_R1_001.fastq.gz',4,{'L3':4}],
+            ['Undetermined_indices','lane3',
+             'Undetermined_S0_L003_R2_001.fastq.gz',4,{'L3':4}],
+            ['Undetermined_indices','lane4',
+             'Undetermined_S0_L004_R1_001.fastq.gz',3,{'L4':3}],
+            ['Undetermined_indices','lane4',
+             'Undetermined_S0_L004_R2_001.fastq.gz',3,{'L4':3}],
+        ]
     def tearDown(self):
         # Remove the temporary test directory
         #shutil.rmtree(self.dirn)
@@ -447,41 +502,7 @@ class TestFastqStatisticsBcl2fastq2(unittest.TestCase):
                           'Read_number',
                           'L1','L2','L3','L4'])
         self.assertEqual(len(fqstatistics.raw),24)
-        expected = [
-            ['AB','AB1','AB1_S1_L001_R1_001.fastq.gz',3,{'L1':3}],
-            ['AB','AB1','AB1_S1_L001_R2_001.fastq.gz',3,{'L1':3}],
-            ['AB','AB1','AB1_S1_L002_R1_001.fastq.gz',2,{'L2':2}],
-            ['AB','AB1','AB1_S1_L002_R2_001.fastq.gz',2,{'L2':2}],
-            ['AB','AB2','AB2_S2_L001_R1_001.fastq.gz',5,{'L1':5}],
-            ['AB','AB2','AB2_S2_L001_R2_001.fastq.gz',5,{'L1':5}],
-            ['AB','AB2','AB2_S2_L002_R1_001.fastq.gz',3,{'L2':3}],
-            ['AB','AB2','AB2_S2_L002_R2_001.fastq.gz',3,{'L2':3}],
-            ['CDE','CDE3','CDE3_S3_L003_R1_001.fastq.gz',7,{'L3':7}],
-            ['CDE','CDE3','CDE3_S3_L003_R2_001.fastq.gz',7,{'L3':7}],
-            ['CDE','CDE3','CDE3_S3_L004_R1_001.fastq.gz',2,{'L4':2}],
-            ['CDE','CDE3','CDE3_S3_L004_R2_001.fastq.gz',2,{'L4':2}],
-            ['CDE','CDE4','CDE4_S4_L003_R1_001.fastq.gz',8,{'L3':8}],
-            ['CDE','CDE4','CDE4_S4_L003_R2_001.fastq.gz',8,{'L3':8}],
-            ['CDE','CDE4','CDE4_S4_L004_R1_001.fastq.gz',6,{'L4':6}],
-            ['CDE','CDE4','CDE4_S4_L004_R2_001.fastq.gz',6,{'L4':6}],
-            ['Undetermined_indices','lane1',
-             'Undetermined_S0_L001_R1_001.fastq.gz',2,{'L1':2}],
-            ['Undetermined_indices','lane1',
-             'Undetermined_S0_L001_R2_001.fastq.gz',2,{'L1':2}],
-            ['Undetermined_indices','lane2',
-             'Undetermined_S0_L002_R1_001.fastq.gz',1,{'L2':1}],
-            ['Undetermined_indices','lane2',
-             'Undetermined_S0_L002_R2_001.fastq.gz',1,{'L2':1}],
-            ['Undetermined_indices','lane3',
-             'Undetermined_S0_L003_R1_001.fastq.gz',4,{'L3':4}],
-            ['Undetermined_indices','lane3',
-             'Undetermined_S0_L003_R2_001.fastq.gz',4,{'L3':4}],
-            ['Undetermined_indices','lane4',
-             'Undetermined_S0_L004_R1_001.fastq.gz',3,{'L4':3}],
-            ['Undetermined_indices','lane4',
-             'Undetermined_S0_L004_R2_001.fastq.gz',3,{'L4':3}],
-        ]
-        for line,expctd in zip(fqstatistics.raw,expected):
+        for line,expctd in zip(fqstatistics.raw,self.expected):
             self.assertEqual(line['Project'],expctd[0])
             self.assertEqual(line['Sample'],expctd[1])
             self.assertEqual(line['Fastq'],expctd[2])
@@ -493,6 +514,24 @@ class TestFastqStatisticsBcl2fastq2(unittest.TestCase):
                     self.assertEqual(line[lane],'')
             self.assertEqual(line['Read_number'],
                              IlluminaFastq(expctd[2]).read_number)
+    def test_report_basic_stats(self):
+        fp = cStringIO.StringIO()
+        self._setup_bcl2fastq2()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        fqstatistics.report_basic_stats(fp=fp)
+        stats = fp.getvalue().strip('\n').split('\n')
+        self.assertEqual(len(stats),25)
+        self.assertEqual(stats[0],"#Project	Sample	Fastq	Size	Nreads	Paired_end")
+        for line,expctd in zip(stats[1:],self.expected):
+            line = line.split('\t')
+            self.assertEqual(line[0],expctd[0]) # Project
+            self.assertEqual(line[1],expctd[1]) # Sample
+            self.assertEqual(line[2],expctd[2]) # Fastq
+            self.assertEqual(int(line[4]),expctd[3]) # Nreads
+            self.assertEqual(line[5],'Y') # Paired_end
     def test_report_per_lane_sample_stats(self):
         fp = cStringIO.StringIO()
         self._setup_bcl2fastq2()
@@ -545,6 +584,23 @@ class TestFastqStatisticsBcl2fastq2NoLaneSplitting(unittest.TestCase):
     def setUp(self):
         # Create a temp working dir
         self.dirn = tempfile.mkdtemp(suffix='TestFastqStats')
+        # Expected data
+        self.expected = [
+            ['AB','AB1','AB1_S1_R1_001.fastq.gz',5,{'L1':3,'L2':2}],
+            ['AB','AB1','AB1_S1_R2_001.fastq.gz',5,{'L1':3,'L2':2}],
+            ['AB','AB2','AB2_S2_R1_001.fastq.gz',8,{'L1':5,'L2':3}],
+            ['AB','AB2','AB2_S2_R2_001.fastq.gz',8,{'L1':5,'L2':3}],
+            ['CDE','CDE3','CDE3_S3_R1_001.fastq.gz',9,{'L3':7,'L4':2}],
+            ['CDE','CDE3','CDE3_S3_R2_001.fastq.gz',9,{'L3':7,'L4':2}],
+            ['CDE','CDE4','CDE4_S4_R1_001.fastq.gz',14,{'L3':8,'L4':6}],
+            ['CDE','CDE4','CDE4_S4_R2_001.fastq.gz',14,{'L3':8,'L4':6}],
+            ['Undetermined_indices','undetermined',
+             'Undetermined_S0_R1_001.fastq.gz',10,
+             {'L1':2,'L2':1,'L3':4,'L4':3}],
+            ['Undetermined_indices','undetermined',
+             'Undetermined_S0_R2_001.fastq.gz',10,
+             {'L1':2,'L2':1,'L3':4,'L4':3}],
+        ]
     def tearDown(self):
         # Remove the temporary test directory
         #shutil.rmtree(self.dirn)
@@ -625,23 +681,7 @@ class TestFastqStatisticsBcl2fastq2NoLaneSplitting(unittest.TestCase):
                           'L1','L2','L3','L4'])
         # Check "raw" stored data
         self.assertEqual(len(fqstatistics.raw),10)
-        expected = [
-            ['AB','AB1','AB1_S1_R1_001.fastq.gz',5,{'L1':3,'L2':2}],
-            ['AB','AB1','AB1_S1_R2_001.fastq.gz',5,{'L1':3,'L2':2}],
-            ['AB','AB2','AB2_S2_R1_001.fastq.gz',8,{'L1':5,'L2':3}],
-            ['AB','AB2','AB2_S2_R2_001.fastq.gz',8,{'L1':5,'L2':3}],
-            ['CDE','CDE3','CDE3_S3_R1_001.fastq.gz',9,{'L3':7,'L4':2}],
-            ['CDE','CDE3','CDE3_S3_R2_001.fastq.gz',9,{'L3':7,'L4':2}],
-            ['CDE','CDE4','CDE4_S4_R1_001.fastq.gz',14,{'L3':8,'L4':6}],
-            ['CDE','CDE4','CDE4_S4_R2_001.fastq.gz',14,{'L3':8,'L4':6}],
-            ['Undetermined_indices','undetermined',
-             'Undetermined_S0_R1_001.fastq.gz',10,
-             {'L1':2,'L2':1,'L3':4,'L4':3}],
-            ['Undetermined_indices','undetermined',
-             'Undetermined_S0_R2_001.fastq.gz',10,
-             {'L1':2,'L2':1,'L3':4,'L4':3}],
-        ]
-        for line,expctd in zip(fqstatistics.raw,expected):
+        for line,expctd in zip(fqstatistics.raw,self.expected):
             self.assertEqual(line['Project'],expctd[0])
             self.assertEqual(line['Sample'],expctd[1])
             self.assertEqual(line['Fastq'],expctd[2])
@@ -653,6 +693,24 @@ class TestFastqStatisticsBcl2fastq2NoLaneSplitting(unittest.TestCase):
                     self.assertEqual(line[lane],'')
             self.assertEqual(line['Read_number'],
                              IlluminaFastq(expctd[2]).read_number)
+    def test_report_basic_stats(self):
+        fp = cStringIO.StringIO()
+        self._setup_bcl2fastq2_no_lane_splitting()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        fqstatistics.report_basic_stats(fp=fp)
+        stats = fp.getvalue().strip('\n').split('\n')
+        self.assertEqual(len(stats),11)
+        self.assertEqual(stats[0],"#Project	Sample	Fastq	Size	Nreads	Paired_end")
+        for line,expctd in zip(stats[1:],self.expected):
+            line = line.split('\t')
+            self.assertEqual(line[0],expctd[0]) # Project
+            self.assertEqual(line[1],expctd[1]) # Sample
+            self.assertEqual(line[2],expctd[2]) # Fastq
+            self.assertEqual(int(line[4]),expctd[3]) # Nreads
+            self.assertEqual(line[5],'Y') # Paired_end
     def test_report_per_lane_sample_stats(self):
         fp = cStringIO.StringIO()
         self._setup_bcl2fastq2_no_lane_splitting()

--- a/bin/fastq_statistics.py
+++ b/bin/fastq_statistics.py
@@ -23,12 +23,6 @@ import os
 import sys
 import optparse
 import logging
-
-# Put .. onto Python search path for modules
-SHARE_DIR = os.path.abspath(
-    os.path.normpath(
-        os.path.join(os.path.dirname(sys.argv[0]),'..')))
-sys.path.append(SHARE_DIR)
 import bcftbx.IlluminaData as IlluminaData
 import bcftbx.TabFile as TabFile
 import bcftbx.utils as bcf_utils

--- a/bin/fastq_statistics.py
+++ b/bin/fastq_statistics.py
@@ -57,19 +57,30 @@ if __name__ == '__main__':
                               description="Generate statistics for FASTQ "
                               "files in ILLUMINA_RUN_DIR (top-level "
                               "directory of a processed Illumina run)")
+    p.add_option("--unaligned",action="store",dest="unaligned_dir",
+                 default="Unaligned",
+                 help="specify an alternative name for the 'Unaligned' "
+                 "directory containing the fastq.gz files")
     p.add_option('-o','--output',action="store",dest="stats_file",
                  default='statistics.info',
                  help="name of output file for per-file statistics (default "
                  "is 'statistics.info')")
     p.add_option('-p','--per-lane-stats',action="store",
-                 dest="per_lane_stats_file",default='per_lane_statistics.info',
+                 dest="per_lane_stats_file",
+                 default='per_lane_statistics.info',
                  help="name of output file for per-lane statistics (default "
                  "is 'per_lane_statistics.info')")
-    p.add_option("--unaligned",action="store",dest="unaligned_dir",
-                 default="Unaligned",
-                 help="specify an alternative name for the 'Unaligned' "
-                 "directory containing the fastq.gz files")
-    p.add_option("--nprocessors",action="store",dest="n",
+    p.add_option('-s','--per-lane-sample-stats',action="store",
+                 dest="per_lane_sample_stats_file",
+                 default='per_lane_sample_stats.info',
+                 help="name of output file for per-lane statistics (default "
+                 "is 'per_lane_sample_stats.info')")
+    p.add_option('-f','--full-stats',action="store",
+                 dest="full_stats_file",
+                 default='statistics_full.info',
+                 help="name of output file for full statistics (default "
+                 "is 'statistics_full.info')")
+    p.add_option('-n',"--nprocessors",action="store",dest="n",
                  default=1,type='int',
                  help="spread work across N processors/cores (default is 1)")
     p.add_option("--force",action="store_true",dest="force",default=False,
@@ -105,9 +116,12 @@ if __name__ == '__main__':
     stats = FastqStatistics(illumina_data,
                             n_processors=options.n)
     stats.report_basic_stats(options.stats_file)
-    stats.report_per_lane_sample_stats("per_lane_sample_stats.info")
-    stats.report_per_lane_summary_stats(options.per_lane_stats_file)
-    stats.report_full_stats("statistics_full.info")
     print "Basic statistics written to %s" % options.stats_file
+    stats.report_per_lane_sample_stats(options.per_lane_sample_stats_file)
+    print "Per-lane sample statistics written to %s" % \
+        options.per_lane_sample_stats_file
+    stats.report_per_lane_summary_stats(options.per_lane_stats_file)
     print "Per-lane summary statistics written to %s" % \
         options.per_lane_stats_file
+    stats.report_full_stats(options.full_stats_file)
+    print "Full statistics written to %s" % options.full_stats_file

--- a/bin/fastq_statistics.py
+++ b/bin/fastq_statistics.py
@@ -1,17 +1,27 @@
 #!/usr/bin/env python
 #
-#     fastq_stats.py: get statistics for fastq files from Illumina run
+#     fastq_statisticss.py: get stats for fastq files from Illumina run
 #     Copyright (C) University of Manchester 2013-17 Peter Briggs
 #
 ########################################################################
 #
-# fastq_stats.py
+# fastq_statistics.py
 #
 #########################################################################
 
-"""fastq_stats.py
+"""
+fastq_statistics.py
 
-Generate statistics for fastq files for an Illumina sequencing run.
+Collect and report various statistics for FASTQ files produced from
+an Illumina sequencing run:
+
+- basic statistics: file size and number of reads for each FASTQ
+- full statistics: file size, number of reads and reads per lane
+  for each FASTQ
+- per-lane summary statistics: total numbers of assigned and
+  unassigned reads for each lane across all FASTQs
+- per-lane, per-sample statistics: number of reads assigned to each
+  sample in each lane
 
 """
 
@@ -26,207 +36,11 @@ import logging
 import bcftbx.IlluminaData as IlluminaData
 import bcftbx.TabFile as TabFile
 import bcftbx.utils as bcf_utils
-from multiprocessing import Pool
+from auto_process_ngs.stats import FastqStatistics
 from auto_process_ngs.stats import FastqStats
-from auto_process_ngs.stats import collect_fastq_data
 
 from auto_process_ngs import get_version
 __version__ = get_version()
-
-#######################################################################
-# Functions
-#######################################################################
-
-def get_fastqs(illumina_data):
-    """Get a list of fastq files from an Illumina run
-
-    Arguments:
-      illumina_data: populated IlluminaData object describing the
-        run.
-
-    Returns:
-      List of populated FastqStats objects.
-
-    """
-    fastqs = []
-    for project in illumina_data.projects:
-        for sample in project.samples:
-            for fastq in sample.fastq:
-                fastqs.append(FastqStats(os.path.join(sample.dirn,fastq),
-                                         project.name,
-                                         sample.name))
-    # Gather same information for undetermined reads (if present)
-    if illumina_data.undetermined is not None:
-        for lane in illumina_data.undetermined.samples:
-            for fastq in lane.fastq:
-                fastqs.append(FastqStats(os.path.join(lane.dirn,fastq),
-                                         illumina_data.undetermined.name,
-                                         lane.name))
-    return fastqs
-
-def fastq_statistics(illumina_data,n_processors=1):
-    """Generate statistics for fastq outputs from an Illumina run
-
-    Given a directory with fastq(.gz) files arranged in the same
-    structure as the output from bcl2fastq or bcl2fastq2,
-    generate statistics for each file.
-
-    Arguments:
-      illumina_data: populated IlluminaData object describing the
-        run.
-      n_processors: number of processors to use (if 1>1 then uses
-        the multiprocessing library to run the statistics gathering
-        using multiple cores).
-
-    Returns:
-      Populated TabFile object containing the statistics.
-
-    """
-    fastqs = get_fastqs(illumina_data)
-    if n_processors > 1:
-        # Multiple cores
-        pool = Pool(n_processors)
-        results = pool.map(collect_fastq_data,fastqs)
-        pool.close()
-        pool.join()
-    else:
-        # Single core
-        results = map(collect_fastq_data,fastqs)
-    # Per-file stats
-    stats = TabFile.TabFile(column_names=('Project',
-                                          'Sample',
-                                          'Fastq',
-                                          'Size',
-                                          'Nreads',
-                                          'Paired_end'))
-    for fastq in results:
-        stats.append(data=(fastq.project,
-                           fastq.sample,
-                           fastq.name,
-                           bcf_utils.format_file_size(fastq.fsize),
-                           fastq.nreads,
-                           'Y' if illumina_data.paired_end else 'N'))
-    # Per-lane stats
-    stats_per_lane = TabFile.TabFile(column_names=('Project',
-                                                   'Sample',
-                                                   'Fastq',))
-    results_r1 = filter(lambda f: f.read_number == 1,results)
-    # Determine which lanes are present and append
-    # columns for each
-    lanes = set()
-    for fastq in results_r1:
-        print "%s: %s" % (fastq.name,fastq.lanes)
-        for lane in fastq.lanes:
-            lanes.add(lane)
-    lanes = sorted(list(lanes))
-    print "%s" % lanes
-    for lane in lanes:
-        stats_per_lane.appendColumn("L%s" % lane)
-    # Write the number of reads in each lane
-    for fastq in results_r1:
-        data = [fastq.project,
-                fastq.sample,
-                fastq.name,]
-        for lane in lanes:
-            try:
-                data.append(fastq.reads_by_lane[lane])
-            except:
-                data.append('')
-        stats_per_lane.append(data=data)
-    # Return the data
-    return (stats,stats_per_lane)
-
-def sequencer_stats(stats_per_lane):
-    """Generate per-lane statistics for an Illumina run
-
-    Given a populated TabFile object containing data about each
-    fastq(.gz) file from an Illumina run (as generated by the
-    'fastq_statistics' function), calculate numbers of assigned,
-    unassigned and total reads for each lane.
-
-    Arguments:
-      stats: populated TabFile object with per file data from
-        fastq_statistics.
-
-    Returns:
-      Populated TabFile object containing the per-lane statistics.
-
-    """
-    # Set up TabFile to hold the data collected
-    sequencer_stats = TabFile.TabFile(column_names=('Lane',
-                                                    'Total reads',
-                                                    'Assigned reads',
-                                                    'Unassigned reads'))
-    # Figure out lanes
-    lanes = stats_per_lane.header()[3:]
-    assigned = {}
-    unassigned = {}
-    # Count assigned and unassigned (= undetermined) reads
-    for line in stats_per_lane:
-        if line['Project'] != 'Undetermined_indices':
-            for lane in lanes:
-                if line[lane]:
-                    try:
-                        assigned[lane] += line[lane]
-                    except KeyError:
-                        assigned[lane] = line[lane]
-        else:
-            for lane in lanes:
-                if line[lane]:
-                    try:
-                        unassigned[lane] += line[lane]
-                    except KeyError:
-                        unassigned[lane] = line[lane]
-    # Write out data for each lane
-    for lane in lanes:
-        lane_number = int(lane[1:])
-        assigned_reads = assigned[lane]
-        unassigned_reads = unassigned[lane]
-        total_reads = assigned_reads + unassigned_reads
-        sequencer_stats.append(data=("Lane %d" % lane_number,
-                                     total_reads,
-                                     assigned_reads,
-                                     unassigned_reads))
-    # Return the data
-    return sequencer_stats
-
-def report_sample_stats(stats_per_lane,out_file):
-    """
-    Report of reads per sample in each lane for an Illumina run
-
-    Given a populated TabFile object containing per-lane data
-    about each fastq(.gz) file from an Illumina run (as generated
-    by the 'fastq_statistics' function), report the number of reads
-    for each sample in each lane plus the total reads for each
-    lane.
-
-    Arguments:
-      stats_per_lane: populated TabFile object with per-lane data
-        for each FASTQ from fastq_statistics.
-    """
-    # Determine output stream
-    if out_file is None:
-        fp = sys.stdout
-    else:
-        fp = open(out_file,'w')
-    # Report
-    lanes = stats_per_lane.header()[3:]
-    for lane in lanes:
-        lane_number = int(lane[1:])
-        samples = filter(lambda x: bool(x[lane]),stats_per_lane)
-        total_reads = sum([s[lane] for s in samples])
-        fp.write("\nLane %d\n" % lane_number)
-        fp.write("Total reads = %d\n" % total_reads)
-        for sample in samples:
-            sample_name = "%s/%s" % (sample['Project'],
-                                     sample['Sample'])
-            nreads = float(sample[lane])
-            fp.write("- %s\t%d\t%.1f%%\n" % (sample_name,
-                                             nreads,
-                                             nreads/total_reads*100.0))
-    # Close file
-    if out_file is not None:
-        fp.close()
 
 #######################################################################
 # Main program
@@ -240,21 +54,23 @@ if __name__ == '__main__':
     # Process command line
     p = optparse.OptionParser(usage="%prog [OPTIONS] ILLUMINA_RUN_DIR",
                               version="%prog "+__version__,
-                              description="Generate statistics for fastq files in "
-                              "ILLUMINA_RUN_DIR (top-level directory of the Illumina "
-                              "run to be processed, plus assigned and unassigned reads "
-                              "per lane)")
-    p.add_option('-o','--output',action="store",dest="stats_file",default='statistics.info',
+                              description="Generate statistics for FASTQ "
+                              "files in ILLUMINA_RUN_DIR (top-level "
+                              "directory of a processed Illumina run)")
+    p.add_option('-o','--output',action="store",dest="stats_file",
+                 default='statistics.info',
                  help="name of output file for per-file statistics (default "
                  "is 'statistics.info')")
     p.add_option('-p','--per-lane-stats',action="store",
                  dest="per_lane_stats_file",default='per_lane_statistics.info',
                  help="name of output file for per-lane statistics (default "
                  "is 'per_lane_statistics.info')")
-    p.add_option("--unaligned",action="store",dest="unaligned_dir",default="Unaligned",
-                 help="specify an alternative name for the 'Unaligned' directory "
-                 "containing the fastq.gz files")
-    p.add_option("--nprocessors",action="store",dest="n",default=1,type='int',
+    p.add_option("--unaligned",action="store",dest="unaligned_dir",
+                 default="Unaligned",
+                 help="specify an alternative name for the 'Unaligned' "
+                 "directory containing the fastq.gz files")
+    p.add_option("--nprocessors",action="store",dest="n",
+                 default=1,type='int',
                  help="spread work across N processors/cores (default is 1)")
     p.add_option("--force",action="store_true",dest="force",default=False,
                  help="force regeneration of statistics from fastq files")
@@ -265,7 +81,6 @@ if __name__ == '__main__':
         p.error("expects a single argument (input directory)")
 
     # Report settings etc
-    print "%s version %s" % (os.path.basename(sys.argv[0]),__version__)
     print "Source dir    : %s" % args[0]
     print "Unaligned dir : %s" % options.unaligned_dir
     print "Stats file    : %s" % options.stats_file
@@ -287,17 +102,12 @@ if __name__ == '__main__':
         logging.error("Failed to get data from %s: %s" % (args[0],ex))
         sys.exit(1)
     # Generate statistics for fastq files
-    stats,per_lane = fastq_statistics(illumina_data,
-                                      n_processors=options.n)
-    stats.write(options.stats_file,include_header=True)
-    print "Statistics written to %s" % options.stats_file
-    per_lane.write(options.per_lane_stats_file,include_header=True)
-    print "Per-lane sequencer stats written to %s" % \
+    stats = FastqStatistics(illumina_data,
+                            n_processors=options.n)
+    stats.report_basic_stats(options.stats_file)
+    stats.report_per_lane_sample_stats("per_lane_sample_stats.info")
+    stats.report_per_lane_summary_stats(options.per_lane_stats_file)
+    stats.report_full_stats("statistics_full.info")
+    print "Basic statistics written to %s" % options.stats_file
+    print "Per-lane summary statistics written to %s" % \
         options.per_lane_stats_file
-    seqstats = sequencer_stats(per_lane)
-    seq_stats_file="per_lane_statistics.summary"
-    seqstats.write(seq_stats_file,include_header=True)
-    print "Summary of per-lane sequencer stats written to %s" % \
-        seq_stats_file
-    report_sample_stats(per_lane,"sample_stats.info")
-    sys.exit()

--- a/bin/fastq_statistics.py
+++ b/bin/fastq_statistics.py
@@ -16,12 +16,6 @@ Generate statistics for fastq files for an Illumina sequencing run.
 """
 
 #######################################################################
-# Module metadata
-#######################################################################
-
-__version__ = "0.1.0"
-
-#######################################################################
 # Import modules that this module depends on
 #######################################################################
 
@@ -43,6 +37,9 @@ import bcftbx.FASTQFile as FASTQFile
 import bcftbx.utils as bcf_utils
 import auto_process_ngs.stats as auto_process_stats
 from multiprocessing import Pool
+
+from auto_process_ngs import get_version
+__version__ = get_version()
 
 #######################################################################
 # Functions


### PR DESCRIPTION
WIP PR to update fastq_statistics.py to generate per-lane statistics for FASTQ files produced by all variations of `bcl2fastq` and `--no-lane-splitting`.