### PR TITLE
ICell8: limit batch sizes when generating statistics

### DIFF
--- a/auto_process_ngs/icell8_utils.py
+++ b/auto_process_ngs/icell8_utils.py
@@ -364,7 +364,7 @@ class ICell8StatsCollector(object):
                 n,('s' if n != 1 else ''))
             counts = {}
             umis = {}
-            progress = ProgressChecker(percent=1,total=n)
+            progress = ProgressChecker(percent=5,total=n)
             for i,r in enumerate(FastqIterator(fastq),start=1):
                 r = ICell8Read1(r)
                 barcode = r.barcode
@@ -475,7 +475,7 @@ class ICell8Stats(object):
                                        else ''))
         # Create unique sorted UMI lists
         print "Sorting UMI lists for each barcode"
-        progress = ProgressChecker(percent=1,total=nbarcodes)
+        progress = ProgressChecker(percent=5,total=nbarcodes)
         for i,barcode in enumerate(self._umis):
             self._umis[barcode] = sorted(list(self._umis[barcode]))
             if verbose:

--- a/auto_process_ngs/test/test_icell8_utils.py
+++ b/auto_process_ngs/test/test_icell8_utils.py
@@ -11,8 +11,8 @@ from auto_process_ngs.icell8_utils import ICell8WellList
 from auto_process_ngs.icell8_utils import ICell8Read1
 from auto_process_ngs.icell8_utils import ICell8ReadPair
 from auto_process_ngs.icell8_utils import ICell8FastqIterator
+from auto_process_ngs.icell8_utils import ICell8StatsCollector
 from auto_process_ngs.icell8_utils import ICell8Stats
-from auto_process_ngs.icell8_utils import ICell8FastqIterator
 from auto_process_ngs.icell8_utils import normalize_sample_name
 from auto_process_ngs.icell8_utils import get_icell8_bases_mask
 
@@ -242,6 +242,49 @@ class TestICell8FastqIterator(unittest.TestCase):
             fqr2_data += "%s\n" % pair.r2
         self.assertEqual(fqr1_data,icell8_fastq_r1)
         self.assertEqual(fqr2_data,icell8_fastq_r2)
