### PR TITLE
WIP implement --lanes option to enable running 'make_fastqs' on a subset of lanes

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1431,7 +1431,7 @@ class AutoProcess:
         print "Bcl format            : %s" % illumina_run.bcl_extension
         print "Source sample sheet   : %s" % sample_sheet
         print "Bases mask            : %s" % bases_mask
-        print "Lanes                 : %s" % ('all' if lanes is None,
+        print "Lanes                 : %s" % ('all' if lanes is None
                                               else
                                               ','.join([str(l) for l in lanes])
         print "Nmismatches           : %d" % nmismatches

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1893,7 +1893,6 @@ class AutoProcess:
             while i < len(sample_sheet_data):
                 line = sample_sheet_data[i]
                 if line['Lane'] in lanes:
-                    print "Keeping %s" % line
                     i += 1
                 else:
                     del(sample_sheet_data[i])

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1495,11 +1495,11 @@ class AutoProcess:
             logging.error("Unable to find outputs from bclToFastq (%s)" % ex)
             return
         if not IlluminaData.verify_run_against_sample_sheet(illumina_data,
-                                                            sample_sheet):
+                                                            tmp_sample_sheet):
             logging.error("Failed to verify bcl to fastq outputs against sample sheet")
             # Get a list of missing FASTQs
             missing_fastqs = IlluminaData.list_missing_fastqs(illumina_data,
-                                                              sample_sheet)
+                                                              tmp_sample_sheet)
             if not missing_fastqs:
                 raise Exception("Verify failed but no missing FASTQs?")
             missing_fastqs_file = os.path.join(self.log_dir,"missing_fastqs.log")

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1882,7 +1882,7 @@ class AutoProcess:
         timestamp = time.strftime("%Y%m%d%H%M%S")
         tmp_sample_sheet = os.path.join(self.tmp_dir,
                                         "SampleSheet.verify.%s.csv" %
-                                        timestamp))
+                                        timestamp)
         sample_sheet_data = IlluminaData.SampleSheet(self.params.sample_sheet)
         if lanes is not None:
             # Remove lanes

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1433,7 +1433,7 @@ class AutoProcess:
         print "Bases mask            : %s" % bases_mask
         print "Lanes                 : %s" % ('all' if lanes is None
                                               else
-                                              ','.join([str(l) for l in lanes])
+                                              ','.join([str(l) for l in lanes]))
         print "Nmismatches           : %d" % nmismatches
         print "Nprocessors           : %s" % nprocessors
         print "Ignore missing bcl    : %s" % ignore_missing_bcl

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1431,6 +1431,9 @@ class AutoProcess:
         print "Bcl format            : %s" % illumina_run.bcl_extension
         print "Source sample sheet   : %s" % sample_sheet
         print "Bases mask            : %s" % bases_mask
+        print "Lanes                 : %s" % ('all' if lanes is None,
+                                              else
+                                              ','.join([str(l) for l in lanes])
         print "Nmismatches           : %d" % nmismatches
         print "Nprocessors           : %s" % nprocessors
         print "Ignore missing bcl    : %s" % ignore_missing_bcl

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -229,6 +229,13 @@ def add_make_fastqs_command(cmdparser):
                             dest="sample_sheet",default=None,
                             help="use an alternative sample sheet to the default "
                             "'custom_SampleSheet.csv' created on setup.")
