### PR TITLE
Use external job runners for intensive copy operations (import_fastq_dirs & publish_qc)

### DIFF
--- a/auto_process_ngs/applications.py
+++ b/auto_process_ngs/applications.py
@@ -553,7 +553,7 @@ class general:
         return ssh_command
 
     @staticmethod
-    def scp(user,server,source,target):
+    def scp(user,server,source,target,recursive=False):
         """Generate Command instance for 'scp'
 
         Creates a Command instance to run 'scp' to copy to another system.
@@ -563,10 +563,16 @@ class general:
           server: name of the server
           source: source file on local system
           target: target destination on remote system
+          recursive: optional, if True then copy source
+            recursively (i.e. specify the '-r' option)
 
         Returns:
           Command object.
 
         """
-        scp_command = Command('scp',source,'%s@%s:%s' % (user,server,target))
+        scp_command = Command('scp')
+        if recursive:
+            scp_command.add_args('-r')
+        scp_command.add_args(source,
+                             '%s@%s:%s' % (user,server,target))
         return scp_command

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -3023,8 +3023,8 @@ class AutoProcess:
             projects.remove(project)
         if not projects:
             logging.warning("No projects with QC results to publish")
-        # Include barcode analysis
-        barcodes_files = ('barcodes.report','barcodes.xls','barcodes.html')
+        # Collect barcode analysis artefacts
+        print "Checking for barcode analysis"
         if self.params.barcode_analysis_dir is not None:
             barcode_analysis_dir = self.params.barcode_analysis_dir
         else:
@@ -3032,11 +3032,18 @@ class AutoProcess:
         if not os.path.isabs(barcode_analysis_dir):
             barcode_analysis_dir = os.path.join(self.analysis_dir,
                                                 barcode_analysis_dir)
-        for filen in barcodes_files:
-            if not os.path.exists(
-                    os.path.join(barcode_analysis_dir,filen)):
-                barcode_analysis_dir = None
-                break
+        barcodes_files = []
+        if os.path.exists(barcode_analysis_dir):
+            print "- Barcode analysis dir: %s" % barcode_analysis_dir
+            for filen in ('barcodes.report',
+                          'barcodes.xls',
+                          'barcodes.html'):
+                filen = os.path.join(barcode_analysis_dir,filen)
+                if os.path.exists(filen):
+                    print "...found %s" % os.path.basename(filen)
+                    barcodes_files.append(filen)
+        if not barcodes_files:
+            print "...no barcode analysis found"
         # Make a directory for the QC reports
         fileops.mkdir(dirn)
         # Start building an index page
@@ -3119,7 +3126,7 @@ class AutoProcess:
                                 ("all lanes" if lanes is None
                                  else "lanes %s" % lanes)))
         # Barcode analysis