+
+class TestICell8StatsCollector(unittest.TestCase):
+    """Tests for the ICell8StatsCollector class
+    """
+    def setUp(self):
+        # Temporary working dir
+        self.wd = tempfile.mkdtemp(suffix='.ICell8Stats')
+        # Test files
+        self.r1 = os.path.join(self.wd,'icell8.r1.fq')
+        with open(self.r1,'w') as fp:
+            fp.write(icell8_fastq_r1)
+    def tearDown(self):
+        # Remove temporary working dir
+        if os.path.isdir(self.wd):
+            shutil.rmtree(self.wd)
+    def test_icell8statscollector(self):
+        """ICell8StatsCollector: collect barcodes and UMIs
+        """
+        collector = ICell8StatsCollector()
+        fastq,counts,umis = collector(self.r1)
+        self.assertEqual(fastq,self.r1)
+        self.assertEqual(len(counts),3)
+        self.assertEqual(counts['GTTCCTGATTA'],1)
+        self.assertEqual(counts['AGAAGAGTACC'],1)
+        self.assertEqual(counts['GTCTGCAACGC'],1)
+        self.assertEqual(len(umis),3)
+        self.assertEqual(umis['GTTCCTGATTA'],set(['AGTCAAGTGCTGGG']))
+        self.assertEqual(umis['AGAAGAGTACC'],set(['TGGAAAATGTTGGC']))
+        self.assertEqual(umis['GTCTGCAACGC'],set(['GGAGGCCGGATCGC']))
+    def test_icell8statscollector_verbose_output(self):
+        """ICell8StatsCollector: collect in verbose mode
+        """
+        collector = ICell8StatsCollector(verbose=True)
+        fastq,counts,umis = collector(self.r1)
+        self.assertEqual(fastq,self.r1)
+        self.assertEqual(len(counts),3)
+        self.assertEqual(counts['GTTCCTGATTA'],1)
+        self.assertEqual(counts['AGAAGAGTACC'],1)
+        self.assertEqual(counts['GTCTGCAACGC'],1)
+        self.assertEqual(len(umis),3)
+        self.assertEqual(umis['GTTCCTGATTA'],set(['AGTCAAGTGCTGGG']))
+        self.assertEqual(umis['AGAAGAGTACC'],set(['TGGAAAATGTTGGC']))
+        self.assertEqual(umis['GTCTGCAACGC'],set(['GGAGGCCGGATCGC']))
 
 class TestICell8Stats(unittest.TestCase):
     """Tests for the ICell8Stats class

--- a/auto_process_ngs/test/test_utils.py
+++ b/auto_process_ngs/test/test_utils.py
@@ -1460,6 +1460,54 @@ class TestOutputFiles(unittest.TestCase):
         out.open('test2',append=True)
         self.assertEqual(len(out),1)
 
+class TestShowProgressChecker(unittest.TestCase):
+    """
+    Tests for the ProgressChecker class
+    """
+    def test_check_progress_every(self):
+        """
+        ProgressChecker: check every N items
+        """
+        progress = ProgressChecker(every=1)
+        self.assertTrue(progress.check(0))
+        self.assertTrue(progress.check(1))
+        progress = ProgressChecker(every=5)
+        self.assertTrue(progress.check(0))
+        self.assertFalse(progress.check(1))
+        self.assertTrue(progress.check(5))
+        self.assertTrue(progress.check(20))
+        self.assertFalse(progress.check(21))
+    def test_check_progress_every_percent(self):
+        """
+        ProgressChecker: check every percentage of items
+        """
+        progress = ProgressChecker(percent=5,total=12209)
+        self.assertTrue(progress.check(0))
+        self.assertFalse(progress.check(1))
+        self.assertFalse(progress.check(609))
+        self.assertTrue(progress.check(610))
+    def test_check_progress_every_percent_zero_total(self):
+        """
+        ProgressChecker: supplied total is zero for percentage
+        """
+        progress = ProgressChecker(percent=5,total=0)
+        self.assertFalse(progress.check(0))
+    def test_check_progress_every_percent_zero_total(self):
+        """
+        ProgressChecker: supplied total is smaller than percentage
+        """
+        progress = ProgressChecker(percent=10,total=9)
+        self.assertTrue(progress.check(0))
+        self.assertTrue(progress.check(1))
+    def test_get_percentage(self):
+        """
+        ProgressChecker: check returned percentage
+        """
+        progress = ProgressChecker(percent=5,total=12209)
+        self.assertEqual(progress.percent(0),float(0))
+        self.assertEqual(progress.percent(610),610.0/12209.0*100.0)
+        self.assertEqual(progress.percent(12209),float(100))
+
 class TestBasesMaskIsPairedEnd(unittest.TestCase):
     """Tests for the bases_mask_is_paired_end function
 

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     utils: utility classes & funcs for auto_process_ngs module
-#     Copyright (C) University of Manchester 2013-2016 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2017 Peter Briggs
 #
 ########################################################################
 #
@@ -32,6 +32,7 @@ Classes:
 - ProjectMetadataFile:
 - ZipArchive:
 - OutputFiles:
+- ProgressChecker:
 
 Functions:
 
@@ -2017,6 +2018,75 @@ class ZipArchive(object):
 
     def __del__(self):
         self.close()
