### PR TITLE
Add 'exit_code' property to SchedulerGroup class

### DIFF
--- a/auto_process_ngs/simple_scheduler.py
+++ b/auto_process_ngs/simple_scheduler.py
@@ -587,6 +587,28 @@ class SchedulerGroup:
                 return False
         return True
 
+    @property
+    def exit_code(self):
+        """Return exit code for the group
+
+        If all jobs have completed with status zero
+        then returns zero, otherwise returns a count
+        of jobs which have non-zero status.
+
+        If the group hasn't completed then returns
+        None.
+        """
+        exit_code = 0
+        if self.completed:
+            for job in self.__jobs:
+                if not job.completed:
+                    return None
+                if job.exit_code != 0:
+                    exit_code += 1
+            return exit_code
+        else:
+            return None
+
     def add(self,args,runner=None,name=None,wd=None,log_dir=None,wait_for=[]):
         """Add a request to run a job
         


### PR DESCRIPTION
PR to add an `exit_code` property to the `SchedulerGroup` class, to mimic that already implemented in the `SchedulerJob` class.

For a group the exit code will be:

 - `None` if the group has yet to complete, or
 - zero if all jobs in the group completed with zero exit status, or
 - non-zero integer which is a count of the jobs which have non-zero exit status.