### PR TITLE
make_fastqs: fix generation of 'empty' placeholder Fastqs

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1413,15 +1413,16 @@ class AutoProcess:
                         create_empty_fastqs = \
                             self.settings.bcl2fastq.create_empty_fastqs
                 if create_empty_fastqs:
-                    logging.warning("Making 'empty' Fastqs as placeholders")
+                    logging.warning("Making 'empty' placeholder Fastqs")
                     for fq in missing_fastqs:
                         fastq = os.path.join(self.analysis_dir,
                                              self.params.unaligned_dir,fq)
                         print "-- %s" % fastq
-                    with gzip.GzipFile(filename=fastq,mode='wb') as fp:
-                        fp.write('')
-                raise Exception("Fastq generation failed to produce "
-                                "expected outputs")
+                        with gzip.GzipFile(filename=fastq,mode='wb') as fp:
+                            fp.write('')
+                else:
+                    raise Exception("Fastq generation failed to produce "
+                                    "expected outputs")
         # Generate statistics
         if generate_stats:
             self.generate_stats(stats_file=stats_file,


### PR DESCRIPTION
PR to fix the generation of empty placeholder Fastq files in `make_fastqs`, for the "standard" protocol when `bcl2fastq` completes ok but some files are missing and `make_empty_fastqs` is set. This functionality is currently broken in `devel`.

This PR also changes the behaviour of `make_fastqs` in this situation, so that it no longer raises an exception after generating the placeholders: this should restore the old behaviour (before the `protocol` option was introduced).