### PR TITLE
WIP update scheduler to handle jobs detected in an error state

### DIFF
--- a/auto_process_ngs/simple_scheduler.py
+++ b/auto_process_ngs/simple_scheduler.py
@@ -418,10 +418,21 @@ class SimpleScheduler(threading.Thread):
             updated_running_list = []
             for job in self.__running:
                 if job.is_running:
-                    logging.debug("Job #%s (id %s) still running \"%s\"" % (job.job_number,
-                                                                            job.job_id,
-                                                                            job))
-                    updated_running_list.append(job)
+                    if not job.in_error_state:
+                        logging.debug("Job #%s (id %s) still running \"%s\""
+                                      % (job.job_number,
+                                         job.job_id,
+                                         job))
+                        updated_running_list.append(job)
+                    else:
+                        logging.debug("Job #%s (id %s) in error state \"%s\""
+                                      % (job.job_number,
+                                         job.job_id,
+                                         job))
+                        logging.warning("Job #%s (id %s) in error state, "
+                                        "terminating" % (job.job_number,
+                                                         job.job_id))
+                        job.terminate()
                 else:
                     self.__reporter.job_end(job)
                     logging.debug("Job #%s (id %s) completed \"%s\"" % (job.job_number,
@@ -726,6 +737,15 @@ class SchedulerJob(Job):
         """
         # Check if job is running
         return self.isRunning()
+
+    @property
+    def in_error_state(self):
+        """Test if a job is in an error state
+
+        Returns True if the job appears to be in an error state,
+        and False if not.
+        """
+        return self.errorState()
 
     @property
     def completed(self):


### PR DESCRIPTION
WIP PR updating the scheduler to deal with jobs that are detected as being in an error state after submission (typically if they've gone to an `Eqw` state on SGE).

It's unclear what the best strategy for dealing with this is overall - if the error state is due to some temporary glitch with job submission then one possibility is to kill and try to resubmit them (perhaps allowing a maximum number of retries before giving up).