### PR TITLE
Standardise local and remote operations in 'fileops'

### DIFF
--- a/auto_process_ngs/fileops.py
+++ b/auto_process_ngs/fileops.py
@@ -47,7 +47,6 @@ import shutil
 import logging
 import bcftbx.utils as bcftbx_utils
 import applications
-import simple_scheduler
 from utils import split_user_host_dir
 
 # Module specific logger
@@ -133,14 +132,14 @@ def _run_command(cmd,sched=None):
     """
     print "Running %s" % cmd
     if sched is None:
-        retcode = cmd.run_subprocess()
+        retcode,output = cmd.subprocess_check_output()
     else:
         job = sched.submit(cmd)
         job.wait()
         retcode = job.exit_code
     return retcode
 
-def mkdir(newdir,sched=None):
+def mkdir(newdir):
     """
     Create a directory
 
@@ -161,13 +160,13 @@ def mkdir(newdir,sched=None):
             newdir.server,
             mkdir_cmd.command_line)
     try:
-        return _run_command(mkdir_cmd,sched=sched)
+        return _run_command(mkdir_cmd)
     except Exception as ex:
         raise Exception(
             "Exception making directory %s: %s" %
             (newdir,ex))
 
-def copy(src,dest,sched=None):
+def copy(src,dest):
     """
     Copy a file
 
@@ -181,12 +180,12 @@ def copy(src,dest,sched=None):
     """
     copy_cmd = copy_command(src,dest)
     try:
-        return _run_command(copy_cmd,sched=sched)
+        return _run_command(copy_cmd)
     except Exception as ex:
         raise Exception("Exception copying %s to %s: "
                         "%s" % (src,dest,ex))
 
-def set_group(group,path,sched=None):
+def set_group(group,path):
     """
     Set the group for a file or directory
 
@@ -206,13 +205,13 @@ def set_group(group,path,sched=None):
     """
     chmod_cmd = set_group_command(group,path)
     try:
-        return _run_command(chmod_cmd,sched=sched)
+        return _run_command(chmod_cmd)
     except Exception as ex:
         raise Exception(
             "Exception changing group to '%s' for "
             "destination %s: %s" % (group,path,ex))
 
-def unzip(zip_file,dest,sched=None):
+def unzip(zip_file,dest):
     """
     Unpack ZIP archive file on local or remote system
 
@@ -226,7 +225,7 @@ def unzip(zip_file,dest,sched=None):
     """
     unzip_cmd = unzip_command(zip_file,dest)
     try:
-        return _run_command(unzip_cmd,sched=sched)
+        return _run_command(unzip_cmd)
     except Exception as ex:
         raise Exception("Failed to unzip %s: %s" %
                         (zip_file,ex))

--- a/auto_process_ngs/test/test_fileops.py
+++ b/auto_process_ngs/test/test_fileops.py
@@ -8,6 +8,8 @@ import tempfile
 import shutil
 import pwd
 import grp
+from bcftbx.JobRunner import SimpleJobRunner
+from auto_process_ngs.simple_scheduler import SimpleScheduler
 from auto_process_ngs.utils import ZipArchive
 from auto_process_ngs.fileops import *
 
@@ -42,30 +44,51 @@ class TestLocation(unittest.TestCase):
         self.assertFalse(location.is_remote)
         self.assertEqual(str(location),'/path/to/somewhere')
 
