### PR TITLE
'archive' command: fix failing set group operation

### DIFF
--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -263,7 +263,8 @@ def archive(ap,archive_dir=None,platform=None,year=None,
                 if not dry_run:
                     set_group = fileops.set_group_command(
                         group,
-                        os.path.join(archive_dir,staging))
+                        os.path.join(archive_dir,staging),
+                        verbose=True)
                     print "Running %s" % set_group
                     set_group_job = sched.submit(
                         set_group,

--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -264,6 +264,7 @@ def archive(ap,archive_dir=None,platform=None,year=None,
                     set_group = fileops.set_group_command(
                         group,
                         os.path.join(archive_dir,staging))
+                    print "Running %s" % set_group
                     set_group_job = sched.submit(
                         set_group,
                         name="set_group.archive")

--- a/auto_process_ngs/fileops.py
+++ b/auto_process_ngs/fileops.py
@@ -423,7 +423,7 @@ def copytree_command(src,dest):
             recursive=True)
     return copytree_cmd
 
-def set_group_command(group,path):
+def set_group_command(group,path,verbose=True):
     """
     Generate command to set group on file or directory
 
@@ -443,16 +443,21 @@ def set_group_command(group,path):
       path (str): path to the file or directory
         to change the group of, identified by a
         specifier of the form '[[USER@]HOST:]PATH'
+      verbose (bool): if True then output a
+        diagnostic for every file processed
+        (default)
 
     Returns:
       Command: Command instance that can be used to
         set the group.
     """
     path = Location(path)
-    chmod_cmd = applications.Command('chgrp',
-                                     '-R',
-                                     group,
-                                     path.path)
+    chmod_cmd = applications.Command('chgrp')
+    if verbose:
+        chmod_cmd.add_args('--verbose')
+    chmod_cmd.add_args('-R',
+                       group,
+                       path.path)
     if path.is_remote:
         # Set group for remote files
         chmod_cmd = applications.general.ssh_command(

--- a/auto_process_ngs/fileops.py
+++ b/auto_process_ngs/fileops.py
@@ -423,7 +423,7 @@ def copytree_command(src,dest):
             recursive=True)
     return copytree_cmd
 
-def set_group_command(group,path,verbose=True):
+def set_group_command(group,path,verbose=False):
     """
     Generate command to set group on file or directory
 
@@ -445,7 +445,7 @@ def set_group_command(group,path,verbose=True):
         specifier of the form '[[USER@]HOST:]PATH'
       verbose (bool): if True then output a
         diagnostic for every file processed
-        (default)
+        (default: don't output diagnostics)
 
     Returns:
       Command: Command instance that can be used to

--- a/auto_process_ngs/simple_scheduler.py
+++ b/auto_process_ngs/simple_scheduler.py
@@ -835,7 +835,8 @@ class SchedulerJob(Job):
         logging.debug("Waiting for job #%s (%s)..." % (self.job_number,
                                                        self.job_id))
         wait_time = 0
-        while ((self.job_id is None) or (not self.completed)):
+        while ((self.job_id is None) or (not self.completed) or
+               (self.exit_status is None)):
             # Check for timeout
             if timeout is not None and wait_time > timeout:
                 self.terminate()

--- a/auto_process_ngs/test/test_fileops.py
+++ b/auto_process_ngs/test/test_fileops.py
@@ -316,6 +316,18 @@ class TestSetGroupCommand(unittest.TestCase):
                                           "/here/files")
         self.assertEqual(set_group_cmd.command_line,
                          ['chgrp',
+                          '--verbose',
+                          '-R',
+                          'adm',
+                          '/here/files'])
+    def test_set_group_command_local_not_verbose(self):
+        """fileops.set_group_command: set group on local files (quiet)
+        """
+        set_group_cmd = set_group_command("adm",
+                                          "/here/files",
+                                          verbose=False)
+        self.assertEqual(set_group_cmd.command_line,
+                         ['chgrp',
                           '-R',
                           'adm',
                           '/here/files'])
@@ -328,6 +340,7 @@ class TestSetGroupCommand(unittest.TestCase):
                          ['ssh',
                           'pjx@remote.com',
                           'chgrp',
+                          '--verbose',
                           '-R',
                           'adm',
                           '/there/files'])

--- a/auto_process_ngs/test/test_fileops.py
+++ b/auto_process_ngs/test/test_fileops.py
@@ -316,18 +316,18 @@ class TestSetGroupCommand(unittest.TestCase):
                                           "/here/files")
         self.assertEqual(set_group_cmd.command_line,
                          ['chgrp',
-                          '--verbose',
                           '-R',
                           'adm',
                           '/here/files'])
-    def test_set_group_command_local_not_verbose(self):
-        """fileops.set_group_command: set group on local files (quiet)
+    def test_set_group_command_local_verbose(self):
+        """fileops.set_group_command: set group on local files (verbose)
         """
         set_group_cmd = set_group_command("adm",
                                           "/here/files",
-                                          verbose=False)
+                                          verbose=True)
         self.assertEqual(set_group_cmd.command_line,
                          ['chgrp',
+                          '--verbose',
                           '-R',
                           'adm',
                           '/here/files'])
@@ -340,7 +340,6 @@ class TestSetGroupCommand(unittest.TestCase):
                          ['ssh',
                           'pjx@remote.com',
                           'chgrp',
-                          '--verbose',
                           '-R',
                           'adm',
                           '/there/files'])


### PR DESCRIPTION
PR to fix error when using the `archive` command in production:

    Setting group of archived files to 'ls-bcf'
    Job scheduled: #2: "set_group.archive" (Thu Nov  2 14:57:13 2017)
    Job started: #2 (211026): "set_group.archive" (Thu Nov  2 14:57:17 2017)
    Thu Nov  2 14:57:17 2017: 1 running, 0 waiting, 1 finished
    set_group.archive completed: exit code None
     WARNING: Setting group failed (non-zero exit status code returned)