+    bcl_to_fastq.add_option('--lanes',action='store',
+                            dest='lanes',default=None,
+                            help="list of lanes to include in the processing. "
+                            "LANES should be single integer (e.g. 1), a list "
+                            "of integers (e.g. 1,3,...), a range (e.g. 1-3), "
+                            "or a combination (e.g. 1,3-5,7). Default is to "
+                            "include all lanes")
     bcl_to_fastq.add_option('--ignore-missing-bcl',action='store_true',
                             dest='ignore_missing_bcl',default=False,
                             help="use the --ignore-missing-bcl option for bcl2fastq (treat "
@@ -853,6 +860,11 @@ if __name__ == "__main__":
                 create_empty_fastqs = False
             else:
                 create_empty_fastqs = None
+            # Deal with --lanes
+            if options.lanes is not None:
+                lanes = bcf_utils.parse_lanes(options.lanes)
+            else:
+                lanes = None
             # Do the make_fastqs step
             d.make_fastqs(skip_rsync=options.skip_rsync,
                           nprocessors=options.nprocessors,
@@ -865,6 +877,7 @@ if __name__ == "__main__":
                           unaligned_dir=options.unaligned_dir,
                           sample_sheet=options.sample_sheet,
                           bases_mask=options.bases_mask,
+                          lanes=lanes,
                           no_lane_splitting=no_lane_splitting,
                           minimum_trimmed_read_length=options.minimum_trimmed_read_length,
                           mask_short_adapter_reads=options.mask_short_adapter_reads,

--- a/docs/source/problems.rst
+++ b/docs/source/problems.rst
@@ -50,31 +50,21 @@ dual indexes, but samples in lanes 5 and 6 need to be demultiplexed using
 only the first part of the dual index (i.e. first 8 bases only, for 16 base
 dual indexes).
 
-1. **Split the sample sheet**
+1. **Edit the sample sheet**
 
-   Use ``prep_sample_sheet.py`` to make two new sample sheets: one for
-   lanes 5 and 6, and another for the remaining lanes::
-
-       prep_sample_sheet.py -o custom_SampleSheet.lanes1-4,7-8.csv \
-            --include-lanes=1-4,7-8 custom_SampleSheet.csv
-       prep_sample_sheet.py -o custom_SampleSheet.lanes5-6.csv \
-            --include-lanes=5-6 custom_SampleSheet.csv
+   First edit the sample sheet to make any necessary changes to
+   to the lanes needing special treatment (e.g. updating barcodes).
+   It might be preferrable to do this in a copy of the original sample
+   sheet.
 
 2. **Process the lanes which use default parameters first**
 
-   Run::
+   Use the ``--lanes`` option of the ``make_fastqs`` command to process
+   the first set of lanes, for example::
 
-       auto_process.py make_fastqs --sample-sheet \
-            custom_SampleSheet.lanes1-4,7-8.csv
+       auto_process.py make_fastqs --lanes=1-4,7-8
 
-3. **Update the sample sheet for the lanes needing special treatment**
-
-   This means, make any necessary adjustments to
-   ``custom_SampleSheet.lanes5-6.csv`` so that the barcodes are correct
-   (for example in this case by truncating the barcode sequences to
-   8 bases).
-
-4. **Process the remaining lanes**
+3. **Process the remaining 'problem' lanes**
 
    In this case we would need to use an updated bases mask to tell the
    demultiplexer to ignore the trailing 8 bases of the barcodes. We
@@ -83,8 +73,8 @@ dual indexes).
 
    For example::
 
-       auto_process.py make_fastqs --sample-sheet \
-            custom_SampleSheet.lanes5-6.csv \
+       auto_process.py make_fastqs \
+            --lanes=5-6 \
             --output-dir=bcl2fastq.lanes56 \
             --use-bases-mask=y101,I8,n8,y101 \
             --stats-file=statistics.lanes56.info \
@@ -93,7 +83,7 @@ dual indexes).
    Using ``--skip-rsync`` means that the processing doesn't try to fetch
    the raw data again.
 
-5. **Merge fastq output directories and regenerate statistics**
+4. **Merge fastq output directories and regenerate statistics**
 
    Assuming that the processing has completed okay there will be an
    initial ``bcl2fastq`` directory with the first set of Fastqs and
@@ -113,7 +103,15 @@ The remaining processing should then be performed as normal.
 .. note::
 
    This process can be adapted to work with multiple subsets of
-   lanes, not just two.
+   lanes, not just two, by repeating step 3 above for each subset.
+
+.. note::
+
+   In older versions of the autoprocess software, it would be necessary
+   to first split the sample sheet into two copies each containing with
+   just one set of lanes (e.g. using
+   ``prep_sample_sheet.py --include-lanes=...``), and making appropriate
+   changes (e.g. to correct the barcodes).
 
 .. _problem-incomplete-run:
 


### PR DESCRIPTION
WIP PR to implement a `--lanes` option for the `make_fastqs` command, to allow the selection of a subset of lanes from the target samplesheet.

This should shortcut the requirement to make multiple samplesheet files when splitting the processing to handle special cases such as differing barcode lengths etc.