-class TestMkdirFunction(unittest.TestCase):
-    """Tests for the 'mkdir' function
+class FileopsTestCase(unittest.TestCase):
+    """Base class for fileops test cases
+
+    Provides setUp, tearDown and _get_scheduler
+    methods.
     """
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()
+        self.sched = None
     def tearDown(self):
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
+        if self.sched is not None:
+            self.sched.stop()
+    def _get_scheduler(self):
+        # Set up a scheduler
+        # Call this to get a scheduler instance
+        self.sched = SimpleScheduler(
+            runner=SimpleJobRunner(log_dir=self.test_dir))
+        self.sched.start()
+
+class TestMkdirFunction(FileopsTestCase):
+    """Tests for the 'mkdir' function
+    """
     def test_local_mkdir(self):
         """fileops.mkdir: make a local directory
         """
         new_dir = os.path.join(self.test_dir,'new_dir')
         self.assertFalse(os.path.exists(new_dir))
-        mkdir(new_dir)
+        status = mkdir(new_dir)
+        self.assertEqual(status,0)
+        self.assertTrue(os.path.isdir(new_dir))
+    def test_local_mkdir_with_scheduler(self):
+        """fileops.mkdir: make a local directory (run via scheduler)
+        """
+        self._get_scheduler()
+        new_dir = os.path.join(self.test_dir,'new_dir')
+        self.assertFalse(os.path.exists(new_dir))
+        status = mkdir(new_dir,sched=self.sched)
+        self.assertEqual(status,0)
         self.assertTrue(os.path.isdir(new_dir))
 
-class TestCopyFunction(unittest.TestCase):
+class TestCopyFunction(FileopsTestCase):
     """Tests for the 'copy' function
     """
-    def setUp(self):
-        self.test_dir = tempfile.mkdtemp()
-    def tearDown(self):
-        if os.path.exists(self.test_dir):
-            shutil.rmtree(self.test_dir)
     def test_local_copy(self):
         """fileops.copy: copy a local file
         """
@@ -75,41 +98,30 @@ class TestCopyFunction(unittest.TestCase):
         self.assertTrue(os.path.isfile(src_file))
         tgt_file = os.path.join(self.test_dir,'test2.txt')
         self.assertFalse(os.path.exists(tgt_file))
-        copy(src_file,tgt_file)
+        status = copy(src_file,tgt_file)
+        self.assertEqual(status,0)
         self.assertTrue(os.path.isfile(tgt_file))
         self.assertEqual(open(tgt_file).read(),
                          "This is a test file")
-
-class TestCopyFunction(unittest.TestCase):
-    """Tests for the 'copy' function
-    """
-    def setUp(self):
-        self.test_dir = tempfile.mkdtemp()
-    def tearDown(self):
-        if os.path.exists(self.test_dir):
-            shutil.rmtree(self.test_dir)
-    def test_local_copy(self):
-        """fileops.copy: copy a local file
+    def test_local_copy_with_scheduler(self):
+        """fileops.copy: copy a local file (run via scheduler)
         """
+        self._get_scheduler()
         src_file = os.path.join(self.test_dir,'test.txt')
         with open(src_file,'w') as fp:
             fp.write("This is a test file")
         self.assertTrue(os.path.isfile(src_file))
         tgt_file = os.path.join(self.test_dir,'test2.txt')
         self.assertFalse(os.path.exists(tgt_file))
-        copy(src_file,tgt_file)
+        status = copy(src_file,tgt_file,sched=self.sched)
+        self.assertEqual(status,0)
         self.assertTrue(os.path.isfile(tgt_file))
         self.assertEqual(open(tgt_file).read(),
                          "This is a test file")
 
-class TestSetGroupFunction(unittest.TestCase):
+class TestSetGroupFunction(FileopsTestCase):
     """Tests for the 'set_group' function
     """
-    def setUp(self):
-        self.test_dir = tempfile.mkdtemp()
-    def tearDown(self):
-        if os.path.exists(self.test_dir):
-            shutil.rmtree(self.test_dir)
     def test_local_set_group(self):
         """fileops.set_group: set group ownership on a local file
         """
@@ -139,20 +151,51 @@ class TestSetGroupFunction(unittest.TestCase):
         # Change group by name
         new_group = grp.getgrgid(new_gid).gr_name
         print "New group name: %s" % new_group
