### PR TITLE
make_fastqs: add 'icell8' protocol

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1645,10 +1645,10 @@ class AutoProcess:
             bcl2fastq.add_args('--ignore-missing-stats')
         if no_lane_splitting:
             bcl2fastq.add_args('--no-lane-splitting')
-        if minimum_trimmed_read_length:
+        if minimum_trimmed_read_length is not None:
             bcl2fastq.add_args('--minimum-trimmed-read-length',
                                minimum_trimmed_read_length)
-        if mask_short_adapter_reads:
+        if mask_short_adapter_reads is not None:
             bcl2fastq.add_args('--mask-short-adapter-reads',
                                mask_short_adapter_reads)
         bcl2fastq.add_args('--bcl2fastq_path',

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -35,6 +35,7 @@ import utils
 import simple_scheduler
 import bcl2fastq_utils
 import samplesheet_utils
+import icell8_utils
 import tenx_genomics_utils
 import settings
 from .qc.processing import report_processing_qc
@@ -1202,6 +1203,8 @@ class AutoProcess:
         """
         # Report protocol
         print "Protocol              : %s" % protocol
+        if protocol not in ('standard','icell8','10x_chromium_sc'):
+            raise Exception("Unknown protocol: '%s'" % protocol)
         # Unaligned dir
         if unaligned_dir is not None:
             self.params['unaligned_dir'] = unaligned_dir
@@ -1290,6 +1293,18 @@ class AutoProcess:
             illumina_run = IlluminaData.IlluminaRun(primary_data_dir)
             print "Platform              : %s" % illumina_run.platform
             print "Bcl format            : %s" % illumina_run.bcl_extension
+            if protocol == 'icell8':
+                # ICell8 data
+                # Update bcl2fastq settings appropriately
+                print "Updating read trimming and masking for ICell8"
+                minimum_trimmed_read_length = 21
+                mask_short_adapter_reads = 0
+                # Reset the default bases mask
+                bases_mask = IlluminaData.IlluminaRunInfo(
+                    illumina_run.runinfo_xml).bases_mask
+                bases_mask = icell8_utils.get_icell8_bases_mask(bases_mask)
+                # Switch to standard protocol
+                protocol = 'standard'
             if protocol == 'standard':
                 # Standard protocol
                 try:

--- a/auto_process_ngs/icell8_utils.py
+++ b/auto_process_ngs/icell8_utils.py
@@ -17,6 +17,7 @@ iCell8 platform:
 - ICell8Stats: class for gathering stats from iCell8 FASTQ pairs
 - collect_fastq_stats: get barcode and distince UMI counts for Fastq
 - normalize_sample_name: replace special characters in well list sample names
+- get_icell8_bases_mask: generate bases mask for iCell8 run
 """
 
 #######################################################################
@@ -109,6 +110,32 @@ def normalize_sample_name(s):
         else:
             name.append(c)
     return ''.join(name)
+
+def get_icell8_bases_mask(bases_mask):
+    """
+    Reset the supplied bases mask string so that only the
+    bases containing the inline barcode and UMIs are kept,
+    and any remaining bases are ignored.
+
+    Arguments:
+      bases_mask (str): initial bases mask string to update
+
+    Returns:
+      String: updated bases mask string
+    """
+    # Extract R1 mask
+    bases_mask = bases_mask.split(',')
+    r1_mask = bases_mask[0]
+    # Update to restrict to 21 bases
+    num_cycles = int(r1_mask[1:])
+    icell8_inline_length = (INLINE_BARCODE_LENGTH + UMI_LENGTH)
+    assert(num_cycles >= icell8_inline_length)
+    discard_length = (num_cycles - icell8_inline_length)
+    r1_mask = "y%d" % icell8_inline_length
+    r1_mask += ("n%d" % discard_length if discard_length > 0 else "")
+    # Rebuild and return
+    bases_mask[0] = r1_mask
+    return ','.join(bases_mask)
 
 ######################################################################
 # Classes

--- a/auto_process_ngs/test/test_icell8_utils.py
+++ b/auto_process_ngs/test/test_icell8_utils.py
@@ -14,6 +14,7 @@ from auto_process_ngs.icell8_utils import ICell8FastqIterator
 from auto_process_ngs.icell8_utils import ICell8Stats
 from auto_process_ngs.icell8_utils import ICell8FastqIterator
 from auto_process_ngs.icell8_utils import normalize_sample_name
+from auto_process_ngs.icell8_utils import get_icell8_bases_mask
 
 well_list_data = """Row	Col	Candidate	For dispense	Sample	Barcode	State	Cells1	Cells2	Signal1	Signal2	Size1	Size2	Integ Signal1	Integ Signal2	Circularity1	Circularity2	Confidence	Confidence1	Confidence2	Dispense tip	Drop index	Global drop index	Source well	Sequencing count	Image1	Image2
 0	4	True	True	ESC2	AACCTTCCTTA	Good	1	0	444		55		24420		0.9805677		1	1	1	1	4	5	A1	Pos0_Hoechst_A01.tif	Pos0_TexasRed_A01.tif
@@ -315,3 +316,18 @@ class TestNormalizeSampleNameFunction(unittest.TestCase):
         """
         self.assertEqual(normalize_sample_name("Neg Ctrl"),"Neg_Ctrl")
         self.assertEqual(normalize_sample_name("S1/S2"),"S1_S2")
+
+class TestGetIcell8BasesMaskFunction(unittest.TestCase):
+    """
+    Tests for the get_icell8_bases_mask function
+    """
+    def test_get_icell8_bases_mask(self):
+        """
+        get_icell8_bases_mask: reset bases mask
+        """
+        self.assertEqual(get_icell8_bases_mask("y101,I7,y101"),
+                         "y21n80,I7,y101")
+        self.assertEqual(get_icell8_bases_mask("y250,I8,I8,y250"),
+                         "y21n229,I8,I8,y250")
+        self.assertEqual(get_icell8_bases_mask("y21,I8,I8,y250"),
+                         "y21,I8,I8,y250")

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -217,7 +217,7 @@ def add_make_fastqs_command(cmdparser):
                                 dest='protocol',default='standard',
                                 help="specify Fastq generation protocol "
                                 "depending on the data being processed. "
-                                "Must be one of 'standard', "
+                                "Must be one of 'standard', 'icell8', "
                                 "'10x_chromium_sc' (default: 'standard')")
     fastq_generation.add_option('--sample-sheet',action="store",
                                 dest="sample_sheet",default=None,

--- a/docs/source/icell8.rst
+++ b/docs/source/icell8.rst
@@ -14,16 +14,28 @@ the read pair:
  * **Inline barcode:** bases 1-11 in R1
  * **UMI:** bases 12-21 in R1
 
-FASTQs can be generated using the ``auto_process.py make_fastqs``
-command, with the following settings suggested by Wafergen specifically
-for NextSeq data:
+Fastq generation
+----------------
 
- * Disable adapter trimming and masking by using
-   ``--minimum-trimmed-read-length=21 --mask-short-adapter-reads=0``
+FASTQs can be generated using::
 
-This is recommended to stop unintentional trimming of UMI sequences
-(which are mostly random) from the R1, should they happen to match
-part of an adapter sequence.
+    auto_process.py make_fastqs --protocol=icell8 ...
+
+.. note::
+
+   ``--protocol=icell8`` runs the standard bcl-to-fastq commands with
+   with the following settings:
+
+   * Disable adapter trimming and masking by setting
+     ``--minimum-trimmed-read-length=21`` and
+     ``--mask-short-adapter-reads=0`` (recommended by Wafergen
+     specifically for NextSeq data)
+   * Updating the bases mask setting so that only the first 21 bases
+     of the R1 read are kept.
+
+   This is recommended to stop unintentional trimming of UMI sequences
+   (which are mostly random) from the R1, should they happen to match
+   part of an adapter sequence.
 
 Subsequently the read pairs can be processed using the utility script
 ``process_icell8.py`` to perform initial filtering and QC as described


### PR DESCRIPTION
PR which adds a new `--protocol=icell8` option to the `make_fastqs` command.

This resets some of the `bcl2fastq` options appropriately for ICell8 samples, specifically:

* Reset the bases mask to only use the first 21 bases of the R1 read,
* Set `--minimum-trimmed-read-length` to 21 and `--mask-short-adapter-reads` to 0 (recommended by Wafergen for NextSeq data).