### PR TITLE
Fix metadata setting in the 'setup' command

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -821,11 +821,11 @@ class AutoProcess:
         # Run datestamp, instrument name and instrument run number
         try:
             datestamp,instrument,run_number = IlluminaData.split_run_name(
-                os.path.basename(self.analysis_dir))
+                os.path.basename(analysis_dir))
             run_number = run_number.lstrip('0')
         except Exception as ex:
             logging.warning("Unable to extract information from run name '%s'" \
-                            % os.path.basename(self.analysis_dir))
+                            % os.path.basename(analysis_dir))
             logging.warning("Exception: %s" % ex)
             datestamp = None
             instrument= None

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -796,14 +796,16 @@ class AutoProcess:
                 ".%s.%s" % (os.path.basename(analysis_dir),
                             uuid.uuid4()))
             self.analysis_dir = tmp_analysis_dir
-            print "Creating temp directory '%s'" % self.analysis_dir
+            logging.debug("Creating temp directory '%s'" %
+                          self.analysis_dir)
             # Create directory structure
             self.create_directory(self.analysis_dir)
             self.log_dir
             self.script_code_dir
         else:
             # Directory already exists
-            logging.warning("Analysis directory already exists")
+            logging.warning("Analysis directory '%s' already exists" %
+                            analysis_dir)
             self.analysis_dir = analysis_dir
             # check for parameter file
             if self.has_parameter_file:
@@ -911,13 +913,14 @@ class AutoProcess:
         samplesheet_utils.check_and_warn(sample_sheet=sample_sheet)
         # Move analysis dir to final location if necessary
         if self.analysis_dir != analysis_dir:
-            print "Moving %s to final directory" % self.analysis_dir
+            logging.debug("Moving %s to final directory" % self.analysis_dir)
             os.rename(self.analysis_dir,analysis_dir)
             self.analysis_dir = analysis_dir
             # Update the custom sample sheet path
             custom_sample_sheet = os.path.join(
                 analysis_dir,
                 os.path.basename(custom_sample_sheet))
+            print "Created analysis directory '%s'" % self.analysis_dir
         # Store the parameters
         self.params['data_dir'] = data_dir
         self.params['analysis_dir'] = self.analysis_dir

--- a/auto_process_ngs/test/test_auto_processor.py
+++ b/auto_process_ngs/test/test_auto_processor.py
@@ -512,6 +512,18 @@ class TestAutoProcessSetup(unittest.TestCase):
                                       'custom_SampleSheet.csv'))
         self.assertEqual(ap.params.bases_mask,
                          'y101,I8,I8,y101')
+        # Check metadata
+        self.assertEqual(ap.metadata.run_name,
+                         "151125_M00879_0001_000000000-ABCDE1")
+        self.assertEqual(ap.metadata.run_number,None)
+        self.assertEqual(ap.metadata.source,None)
+        self.assertEqual(ap.metadata.platform,"miseq")
+        self.assertEqual(ap.metadata.source,None)
+        self.assertEqual(ap.metadata.assay,"TruSeq HT")
+        self.assertEqual(ap.metadata.bcl2fastq_software,None)
+        self.assertEqual(ap.metadata.instrument_name,"M00879")
+        self.assertEqual(ap.metadata.instrument_datestamp,"151125")
+        self.assertEqual(ap.metadata.instrument_run_number,"1")
         # Delete to force write of data to disk
         del(ap)
         # Check directory exists

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -1532,6 +1532,10 @@ class AnalysisDirMetadata(MetadataDict):
     platform: sequencing platform e.g. 'miseq'
     assay: the 'assay' from the IEM SampleSheet e.g. 'Nextera XT'
     bcl2fastq_software: info on the Bcl conversion software used
+    instrument_name: name/i.d. for the sequencing instrument
+    instrument_datestamp: datestamp from the sequencing instrument
+    instrument_run_number: the run number from the sequencing
+      instrument
 
     """
     def __init__(self,filen=None):


### PR DESCRIPTION
PR to fix issue #139 (`setup` fails to set the metadata for the instrument name, datestamp or run number).