### PR TITLE
Explicitly set 'primary' fastq directory for AnalysisProjects

### DIFF
--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -210,7 +210,7 @@ class MockAnalysisProject(object):
     >>> m.create()
 
     """
-    def __init__(self,name,fastq_names=None,fastq_dir=None):
+    def __init__(self,name,fastq_names=None,fastq_dir=None,metadata=dict()):
         """
         Create a new MockAnalysisProject instance
         """
@@ -222,6 +222,7 @@ class MockAnalysisProject(object):
             self.fastq_dir = 'fastqs'
         else:
             self.fastq_dir = fastq_dir
+        self.metadata = metadata
 
     def add_fastq(self,fq):
         """
@@ -254,10 +255,11 @@ class MockAnalysisProject(object):
             fq = os.path.basename(fq)
             with open(os.path.join(fqs_dir,fq),'w') as fp:
                 fp.write('')
-        # Add (empty) README.info
+        # Add README.info
         if readme:
-            open(os.path.join(project_dir,'README.info'),
-                 'w').write('')
+            with open(os.path.join(project_dir,'README.info'),'w') as info:
+                for key in self.metadata:
+                    info.write("%s\t%s" % (key,self.metadata[key]))
         # Add ScriptCode directory
         if scriptcode:
             os.mkdir(os.path.join(project_dir,'ScriptCode'))


### PR DESCRIPTION
PR to explicitly add the concept of a 'primary' fastq subdirectory for the `AnalysisProject` class, which is essentially the default fastq directory that will be used on load unless an alternative is explicitly specified.

The primary fastq set is distinct from the 'active' fastq directory, and can be switched using the `set_primary_fastq_dir` method.