-        set_group(new_group,test_file)
+        status = set_group(new_group,test_file)
+        self.assertEqual(status,0)
+        print "File: %s GID: %s"  % (test_file,
+                                     os.stat(test_file).st_gid)
+        self.assertEqual(os.stat(test_file).st_gid,new_gid)
+    def test_local_set_group_with_scheduler(self):
+        """fileops.set_group: set group ownership on a local file (using scheduler)
+        """
+        self._get_scheduler()
+        # Get a list of groups
+        current_user = pwd.getpwuid(os.getuid()).pw_name
+        groups = [g.gr_gid for g in grp.getgrall()
+                  if current_user in g.gr_mem]
+        print "Available groups: %s" % groups
+        if len(groups) < 2:
+            raise unittest.SkipTest("user '%s' must be in at least "
+                                    "two groups" % current_user)
+        # Make test file and get group
+        test_file = os.path.join(self.test_dir,'test.txt')
+        with open(test_file,'w') as fp:
+            fp.write("This is a test file")
+        self.assertTrue(os.path.isfile(test_file))
+        gid = os.stat(test_file).st_gid
+        print "File: %s GID: %s" % (test_file,gid)
+        # Get a second group
+        new_gid = None
+        for group in groups:
+            if group != gid:
+                new_gid = group
+                break
+        print "Selected new GID: %s" % new_gid
+        self.assertNotEqual(os.stat(test_file).st_gid,new_gid)
+        # Change group by name
+        new_group = grp.getgrgid(new_gid).gr_name
+        print "New group name: %s" % new_group
+        status = set_group(new_group,test_file,sched=self.sched)
+        self.assertEqual(status,0)
         print "File: %s GID: %s"  % (test_file,
                                      os.stat(test_file).st_gid)
         self.assertEqual(os.stat(test_file).st_gid,new_gid)
 
-class TestUnzip(unittest.TestCase):
+class TestUnzip(FileopsTestCase):
     """Tests for the 'unzip' function
     """
-    def setUp(self):
-        self.test_dir = tempfile.mkdtemp()
-    def tearDown(self):
-        if os.path.exists(self.test_dir):
-            shutil.rmtree(self.test_dir)
-    def test_local_copy(self):
+    def test_local_unzip(self):
         """fileops.unzip: unzip a local file
         """
         test_file = os.path.join(self.test_dir,'test.txt')
@@ -167,7 +210,31 @@ class TestUnzip(unittest.TestCase):
         self.assertTrue(os.path.isfile(zip_file))
         out_dir = os.path.join(self.test_dir,'files')
         self.assertFalse(os.path.exists(out_dir))
-        unzip(zip_file,self.test_dir)
+        status = unzip(zip_file,self.test_dir)
+        self.assertEqual(status,0)
+        self.assertTrue(os.path.isdir(out_dir))
+        out_file = os.path.join(out_dir,'test.txt')
+        self.assertTrue(os.path.isfile(out_file))
+        self.assertEqual(open(out_file).read(),
+                         "This is a test file")
+    def test_local_unzip_with_scheduler(self):
+        """fileops.unzip: unzip a local file (using scheduler)
+        """
+        self._get_scheduler()
+        test_file = os.path.join(self.test_dir,'test.txt')
+        with open(test_file,'w') as fp:
+            fp.write("This is a test file")
+        zip_file = os.path.join(self.test_dir,'test.zip')
+        z = ZipArchive(zip_file,
+                       contents=(test_file,),
+                       relpath=self.test_dir,
+                       prefix='files')
+        z.close()
+        self.assertTrue(os.path.isfile(zip_file))
+        out_dir = os.path.join(self.test_dir,'files')
+        self.assertFalse(os.path.exists(out_dir))
+        status = unzip(zip_file,self.test_dir,sched=self.sched)
+        self.assertEqual(status,0)
         self.assertTrue(os.path.isdir(out_dir))
         out_file = os.path.join(out_dir,'test.txt')
         self.assertTrue(os.path.isfile(out_file))

--- a/auto_process_ngs/test/test_fileops.py
+++ b/auto_process_ngs/test/test_fileops.py
@@ -241,3 +241,80 @@ class TestUnzip(FileopsTestCase):
         self.assertEqual(open(out_file).read(),
                          "This is a test file")
 