-        if barcode_analysis_dir:
+        if barcodes_files:
             # Create section
             index_page.add("<h2>Barcode analysis</h2>")
             index_page.add("<p>Plain text report: "
@@ -3133,8 +3140,7 @@ class AutoProcess:
             barcodes_dirn = os.path.join(dirn,'barcodes')
             fileops.mkdir(barcodes_dirn)
             for filen in barcodes_files:
-                fileops.copy(os.path.join(barcode_analysis_dir,filen),
-                             barcodes_dirn)
+                fileops.copy(filen,barcodes_dirn)
         if projects:
             # Table of projects
             index_page.add("<h2>QC Reports</h2>")

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -2874,25 +2874,53 @@ class AutoProcess:
 
     def publish_qc(self,projects=None,location=None,ignore_missing_qc=False,
                    regenerate_reports=False,force=False):
-        # Copy the QC reports to the webserver
-        #
-        # Raises an exception if:
-        #
-        # - 'source' and 'run_number' metadata items are not set
-        # - a subset of projects don't have associated QC outputs
-        #   (unless 'ignore_missing_qc' is True)
-        #
-        # projects: specify a pattern to match one or more projects to
-        #           publish the reports for (default is to publish all reports)
-        # location: override the target location specified in the settings
-        #           can be of the form '[[user@]server:]directory'
-        # ignore_missing_qc: if True then skip directories with missing QC data
-        #           or reports (otherwise raises an exception)
-        # regenerate_reports: if True then try to create reports even when they
-        #           already exist
-        # force:    if True then force QC report (re)generation even
-        #           if QC is unverified
-        #
+        """
+        Copy the QC reports to the webserver
+
+        Looks for and copies various QC reports and outputs to
+        a 'QC server' directory, and generates an HTML index.
+
+        The reports include:
+
+        - processing QC report
+        - 'cellranger mkfastq' QC report
+        - barcode analysis report
+
+        Also if the analysis includes project directories then for
+        each Fastq set in each project:
+
+        - QC report for standard QC
+        - MultiQC report
+
+        Also if a project comprises ICell8 or 10xGenomics Chromium
+        data:
+
+        - ICell8 processing report, or
+        - 'cellranger count' reports for each sample
+
+        Raises an exception if:
+
+        - 'source' and 'run_number' metadata items are not set
+        - a subset of projects don't have associated QC outputs
+          (unless 'ignore_missing_qc' is True)
+
+        Arguments:
+          projects (str): specify a glob-style pattern to match one
+            or more projects to publish the reports for (default is
+            to publish all reports)
+          location (str): override the target location specified in
+            the settings; can be of the form
+            '[[user@]server:]directory'
+          ignore_missing_qc (bool): if True then skip directories
+            with missing QC data or reports (default is to raise
+            an exception if projects have missing QC)
+          regenerate_reports (bool): if True then try to create
+            reports even when they already exist (default is to
+            use existing reports)
+          force (bool): if True then force QC report (re)generation
+            even if QC is unverified (default is to raise an
+            exception if projects cannot be verified)
+        """
         # Turn off saving of parameters etc
         self._save_params = False
         self._save_metadata = False

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -3023,6 +3023,15 @@ class AutoProcess:
             projects.remove(project)
         if not projects:
             logging.warning("No projects with QC results to publish")
+        # Collect processing statistics
+        print "Checking for processing QC report"
+        processing_qc_html = os.path.join(self.analysis_dir,
+                                          "processing_qc.html")
+        if os.path.exists(processing_qc_html):
+            print "...found %s" % os.path.basename(processing_qc_html)
+        else:
+            print "...no processing QC report found"
+            processing_qc_html = None
         # Collect barcode analysis artefacts
         print "Checking for barcode analysis"
         if self.params.barcode_analysis_dir is not None:
@@ -3094,15 +3103,12 @@ class AutoProcess:
         index_page.add("<tr><td class='param'>Reference</td><td>%s</td></tr>" %
                        self.run_reference_id)
         index_page.add("</table>")
-        # Add link to processing statistics
-        processing_qc_html = os.path.join(self.analysis_dir,
-                                          "processing_qc.html")
-        if os.path.exists(processing_qc_html):
+        # Processing QC report
+        if processing_qc_html:
+            fileops.copy(processing_qc_html,dirn)
             index_page.add("<h2>Processing Statistics</h2>")
             index_page.add("<a href='%s'>Processing QC report</a>" %
                            os.path.basename(processing_qc_html))
-        else:
-            processing_qc_html = None
         # Add to link to 10xGenomics cellranger QC summaries
         cellranger_qc_html = filter(lambda f: os.path.isfile(f) and
                                     os.path.basename(f).startswith(
@@ -3307,8 +3313,6 @@ class AutoProcess:
         index_html = os.path.join(self.tmp_dir,'index.html')
         index_page.write(index_html)
         fileops.copy(index_html,dirn)
-        if processing_qc_html:
-            fileops.copy(processing_qc_html,dirn)
         for qc_html in cellranger_qc_html:
             fileops.copy(qc_html,dirn)
         # Print the URL if given

--- a/auto_process_ngs/test/test_applications.py
+++ b/auto_process_ngs/test/test_applications.py
@@ -185,3 +185,11 @@ class TestGeneral(unittest.TestCase):
             general.scp('user','example.com','my_file','remotedir').command_line,
             ['scp','my_file','user@example.com:remotedir'])
 
+    def test_scp_recursive(self):
+        """Construct 'scp -r' command lines
+        """
+        self.assertEqual(
+            general.scp('user','example.com','my_dir','remotedir',
+                        recursive=True).command_line,
+            ['scp','-r','my_dir','user@example.com:remotedir'])
+

--- a/auto_process_ngs/test/test_fileops.py
+++ b/auto_process_ngs/test/test_fileops.py
@@ -86,6 +86,32 @@ class TestCopyFunction(FileopsTestCase):
         self.assertEqual(open(tgt_file).read(),
                          "This is a test file")
 
+class TestCopytreeFunction(FileopsTestCase):
+    """Tests for the 'copy' function
+    """
+    def test_local_copytree(self):
+        """fileops.copytree: recursively copy a local directory
+        """
+        # Build a source directory
+        src_dir = os.path.join(self.test_dir,'test_src')
+        os.mkdir(src_dir)
+        os.mkdir(os.path.join(src_dir,'subdir'))
+        with open(os.path.join(src_dir,'test1.txt'),'w') as fp:
+            fp.write("This is test file 1")
+        with open(os.path.join(src_dir,'subdir','test2.txt'),'w') as fp:
+            fp.write("This is test file 2")
+        # Copy contents recursively
+        tgt_dir = os.path.join(self.test_dir,'test_dst')
+        self.assertFalse(os.path.exists(tgt_dir))
+        status = copytree(src_dir,tgt_dir)
+        self.assertEqual(status,0)
+        self.assertTrue(os.path.isdir(tgt_dir))
+        self.assertTrue(os.path.isdir(os.path.join(tgt_dir,'subdir')))
+        self.assertEqual(open(os.path.join(tgt_dir,'test1.txt')).read(),
+                         "This is test file 1")
+        self.assertEqual(open(os.path.join(tgt_dir,'subdir','test2.txt')).read(),
+                         "This is test file 2")
+
 class TestSetGroupFunction(FileopsTestCase):
     """Tests for the 'set_group' function
     """
@@ -171,6 +197,31 @@ class TestCopyCommand(unittest.TestCase):
                          ['scp',
                           '/here/myfile.txt',
                           'pjx@remote.com:/there/myfile.txt'])
+
+class TestCopytreeCommand(unittest.TestCase):
+    """Tests for the 'copytree_command' function
+    """
+    def test_copytree_command_to_local(self):
+        """fileops.copytree_command: copy directory locally
+        """
+        copytree_cmd = copytree_command("/here",
+                                        "/there")
+        self.assertEqual(copytree_cmd.command_line,
+                         ['cp',
+                          '-a',
+                          '-n',
+                          '/here',
+                          '/there'])
+    def test_copytree_command_to_remote(self):
+        """fileops.copytree_command: copy directory to remote
+        """
+        copytree_cmd = copytree_command("/here",
+                                        "pjx@remote.com:/there")
+        self.assertEqual(copytree_cmd.command_line,
+                         ['scp',
+                          '-r',
+                          '/here',
+                          'pjx@remote.com:/there'])
 
 class TestSetGroupCommand(unittest.TestCase):
     """Tests for the 'set_group_command' function


### PR DESCRIPTION
PR to use functions in `fileops` to farm out intensive file copying operations (and similar) to external job runners in various autoprocess commands, specifically `import_fastq_dirs` and `publish_qc`.