### PR TITLE
Implement local `parse_version` function to replace one from `setuptools.pkg_resources`

### DIFF
--- a/auto_process_ngs/bcl2fastq_utils.py
+++ b/auto_process_ngs/bcl2fastq_utils.py
@@ -36,7 +36,6 @@ import auto_process_ngs.applications as applications
 import auto_process_ngs.utils as utils
 import bcftbx.IlluminaData as IlluminaData
 import bcftbx.utils as bcf_utils
-from pkg_resources import parse_version
 
 #######################################################################
 # Functions
@@ -242,12 +241,12 @@ def get_required_samplesheet_format(bcl2fastq_version):
         etc).
 
     """
-    version = parse_version(bcl2fastq_version)
+    version = utils.parse_version(bcl2fastq_version)
     major,minor = version[0:2]
-    if (major,minor) == parse_version('1.8')[0:2]:
+    if (major,minor) == utils.parse_version('1.8')[0:2]:
         # Version 1.8.*
         return 'CASAVA'
-    elif major == parse_version('2')[0]:
+    elif major == utils.parse_version('2')[0]:
         # Version 2.*
         return 'IEM'
     else:

--- a/auto_process_ngs/test/test_utils.py
+++ b/auto_process_ngs/test/test_utils.py
@@ -1781,6 +1781,13 @@ class TestParseVersion(unittest.TestCase):
         self.assertTrue(
             parse_version("1.10") > parse_version("1.9.rc1"))
 
+    def test_handle_empty_version(self):
+        """parse_version handles empty version
+        """
+        self.assertEqual(parse_version(""),(-99999,))
+        self.assertTrue(
+            parse_version("") < parse_version("1.8.4"))
+
 class TestPrettyPrintRows(unittest.TestCase):
     """Tests for the pretty_print_rows function
 

--- a/auto_process_ngs/test/test_utils.py
+++ b/auto_process_ngs/test/test_utils.py
@@ -1754,6 +1754,33 @@ class TestFindExecutables(unittest.TestCase):
                                           self.info_func,
                                           paths=paths),exes)
 
+class TestParseVersion(unittest.TestCase):
+    """Tests for the parse_version function
+    """
+    def test_parse_version(self):
+        """parse_version splits version numbers
+        """
+        self.assertEqual(parse_version("2.17.1.4"),
+                         (2,17,1,4))
+        self.assertEqual(parse_version("1.8.4"),
+                         (1,8,4))
+        self.assertEqual(parse_version("1.9.rc1"),
+                         (1,9,"rc1"))
+
+    def test_compare_versions(self):
+        """parse_version compares versions correctly
+        """
+        self.assertTrue(
+            parse_version("2.17.1.4") > parse_version("1.8.4"))
+        self.assertTrue(
+            parse_version("2.17.1.4") == parse_version("2.17.1.4"))
+        self.assertTrue(
+            parse_version("1.8.4") < parse_version("2.17.1.4"))
+        self.assertTrue(
+            parse_version("10.0") > parse_version("9.1"))
+        self.assertTrue(
+            parse_version("1.10") > parse_version("1.9.rc1"))
+
 class TestPrettyPrintRows(unittest.TestCase):
     """Tests for the pretty_print_rows function
 

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -2255,6 +2255,10 @@ def parse_version(s):
     Where possible components will be coverted to
     integers.
 
+    If the version string is empty then the version
+    number will be set to an arbitrary negative
+    integer.
+
     Typically the result from this function would not
     be used directly, instead it is used to compare
     two versions, for example:
@@ -2268,6 +2272,10 @@ def parse_version(s):
     Returns:
       Tuple: tuple of the version string
     """
+    if s == "":
+        # Essentially versionless; set to an
+        # arbitrarily small integer
+        s = "-99999"
     items = []
     for i in s.split('.'):
         try:

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -39,6 +39,7 @@ Functions:
 - split_user_host_dir:
 - get_numbered_subdir:
 - find_executables:
+- parse_version:
 - pretty_print_rows:
 - write_script_file:
 - edit_file:
@@ -71,7 +72,6 @@ from qc.illumina_qc import QCSample
 from qc.illumina_qc import expected_qc_outputs
 from qc.illumina_qc import check_qc_outputs
 from .exceptions import MissingParameterFileException
-from pkg_resources import parse_version
 
 # Module specific logger
 logger = logging.getLogger(__name__)
@@ -2244,6 +2244,38 @@ def find_executables(names,info_func,reqs=None,paths=None):
     else:
         print "%s: No packages found" % ','.join(names)
     return available_exes
+
+def parse_version(s):
+    """
+    Split a version string into a tuple for comparison
+
+    Given a version string of the form e.g. "X.Y.Z",
+    return a tuple of the components e.g. (X,Y,Z)
+
+    Where possible components will be coverted to
+    integers.
+
+    Typically the result from this function would not
+    be used directly, instead it is used to compare
+    two versions, for example:
+
+    >>> parse_version("2.17") < parse_version("1.8")
+    False
+
+    Arguments:
+      s (str): version string
+
+    Returns:
+      Tuple: tuple of the version string
+    """
+    items = []
+    for i in s.split('.'):
+        try:
+            i = int(i)
+        except ValueError:
+            pass
+        items.append(i)
+    return tuple(items)
 
 def pretty_print_rows(data,prepend=False):
     """Format row-wise data into 'pretty' lines


### PR DESCRIPTION
PR which implements our own `parse_version` function to replace the one from `setuptools.pkg_resources` - this was giving warnings if using `setuptools` 8.0 or later about converting the `Version` instances to tuples, but it wasn't clear why this was arising in the autoprocess code.

This PR is a lazy workaround to avoid having the warning.