+class TestCopyCommand(unittest.TestCase):
+    """Tests for the 'copy_command' function
+    """
+    def test_copy_command_to_local(self):
+        """fileops.copy_command: copy file locally
+        """
+        copy_cmd = copy_command("/here/myfile.txt",
+                                "/there/myfile.txt")
+        self.assertEqual(copy_cmd.command_line,
+                         ['cp',
+                          '/here/myfile.txt',
+                          '/there/myfile.txt'])
+    def test_copy_command_to_remote(self):
+        """fileops.copy_command: copy file to remote
+        """
+        copy_cmd = copy_command("/here/myfile.txt",
+                                "pjx@remote.com:/there/myfile.txt")
+        self.assertEqual(copy_cmd.command_line,
+                         ['scp',
+                          '/here/myfile.txt',
+                          'pjx@remote.com:/there/myfile.txt'])
+
+class TestSetGroupCommand(unittest.TestCase):
+    """Tests for the 'set_group_command' function
+    """
+    def test_set_group_command_local(self):
+        """fileops.set_group_command: set group on local files
+        """
+        set_group_cmd = set_group_command("adm",
+                                          "/here/files")
+        self.assertEqual(set_group_cmd.command_line,
+                         ['chgrp',
+                          '-R',
+                          'adm',
+                          '/here/files'])
+    def test_set_group_command_remote(self):
+        """fileops.set_group_command: set group on remote files
+        """
+        set_group_cmd = set_group_command("adm",
+                                          "pjx@remote.com:/there/files")
+        self.assertEqual(set_group_cmd.command_line,
+                         ['ssh',
+                          'pjx@remote.com',
+                          'chgrp',
+                          '-R',
+                          'adm',
+                          '/there/files'])
+
+class TestUnzipCommand(unittest.TestCase):
+    """Tests for the 'unzip_command' function
+    """
+    def test_unzip_command_local(self):
+        """fileops.unzip_command: unzip local ZIP archive
+        """
+        unzip_cmd = unzip_command("/here/myarchive.zip",
+                                  "/here/unpacked")
+        self.assertEqual(unzip_cmd.command_line,
+                         ['unzip',
+                          '-q',
+                          '-o',
+                          '-d',
+                          '/here/unpacked',
+                          '/here/myarchive.zip'])
+    def test_unzip_command_remote(self):
+        """fileops.unzip_command: unzip remote ZIP archive
+        """
+        unzip_cmd = unzip_command("pjx@remote.com:/there/myarchive.zip",
+                                  "/there/unpacked")
+        self.assertEqual(unzip_cmd.command_line,
+                         ['ssh',
+                          'pjx@remote.com',
+                          'unzip',
+                          '-q',
+                          '-o',
+                          '-d',
+                          '/there/unpacked',
+                          '/there/myarchive.zip'])

--- a/auto_process_ngs/test/test_fileops.py
+++ b/auto_process_ngs/test/test_fileops.py
@@ -52,18 +52,9 @@ class FileopsTestCase(unittest.TestCase):
     """
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()
-        self.sched = None
     def tearDown(self):
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
-        if self.sched is not None:
-            self.sched.stop()
-    def _get_scheduler(self):
-        # Set up a scheduler
-        # Call this to get a scheduler instance
-        self.sched = SimpleScheduler(
-            runner=SimpleJobRunner(log_dir=self.test_dir))
-        self.sched.start()
 
 class TestMkdirFunction(FileopsTestCase):
     """Tests for the 'mkdir' function
@@ -74,15 +65,6 @@ class TestMkdirFunction(FileopsTestCase):
         new_dir = os.path.join(self.test_dir,'new_dir')
         self.assertFalse(os.path.exists(new_dir))
         status = mkdir(new_dir)
-        self.assertEqual(status,0)
-        self.assertTrue(os.path.isdir(new_dir))
-    def test_local_mkdir_with_scheduler(self):
-        """fileops.mkdir: make a local directory (run via scheduler)
-        """
-        self._get_scheduler()
-        new_dir = os.path.join(self.test_dir,'new_dir')
-        self.assertFalse(os.path.exists(new_dir))
-        status = mkdir(new_dir,sched=self.sched)
         self.assertEqual(status,0)
         self.assertTrue(os.path.isdir(new_dir))
 
@@ -99,21 +81,6 @@ class TestCopyFunction(FileopsTestCase):
         tgt_file = os.path.join(self.test_dir,'test2.txt')
         self.assertFalse(os.path.exists(tgt_file))
         status = copy(src_file,tgt_file)
