### PR TITLE
WIP enable resumption of terminated ICell8 processing pipeline

### DIFF
--- a/bin/process_icell8.py
+++ b/bin/process_icell8.py
@@ -1849,7 +1849,8 @@ if __name__ == "__main__":
         logger.warning("Ignoring project '%s'" % args.project)
     elif args.project:
         analysis_project = AnalysisProject(args.project,
-                                           args.project)
+                                           args.project,
+                                           fastq_dir='fastqs')
         for sample in analysis_project.samples:
             for fq in sample.fastq:
                 fastqs.append(os.path.join(


### PR DESCRIPTION
Various improvements aimed at enabling the resumption of a terminated ICell8 processing pipeline run, without needing to delete everything and then restart from scratch.

The modifications include (but aren't limited to):

- splitting into sub-pipelines
- writing intermediates to temporary working areas that are copied to final locations on task completion, so that it's clear whether these tasks actually finished okay
- only running certain tasks if the products don't already exist