### PR TITLE
Consolidate local and remote file ops in 'publish_qc' and 'archive'

### DIFF
--- a/auto_process_ngs/applications.py
+++ b/auto_process_ngs/applications.py
@@ -177,7 +177,7 @@ class Command:
         """
         # Deal with output destinations
         if log is None:
-            fpout = sys.stdout
+            fpout = None
         else:
             logging.debug("Writing stdout to %s" % log)
             fpout = open(log,'w')
@@ -185,7 +185,7 @@ class Command:
             if log is not None:
                 fperr = subprocess.STDOUT
             else:
-                fperr = sys.stderr
+                fperr = None
         else:
             fperr = open(err,'w')
             logging.debug("Writing stderr to %s" % err)

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -29,6 +29,7 @@ import bcftbx.htmlpagewriter as htmlpagewriter
 from bcftbx.JobRunner import fetch_runner
 import config
 import applications
+import fileops
 import utils
 import simple_scheduler
 import bcl2fastq_utils
@@ -737,7 +738,7 @@ class AutoProcess:
                                                     target.path)
                 print "Trying '%s'" % sample_sheet
                 tmp_sample_sheet = os.path.join(self.tmp_dir,
-                                                os.path.basename(target))
+                                                os.path.basename(target.path))
                 rsync = applications.general.rsync(sample_sheet,
                                                    self.tmp_dir)
                 print "%s" % rsync
@@ -2577,7 +2578,7 @@ class AutoProcess:
             project_pattern = projects
         # Get location to publish qc reports to
         if location is None:
-            location = fileops.Location(self.settings.qc_web_server.dirn))
+            location = fileops.Location(self.settings.qc_web_server.dirn)
         else:
             location = fileops.Location(location)
         # Check the settings
@@ -2741,7 +2742,7 @@ class AutoProcess:
             fileops.mkdir(barcodes_dirn)
             for filen in barcodes_files:
                 fileops.copy(os.path.join(barcode_analysis_dir,filen),
-                             barcodes_dirn))
+                             barcodes_dirn)
         if projects:
             # Table of projects
             index_page.add("<h2>QC Reports</h2>")

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -2590,9 +2590,9 @@ class AutoProcess:
         else:
             print "Copying QC to local directory"
             print "dirn:\t%s" % location.path
-        if dirn is None:
+        if location.path is None:
             raise Exception, "No target directory specified"
-        dirn = os.path.join(location.path,
+        dirn = os.path.join(str(location),
                             os.path.basename(self.analysis_dir))
         # Get general data
         analysis_dir = utils.AnalysisDir(self.analysis_dir)

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -726,13 +726,15 @@ class AutoProcess:
                 targets = (sample_sheet,)
             # Try each possibility until one sticks
             for target in targets:
-                user,host,location = utils.split_user_host_dir(target)
-                if host is not None:
-                    sample_sheet = target
-                elif os.path.isabs(target):
-                    sample_sheet = target
+                target = fileops.Location(target)
+                if target.is_remote:
+                    sample_sheet = target.location
                 else:
-                    sample_sheet = os.path.join(data_dir,target)
+                    if os.path.isabs(target.path):
+                        sample_sheet = target.path
+                    else:
+                        sample_sheet = os.path.join(data_dir,
+                                                    target.path)
                 print "Trying '%s'" % sample_sheet
                 tmp_sample_sheet = os.path.join(self.tmp_dir,
                                                 os.path.basename(target))

--- a/auto_process_ngs/fileops.py
+++ b/auto_process_ngs/fileops.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+#
+#     fileops: single interface for file ops on local and remote systems
+#     Copyright (C) University of Manchester 2017 Peter Briggs
+#
+########################################################################
+#
+# fileops.py
+#
+#########################################################################
+
+"""
+fileops
+
+Utility functions providing a single interface for performing
+various file system operations (e.g. make a directory, copy
+files etc) trasparently on either a local or a remote system.
+
+Classes:
+
+- Location: extracts information from a location specifier
+
+Functions:
+
+- mkdir: create a directory
+- copy: copy a file
+- set_group: set the group on a file or directory
+- unzip: unpack a ZIP archive
+"""
+
+########################################################################
+# Imports
+#########################################################################
+
+import os
+import shutil
+import logging
+import bcftbx.utils as bcftbx_utils
+import applications
+from utils import split_user_host_dir
+
+# Module specific logger
+logger = logging.getLogger(__name__)
+
+########################################################################
+# Classes
+#########################################################################
+
+class Location(object):
+    """
+    Class for examining a file-system location specifier
+
+    A location specifier can be a local or a remote file or
+    directory. The general form is:
+
+    ``[[user@]server:]path``
+
+    For a local location, only the 'path' component needs to
+    be supplied.
+
+    For a remote location, 'server' and 'path' must be
+    supplied, while 'user' is optional.
+
+    The following properties are available:
+
+    - user: the user name (or None if not specified)
+    - server: the server name (or None if not specified)
+    - path: the path component
+    - is_remote: True if the location is remote, False if it
+      is local
+    """
+    def __init__(self,location):
+        """
+        Create a new Location instance
+
+        Arguments:
+          location (str): location specifer of the form
+            '[[user@]server:]path'
+        """
+        self._location = location
+        self._user,self._server,self._path = split_user_host_dir(
+            self._location)
+    @property
+    def user(self):
+        """
+        Return 'user' part of '[[user@]server:]path'
+        """
+        return self._user
+    @property
+    def server(self):
+        """
+        Return 'server' part of '[[user@]server:]path'
+        """
+        return self._server
+    @property
+    def path(self):
+        """
+        Return 'path' part of '[[user@]server:]path'
+        """
+        return self._path
+    @property
+    def is_remote(self):
+        """
+        Check if location is on a remote server
+        """
+        return (self._server is not None)
+    def __repr__(self):
+        return self._location
+
+########################################################################
+# Functions
+#########################################################################
+
+def mkdir(newdir):
+    """
+    Create a directory
+
+    The new directory should be identified using a
+    specifier of the form '[[USER@]HOST:]NEWDIR'.
+
+    Arguments:
+      newdir (str): location of the new directory (can
+        be on local or remote system)
+    """
+    newdir = Location(newdir)
+    if not newdir.is_remote:
+        # Local directory
+        bcftbx_utils.mkdir(newdir.path)
+    else:
+        # Remote directory
+        try:
+            mkdir_cmd = applications.general.ssh_command(
+                newdir.user,
+                newdir.server,
+                ('mkdir',newdir.path))
+            print "Running %s" % mkdir_cmd
+            mkdir_cmd.run_subprocess()
+        except Exception as ex:
+            raise Exception(
+                "Exception making remote directory %s: %s" %
+                (newdir,ex))
+
+def copy(src,dest):
+    """
+    Copy a file
+
+    Copies a local file to a local or remote location.
+
+    Arguments:
+      src (str): local file to copy
+      dest (str): destination (file or directory)
+        on a local or remote system, identified by
+        a specifier of the form '[[USER@]HOST:]DEST'
+    """
+    dest = Location(dest)
+    if not dest.is_remote:
+        # Local copy
+        shutil.copy(src,dest.path)
+    else:
+        try:
+            # Remote copy
+            copy_cmd = applications.general.scp(
+                dest.user,
+                dest.server,
+                src,dest.path)
+            print "Running %s" % copy_cmd
+            copy_cmd.run_subprocess()
+        except Exception as ex:
+            raise Exception("Exception copying %s to remote "
+                            "destination %s: %s" %
+                            (src,dest,ex))
+
+def set_group(group,path):
+    """
+    Set the group for a file or directory
+
+    'path' can be a file or directory on a local
+    or remote system; if it is a directory then it
+    will operate recursively i.e. all subdirectories
+    and files will also have their group changed.
+
+    'group' is the name of the group to change
+    ownership to (must exist on the target system).
+
+    Arguments:
+      group (str): name of the new group
+      path (str): path to the file or directory
+        to change the group of, identified by a
+        specifier of the form '[[USER@]HOST:]PATH'
+    """
+    path = Location(path)
+    if not path.is_remote:
+        # Set the group for local files
+        gid = bcftbx_utils.get_gid_from_group(group)
+        if gid is None:
+            raise Exception("Failed to get gid for group '%s'" % group)
+        for f in bcftbx_utils.walk(path.path,include_dirs=True):
+            logger.debug("Updating group for %s" % f)
+            os.lchown(f,-1,gid)
+    else:
+        try:
+            # Set group for remote files
+            chmod_cmd = applications.general.ssh_command(
+                path.user,
+                path.server,
+                ('chgrp','-R',group,path.path))
+            print "Running %s" % chmod_cmd
+            chmod_cmd.run_subprocess()
+        except Exception as ex:
+            raise Exception(
+                "Exception changing group to '%s' on remote "
+                "destination %s: %s" %
+                (group,path,ex))
+
+def unzip(zip_file,dest):
+    """
+    Unpack ZIP archive file on local or remote system
+
+    Arguments:
+      zip_file (str): ZIP archive file identified
+        using a specifier of the form
+        '[[USER@]HOST:]ZIP_FILE'
+      dest (str): path to extract the archive
+        contents to (on the same system as the ZIP
+        archive)
+    """
+    zip_file = Location(zip_file)
+    unzip_cmd = applications.Command('unzip',
+                                     '-q',
+                                     '-o',
+                                     '-d',dest,
+                                     zip_file.path)
+    if zip_file.is_remote:
+        # Wrap in ssh command for remote zip file
+        unzip_cmd = applications.general.ssh_command(
+            zip_file.user,
+            zip_file.server,
+            unzip_cmd.command_line)
+    try:
+        print "Running %s" % unzip_cmd
+        unzip_cmd.run_subprocess()
+    except Exception as ex:
+        raise Exception("Failed to unzip %s: %s" %
+                        (zip_file,ex))

--- a/auto_process_ngs/test/test_fileops.py
+++ b/auto_process_ngs/test/test_fileops.py
@@ -1,0 +1,176 @@
+#######################################################################
+# Tests for fileops.py module
+#######################################################################
+
+import unittest
+import os
+import tempfile
+import shutil
+import pwd
+import grp
+from auto_process_ngs.utils import ZipArchive
+from auto_process_ngs.fileops import *
+
+class TestLocation(unittest.TestCase):
+    """Tests for the Location class
+    """
+    def test_location_user_server_path(self):
+        """fileops.Location: handle user@host.name:/path/to/somewhere
+        """
+        location = Location('user@host.name:/path/to/somewhere')
+        self.assertEqual(location.user,'user')
+        self.assertEqual(location.server,'host.name')
+        self.assertEqual(location.path,'/path/to/somewhere')
+        self.assertTrue(location.is_remote)
+        self.assertEqual(str(location),'user@host.name:/path/to/somewhere')
+    def test_location_server_path(self):
+        """fileops.Location: handle host.name:/path/to/somewhere
+        """
+        location = Location('host.name:/path/to/somewhere')
+        self.assertEqual(location.user,None)
+        self.assertEqual(location.server,'host.name')
+        self.assertEqual(location.path,'/path/to/somewhere')
+        self.assertTrue(location.is_remote)
+        self.assertEqual(str(location),'host.name:/path/to/somewhere')
+    def test_location_path(self):
+        """fileops.Location: handle /path/to/somewhere
+        """
+        location = Location('/path/to/somewhere')
+        self.assertEqual(location.user,None)
+        self.assertEqual(location.server,None)
+        self.assertEqual(location.path,'/path/to/somewhere')
+        self.assertFalse(location.is_remote)
+        self.assertEqual(str(location),'/path/to/somewhere')
+
+class TestMkdirFunction(unittest.TestCase):
+    """Tests for the 'mkdir' function
+    """
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+    def test_local_mkdir(self):
+        """fileops.mkdir: make a local directory
+        """
+        new_dir = os.path.join(self.test_dir,'new_dir')
+        self.assertFalse(os.path.exists(new_dir))
+        mkdir(new_dir)
+        self.assertTrue(os.path.isdir(new_dir))
+
+class TestCopyFunction(unittest.TestCase):
+    """Tests for the 'copy' function
+    """
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+    def test_local_copy(self):
+        """fileops.copy: copy a local file
+        """
+        src_file = os.path.join(self.test_dir,'test.txt')
+        with open(src_file,'w') as fp:
+            fp.write("This is a test file")
+        self.assertTrue(os.path.isfile(src_file))
+        tgt_file = os.path.join(self.test_dir,'test2.txt')
+        self.assertFalse(os.path.exists(tgt_file))
+        copy(src_file,tgt_file)
+        self.assertTrue(os.path.isfile(tgt_file))
+        self.assertEqual(open(tgt_file).read(),
+                         "This is a test file")
+
+class TestCopyFunction(unittest.TestCase):
+    """Tests for the 'copy' function
+    """
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+    def test_local_copy(self):
+        """fileops.copy: copy a local file
+        """
+        src_file = os.path.join(self.test_dir,'test.txt')
+        with open(src_file,'w') as fp:
+            fp.write("This is a test file")
+        self.assertTrue(os.path.isfile(src_file))
+        tgt_file = os.path.join(self.test_dir,'test2.txt')
+        self.assertFalse(os.path.exists(tgt_file))
+        copy(src_file,tgt_file)
+        self.assertTrue(os.path.isfile(tgt_file))
+        self.assertEqual(open(tgt_file).read(),
+                         "This is a test file")
+
+class TestSetGroupFunction(unittest.TestCase):
+    """Tests for the 'set_group' function
+    """
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+    def test_local_set_group(self):
+        """fileops.set_group: set group ownership on a local file
+        """
+        # Get a list of groups
+        current_user = pwd.getpwuid(os.getuid()).pw_name
+        groups = [g.gr_gid for g in grp.getgrall()
+                  if current_user in g.gr_mem]
+        print "Available groups: %s" % groups
+        if len(groups) < 2:
+            raise unittest.SkipTest("user '%s' must be in at least "
+                                    "two groups" % current_user)
+        # Make test file and get group
+        test_file = os.path.join(self.test_dir,'test.txt')
+        with open(test_file,'w') as fp:
+            fp.write("This is a test file")
+        self.assertTrue(os.path.isfile(test_file))
+        gid = os.stat(test_file).st_gid
+        print "File: %s GID: %s" % (test_file,gid)
+        # Get a second group
+        new_gid = None
+        for group in groups:
+            if group != gid:
+                new_gid = group
+                break
+        print "Selected new GID: %s" % new_gid
+        self.assertNotEqual(os.stat(test_file).st_gid,new_gid)
+        # Change group by name
+        new_group = grp.getgrgid(new_gid).gr_name
+        print "New group name: %s" % new_group
+        set_group(new_group,test_file)
+        print "File: %s GID: %s"  % (test_file,
+                                     os.stat(test_file).st_gid)
+        self.assertEqual(os.stat(test_file).st_gid,new_gid)
+
+class TestUnzip(unittest.TestCase):
+    """Tests for the 'unzip' function
+    """
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+    def test_local_copy(self):
+        """fileops.unzip: unzip a local file
+        """
+        test_file = os.path.join(self.test_dir,'test.txt')
+        with open(test_file,'w') as fp:
+            fp.write("This is a test file")
+        zip_file = os.path.join(self.test_dir,'test.zip')
+        z = ZipArchive(zip_file,
+                       contents=(test_file,),
+                       relpath=self.test_dir,
+                       prefix='files')
+        z.close()
+        self.assertTrue(os.path.isfile(zip_file))
+        out_dir = os.path.join(self.test_dir,'files')
+        self.assertFalse(os.path.exists(out_dir))
+        unzip(zip_file,self.test_dir)
+        self.assertTrue(os.path.isdir(out_dir))
+        out_file = os.path.join(out_dir,'test.txt')
+        self.assertTrue(os.path.isfile(out_file))
+        self.assertEqual(open(out_file).read(),
+                         "This is a test file")
+


### PR DESCRIPTION
PR that abstracts the code used in the `publish_qc` and `archive` commands for performing operations which might be on local or remote file systems, specifically:

 * making a new directory (`mkdir`)
 * copying a local file (`copy`)
 * modifying the group of a file or directory (`set_group`)
 * unzipping a ZIP archive (`unzip`)

In each case the invocation specifies local resources using a filesystem path (e.g. `/path/to/local/file`) and remote resources using the format `[USER@]HOST:/path/to/remote/file`. The functions determine the appropriate commands to run to perform the requested action.

This PR aims to address issue #76.