### PR TITLE
Run QC with multiple threads

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -2262,9 +2262,9 @@ class AutoProcess:
                 logging.warning("'undetermined' directory already exists, skipping")
 
     def run_qc(self,projects=None,max_jobs=4,ungzip_fastqs=False,
-               fastq_screen_subset=1000000,runner=None,
-               fastq_dir=None,qc_dir=None,report_html=None,
-               run_multiqc=True):
+               fastq_screen_subset=100000,nthreads=1,
+               runner=None,fastq_dir=None,qc_dir=None,
+               report_html=None,run_multiqc=True):
         """Run QC pipeline script for projects
 
         Run the illumina_qc.sh script to perform QC on projects.
@@ -2290,6 +2290,8 @@ class AutoProcess:
           fastq_screen_subset: subset of reads to use in fastq_screen
                     (default is 1000000, set to zero or None to use
                     all reads)
+          nthreads: (optional) specify number of threads to run the
+                    QC pipeline with (default is 1)
           runner:   (optional) specify a non-default job runner to
                     use for the QC.
           fastq_dir: (optional) specify the subdirectory to take the
@@ -2389,8 +2391,10 @@ class AutoProcess:
                             qc_cmd.add_args('--ungzip-fastqs')
                         if fastq_screen_subset is None:
                             fastq_screen_subset = 0
-                        qc_cmd.add_args('--subset',fastq_screen_subset,
-                                        '--qc_dir',project_qc_dir)
+                        qc_cmd.add_args(
+                            '--threads',nthreads,
+                            '--subset',fastq_screen_subset,
+                            '--qc_dir',project_qc_dir)
                         job = group.add(qc_cmd,name=label,wd=project.dirn)
                         print "Job: %s" %  job
                 # Indicate no more jobs to add

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -2288,7 +2288,7 @@ class AutoProcess:
                     copies of any fastq.gz inputs (default is False,
                     don't decompress the input files)
           fastq_screen_subset: subset of reads to use in fastq_screen
-                    (default is 1000000, set to zero or None to use
+                    (default is 100000, set to zero or None to use
                     all reads)
           nthreads: (optional) specify number of threads to run the
                     QC pipeline with (default is 1)

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -118,6 +118,9 @@ class Settings:
         # qc
         self.add_section('qc')
         self.qc['nprocessors'] = config.getint('qc','nprocessors',1)
+        self.qc['fastq_screen_subset'] = config.getint('qc',
+                                                       'fastq_screen_subset',
+                                                       100000)
         # Sequencing platform-specific defaults
         self.add_section('platform')
         for section in filter(lambda x: x.startswith('platform:'),

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -115,6 +115,9 @@ class Settings:
         # bcl2fastq
         self.add_section('bcl2fastq')
         self.bcl2fastq = self.get_bcl2fastq_config('bcl2fastq',config)
+        # qc
+        self.add_section('qc')
+        self.qc['nprocessors'] = config.getint('qc','nprocessors',1)
         # Sequencing platform-specific defaults
         self.add_section('platform')
         for section in filter(lambda x: x.startswith('platform:'),

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -442,8 +442,8 @@ def add_run_qc_command(cmdparser):
                               description="Run QC procedures for sequencing projects in "
                               "ANALYSIS_DIR.")
     default_nthreads = __settings.qc.nprocessors
+    fastq_screen_subset = __settings.qc.fastq_screen_subset
     max_concurrent_jobs = __settings.general.max_concurrent_jobs
-    fastq_screen_subset = 1000000
     p.add_option('--projects',action='store',
                  dest='project_pattern',default=None,
                  help="simple wildcard-based pattern specifying a subset of projects "

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -455,6 +455,10 @@ def add_run_qc_command(cmdparser):
                  help="specify size of subset of total reads to use for "
                  "fastq_screen (i.e. --subset option); (default %d, set to "
                  "0 to use all reads)" % fastq_screen_subset)
+    p.add_option('-t','--threads',action='store',dest="nthreads",
+                 type='int',default=1,
+                 help="number of threads to use for QC script "
+                 "(default: 1)")
     p.add_option('--ungzip-fastqs',action='store_true',dest='ungzip_fastqs',
                  help="create decompressed copies of fastq.gz files")
     p.add_option('--max-jobs',action='store',
@@ -923,6 +927,7 @@ if __name__ == "__main__":
                                max_jobs=options.max_jobs,
                                ungzip_fastqs=options.ungzip_fastqs,
                                fastq_screen_subset=options.subset,
+                               nthreads=options.nthreads,
                                fastq_dir=options.fastq_dir,
                                qc_dir=options.qc_dir,
                                report_html=options.html_file,

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -441,6 +441,7 @@ def add_run_qc_command(cmdparser):
                               usage="%prog run_qc [OPTIONS] [ANALYSIS_DIR]",
                               description="Run QC procedures for sequencing projects in "
                               "ANALYSIS_DIR.")
+    default_nthreads = __settings.qc.nprocessors
     max_concurrent_jobs = __settings.general.max_concurrent_jobs
     fastq_screen_subset = 1000000
     p.add_option('--projects',action='store',
@@ -456,9 +457,9 @@ def add_run_qc_command(cmdparser):
                  "fastq_screen (i.e. --subset option); (default %d, set to "
                  "0 to use all reads)" % fastq_screen_subset)
     p.add_option('-t','--threads',action='store',dest="nthreads",
-                 type='int',default=1,
+                 type='int',default=default_nthreads,
                  help="number of threads to use for QC script "
-                 "(default: 1)")
+                 "(default: %d)" % default_nthreads)
     p.add_option('--ungzip-fastqs',action='store_true',dest='ungzip_fastqs',
                  help="create decompressed copies of fastq.gz files")
     p.add_option('--max-jobs',action='store',

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -94,6 +94,13 @@ if __name__ == "__main__":
                    "subset of samples to run the QC on. If specified "
                    "then only FASTQs with sample names matching "
                    "PATTERN will be examined.")
+    p.add_argument('--fastq_screen_subset',metavar='SUBSET',
+                   action='store',dest='fastq_screen_subset',
+                   default=__settings.qc.fastq_screen_subset,type=int,
+                   help="specify size of subset of total reads to use "
+                   "for fastq_screen (i.e. --subset option); (default "
+                   "%d, set to 0 to use all reads)" %
+                   __settings.qc.fastq_screen_subset)
     p.add_argument('-t','--threads',action='store',dest="nthreads",
                    type=int,default=__settings.qc.nprocessors,
                    help="number of threads to use for QC script "
@@ -196,7 +203,8 @@ if __name__ == "__main__":
                 qc_cmd = Command('illumina_qc.sh',fq)
                 if args.nthreads > 1:
                     qc_cmd.add_args('--threads',args.nthreads)
-                qc_cmd.add_args('--qc_dir',qc_dir)
+                qc_cmd.add_args('--subset',args.fastq_screen_subset,
+                                '--qc_dir',qc_dir)
                 job = sched.submit(qc_cmd,
                                    wd=project.dirn,
                                    name="%s.%s" % (qc_base,

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -94,10 +94,10 @@ if __name__ == "__main__":
                    "subset of samples to run the QC on. If specified "
                    "then only FASTQs with sample names matching "
                    "PATTERN will be examined.")
-    p.add_argument('-t','--threads',
-                   action='store',dest="nthreads",default=1,
+    p.add_argument('-t','--threads',action='store',dest="nthreads",
+                   type=int,default=__settings.qc.nprocessors,
                    help="number of threads to use for QC script "
-                   "(default: 1)")
+                   "(default: %d)" % __settings.qc.nprocessors)
     p.add_argument('-r','--runner',metavar='RUNNER',action='store',
                    dest="runner",default=str(__settings.runners.qc),
                    help="explicitly specify runner definition for "

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -18,6 +18,10 @@ default_version = <=1.8.4
 no_lane_splitting = False
 create_empty_fastqs = True
 
+# QC settings
+[qc]
+nprocessors = 1
+
 # Platform specific settings
 # Make sections [platform:NAME] and add parameters to
 # override the default bcl2fastq settings (i.e. number of

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -21,6 +21,7 @@ create_empty_fastqs = True
 # QC settings
 [qc]
 nprocessors = 1
+fastq_screen_subset = 100000
 
 # Platform specific settings
 # Make sections [platform:NAME] and add parameters to


### PR DESCRIPTION
PR to address issue #95 and allow the `run_qc` command in `auto_process.py` to be invoked with multiple threads.

The PR also adds a new `qc` section to the configuration settings where the default number of threads can be specified.