### PR TITLE
WIP allow QC output to be written to arbitrary directories

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -2357,7 +2357,8 @@ class AutoProcess:
                     '--title','%s/%s' % (self.run_name,project.name),
                     '--filename',multiqc_out,
                     '--force',
-                    qc_dir)
+                    project_qc_dir)
+                print "Running %s" % multiqc_cmd
                 label = "multiqc.%s" % project.name
                 job = sched.submit(multiqc_cmd,
                                    name=label,

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -2290,14 +2290,14 @@ class AutoProcess:
         for project in projects:
             print "*** Setting up QC for %s ***" % project.name
             # Make the qc directory if it doesn't exist
-            qc_dir = os.path.join(project.dirn,'qc')
+            qc_dir = project.qc_dir
             if not os.path.exists(qc_dir):
-                print "Making 'qc' subdirectory"
+                print "Making QC directory: %s" % qc_dir
                 bcf_utils.mkdir(qc_dir,mode=0775)
             # Set up the logs directory
             log_dir = os.path.join(qc_dir,'logs')
             if not os.path.exists(log_dir):
-                print "Making 'qc/logs' subdirectory"
+                print "Making QC logs directory: %s" % log_dir
                 bcf_utils.mkdir(log_dir,mode=0775)
             # Loop over samples and queue up those where the QC
             # isn't validated
@@ -2327,7 +2327,8 @@ class AutoProcess:
                             qc_cmd.add_args('--ungzip-fastqs')
                         if fastq_screen_subset is None:
                             fastq_screen_subset = 0
-                        qc_cmd.add_args('--subset',fastq_screen_subset)
+                        qc_cmd.add_args('--subset',fastq_screen_subset,
+                                        '--qc_dir',qc_dir)
                         job = group.add(qc_cmd,name=label,wd=project.dirn)
                         print "Job: %s" %  job
                 # Indicate no more jobs to add
@@ -2353,11 +2354,11 @@ class AutoProcess:
         # Verify the outputs and generate QC reports
         failed_projects = []
         for project in projects:
-            if not project.verify_qc():
+            if not project.verify_qc(qc_dir=qc_dir):
                 failed_projects.append(project)
             else:
                 print "QC okay, generating report for %s" % project.name
-                project.qc_report()
+                project.qc_report(qc_dir=qc_dir)
             if run_multiqc:
                 multiqc_report = os.path.join(project.dirn,
                                               "multiqc_report.html")

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -2299,19 +2299,14 @@ class AutoProcess:
         # pipeline with the associated fastq.gz files
         for project in projects:
             print "*** Setting up QC for %s ***" % project.name
+            # Set up qc directory
+            qc_dir = project.setup_qc_dir(qc_dir,fastq_dir=fastq_dir)
+            project.use_qc_dir(qc_dir)
+            print "Using QC directory %s" % project.qc_dir
             # Sort out fastq source
-            if fastq_dir is not None:
-                project.use_fastq_dir(fastq_dir)
-                print "Set fastq_dir to %s" % project.fastq_dir
-            # Sort out qc directory
-            if qc_dir is not None:
-                project.use_qc_dir(qc_dir)
-                print "Set QC directory to %s" % project.qc_dir
-            # Make the qc directory if it doesn't exist
-            qc_dir = project.qc_dir
-            if not os.path.exists(qc_dir):
-                print "Making QC directory: %s" % qc_dir
-                bcf_utils.mkdir(qc_dir,mode=0775)
+            fastq_dir = project.qc_info(qc_dir).fastq_dir
+            project.use_fastq_dir(fastq_dir)
+            print "Set fastq_dir to %s" % project.fastq_dir
             # Set up the logs directory
             log_dir = os.path.join(qc_dir,'logs')
             if not os.path.exists(log_dir):

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -2355,7 +2355,7 @@ class AutoProcess:
                 multiqc_cmd = applications.Command(
                     'multiqc',
                     '--title','%s/%s' % (self.run_name,project.name),
-                    '--filename',multiqc_out,
+                    '--filename','./%s' % multiqc_out,
                     '--force',
                     project_qc_dir)
                 print "Running %s" % multiqc_cmd

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -2300,15 +2300,15 @@ class AutoProcess:
         for project in projects:
             print "*** Setting up QC for %s ***" % project.name
             # Set up qc directory
-            qc_dir = project.setup_qc_dir(qc_dir,fastq_dir=fastq_dir)
-            project.use_qc_dir(qc_dir)
+            project_qc_dir = project.setup_qc_dir(qc_dir,fastq_dir=fastq_dir)
+            project.use_qc_dir(project_qc_dir)
             print "Using QC directory %s" % project.qc_dir
             # Sort out fastq source
-            fastq_dir = project.qc_info(qc_dir).fastq_dir
+            fastq_dir = project.qc_info(project_qc_dir).fastq_dir
             project.use_fastq_dir(fastq_dir)
             print "Set fastq_dir to %s" % project.fastq_dir
             # Set up the logs directory
-            log_dir = os.path.join(qc_dir,'logs')
+            log_dir = os.path.join(project_qc_dir,'logs')
             if not os.path.exists(log_dir):
                 print "Making QC logs directory: %s" % log_dir
                 bcf_utils.mkdir(log_dir,mode=0775)
@@ -2323,7 +2323,7 @@ class AutoProcess:
                 group = None
                 print "Examining files in sample %s" % sample.name
                 for fq in sample.fastq:
-                    if sample.verify_qc(qc_dir,fq):
+                    if sample.verify_qc(project_qc_dir,fq):
                         logging.debug("\t%s: QC verified" % fq)
                     else:
                         print "\t%s: setting up QC run" % os.path.basename(fq)
@@ -2341,7 +2341,7 @@ class AutoProcess:
                         if fastq_screen_subset is None:
                             fastq_screen_subset = 0
                         qc_cmd.add_args('--subset',fastq_screen_subset,
-                                        '--qc_dir',qc_dir)
+                                        '--qc_dir',project_qc_dir)
                         job = group.add(qc_cmd,name=label,wd=project.dirn)
                         print "Job: %s" %  job
                 # Indicate no more jobs to add
