### PR TITLE
ICell8: enable contaminant filter to be turned off

### DIFF
--- a/docs/source/icell8.rst
+++ b/docs/source/icell8.rst
@@ -81,6 +81,12 @@ The following steps are performed:
    then they must be explicitly supplied to the utility using
    the ``-m``/``--mammalian`` and ``-c``/``--contaminants`` options.
 
+.. note::
+
+   The contaminant filtering step can be turned off by specifying
+   the ``--no-contaminant-filter`` option, for example if analysing
+   data from a non-mammalian organism.
+
 Reorganisation by barcode and sample
 ------------------------------------
 
@@ -171,6 +177,9 @@ Reference data and quality filtering
 
    Set using the ``-c`` option on the command line, or via
    ``[icell8] contaminant_conf_file`` in the configuration file.
+
+   To turn off the contaminant filtering, specify the
+   ``--no-contaminant-filter`` option.
 
  * **Quality filtering of barcode and UMI sequences**: by default
    read pairs are *not* removed if the associated barcode or UMI


### PR DESCRIPTION
PR to implement new `--no-contaminant-filter` option for `process_icell8.py`, to turn off contaminant filtering step.