### PR TITLE
10xgenomics: integrate Fastq generation into auto_process 'make_fastqs' command

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1164,7 +1164,12 @@ class AutoProcess:
                                     runner=runner)
             return
         # Log dir
-        self.set_log_dir(self.get_log_subdir('make_fastqs'))
+        log_dir = 'make_fastqs'
+        if protocol:
+            log_dir += "_%s" % protocol
+        if lanes:
+            log_dir += "_%s" % ''.join(sorted(lanes))
+        self.set_log_dir(self.get_log_subdir(log_dir))
         # Fetch primary data
         if not skip_rsync:
             if self.get_primary_data() != 0:

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1069,7 +1069,7 @@ class AutoProcess:
         undetermined_dir = os.path.join(self.analysis_dir,dirs[0])
         return utils.AnalysisProject(dirs[0],undetermined_dir)
         
-    def make_fastqs(self,protocol=None,
+    def make_fastqs(self,protocol='standard',
                     unaligned_dir=None,sample_sheet=None,lanes=None,
                     ignore_missing_bcl=False,ignore_missing_stats=False,
                     skip_rsync=False,remove_primary_data=False,

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1507,8 +1507,9 @@ class AutoProcess:
         # Generate temporary sample sheet with required format
         fmt = bcl2fastq_utils.get_required_samplesheet_format(bcl2fastq_info[2])
         tmp_sample_sheet = os.path.join(self.tmp_dir,
-                                        "SampleSheet.%s.csv" %
-                                        time.strftime("%Y%m%d%H%M%S"))
+                                        "SampleSheet.%s.%s.csv" %
+                                        (fmt,
+                                         time.strftime("%Y%m%d%H%M%S")))
         print "Generating '%s' format sample sheet: %s" % (fmt,tmp_sample_sheet)
         bcl2fastq_utils.make_custom_sample_sheet(sample_sheet,
                                                  tmp_sample_sheet,

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1268,6 +1268,7 @@ class AutoProcess:
                         output_dir=self.params.unaligned_dir,
                         lanes=(None if lanes is None
                                else ','.join([str(l) for l in lanes])),
+                        bases_mask=bases_mask,
                         cellranger_jobmode=cellranger_jobmode,
                         cellranger_maxjobs=cellranger_maxjobs,
                         cellranger_mempercore=cellranger_mempercore,

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1245,8 +1245,9 @@ class AutoProcess:
             elif protocol == '10x_chromium':
                 # 10xGenomics Chromium
                 try:
+                    # Check we have bcl2fastq
                     bcl2fastq = bcl2fastq_utils.available_bcl2fastq_versions(
-                        '>=2')
+                        '>=2.17')
                     if bcl2fastq:
                         bcl2fastq_exe = bcl2fastq[0]
                         bcl2fastq_info = bcl2fastq_utils.bcl_to_fastq_info(
@@ -1254,6 +1255,7 @@ class AutoProcess:
                     else:
                         raise Exception("No appropriate bcl2fastq software "
                                         "located")
+                    # Check we have cellranger
                     cellranger = utils.find_executables(
                         ('cellranger',),
                         tenx_genomics_utils.cellranger_info)

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1239,7 +1239,7 @@ class AutoProcess:
             return
         # Log dir
         log_dir = 'make_fastqs'
-        if protocol:
+        if protocol != 'standard':
             log_dir += "_%s" % protocol
         if lanes:
             log_dir += "_L%s" % ''.join([str(l) for l in sorted(lanes)])

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1181,7 +1181,7 @@ class AutoProcess:
         if protocol:
             log_dir += "_%s" % protocol
         if lanes:
-            log_dir += "_%s" % ''.join(sorted(lanes))
+            log_dir += "_L%s" % ''.join([str(l) for l in sorted(lanes)])
         self.set_log_dir(self.get_log_subdir(log_dir))
         # Fetch primary data
         if not skip_rsync:

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1510,7 +1510,7 @@ class AutoProcess:
         # Determine initial number of mismatches
         nmismatches = bcl2fastq_utils.get_nmismatches(bases_mask)
         # Check for barcode collisions
-        collisions = bcl2fastq_utils.check_barcode_collisions(sample_sheet,
+        collisions = bcl2fastq_utils.check_barcode_collisions(tmp_sample_sheet,
                                                               nmismatches)
         if collisions:
             # Report problem barcodes
@@ -1524,7 +1524,7 @@ class AutoProcess:
             while nmismatches > 0 and collisions:
                 nmismatches -= 1
                 collisions = bcl2fastq_utils.check_barcode_collisions(
-                    sample_sheet,
+                    tmp_sample_sheet,
                     nmismatches)
                 if not collisions:
                     print "No collisions using %d mismatches" % nmismatches

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1453,9 +1453,9 @@ class AutoProcess:
             self.params['bases_mask'] = bases_mask
         # Check for basic information needed to do bcl2fastq conversion
         if self.params.data_dir is None:
-            raise Exception, "No source data directory"
+            raise Exception("No source data directory")
         if bases_mask is None:
-            raise Exception, "No bases mask"
+            raise Exception("No bases mask")
         # Number of cores
         if nprocessors is None:
             nprocessors = self.settings.bcl2fastq.nprocessors

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1253,7 +1253,7 @@ class AutoProcess:
                 return
         # Do fastq generation using the specified protocol
         if not skip_fastq_generation:
-            if protocol is None:
+            if protocol == 'standard':
                 # Standard protocol
                 try:
                     exit_code = self.bcl_to_fastq(

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1195,7 +1195,7 @@ class AutoProcess:
         # data if necessary
         verify_include_sample_dir = False
         if protocol == '10x_chromium_sc':
-            if tenx_genomics_utils.has_chromium_indices(
+            if tenx_genomics_utils.has_chromium_sc_indices(
                     self.params.sample_sheet):
                 # Force inclusion of sample-name subdirectories
                 # when verifying Chromium SC data

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1234,7 +1234,7 @@ class AutoProcess:
             skip_rsync = True
             skip_fastq_generation = True
         # Check if there's anything to do
-        if not (skip_rsync or skip_fastq_generation or generate_stats):
+        if (skip_rsync and skip_fastq_generation) and not generate_stats:
             print "Nothing to do"
             return
         # Log dir

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1213,6 +1213,20 @@ class AutoProcess:
             elif protocol == '10x_chromium':
                 # 10xGenomics Chromium
                 try:
+                    bcl2fastq = bcl2fastq_utils.available_bcl2fastq_versions(
+                        '>=2')
+                    if bcl2fastq:
+                        bcl2fastq_exe = bcl2fastq[0]
+                        bcl2fastq_info = bcl2fastq_utils.bcl_to_fastq_info(
+                            bcl2fastq_exe)
+                    else:
+                        raise Exception("No appropriate bcl2fastq software "
+                                        "located")
+                    cellranger = utils.find_executables(
+                        ('cellranger',),
+                        tenx_genomics_utils.cellranger_info)
+                    if not cellranger:
+                        raise Exception("No cellranger package found")
                     if unaligned_dir is not None:
                         self.params['unaligned_dir'] = unaligned_dir
                     elif self.params['unaligned_dir'] is None:
@@ -1440,13 +1454,6 @@ class AutoProcess:
         bcl2fastq = bcl2fastq_utils.available_bcl2fastq_versions(
             require_bcl2fastq)
         if bcl2fastq:
-            print "Found available bcl2fastq packages:"
-            for i,package in enumerate(bcl2fastq):
-                bcl2fastq_info = bcl2fastq_utils.bcl_to_fastq_info(package)
-                print "%s %s\t%s\t%s" % (('*' if i == 0 else ' '),
-                                         bcl2fastq_info[0],
-                                         bcl2fastq_info[1],
-                                         bcl2fastq_info[2])
             bcl2fastq_exe = bcl2fastq[0]
             bcl2fastq_info = bcl2fastq_utils.bcl_to_fastq_info(bcl2fastq_exe)
         else:

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1323,22 +1323,6 @@ class AutoProcess:
             elif protocol == '10x_chromium_sc':
                 # 10xGenomics Chromium SC
                 try:
-                    # Check we have bcl2fastq
-                    bcl2fastq = bcl2fastq_utils.available_bcl2fastq_versions(
-                        '>=2.17')
-                    if bcl2fastq:
-                        bcl2fastq_exe = bcl2fastq[0]
-                        bcl2fastq_info = bcl2fastq_utils.bcl_to_fastq_info(
-                            bcl2fastq_exe)
-                    else:
-                        raise Exception("No appropriate bcl2fastq software "
-                                        "located")
-                    # Check we have cellranger
-                    cellranger = utils.find_executables(
-                        ('cellranger',),
-                        tenx_genomics_utils.cellranger_info)
-                    if not cellranger:
-                        raise Exception("No cellranger package found")
                     # Put a copy of sample sheet in the log directory
                     shutil.copy(sample_sheet,self.log_dir)
                     # Run cellranger mkfastq

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     auto_processor.py: core module for automated processing of Illumina sequence data
-#     Copyright (C) University of Manchester 2013-16 Peter Briggs
+#     Copyright (C) University of Manchester 2013-17 Peter Briggs
 #
 #########################################################################
 #
@@ -1541,7 +1541,6 @@ class AutoProcess:
         print "Bcl-to-fastq version  : %s %s" % (bcl2fastq_info[1],
                                                bcl2fastq_info[2])
         print "Primary data dir      : %s" % primary_data_dir
-        print "%s" % illumina_run.run_dir
         print "Platform              : %s" % illumina_run.platform
         print "Bcl format            : %s" % illumina_run.bcl_extension
         print "Source sample sheet   : %s" % sample_sheet

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1233,6 +1233,10 @@ class AutoProcess:
             print "Expected Fastq outputs already present"
             skip_rsync = True
             skip_fastq_generation = True
+        # Check if there's anything to do
+        if not (skip_rsync or skip_fastq_generation or generate_stats):
+            print "Nothing to do"
+            return
         # Log dir
         log_dir = 'make_fastqs'
         if protocol:

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1151,13 +1151,13 @@ class AutoProcess:
           runner              : (optional) specify a non-default job runner to use for
                                 fastq generation
           cellranger_jobmode  : (optional) job mode to run cellranger in
-                                (10xGenomics Chromium data only)
+                                (10xGenomics Chromium SC data only)
           cellranger_mempercore: (optional) memory assumed per core (in Gbs)
-                                (10xGenomics Chromium data only)
+                                (10xGenomics Chromium SC data only)
           cellranger_maxjobs  : (optional) maxiumum number of concurrent jobs
-                                to run (10xGenomics Chromium data only)
+                                to run (10xGenomics Chromium SC data only)
           cellranger_jobinterval: (optional) how often jobs are submitted (in
-                                ms) (10xGenomics Chromium data only)
+                                ms) (10xGenomics Chromium SC data only)
 
         """
         # Check primary data
@@ -1191,14 +1191,14 @@ class AutoProcess:
                 if l not in samplesheet_lanes:
                     raise Exception("Requested lane '%d' not present "
                                     "in samplesheet" % l)
-        # Adjust verification settings for 10xGenomics Chromium
+        # Adjust verification settings for 10xGenomics Chromium SC
         # data if necessary
         verify_include_sample_dir = False
-        if protocol == '10x_chromium':
+        if protocol == '10x_chromium_sc':
             if tenx_genomics_utils.has_chromium_indices(
                     self.params.sample_sheet):
                 # Force inclusion of sample-name subdirectories
-                # when verifying Chromium data
+                # when verifying Chromium SC data
                 print "Sample sheet includes Chromium SC indices"
                 verify_include_sample_dir = True
         # Check for pre-existing Fastq outputs
@@ -1244,8 +1244,8 @@ class AutoProcess:
                         runner=runner)
                 except Exception,ex:
                     raise Exception("Bcl2fastq stage failed: '%s'" % ex)
-            elif protocol == '10x_chromium':
-                # 10xGenomics Chromium
+            elif protocol == '10x_chromium_sc':
+                # 10xGenomics Chromium SC
                 try:
                     # Check we have bcl2fastq
                     bcl2fastq = bcl2fastq_utils.available_bcl2fastq_versions(

--- a/auto_process_ngs/bcl2fastq_utils.py
+++ b/auto_process_ngs/bcl2fastq_utils.py
@@ -36,6 +36,7 @@ import auto_process_ngs.applications as applications
 import auto_process_ngs.utils as utils
 import bcftbx.IlluminaData as IlluminaData
 import bcftbx.utils as bcf_utils
+from pkg_resources import parse_version
 
 #######################################################################
 # Functions

--- a/auto_process_ngs/bcl2fastq_utils.py
+++ b/auto_process_ngs/bcl2fastq_utils.py
@@ -212,13 +212,13 @@ def make_custom_sample_sheet(input_sample_sheet,output_sample_sheet=None,
     sample_sheet.fix_duplicated_names()
     # Select subset of lanes if requested
     if lanes is not None:
-        print "Updating to include only specified lanes: %s" % \
-            ','.join([str(l) for l in lanes])
+        logging.debug("Updating to include only specified lanes: %s" %
+                      ','.join([str(l) for l in lanes]))
         i = 0
         while i < len(sample_sheet):
             line = sample_sheet[i]
             if line['Lane'] in lanes:
-                print "Keeping %s" % line
+                logging.debug("Keeping %s" % line)
                 i += 1
             else:
                 del(sample_sheet[i])

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -47,7 +47,17 @@ logger = logging.getLogger(__name__)
 
 def flow_cell_id(run_name):
     """
-    Extract the flow cell ID from the run name
+    Extract the flow cell ID from a run name
+
+    For example for run name "170426_K00311_0033_AHJCY7BBXX"
+    the extracted flow cell ID will be "HJCY7BBXX".
+
+    Arguments:
+      run_name (str): path to the run name to extract
+        flow cell ID from
+
+    Returns:
+      String: the extracted flow cell ID.
     """
     flow_cell_id = os.path.basename(run_name).split("_")[-1]
     return flow_cell_id[1:]

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -11,7 +11,7 @@ Utility classes and functions for processing the outputs from 10xGenomics's
 Chromium SC 3'v2 system:
 
 - flow_cell_id
-- has_chromium_indices
+- has_chromium_sc_indices
 - cellranger_info
 - make_qc_summary_html
 - run_cellranger_mkfastq
@@ -62,11 +62,11 @@ def flow_cell_id(run_name):
     flow_cell_id = os.path.basename(run_name).split("_")[-1]
     return flow_cell_id[1:]
 
-def has_chromium_indices(sample_sheet):
+def has_chromium_sc_indices(sample_sheet):
     """
-    Check if a sample sheet contains Chromium indices
+    Check if a sample sheet contains Chromium SC indices
 
-    The Chromium indices can be obtained from:
+    The Chromium SC indices can be obtained from:
 
     https://support.10xgenomics.com/permalink/27rGqWvNYYuqkgeS66sksm
 
@@ -82,7 +82,7 @@ def has_chromium_indices(sample_sheet):
 
     Returns:
       Boolean: True if the sample sheet contains at least
-        one Chromium index, False if not.
+        one Chromium SC index, False if not.
     """
     index_pattern = re.compile(r"SI-GA-[A-H](1[1-2]|[1-9])$")
     s = SampleSheet(sample_sheet)

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -11,6 +11,7 @@ Utility classes and functions for processing the outputs from 10xGenomics's
 Chromium SC 3'v2 system:
 
 - flow_cell_id
+- has_chromium_indices
 - cellranger_info
 - make_qc_summary_html
 - run_cellranger_mkfastq
@@ -23,7 +24,9 @@ Chromium SC 3'v2 system:
 #######################################################################
 
 import os
+import re
 import json
+from bcftbx.IlluminaData import SampleSheet
 from bcftbx.JobRunner import SimpleJobRunner
 from bcftbx.utils import find_program
 from .applications import Command
@@ -48,6 +51,35 @@ def flow_cell_id(run_name):
     """
     flow_cell_id = os.path.basename(run_name).split("_")[-1]
     return flow_cell_id[1:]
+
+def has_chromium_indices(sample_sheet):
+    """
+    Check if a sample sheet contains Chromium indices
+
+    The Chromium indices can be obtained from:
+
+    https://support.10xgenomics.com/permalink/27rGqWvNYYuqkgeS66sksm
+
+    The Chromium SC 3'v2 indices are of the form:
+
+    SI-GA-[A-H][1-12]
+
+    e.g. 'SI-GA-B11'
+
+    Arguments:
+      sample_sheet (str): path to the sample sheet CSV
+        file to check
+
+    Returns:
+      Boolean: True if the sample sheet contains at least
+        one Chromium index, False if not.
+    """
+    index_pattern = re.compile(r"SI-GA-[A-H](1[1-2]|[1-9])$")
+    s = SampleSheet(sample_sheet)
+    for line in s:
+        if index_pattern.match(line['index']):
+            return True
+    return False
 
 def make_qc_summary_html(json_file,html_file):
     """

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -30,6 +30,8 @@ from bcftbx.IlluminaData import SampleSheet
 from bcftbx.JobRunner import SimpleJobRunner
 from bcftbx.utils import find_program
 from .applications import Command
+from .bcl2fastq_utils import available_bcl2fastq_versions
+from .bcl2fastq_utils import bcl_to_fastq_info
 from .simple_scheduler import SchedulerJob
 from .docwriter import Document
 from .docwriter import List
@@ -250,6 +252,26 @@ def run_cellranger_mkfastq(sample_sheet,
     Returns:
       Integer: exit code from the cellranger command.
     """
+    # Check we have cellranger
+    cellranger = find_program('cellranger')
+    if not cellranger:
+        raise Exception("No cellranger package found")
+    print "Using cellranger %s: %s" % (cellranger_info(cellranger)[-1],
+                                       cellranger)
+    # Check we have bcl2fastq
+    bcl2fastq = find_program('bcl2fastq')
+    if not bcl2fastq:
+        raise Exception("No bcl2fastq package found")
+    bcl2fastq = available_bcl2fastq_versions(
+        paths=(os.path.dirname(bcl2fastq),),
+        reqs='>=2.17')
+    if not bcl2fastq:
+        raise Exception("No appropriate bcl2fastq software "
+                        "located")
+    bcl2fastq = bcl2fastq[0]
+    print "Using bcl2fastq %s: %s" % (
+        bcl_to_fastq_info(bcl2fastq)[-1],
+        bcl2fastq)
     # Construct the command
     cmd = Command("cellranger","mkfastq",
                   "--samplesheet",sample_sheet,

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -19,6 +19,9 @@ Chromium SC 3'v2 system:
 
 import os
 import json
+from bcftbx.JobRunner import SimpleJobRunner
+from .applications import Command
+from .simple_scheduler import SchedulerJob
 from .docwriter import Document
 from .docwriter import List
 from .docwriter import Link
@@ -110,7 +113,7 @@ def run_cellranger_mkfastq(sample_sheet,
     data.
 
     Arguments:
-      samplesheet (str): path to input samplesheet with
+      sample_sheet (str): path to input samplesheet with
         10xGenomics barcode indices
       primary_data_dir (str): path to the top-level
         directory holding the sequencing data
@@ -136,7 +139,7 @@ def run_cellranger_mkfastq(sample_sheet,
     """
     # Construct the command
     cmd = Command("cellranger","mkfastq",
-                  "--samplesheet",samplesheet,
+                  "--samplesheet",sample_sheet,
                   "--run",primary_data_dir,
                   "--output-dir",output_dir)
     if lanes is not None:
@@ -152,8 +155,8 @@ def run_cellranger_mkfastq(sample_sheet,
         # Make a log directory
         if log_dir is None:
             log_dir = os.getcwd()
-        log_dir = get_log_subdir(log_dir,"cellranger_mkfastq")
-        mkdir(log_dir)
+        else:
+            log_dir = os.path.abspath(log_dir)
         # Submit the job
         cellranger_mkfastq_job = SchedulerJob(
             SimpleJobRunner(),

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -205,6 +205,7 @@ def run_cellranger_mkfastq(sample_sheet,
                            primary_data_dir,
                            output_dir,
                            lanes=None,
+                           bases_mask=None,
                            cellranger_jobmode=None,
                            cellranger_maxjobs=None,
                            cellranger_mempercore=None,
@@ -227,6 +228,9 @@ def run_cellranger_mkfastq(sample_sheet,
       lanes (str): optional, specify the subset of lanes
         to process (default is to process all lanes
         in the run)
+      bases_mask (str): optional, specify an alternative
+        bases mask setting (default is to let cellranger
+        determine the bases mask automatically)
       cellranger_jobmode (str): specify the job mode to
         pass to cellranger (default: None)
       cellranger_maxjobs (int): specify the maximum
@@ -253,6 +257,8 @@ def run_cellranger_mkfastq(sample_sheet,
                   "--output-dir",output_dir)
     if lanes is not None:
         cmd.add_args("--lanes=%s" % lanes)
+    if bases_mask is not None:
+        cmd.add_args("--use-bases-mask=%s" % bases_mask)
     add_cellranger_args(cmd,
                         jobmode=cellranger_jobmode,
                         mempercore=cellranger_mempercore,

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -10,7 +10,12 @@ tenx_genomics_utils.py
 Utility classes and functions for processing the outputs from 10xGenomics's
 Chromium SC 3'v2 system:
 
+- flow_cell_id
+- cellranger_info
 - make_qc_summary_html
+- run_cellranger_mkfastq
+- add_cellranger_args
+
 """
 
 #######################################################################

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -92,6 +92,44 @@ def make_qc_summary_html(json_file,html_file):
     # Write the report
     qc_summary.write(html_file)
 
+def add_cellranger_args(cellranger_cmd,
+                        jobmode=None,
+                        maxjobs=None,
+                        mempercore=None,
+                        jobinterval=None):
+    """
+    Configure options for cellranger
+
+    Given a Command instance for running cellranger,
+    add the appropriate options (e.g. --jobmode)
+    according to the supplied arguments.
+
+    Arguments:
+      cellranger_cmd (Command): Command instance for
+        running cellranger
+      jobmode (str): if specified, will be passed to the
+        --jobmode option
+      maxjobs (int): if specified, will be passed to the
+        --mempercore option
+      mempercore (int): if specified, will be passed to
+        the --maxjobs option
+      jobinterval (int):  if specified, will be passed to
+        the --jobinterval option
+
+    Returns:
+      Command: the original command updated with the
+        appropriate options.
+    """
+    if jobmode is not None:
+        cellranger_cmd.add_args("--jobmode=%s" % jobmode)
+    if mempercore is not None:
+        cellranger_cmd.add_args("--mempercore=%s" % mempercore)
+    if maxjobs is not None:
+        cellranger_cmd.add_args("--maxjobs=%s" % maxjobs)
+    if jobinterval is not None:
+        cellranger_cmd.add_args("--jobinterval=%s" % jobinterval)
+    return cellranger_cmd
+
 import sys
 if __name__ == "__main__":
     json_file = sys.argv[1]

--- a/auto_process_ngs/test/test_bcl2fastq.py
+++ b/auto_process_ngs/test/test_bcl2fastq.py
@@ -503,6 +503,73 @@ class TestBclToFastqInfo(unittest.TestCase):
         self.assertEqual(name,'')
         self.assertEqual(version,'')
 
+class TestMakeCustomSampleSheet(unittest.TestCase):
+    """Tests for the make_custom_sample_sheet function
+    """
+    def setUp(self):
+        # Create a temporary working dir
+        self.wd = tempfile.mkdtemp()
+        self.iem_content = """[Header]
+IEMFileVersion,4
+
+[Reads]
+101
+101
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+1,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+2,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+2,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+3,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+3,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+4,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+4,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+"""
+    def tearDown(self):
+        # Remove working dir
+        if self.wd is not None:
+            shutil.rmtree(self.wd)
+    def test_make_custom_sample_sheet_lanes(self):
+        """
+        make_custom_sample_sheet: output subset of lanes
+        """
+        sample_sheet_in = os.path.join(self.wd,
+                                       "SampleSheet.csv")
+        with open(sample_sheet_in,'w') as fp:
+            fp.write(self.iem_content)
+        sample_sheet_out = os.path.join(self.wd,
+                                       "custom_SampleSheet.csv")
+        make_custom_sample_sheet(sample_sheet_in,
+                                 output_sample_sheet=sample_sheet_out,
+                                 lanes=[3,4])
+        expected = """[Header]
+IEMFileVersion,4
+
+[Reads]
+101
+101
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+3,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+3,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+4,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+4,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+"""
+        self.assertTrue(os.path.exists(sample_sheet_out))
+        self.assertEqual(open(sample_sheet_out,'r').read(),
+                         expected)
+
 class TestGetNmismatches(unittest.TestCase):
     """Tests for the get_nmismatches function
 

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -19,9 +19,9 @@ class TestFlowCellId(unittest.TestCase):
         self.assertEqual(flow_cell_id("170426_K00311_0033_AHJCY7BBXX"),
                          "HJCY7BBXX")
 
-class TestHasChromiumIndices(unittest.TestCase):
+class TestHasChromiumSCIndices(unittest.TestCase):
     """
-    Tests for the 'has_chromium_indices' function
+    Tests for the 'has_chromium_sc_indices' function
     """
     def setUp(self):
         # Sample sheet contents
@@ -80,7 +80,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
 4,smpl4,smpl4,,,A007,SI-GA-D1,10xGenomics,
 """
         # Make temporary working dir
-        self.wd = tempfile.mkdtemp(suffix="TestHasChromiumIndices")
+        self.wd = tempfile.mkdtemp(suffix="TestHasChromiumSCIndices")
     def tearDown(self):
         # Remove temp dir
         shutil.rmtree(self.wd)
@@ -97,21 +97,21 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
         """
         s = self._make_sample_sheet(
             self.sample_sheet_with_chromium_indices)
-        self.assertTrue(has_chromium_indices(s))
+        self.assertTrue(has_chromium_sc_indices(s))
     def test_sample_sheet_no_chromium_indices(self):
         """
-        has_chromium_indices: sample sheet with no Chromium indices
+        has_chromium_indices: sample sheet with no Chromium SC indices
         """
         s = self._make_sample_sheet(
             self.sample_sheet_standard_indices)
-        self.assertFalse(has_chromium_indices(s))
+        self.assertFalse(has_chromium_sc_indices(s))
     def test_sample_sheet_some_chromium_sc_3_v2_indices(self):
         """
         has_chromium_indices: sample sheet with some Chromium SC 3'v2 indices
         """
         s = self._make_sample_sheet(
             self.sample_sheet_mixed_indices)
-        self.assertTrue(has_chromium_indices(s))
+        self.assertTrue(has_chromium_sc_indices(s))
 
 class TestCellrangerInfo(unittest.TestCase):
     """

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -8,6 +8,100 @@ import os
 import shutil
 from auto_process_ngs.tenx_genomics_utils import *
 
+class TestHasChromiumIndices(unittest.TestCase):
+    """
+    Tests for the 'has_chromium_indices' function
+    """
+    def setUp(self):
+        # Sample sheet contents
+        self.sample_sheet_with_chromium_indices = """[Header]
+IEMFileVersion,4
+
+[Reads]
+76
+76
+
+[Settings]
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+1,smpl1,smpl1,,,A001,SI-GA-A1,10xGenomics,
+2,smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
+3,smpl3,smpl3,,,A006,SI-GA-C1,10xGenomics,
+4,smpl4,smpl4,,,A007,SI-GA-D1,10xGenomics,
+"""
+        self.sample_sheet_standard_indices = """[Header]
+IEMFileVersion,4
+
+[Reads]
+76
+76
+
+[Settings]
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+1,smpl1,smpl1,,,A001,GGTTTACT,standard,
+2,smpl2,smpl2,,,A005,GTAATCTT,standard,
+3,smpl3,smpl3,,,A006,CCACTTAT,standard,
+4,smpl4,smpl4,,,A007,CACTCGGA,standard,
+"""
+        self.sample_sheet_mixed_indices = """[Header]
+IEMFileVersion,4
+
+[Reads]
+76
+76
+
+[Settings]
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+1,smpl1,smpl1,,,A001,GGTTTACT,standard,
+2,smpl2,smpl2,,,A005,GTAATCTT,standard,
+3,smpl3,smpl3,,,A006,SI-GA-C1,10xGenomics,
+4,smpl4,smpl4,,,A007,SI-GA-D1,10xGenomics,
+"""
+        # Make temporary working dir
+        self.wd = tempfile.mkdtemp(suffix="TestHasChromiumIndices")
+    def tearDown(self):
+        # Remove temp dir
+        shutil.rmtree(self.wd)
+    def _make_sample_sheet(self,content):
+        # Make a sample sheet with supplied content in
+        # the temporary area
+        sample_sheet_csv = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet_csv,'w') as s:
+            s.write(content)
+        return sample_sheet_csv
+    def test_sample_sheet_all_chromium_sc_3_v2_indices(self):
+        """
+        has_chromium_indices: sample sheet with Chromium SC 3'v2 indices only
+        """
+        s = self._make_sample_sheet(
+            self.sample_sheet_with_chromium_indices)
+        self.assertTrue(has_chromium_indices(s))
+    def test_sample_sheet_no_chromium_indices(self):
+        """
+        has_chromium_indices: sample sheet with no Chromium indices
+        """
+        s = self._make_sample_sheet(
+            self.sample_sheet_standard_indices)
+        self.assertFalse(has_chromium_indices(s))
+    def test_sample_sheet_some_chromium_sc_3_v2_indices(self):
+        """
+        has_chromium_indices: sample sheet with some Chromium SC 3'v2 indices
+        """
+        s = self._make_sample_sheet(
+            self.sample_sheet_mixed_indices)
+        self.assertTrue(has_chromium_indices(s))
+
 class TestCellrangerInfo(unittest.TestCase):
     """
     Tests for the cellranger_info function

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -8,6 +8,17 @@ import os
 import shutil
 from auto_process_ngs.tenx_genomics_utils import *
 
+class TestFlowCellId(unittest.TestCase):
+    """
+    Tests for the 'flow_cell_id' function
+    """
+    def test_flow_cell_id(self):
+        """
+        flow_cell_id: returns correct ID
+        """
+        self.assertEqual(flow_cell_id("170426_K00311_0033_AHJCY7BBXX"),
+                         "HJCY7BBXX")
+
 class TestHasChromiumIndices(unittest.TestCase):
     """
     Tests for the 'has_chromium_indices' function

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -1,0 +1,38 @@
+#######################################################################
+# Tests for tenx_genomics_utils.py module
+#######################################################################
+
+import unittest
+import tempfile
+import os
+import shutil
+from auto_process_ngs.tenx_genomics_utils import *
+
+class TestCellrangerInfo(unittest.TestCase):
+    """
+    Tests for the cellranger_info function
+    """
+    def setUp(self):
+        # Make temporary working dir
+        self.wd = tempfile.mkdtemp(suffix="TestCellrangerInfo")
+        # Store the original state of PATH env var
+        self.original_path = os.environ['PATH']
+    def tearDown(self):
+        # Restore the PATH env var
+        os.environ['PATH'] = self.original_path
+        # Remove temp dir
+        shutil.rmtree(self.wd)
+    def _make_mock_cellranger_201(self):
+        # Make a fake cellranger 2.0.1 executable
+        cellranger_201 = os.path.join(self.wd,"cellranger")
+        with open(cellranger_201,'w') as fp:
+            fp.write("#!/bin/bash\ncat <<EOF\ncellranger $1  (2.0.1)\nCopyright (c) 2017 10x Genomics, Inc.  All rights reserved.\n-------------------------------------------------------------------------------\n\nUsage:\n    cellranger mkfastq\n\n    cellranger count\n    cellranger aggr\n    cellranger reanalyze\n    cellranger mkloupe\n    cellranger mat2csv\n\n    cellranger mkgtf\n    cellranger mkref\n\n    cellranger vdj\n\n    cellranger mkvdjref\n\n    cellranger testrun\n    cellranger upload\n    cellranger sitecheckEOF")
+        os.chmod(cellranger_201,0775)
+        return cellranger_201
+            
+    def test_cellranger_201(self):
+        """cellranger_info: collect info for cellranger 2.0.1
+        """
+        cellranger = self._make_mock_cellranger_201()
+        self.assertEqual(cellranger_info(path=cellranger),
+                         (cellranger,'cellranger','2.0.1'))

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -390,6 +390,28 @@ def add_make_fastqs_command(cmdparser):
                            default_display=default_nprocessors)
     add_runner_option(bcl_to_fastq)
     p.add_option_group(bcl_to_fastq)
+    # Cellranger (10xgenomics Chromium) options
+    cellranger = optparse.OptionGroup(p,'Cellranger options (10xGenomics '
+                                      'Chromium data only)')
+    cellranger.add_option("--jobmode",
+                          dest="job_mode",default="sge",
+                          help="job mode to run cellranger in (default: "
+                          "'sge'")
+    cellranger.add_option("--mempercore",
+                          dest="mem_per_core",default=5,
+                          help="memory assumed per core (in Gbs; "
+                          "default: 5Gb)")
+    cellranger.add_option("--maxjobs",type=int,
+                          dest="max_jobs",
+                          default=__settings.general.max_concurrent_jobs,
+                          help="maxiumum number of concurrent jobs to run "
+                          "(default: %d)"
+                          % __settings.general.max_concurrent_jobs)
+    cellranger.add_option("--jobinterval",type=int,
+                          dest="job_interval",default=100,
+                          help="how often jobs are submitted (in ms; "
+                          "default: 100ms)")
+    p.add_option_group(cellranger)
     # Statistics
     statistics = optparse.OptionGroup(p,'Statistics generation')
     statistics.add_option('--stats-file',action='store',
@@ -930,7 +952,11 @@ if __name__ == "__main__":
                 barcodes_file=options.barcodes_file,
                 skip_fastq_generation=skip_fastq_generation,
                 only_fetch_primary_data=options.only_fetch_primary_data,
-                create_empty_fastqs=create_empty_fastqs)
+                create_empty_fastqs=create_empty_fastqs,
+                cellranger_jobmode=options.job_mode,
+                cellranger_mempercore=options.mem_per_core,
+                cellranger_maxjobs=options.max_jobs,
+                cellranger_jobinterval=options.job_interval)
         elif cmd == 'merge_fastq_dirs':
             d.merge_fastq_dirs(options.unaligned_dir,
                                output_dir=options.output_dir,

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -896,11 +896,6 @@ if __name__ == "__main__":
         # Run the specified stage
         d = AutoProcess(analysis_dir,allow_save_params=allow_save)
         if cmd == 'make_fastqs':
-            # Deal with --protocol
-            if options.protocol == 'standard':
-                protocol = None
-            else:
-                protocol = options.protocol
             # Deal with --no-lane-splitting
             if options.no_lane_splitting and options.use_lane_splitting:
                 p.error("--no-lane-splitting and --use-lane-splitting "
@@ -932,7 +927,7 @@ if __name__ == "__main__":
             # Do the make_fastqs step
             try:
                 d.make_fastqs(
-                    protocol=protocol,
+                    protocol=options.protocol,
                     skip_rsync=options.skip_rsync,
                     nprocessors=options.nprocessors,
                     runner=options.runner,

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -930,34 +930,38 @@ if __name__ == "__main__":
             skip_fastq_generation = (options.skip_fastq_generation or
                                      options.skip_bcl2fastq)
             # Do the make_fastqs step
-            d.make_fastqs(
-                protocol=protocol,
-                skip_rsync=options.skip_rsync,
-                nprocessors=options.nprocessors,
-                runner=options.runner,
-                remove_primary_data=options.remove_primary_data,
-                ignore_missing_bcl=options.ignore_missing_bcl,
-                ignore_missing_stats=options.ignore_missing_stats,
-                generate_stats=(not options.no_stats),
-                require_bcl2fastq_version=options.bcl2fastq_version,
-                unaligned_dir=options.unaligned_dir,
-                sample_sheet=options.sample_sheet,
-                bases_mask=options.bases_mask,
-                lanes=lanes,
-                no_lane_splitting=no_lane_splitting,
-                minimum_trimmed_read_length=options.minimum_trimmed_read_length,
-                mask_short_adapter_reads=options.mask_short_adapter_reads,
-                stats_file=options.stats_file,
-                per_lane_stats_file=options.per_lane_stats_file,
-                report_barcodes=options.report_barcodes,
-                barcodes_file=options.barcodes_file,
-                skip_fastq_generation=skip_fastq_generation,
-                only_fetch_primary_data=options.only_fetch_primary_data,
-                create_empty_fastqs=create_empty_fastqs,
-                cellranger_jobmode=options.job_mode,
-                cellranger_mempercore=options.mem_per_core,
-                cellranger_maxjobs=options.max_jobs,
-                cellranger_jobinterval=options.job_interval)
+            try:
+                d.make_fastqs(
+                    protocol=protocol,
+                    skip_rsync=options.skip_rsync,
+                    nprocessors=options.nprocessors,
+                    runner=options.runner,
+                    remove_primary_data=options.remove_primary_data,
+                    ignore_missing_bcl=options.ignore_missing_bcl,
+                    ignore_missing_stats=options.ignore_missing_stats,
+                    generate_stats=(not options.no_stats),
+                    require_bcl2fastq_version=options.bcl2fastq_version,
+                    unaligned_dir=options.unaligned_dir,
+                    sample_sheet=options.sample_sheet,
+                    bases_mask=options.bases_mask,
+                    lanes=lanes,
+                    no_lane_splitting=no_lane_splitting,
+                    minimum_trimmed_read_length=options.minimum_trimmed_read_length,
+                    mask_short_adapter_reads=options.mask_short_adapter_reads,
+                    stats_file=options.stats_file,
+                    per_lane_stats_file=options.per_lane_stats_file,
+                    report_barcodes=options.report_barcodes,
+                    barcodes_file=options.barcodes_file,
+                    skip_fastq_generation=skip_fastq_generation,
+                    only_fetch_primary_data=options.only_fetch_primary_data,
+                    create_empty_fastqs=create_empty_fastqs,
+                    cellranger_jobmode=options.job_mode,
+                    cellranger_mempercore=options.mem_per_core,
+                    cellranger_maxjobs=options.max_jobs,
+                    cellranger_jobinterval=options.job_interval)
+            except Exception as ex:
+                logging.fatal("make_fastqs: %s" % ex)
+                sys.exit(1)
         elif cmd == 'merge_fastq_dirs':
             d.merge_fastq_dirs(options.unaligned_dir,
                                output_dir=options.output_dir,

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -217,8 +217,8 @@ def add_make_fastqs_command(cmdparser):
                                 dest='protocol',default='standard',
                                 help="specify Fastq generation protocol "
                                 "depending on the data being processed. "
-                                "Must be one of 'standard', '10x_chromium' "
-                                "(default: 'standard')")
+                                "Must be one of 'standard', "
+                                "'10x_chromium_sc' (default: 'standard')")
     fastq_generation.add_option('--sample-sheet',action="store",
                                 dest="sample_sheet",default=None,
                                 help="use an alternative sample sheet to "
@@ -391,9 +391,9 @@ def add_make_fastqs_command(cmdparser):
                            default_display=default_nprocessors)
     add_runner_option(bcl_to_fastq)
     p.add_option_group(bcl_to_fastq)
-    # Cellranger (10xgenomics Chromium) options
+    # Cellranger (10xgenomics Chromium SC 3') options
     cellranger = optparse.OptionGroup(p,'Cellranger options (10xGenomics '
-                                      'Chromium data only)')
+                                      'Chromium SC 3\' data only)')
     cellranger.add_option("--jobmode",
                           dest="job_mode",default="sge",
                           help="job mode to run cellranger in (default: "

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -237,6 +237,12 @@ def add_make_fastqs_command(cmdparser):
                                 help="explicitly set the output "
                                 "(sub)directory for bcl-to-fastq "
                                 "conversion (overrides default)")
+    fastq_generation.add_option('--use-bases-mask',action="store",
+                                dest="bases_mask",default=None,
+                                help="explicitly set the bases-mask string "
+                                "to indicate how each cycle should be used "
+                                "in the bcl-to-fastq conversion (overrides "
+                                "default)")
     fastq_generation.add_option('--skip-fastq-generation',
                                 action='store_true',
                                 dest='skip_fastq_generation',default=False,
@@ -244,11 +250,6 @@ def add_make_fastqs_command(cmdparser):
     p.add_option_group(fastq_generation)
     # Options to control bcl2fastq
     bcl_to_fastq = optparse.OptionGroup(p,'Bcl-to-fastq options')
-    bcl_to_fastq.add_option('--use-bases-mask',action="store",
-                            dest="bases_mask",default=None,
-                            help="explicitly set the bases-mask string to indicate how each "
-                            "cycle should be used in the bcl-to-fastq conversion (overrides "
-                            "default)")
     bcl_to_fastq.add_option('--ignore-missing-bcl',action='store_true',
                             dest='ignore_missing_bcl',default=False,
                             help="use the --ignore-missing-bcl option for bcl2fastq (treat "

--- a/bin/process_10xgenomics.py
+++ b/bin/process_10xgenomics.py
@@ -38,6 +38,7 @@ from auto_process_ngs.utils import ZipArchive
 from auto_process_ngs.tenx_genomics_utils import flow_cell_id
 from auto_process_ngs.tenx_genomics_utils import make_qc_summary_html
 from auto_process_ngs.tenx_genomics_utils import add_cellranger_args
+from auto_process_ngs.tenx_genomics_utils import run_cellranger_mkfastq
 import auto_process_ngs.envmod as envmod
 
 # Initialise logging
@@ -76,60 +77,18 @@ def cellranger_mkfastq(samplesheet,
                        project_metadata_file='projects.info'):
     """
     """
-    # Construct the command
-    cmd = Command("cellranger","mkfastq",
-                  "--samplesheet",samplesheet,
-                  "--run",primary_data_dir,
-                  "--output-dir",output_dir)
-    if lanes is not None:
-        cmd.add_args("--lanes=%s" % lanes)
-    add_cellranger_args(cmd,
-                        jobmode=cellranger_jobmode,
-                        mempercore=cellranger_mempercore,
-                        maxjobs=cellranger_maxjobs,
-                        jobinterval=cellranger_jobinterval)
-    # Run the command
-    print "Running: %s" % cmd
+    # Run cellranger mkfastq
+    run_cellranger_mkfastq(samplesheet,
+                           primary_data_dir,
+                           output_dir,
+                           lanes=lanes,
+                           cellranger_jobmode=cellranger_jobmode,
+                           cellranger_maxjobs=cellranger_maxjobs,
+                           cellranger_mempercore=cellranger_mempercore,
+                           cellranger_jobinterval=cellranger_jobinterval,
+                           log_dir=log_dir,
+                           dry_run=dry_run)
     if not dry_run:
-        # Make a log directory
-        if log_dir is None:
-            log_dir = os.getcwd()
-        log_dir = get_log_subdir(log_dir,"cellranger_mkfastq")
-        mkdir(log_dir)
-        # Submit the job
-        cellranger_mkfastq_job = SchedulerJob(
-            SimpleJobRunner(),
-            cmd.command_line,
-            name='cellranger_mkfastq',
-            working_dir=os.getcwd(),
-            log_dir=log_dir)
-        cellranger_mkfastq_job.start()
-        try:
-            cellranger_mkfastq_job.wait()
-        except KeyboardInterrupt,ex:
-            logging.warning("Keyboard interrupt, terminating cellranger")
-            cellranger_mkfastq_job.terminate()
-            raise ex
-        exit_code = cellranger_mkfastq_job.exit_code
-        print "cellranger mkfastq completed: exit code %s" % exit_code
-        if exit_code != 0:
-            logging.error("cellranger mkfastq exited with an error")
-            return
-        # Deal with the QC summary report
-        flow_cell_dir = flow_cell_id(primary_data_dir)
-        if lanes is not None:
-            lanes_suffix = "_%s" % lanes.replace(',','')
-        else:
-            lanes_suffix = ""
-        flow_cell_dir = "%s%s" % (flow_cell_dir,lanes_suffix)
-        if not os.path.isdir(flow_cell_dir):
-            logging.error("No output directory '%s'" % flow_cell_dir)
-            return
-        json_file = os.path.join(flow_cell_dir,
-                                 "outs",
-                                 "qc_summary.json")
-        html_file = "cellranger_qc_summary%s.html" % lanes_suffix
-        make_qc_summary_html(json_file,html_file)
         # Update the project metadata file
         update_project_metadata(output_dir,project_metadata_file)
 

--- a/bin/process_10xgenomics.py
+++ b/bin/process_10xgenomics.py
@@ -37,6 +37,7 @@ from auto_process_ngs.utils import ProjectMetadataFile
 from auto_process_ngs.utils import ZipArchive
 from auto_process_ngs.tenx_genomics_utils import flow_cell_id
 from auto_process_ngs.tenx_genomics_utils import make_qc_summary_html
+from auto_process_ngs.tenx_genomics_utils import add_cellranger_args
 import auto_process_ngs.envmod as envmod
 
 # Initialise logging
@@ -369,23 +370,6 @@ def build_fastq_path_dir(project_dir):
         logging.debug("Linking: %s -> %s" % (link_name,target))
         os.symlink(target,link_name)
     return fastq_path_dir
-
-def add_cellranger_args(cmd,
-                        jobmode='sge',
-                        maxjobs=None,
-                        mempercore=None,
-                        jobinterval=None):
-    """
-    """
-    if jobmode is not None:
-        cmd.add_args("--jobmode=%s" % jobmode)
-    if mempercore is not None:
-        cmd.add_args("--mempercore=%s" % mempercore)
-    if maxjobs is not None:
-        cmd.add_args("--maxjobs=%s" % maxjobs)
-    if jobinterval is not None:
-        cmd.add_args("--jobinterval=%s" % jobinterval)
-    return cmd
 
 def get_log_subdir(log_dir,name):
     """

--- a/bin/process_10xgenomics.py
+++ b/bin/process_10xgenomics.py
@@ -77,6 +77,12 @@ def cellranger_mkfastq(samplesheet,
                        project_metadata_file='projects.info'):
     """
     """
+    # Make a log directory
+    if not dry_run:
+        if log_dir is None:
+            log_dir = os.getcwd()
+        log_dir = get_log_subdir(log_dir,"cellranger_mkfastq")
+        mkdir(log_dir)
     # Run cellranger mkfastq
     run_cellranger_mkfastq(samplesheet,
                            primary_data_dir,

--- a/bin/process_10xgenomics.py
+++ b/bin/process_10xgenomics.py
@@ -77,6 +77,9 @@ def cellranger_mkfastq(samplesheet,
                        project_metadata_file='projects.info'):
     """
     """
+    # Warn that this command is now deprecated
+    logging.warning("This command is deprecated, use 'auto_process"
+                    "make_fastqs --protocol=10x_chromium_sc' instead")
     # Make a log directory
     if not dry_run:
         if log_dir is None:
@@ -284,6 +287,8 @@ def update_project_metadata(unaligned_dir,
                             project_metadata_file):
     """
     """
+    # Warn that this command is now deprecated
+    logging.warning("This command is deprecated")
     analysis_dir = os.path.dirname(os.path.abspath(unaligned_dir))
     unaligned_dir = os.path.basename(unaligned_dir)
     try:

--- a/docs/source/10xgenomics.rst
+++ b/docs/source/10xgenomics.rst
@@ -38,29 +38,33 @@ There are currently two possible scenarios:
 The Fastq protocols for these two scenarios are slightly different and
 are described in the following sections.
 
+.. note::
+
+   The output directory structure from ``cellranger mkfastq`` doesn't
+   conform precisely to that from ``bcl2fastq2`` as outlined in the
+   manual for the latter.
+
 Sequencing run only contains Chromium samples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In this case the initial step after setp is to fetch the primary data
-for the run, by running the command::
+Fastq generation can be performed by running the command::
 
-    auto_process.py make_fastqs --only-fetch-primary-data
+    auto_process.py make_fastqs --protocol=10x_chromium_sc
 
-Once the data has been retrieved, the Fastq generation can be performed
-using ``process_10xgenomics.py`` to run ``cellranger mkfastq``, e.g.::
+which fetches the data and runs ``cellranger mkfastq``.
 
-    process_10xgenomics.py mkfastq \
-        -s custom_SampleSheet.10xgenomics.csv \
-        -r primary_data/170426_K00311_0033_AHJCY7BBXX \
-        -o bcl2fastq
+.. info::
+
+   This replaces the ``process_10xgenomics.py mkfastq`` command::
+
+       process_10xgenomics.py mkfastq \
+           -s custom_SampleSheet.10xgenomics.csv \
+           -r primary_data/170426_K00311_0033_AHJCY7BBXX \
+           -o bcl2fastq
 
 This will generate the Fastqs in the specified output directory (e.g.
 ``bcl2fastq``) along with an HTML report derived from the ``cellranger``
-JSON QC summary file.
-
-Finally, to generate statistics for the Fastqs run::
-
-    auto_process.py update_fastq_statistics
+JSON QC summary file, statistics for the Fastqs.
 
 Sequencing run contains both Chromium and non-Chromium samples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -75,15 +79,16 @@ It is recommended to generate Fastqs for the lanes containing
 ``auto_process.py make_fastqs --lanes=...`` command.
 
 When this has completed, the Fastqs can be generated for the lanes
-with the Chromium datasets using the ``process_10xgenomics.py``
-utility and specifying the lanes which contain these data via the
-``-l/--lanes`` option. E.g.::
+with the Chromium datasets by rerunning the ``make_fastqs`` command
+specifying the ``10x_chromium_sc`` protocol along with the lanes
+which contain these data, e.g.::
 
-    process_10xgenomics.py mkfastq \
-        -s custom_SampleSheet.10xgenomics.csv \
-        -r primary_data/170426_K00311_0033_AHJCY7BBXX \
-	-l 5,6 \
-        -o bcl2fastq.chromium
+    auto_process.py make_fastqs \
+        --protocol=10x_chromium_sc \
+        --lanes=5,6 \
+	--output-dir=bcl2fastq.chromium \
+        --skip-rsync \
+        --no-stats
 
 This will generate the Fastqs in the specified output directory (e.g.
 ``bcl2fastq.chromium``) along with an HTML report derived from the

--- a/docs/source/10xgenomics.rst
+++ b/docs/source/10xgenomics.rst
@@ -55,12 +55,8 @@ which fetches the data and runs ``cellranger mkfastq``.
 
 .. info::
 
-   This replaces the ``process_10xgenomics.py mkfastq`` command::
-
-       process_10xgenomics.py mkfastq \
-           -s custom_SampleSheet.10xgenomics.csv \
-           -r primary_data/170426_K00311_0033_AHJCY7BBXX \
-           -o bcl2fastq
+   This replaces the ``process_10xgenomics.py mkfastq`` command,
+   which is now deprecated and likely to be removed in future.
 
 This will generate the Fastqs in the specified output directory (e.g.
 ``bcl2fastq``) along with an HTML report derived from the ``cellranger``
@@ -122,7 +118,8 @@ non-Chromium datasets (if any).
            -u bcl2fastq.chromium
 
    which will add entries for the Chromium projects and samples
-   to the ``projects.info`` file.
+   to the ``projects.info`` file. However this option is likely
+   to be deprecated in future.
 
 Once the file has been edited to include additional data on the user,
 PI etc, the ``setup_analysis_dirs`` command can be used to create


### PR DESCRIPTION
PR to merge the 10xgenomics Fastq generation (currently performed by the `process_10xgenomics.py mkfastq` command) into the `autoprocess.py make_fastqs` command.

The update adds a new `--protocol` option to `make_fastqs` will will specify the type of data being processed and enable the autoprocessor to switch to the correct procedure for Fastq generation (as well as perform automatic verification and stats generation).

NB needs the changes to `genomics/bcftbx` in https://github.com/fls-bioinformatics-core/genomics/pull/48