### PR TITLE
ICell8: explicitly specific default runner for ICell8 processing in settings

### DIFF
--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -163,6 +163,7 @@ class Settings:
                      'qc',
                      'stats',
                      'rsync',
+                     'icell8',
                      'icell8_contaminant_filter',
                      'icell8_statistics',):
             self.runners[name] = config.getrunner('runners',name,

--- a/bin/process_icell8.py
+++ b/bin/process_icell8.py
@@ -1644,7 +1644,7 @@ if __name__ == "__main__":
     try:
         default_runner = runners['default']
     except KeyError:
-        default_runner = __settings.general.default_runner
+        default_runner = __settings.runners.icell8
     for stage in stages:
         if stage not in runners:
             if stage == 'qc':

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -51,6 +51,7 @@ bcl2fastq = SimpleJobRunner
 qc = SimpleJobRunner
 stats = SimpleJobRunner
 rsync = SimpleJobRunner
+icell8 = SimpleJobRunner
 icell8_contaminant_filter = SimpleJobRunner
 icell8_statistics = SimpleJobRunner
 


### PR DESCRIPTION
Currently the default runner for the `process_icell8.py` utility is the general default runner specified in the `settings.ini` file.

This PR introduces a new setting option to explicitly override this default with a different runner.

This change has been prompted by the requirement to explicitly target a subset of cluster nodes when running the pipeline in our local production environment.