### PR TITLE
manage_fastqs.py: add support for multiple fastq sets in a project

### DIFF
--- a/bin/manage_fastqs.py
+++ b/bin/manage_fastqs.py
@@ -210,6 +210,16 @@ if __name__ == "__main__":
             sys.exit(1)
     print "ok"
 
+    # Switch to requested Fastq set
+    if options.fastq_dir is not None:
+        try:
+            project.use_fastq_dir(fastq_dir=options.fastq_dir)
+        except Exception as ex:
+            sys.stderr.write("ERROR %s\n" % ex)
+            sys.stderr.write("FAILED unable to switch to fastq set '%s'\n"
+                             % options.fastq_dir)
+            sys.exit(1)
+
     # Filter fastqs on pattern
     if options.pattern is not None:
         print "Filtering fastqs using pattern '%s'" % options.pattern
@@ -219,15 +229,6 @@ if __name__ == "__main__":
     try:
         cmd = args[2]
     except IndexError:
-        # Switch to requested Fastq set
-        if options.fastq_dir is not None:
-            try:
-                project.use_fastq_dir(fastq_dir=options.fastq_dir)
-            except Exception as ex:
-                sys.stderr.write("ERROR %s\n" % ex)
-                sys.stderr.write("FAILED unable to switch to fastq set '%s'\n"
-                                 % options.fastq_dir)
-                sys.exit(1)
         # List fastqs and exit
         total_size = 0
         n_fastqs = 0

--- a/docs/source/managing_data.rst
+++ b/docs/source/managing_data.rst
@@ -23,6 +23,12 @@ For example, to get a list of projects within a run::
 
     manage_fastqs.py RUN_DIR
 
+.. note::
+
+   If a project contains multiple sets of FASTQs then these
+   will be listed under the project name, with the default
+   "primary" project marked with an asterisk.
+
 To see a list of the FASTQ files associated with a particular project::
 
     manage_fastqs.py RUN_DIR PROJECTNAME
@@ -44,6 +50,19 @@ Finally to make a zip file containing the FASTQs, use the ``zip`` command::
 .. note::
 
     The ``zip`` option works best if the FASTQs are relatively small.
+
+Working with multiple FASTQ sets
+--------------------------------
+
+If a project has more than one FASTQ set associated with it then by
+default the operations described above will use the "primary" set
+(typically, the set of FASTQ files in the ``fastqs`` subdirectory
+of the project).
+
+To operate on an alternative set, use the ``--fastq_dir`` option to
+switch e.g.::
+
+    manage_fastqs.py RUN_DIR PROJECTNAME --fastq_dir=ALT_FASTQS_DIR
 
 Handling subsets of files
 -------------------------


### PR DESCRIPTION
PR which updates the `manage_fastqs.py` utility to support multiple fastq sets in a project.

The changes are:

* Lists the names of multiple fastq sets when listing projects (if there is more than one)
* Implements new `--fastq_dir` option to allow user to specify a different (non-default) fastq set when operating on a specific project.