-        self.assertEqual(status,0)
-        self.assertTrue(os.path.isfile(tgt_file))
-        self.assertEqual(open(tgt_file).read(),
-                         "This is a test file")
-    def test_local_copy_with_scheduler(self):
-        """fileops.copy: copy a local file (run via scheduler)
-        """
-        self._get_scheduler()
-        src_file = os.path.join(self.test_dir,'test.txt')
-        with open(src_file,'w') as fp:
-            fp.write("This is a test file")
-        self.assertTrue(os.path.isfile(src_file))
-        tgt_file = os.path.join(self.test_dir,'test2.txt')
-        self.assertFalse(os.path.exists(tgt_file))
-        status = copy(src_file,tgt_file,sched=self.sched)
         self.assertEqual(status,0)
         self.assertTrue(os.path.isfile(tgt_file))
         self.assertEqual(open(tgt_file).read(),
@@ -156,41 +123,6 @@ class TestSetGroupFunction(FileopsTestCase):
         print "File: %s GID: %s"  % (test_file,
                                      os.stat(test_file).st_gid)
         self.assertEqual(os.stat(test_file).st_gid,new_gid)
-    def test_local_set_group_with_scheduler(self):
-        """fileops.set_group: set group ownership on a local file (using scheduler)
-        """
-        self._get_scheduler()
-        # Get a list of groups
-        current_user = pwd.getpwuid(os.getuid()).pw_name
-        groups = [g.gr_gid for g in grp.getgrall()
-                  if current_user in g.gr_mem]
-        print "Available groups: %s" % groups
-        if len(groups) < 2:
-            raise unittest.SkipTest("user '%s' must be in at least "
-                                    "two groups" % current_user)
-        # Make test file and get group
-        test_file = os.path.join(self.test_dir,'test.txt')
-        with open(test_file,'w') as fp:
-            fp.write("This is a test file")
-        self.assertTrue(os.path.isfile(test_file))
-        gid = os.stat(test_file).st_gid
-        print "File: %s GID: %s" % (test_file,gid)
-        # Get a second group
-        new_gid = None
-        for group in groups:
-            if group != gid:
-                new_gid = group
-                break
-        print "Selected new GID: %s" % new_gid
-        self.assertNotEqual(os.stat(test_file).st_gid,new_gid)
-        # Change group by name
-        new_group = grp.getgrgid(new_gid).gr_name
-        print "New group name: %s" % new_group
-        status = set_group(new_group,test_file,sched=self.sched)
-        self.assertEqual(status,0)
-        print "File: %s GID: %s"  % (test_file,
-                                     os.stat(test_file).st_gid)
-        self.assertEqual(os.stat(test_file).st_gid,new_gid)
 
 class TestUnzip(FileopsTestCase):
     """Tests for the 'unzip' function
@@ -211,29 +143,6 @@ class TestUnzip(FileopsTestCase):
         out_dir = os.path.join(self.test_dir,'files')
         self.assertFalse(os.path.exists(out_dir))
         status = unzip(zip_file,self.test_dir)
-        self.assertEqual(status,0)
-        self.assertTrue(os.path.isdir(out_dir))
-        out_file = os.path.join(out_dir,'test.txt')
-        self.assertTrue(os.path.isfile(out_file))
-        self.assertEqual(open(out_file).read(),
-                         "This is a test file")
-    def test_local_unzip_with_scheduler(self):
-        """fileops.unzip: unzip a local file (using scheduler)
-        """
-        self._get_scheduler()
-        test_file = os.path.join(self.test_dir,'test.txt')
-        with open(test_file,'w') as fp:
-            fp.write("This is a test file")
-        zip_file = os.path.join(self.test_dir,'test.zip')
-        z = ZipArchive(zip_file,
-                       contents=(test_file,),
-                       relpath=self.test_dir,
-                       prefix='files')
-        z.close()
-        self.assertTrue(os.path.isfile(zip_file))
-        out_dir = os.path.join(self.test_dir,'files')
-        self.assertFalse(os.path.exists(out_dir))
-        status = unzip(zip_file,self.test_dir,sched=self.sched)
         self.assertEqual(status,0)
         self.assertTrue(os.path.isdir(out_dir))
         out_file = os.path.join(out_dir,'test.txt')


### PR DESCRIPTION
PR to look at standardising the local and remote operations provided by the `fileops` module, and enabling them optionally also to be farmed out to job runners.

Aims to address some of the outstanding aspects of issue #76 - could also be used to try and address issue #80.