### PR TITLE
fileops: update set_group_command to use find/chgrp combination

### DIFF
--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -98,8 +98,9 @@ def archive(ap,archive_dir=None,platform=None,year=None,
       final (bool): if True then finalize the archive by
         moving the '.pending' temporary archive to the final
         location
-      force (bool): if True then do archiving even if key
-        metadata items are not set; otherwise abort archiving
+      force (bool): if True then do archiving even if there are
+        errors (e.g. key metadata items not set, permission error
+        when setting group etc); otherwise abort archiving
         operation.
       dry_run (bool): report what would be done but don't
         perform any operations.
@@ -264,6 +265,7 @@ def archive(ap,archive_dir=None,platform=None,year=None,
                     set_group = fileops.set_group_command(
                         group,
                         os.path.join(archive_dir,staging),
+                        safe=force,
                         verbose=True)
                     print "Running %s" % set_group
                     set_group_job = sched.submit(
@@ -284,7 +286,10 @@ def archive(ap,archive_dir=None,platform=None,year=None,
         sched.stop()
         # Bail out if there was a problem
         if retval != 0:
-            raise Exception("Staging to archive failed")
+            if not force:
+                raise Exception("Staging to archive failed")
+            else:
+                logger.warning("Staging to archive failed (ignored)")
     # Move to final location
     if final:
         print "Moving to final location: %s" % final_dest

--- a/auto_process_ngs/test/test_fileops.py
+++ b/auto_process_ngs/test/test_fileops.py
@@ -315,10 +315,13 @@ class TestSetGroupCommand(unittest.TestCase):
         set_group_cmd = set_group_command("adm",
                                           "/here/files")
         self.assertEqual(set_group_cmd.command_line,
-                         ['chgrp',
-                          '-R',
+                         ['find',
+                          '/here/files',
+                          '-exec',
+                          'chgrp',
                           'adm',
-                          '/here/files'])
+                          '{}',
+                          ';'])
     def test_set_group_command_local_verbose(self):
         """fileops.set_group_command: set group on local files (verbose)
         """
@@ -326,11 +329,32 @@ class TestSetGroupCommand(unittest.TestCase):
                                           "/here/files",
                                           verbose=True)
         self.assertEqual(set_group_cmd.command_line,
-                         ['chgrp',
+                         ['find',
+                          '/here/files',
+                          '-exec',
+                          'chgrp',
                           '--verbose',
-                          '-R',
                           'adm',
-                          '/here/files'])
+                          '{}',
+                          ';'])
+
+    def test_set_group_command_local_safe(self):
+        """fileops.set_group_command: set group on local files ('safe' mode)
+        """
+        set_group_cmd = set_group_command("adm",
+                                          "/here/files",
+                                          safe=True)
+        self.assertEqual(set_group_cmd.command_line,
+                         ['find',
+                          '/here/files',
+                          '-user',
+                          getpass.getuser(),
+                          '-exec',
+                          'chgrp',
+                          'adm',
+                          '{}',
+                          ';'])
+
     def test_set_group_command_remote(self):
         """fileops.set_group_command: set group on remote files
         """
@@ -339,10 +363,13 @@ class TestSetGroupCommand(unittest.TestCase):
         self.assertEqual(set_group_cmd.command_line,
                          ['ssh',
                           'pjx@remote.com',
+                          'find',
+                          '/there/files',
+                          '-exec',
                           'chgrp',
-                          '-R',
                           'adm',
-                          '/there/files'])
+                          '{}',
+                          ';'])
 
 class TestUnzipCommand(unittest.TestCase):
     """Tests for the 'unzip_command' function

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -621,8 +621,9 @@ def add_archive_command(cmdparser):
                  help="copy data to final archive location (default is to "
                  "copy to staging area)")
     p.add_option('--force',action='store_true',dest='force',default=False,
-                 help="perform archiving operation even if key metadata items are "
-                 "not set")
+                 help="attempt to complete archiving operations ignoring "
+                 "any errors (e.g. key metadata items not set, unable to "
+                 "set group etc)")
     add_dry_run_option(p)
     add_debug_option(p)
 


### PR DESCRIPTION
PR to update the `fileops` `set_group` command, to gracefully handle files and directories that can't be updated by the current user (cf issue #86).

NB this is a second attempt at adding these changes, after failed PR #133.