+
+class ProgressChecker(object):
+    """
+    Check if an index is a multiple of a value or percentage
+
+    Utility class to help with reporting progress of iterations
+    over large numbers of items.
+
+    Typically progress would only be reported after a certain
+    number or percentage of items have been consumed; the
+    ProgressChecker can be used to check if this number or
+    percentage has been reached.
+
+    Example usage: to report after every 100th item:
+
+    >>> progress = ProgressChecker(every=100)
+    >>> for i in range(10000):
+    >>>    if progress.check(i):
+    >>>       print "Item %d" % i
+
+    To report every 5% of items:
+
+    >>> nitems = 10000
+    >>> progress = ProgressChecker(percent=5,total=nitems)
+    >>> for i in range(nitems):
+    >>>    if progress.check(i):
+    >>>       print "Item %d (%.2f%%)" % (i,progress.percent(i))
+    """
+    def __init__(self,every=None,percent=None,total=None):
+        """
+        Create a new ProgressChecker instance
+
+        Arguments:
+          every (int): specify interval number of items
+            for reporting
+          percent (float): specify a percentage interval
+          total (int): total number of items (must be
+            provided if using `percent`)
+        """
+        if every is None:
+            every = max(int(float(total)*float(percent)/100.0),1)
+        self._every = int(every)
+        self._total = total
+
+    def check(self,i):
+        """
+        Check index to see if it matches the interval
+
+        Arguments:
+          i (int): index to check
+
+        Returns:
+          Boolean: True if index matches the interval,
+            False if not.
+        """
+        return (i%self._every == 0)
+
+    def percent(self,i):
+        """
+        Convert index to a percentage
+
+        Arguments:
+          i (int): index to convert
+
+        Returns:
+          Float: index expressed as a percentage of the
+            total number of items.
+        """
+        return float(i)/float(self._total)*100.0
 
 #######################################################################
 # Functions

--- a/bin/icell8_stats.py
+++ b/bin/icell8_stats.py
@@ -202,6 +202,11 @@ if __name__ == "__main__":
                    type=int,default=1,
                    help="number of processors/cores available for "
                    "statistics generation (default: 1)")
+    p.add_argument("-m","--max-batch-size",
+                   type=int,default=MAXIMUM_BATCH_SIZE,
+                   help="maximum number of reads per batch "
+                   "when dividing Fastqs (multicore only; "
+                   "default: %d)" % MAXIMUM_BATCH_SIZE)
     args = p.parse_args()
 
     # Input Fastqs
@@ -236,11 +241,14 @@ if __name__ == "__main__":
     # Split into batches for multiprocessing
     if nprocs > 1:
         try:
-            batch_size,nbatches = get_batch_size(fastqs,
-                                                 min_batches=nprocs)
-            batched_fastqs = batch_fastqs(fastqs,batch_size,
-                                          basename="icell8_stats",
-                                          out_dir=working_dir)
+            batch_size,nbatches = get_batch_size(
+                fastqs,
+                max_batch_size=args.max_batch_size,
+                min_batches=nprocs)
+            batched_fastqs = batch_fastqs(
+                fastqs,batch_size,
+                basename="icell8_stats",
+                out_dir=working_dir)
         except Exception as ex:
             logging.critical("Failed to split Fastqs into batches: "
                              "%s" % ex)

--- a/bin/icell8_stats.py
+++ b/bin/icell8_stats.py
@@ -29,7 +29,7 @@ from auto_process_ngs.icell8_utils import ICell8WellList
 from auto_process_ngs.icell8_utils import ICell8Stats
 
 # Module specific logger
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("icell8_stats")
 
 ######################################################################
 # Magic numbers

--- a/bin/icell8_stats.py
+++ b/bin/icell8_stats.py
@@ -20,8 +20,8 @@ import argparse
 import logging
 import tempfile
 import shutil
-from bcftbx import FASTQFile
 from bcftbx.TabFile import TabFile
+from auto_process_ngs.stats import FastqReadCounter
 from auto_process_ngs.fastq_utils import pair_fastqs
 from auto_process_ngs.fastq_utils import get_read_number
 from auto_process_ngs.applications import Command