@@ -2350,7 +2350,8 @@ class AutoProcess:
                     groups.append(group.name)
             # Add MultiQC job (if requested)
             if run_multiqc:
-                multiqc_out = "multi%s_report.html" % os.path.basename(qc_dir)
+                multiqc_out = "multi%s_report.html" % \
+                              os.path.basename(project_qc_dir)
                 multiqc_cmd = applications.Command(
                     'multiqc',
                     '--title','%s/%s' % (self.run_name,project.name),

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -2382,8 +2382,14 @@ class AutoProcess:
                     out_file = report_html
                 if not os.path.isabs(out_file):
                     out_file = os.path.join(project.dirn,out_file)
+                title = "%s/%s" % (self.run_name,
+                                   project.name)
+                if fastq_dir is not None:
+                    title = "%s (%s)" % (title,fastq_dir)
+                title = "%s: QC report" % title
                 print "QC okay, generating report for %s" % project.name
                 project.qc_report(qc_dir=qc_dir,
+                                  title=title,
                                   report_html=out_file)
             if run_multiqc:
                 multiqc_report = os.path.join(project.dirn,

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -631,11 +631,21 @@ class AnalysisProject:
         else:
             return 'fastq'
 
-    def use_fastq_dir(self,fastq_dir):
+    def use_fastq_dir(self,fastq_dir=None):
         """
         Switch fastq directory and repopulate
+
+        Switch to a specified source fastq dir, or to the
+        'default' if none is supplied
         """
-        if fastq_dir not in self.fastq_dirs:
+        if fastq_dir is None:
+            if 'fastqs' in self.fastq_dirs:
+                fastq_dir = 'fastqs'
+            elif '.' in self.fastq_dirs:
+                fastq_dir = '.'
+            else:
+                fastq_dir = self.fastq_dirs[0]
+        elif fastq_dir not in self.fastq_dirs:
             raise Exception("Fastq dir '%s' not found in "
                             "project '%s' (%s)" %
                             (fastq_dir,self.name,self.dirn))
@@ -675,7 +685,7 @@ class AnalysisProject:
             qc_dir = os.path.join(self.dirn,qc_dir)
         if not os.path.exists(qc_dir):
             print "Creating QC dir: %s" % qc_dir
-            bcf_utils.mkdir(qc_dir)
+            bcf_utils.mkdir(qc_dir,mode=0775)
         else:
             print "QC dir already exists: %s" % qc_dir
         # Set up metadata

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -1142,7 +1142,8 @@ class MetadataDict(bcf_utils.AttributeDictionary):
             self[key] = None
         if self.__filen:
             # Load data from external file
-            load(self,self.__filen)
+            if os.path.exists(self.__filen):
+                self.load(self.__filen)
         # Set up order of keys for output
         if order is None:
             self.__key_order = self.__attributes.keys()

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -783,13 +783,15 @@ class AnalysisProject:
         """
         return QCReporter(self)
 
-    def qc_report(self,report_html=None,qc_dir=None,force=False):
+    def qc_report(self,title=None,report_html=None,qc_dir=None,
+                  force=False):
         """
         Report QC outputs for project
 
         Generates HTML and zipped QC reports.
 
         Arguments:
+          title (str): title text for the report
           report_html (str): path for output HTML report file
           qc_dir (str): path for QC output dir (if None then
             use default QC directory)
@@ -811,10 +813,11 @@ class AnalysisProject:
         # Create HTML report
         logger.debug("Creating HTML QC report for %s" % self.name)
         try:
-            if self.info.run is not None:
-                title = "%s/%s: QC report" % (self.info.run,self.name)
-            else:
-                title = "%s: QC report" % self.name
+            if not title:
+                if self.info.run is not None:
+                    title = "%s/%s: QC report" % (self.info.run,self.name)
+                else:
+                    title = "%s: QC report" % self.name
             if report_html is None:
                 report_html = os.path.join(self.dirn,"qc_report.html")
             self.qc.report(title=title,

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -859,6 +859,17 @@ class AnalysisProject:
         return self._qc_dir
 
     @property
+    def qc_dirs(self):
+        """
+        List QC output directories
+        """
+        qc_dirs = []
+        for d in bcf_utils.list_dirs(self.dirn):
+            if d.startswith("qc"):
+                qc_dirs.append(d)
+        return qc_dirs
+
+    @property
     def qc(self):
         """
         Return QCReporter instance for QC outputs

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -898,6 +898,8 @@ class AnalysisProject:
         """
         if qc_dir is None:
             qc_dir = self._qc_dir
+        elif not os.path.isabs(qc_dir):
+            qc_dir = os.path.join(self.dirn,qc_dir)
         if not (force or self.verify_qc(qc_dir=qc_dir)):
             logger.debug("Failed to generate QC report for %s: QC "
                           "not verified and force not specified"
@@ -1000,6 +1002,10 @@ class AnalysisProject:
           Boolean: True if QC run is completed, False
             if QC couldn't be verified.
         """
+        if qc_dir is None:
+            qc_dir = self._qc_dir
+        elif not os.path.isabs(qc_dir):
+            qc_dir = os.path.join(self.dirn,qc_dir)
         try:
             return self.qc.verify(qc_dir=qc_dir)
         except AttributeError:

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -452,8 +452,20 @@ def add_run_qc_command(cmdparser):
                  help="create decompressed copies of fastq.gz files")
     p.add_option('--max-jobs',action='store',
                  dest='max_jobs',default=max_concurrent_jobs,type='int',
-                 help="explicitly specify maximum number of concurrent QC jobs to run "
-                 "(default %s, change in settings file)" % max_concurrent_jobs)
+                 help="explicitly specify maximum number of concurrent QC "
+                 "jobs to run (default %s, change in settings file)"
+                 % max_concurrent_jobs)
+    p.add_option('--qc_dir',action='store',dest='qc_dir',default='qc',
+                 help="explicitly specify QC output directory (nb if "
+                 "supplied then the same QC_DIR will be used for each "
+                 "project. Non-absolute paths are assumed to be relative to "
+                 "the project directory). Default: 'qc'")
+    p.add_option('--fastq_dir',action='store',dest='fastq_dir',default=None,
+                 help="explicitly specify subdirectory of DIR with "
+                 "Fastq files to run the QC on.")
+    p.add_option('--report',action='store',dest='html_file',default=None,
+                 help="file name for output HTML QC report (default: "
+                 "<QC_DIR>_report.html)")
     add_runner_option(p)
     add_modulefiles_option(p)
     add_debug_option(p)
@@ -898,6 +910,9 @@ if __name__ == "__main__":
                                max_jobs=options.max_jobs,
                                ungzip_fastqs=options.ungzip_fastqs,
                                fastq_screen_subset=options.subset,
+                               fastq_dir=options.fastq_dir,
+                               qc_dir=options.qc_dir,
+                               report_html=options.html_file,
                                runner=options.runner)
             sys.exit(retcode)
         elif cmd == 'samplesheet':

--- a/bin/qcreporter2.py
+++ b/bin/qcreporter2.py
@@ -30,8 +30,18 @@ def main():
                               version="%prog "+get_version(),
                               description="Generate QC report for each directory "
                               "DIR")
+    p.add_option('--qc_dir',action='store',dest='qc_dir',default='qc',
+                 help="explicitly specify QC output directory (nb if "
+                 "supplied then the same QC_DIR will be used for each "
+                 "DIR. Non-absolute paths are assumed to be relative to "
+                 "DIR). Default: 'qc'")
+    p.add_option('-f','--filename',action='store',dest='filename',
+                 default=None,
+                 help="file name for output QC report (default: "
+                 "<DIR>/<QC_DIR>_report.html)")
     p.add_option('--verify',action='store_true',dest='verify',
-                 help="verify the QC products only (don't write the report)")
+                 help="verify the QC products only (don't write the "
+                 "report)")
     opts,args = p.parse_args()
     if len(args) < 1:
         p.error("Need to supply at least one directory")
@@ -42,15 +52,31 @@ def main():
         dir_path = os.path.abspath(d)
         p = AnalysisProject(project_name,dir_path)
         print "Project: %s" % p.name
+        if opts.qc_dir is None:
+            qc_dir = p.qc_dir
+        else:
+            qc_dir = opts.qc_dir
+        if not os.path.isabs(qc_dir):
+            qc_dir = os.path.join(p.dirn,qc_dir)
+        print "QC output dir: %s" % qc_dir
         print "-"*(len('Project: ')+len(p.name))
         print "%d samples | %d fastqs" % (len(p.samples),len(p.fastqs))
         if opts.verify:
-            if not QCReporter(p).verify():
+            if not QCReporter(p).verify(qc_dir=qc_dir):
                 print "Verification: FAILED"
             else:
                 print "Verification: OK"
         else:
-            qc = QCReporter(p).report()
+            qc_base = os.path.basename(qc_dir)
+            if opts.filename is None:
+                out_file = '%s_report.html' % qc_base
+            else:
+                out_file = opts.filename
+            if not os.path.isabs(out_file):
+                out_file = os.path.join(p.dirn,out_file)
+            print "Writing QC report to %s" % out_file
+            qc = QCReporter(p).report(qc_dir=qc_dir,
+                                      filename=out_file)
 
 if __name__ == '__main__':
     main()

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -110,6 +110,11 @@ if __name__ == "__main__":
                    "modules to load before executing commands "
                    "(overrides any modules specified in the global "
                    "settings)")
+    p.add_argument('--qc_dir',metavar='QC_DIR',
+                   action='store',dest='qc_dir',default=None,
+                   help="explicitly specify QC output directory. "
+                   "NB if a relative path is supplied then it's assumed "
+                   "to be a subdirectory of DIR (default: DIR/qc)")
     p.add_argument('--fastq_dir',metavar='SUBDIR',
                    action='store',dest='fastq_dir',default=None,
                    help="explicitly specify subdirectory of DIR with "
@@ -156,7 +161,13 @@ if __name__ == "__main__":
         print "-- %s" % sample.name
 
     # Sort out QC dir
-    qc_dir = os.path.join(project.dirn,'qc')
+    if args.qc_dir is None:
+        qc_dir = 'qc'
+    else:
+        qc_dir = args.qc_dir
+        if not os.path.isabs(qc_dir):
+            qc_dir = os.path.join(project.dirn,qc_dir)
+    print "QC output dir: %s" % qc_dir
     log_dir = os.path.join(qc_dir,'logs')
     mkdir(qc_dir)
     mkdir(log_dir)
@@ -177,6 +188,7 @@ if __name__ == "__main__":
                 qc_cmd = Command('illumina_qc.sh',fq)
                 if args.nthreads > 1:
                     qc_cmd.add_args('--threads',args.nthreads)
+                qc_cmd.add_args('--qc_dir',qc_dir)
                 job = sched.submit(qc_cmd,
                                    wd=project.dirn,
                                    name="qc.%s" % os.path.basename(fq),

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -164,16 +164,10 @@ if __name__ == "__main__":
     for sample in samples:
         print "-- %s" % sample.name
 
-    # Sort out QC dir
-    if args.qc_dir is None:
-        qc_dir = 'qc'
-    else:
-        qc_dir = args.qc_dir
-    if not os.path.isabs(qc_dir):
-        qc_dir = os.path.join(project.dirn,qc_dir)
+    # Set up QC dir
+    qc_dir = project.setup_qc_dir(qc_dir=args.qc_dir)
     print "QC output dir: %s" % qc_dir
     log_dir = os.path.join(qc_dir,'logs')
-    mkdir(qc_dir)
     mkdir(log_dir)
     qc_base = os.path.basename(qc_dir)
 


### PR DESCRIPTION
WIP PR to enable the QC output to be directed to a different directory than the standard `qc` subdirectory of the current project.