@@ -64,7 +64,7 @@ def batch_fastqs(fastqs,nbatches,basename="batched",
     print "Fetching read counts:"
     nreads = 0
     for fq in fastqs:
-        n = FASTQFile.nreads(fq)
+        n = FastqReadCounter.zcat_wc(fq)
         print "%s:\t%d" % (os.path.basename(fq),n)
         nreads += n
     print "Total reads: %d" % nreads

--- a/bin/icell8_stats.py
+++ b/bin/icell8_stats.py
@@ -69,6 +69,9 @@ def get_batch_size(fastqs,min_batches=1,
       max_batch_size (int): the maxiumum batch size
       incr_function (Function): optional function to use
         to generate new number of batches to try
+
+    Returns:
+      Tuple: tuple of (batch_size,nbatches).
     """
     # Count the total number of reads
     print "Fetching read counts"
@@ -103,7 +106,7 @@ def get_batch_size(fastqs,min_batches=1,
         batch_size += 1
     print "Final batch size: %d" % batch_size
     assert(batch_size*nbatches >= nreads)
-    return nbatches
+    return (batch_size,nbatches)
 
 def batch_fastqs(fastqs,batch_size,basename="batched",
                  out_dir=None):
@@ -233,7 +236,8 @@ if __name__ == "__main__":
     # Split into batches for multiprocessing
     if nprocs > 1:
         try:
-            batch_size = get_batch_size(fastqs,min_batches=nprocs)
+            batch_size,nbatches = get_batch_size(fastqs,
+                                                 min_batches=nprocs)
             batched_fastqs = batch_fastqs(fastqs,batch_size,
                                           basename="icell8_stats",
                                           out_dir=working_dir)

--- a/bin/icell8_stats.py
+++ b/bin/icell8_stats.py
@@ -273,7 +273,9 @@ if __name__ == "__main__":
         batched_fastqs = fastqs
 
     # Collect statistics
-    stats = ICell8Stats(*batched_fastqs,nprocs=nprocs)
+    stats = ICell8Stats(*batched_fastqs,
+                        nprocs=nprocs,
+                        verbose=True)
 
     # Remove the working directory
     shutil.rmtree(working_dir)

--- a/bin/icell8_stats.py
+++ b/bin/icell8_stats.py
@@ -28,6 +28,15 @@ from auto_process_ngs.applications import Command
 from auto_process_ngs.icell8_utils import ICell8WellList
 from auto_process_ngs.icell8_utils import ICell8Stats
 
+# Module specific logger
+logger = logging.getLogger(__name__)
+
+######################################################################
+# Magic numbers
+######################################################################
+
+MAXIMUM_BATCH_SIZE = 100000000
+
 ######################################################################
 # Functions
 ######################################################################
@@ -62,6 +71,11 @@ def batch_fastqs(fastqs,nbatches,basename="batched",
 
     # Determine batch size
     batch_size = nreads/nbatches
+    if MAXIMUM_BATCH_SIZE > 0 and batch_size > MAXIMUM_BATCH_SIZE:
+        # Reset the batch size
+        logger.warning("Batch size exceeded maximum (%s), resetting" %
+                       MAXIMUM_BATCH_SIZE)
+        batch_size = MAXIMUM_BATCH_SIZE
     if nreads%batch_size:
         # Round up batch size
         batch_size += 1


### PR DESCRIPTION
PR to address issue encountered when generating statistics for large volumes of read pairs (e.g. when an entire HISeq 4000 flowcell is used for ICell8 samples) using multiple cores.

In this case, using 8 cores the `icell8_stats.py` utility failed with each subprocess giving errors of the form:

    SystemError: NULL result without error in PyObject_Call

The exact details aren't clear to me, however broadly speaking this appears to be associated with trying to push too much data from the thread back to the calling subprogram.

One workaround is to specify `nprocessors=1` when generating stats (essentially avoiding the multiprocessing issue). This PR aims to implement a fix by imposing an upper limit on the number of read pairs passed to each thread, which hopefully will avoid the problem in the multiprocessing context.