### PR TITLE
Set default year from the datestamp in 'publish_qc' and 'archive' commands

### DIFF
--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -133,7 +133,7 @@ def archive(ap,archive_dir=None,platform=None,year=None,
         raise Exception("No platform specified (use --platform "
                         "option?)")
     if year is None:
-        year = time.strftime("%Y")
+        year = "20%s" % str(ap.metadata.instrument_datestamp)[0:2]
     archive_dir = os.path.join(archive_dir,year,platform)
     # Determine target directory
     if not is_staging:

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -136,7 +136,7 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
     else:
         location = fileops.Location(location)
     if use_hierarchy:
-        year = time.strftime("%Y")
+        year = "20%s" % str(ap.metadata.instrument_datestamp)[0:2]
         platform = ap.metadata.platform
     # Check the settings
     if location.is_remote:

--- a/auto_process_ngs/test/commands/test_archive_cmd.py
+++ b/auto_process_ngs/test/commands/test_archive_cmd.py
@@ -45,6 +45,7 @@ class TestArchiveCommand(unittest.TestCase):
         mockdir = MockAnalysisDirFactory.bcl2fastq2(
             '170901_M00879_0087_000000000-AGEW9',
             'miseq',
+            metadata={ "instrument_datestamp": "170901" },
             top_dir=self.dirn)
         mockdir.create()
         # Make a mock archive directory
@@ -110,6 +111,7 @@ class TestArchiveCommand(unittest.TestCase):
         mockdir = MockAnalysisDirFactory.bcl2fastq2(
             '170901_M00879_0087_000000000-AGEW9',
             'miseq',
+            metadata={ "instrument_datestamp": "170901" },
             top_dir=self.dirn)
         mockdir.create()
         # Make a mock archive directory
@@ -163,6 +165,7 @@ class TestArchiveCommand(unittest.TestCase):
         mockdir = MockAnalysisDirFactory.bcl2fastq2(
             '170901_M00879_0087_000000000-AGEW9',
             'miseq',
+            metadata={ "instrument_datestamp": "170901" },
             top_dir=self.dirn)
         mockdir.create()
         # Make a mock archive directory
@@ -223,6 +226,7 @@ class TestArchiveCommand(unittest.TestCase):
         mockdir = MockAnalysisDirFactory.bcl2fastq2(
             '170901_M00879_0087_000000000-AGEW9',
             'miseq',
+            metadata={ "instrument_datestamp": "170901" },
             top_dir=self.dirn)
         mockdir.create()
         # Make a mock archive directory
@@ -283,6 +287,7 @@ class TestArchiveCommand(unittest.TestCase):
         mockdir = MockAnalysisDirFactory.bcl2fastq2(
             '170901_M00879_0087_000000000-AGEW9',
             'miseq',
+            metadata={ "instrument_datestamp": "170901" },
             top_dir=self.dirn)
         mockdir.create()
         # Make a mock archive directory
@@ -345,6 +350,7 @@ class TestArchiveCommand(unittest.TestCase):
         mockdir = MockAnalysisDirFactory.bcl2fastq2(
             '170901_M00879_0087_000000000-AGEW9',
             'miseq',
+            metadata={ "instrument_datestamp": "170901" },
             top_dir=self.dirn)
         mockdir.create()
         # Make a mock archive directory

--- a/auto_process_ngs/test/commands/test_archive_cmd.py
+++ b/auto_process_ngs/test/commands/test_archive_cmd.py
@@ -413,3 +413,66 @@ class TestArchiveCommand(unittest.TestCase):
         for f in files:
             f = os.path.join(final_archive_dir,f)
             self.assertTrue(os.path.exists(f))
+
+    def test_archive_automatically_sets_correct_year(self):
+        """archive: test archiving sets the year correctly if not specified
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901" },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Make a mock archive directory
+        archive_dir = os.path.join(self.dirn,"archive")
+        final_dir = os.path.join(archive_dir,
+                                 "2017",
+                                 "miseq")
+        os.makedirs(final_dir)
+        self.assertTrue(os.path.isdir(final_dir))
+        self.assertEqual(len(os.listdir(final_dir)),0)
+        # Make autoprocess instance and set required metadata
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        ap.set_metadata("source","testing")
+        ap.set_metadata("run_number","87")
+        # Do staging archiving op with no year
+        status = archive(ap,
+                         archive_dir=archive_dir,
+                         platform='miseq',
+                         read_only_fastqs=False,
+                         final=False)
+        self.assertEqual(status,0)
+        # Check that staging dir exists
+        staging_dir = os.path.join(
+            final_dir,
+            "__170901_M00879_0087_000000000-AGEW9_analysis.pending")
+        final_archive_dir = os.path.join(
+            final_dir,
+            "170901_M00879_0087_000000000-AGEW9_analysis")
+        self.assertTrue(os.path.exists(staging_dir))
+        self.assertFalse(os.path.exists(final_archive_dir))
+        self.assertEqual(len(os.listdir(final_dir)),1)
+        # Do final archiving op with no year
+        status = archive(ap,
+                         archive_dir=archive_dir,
+                         platform='miseq',
+                         read_only_fastqs=False,
+                         final=True)
+        self.assertEqual(status,0)
+        self.assertFalse(os.path.exists(staging_dir))
+        self.assertTrue(os.path.exists(final_archive_dir))
+        self.assertEqual(len(os.listdir(final_dir)),1)
+        # Check contents
+        dirs = ("AB","CDE","logs","undetermined")
+        for d in dirs:
+            d = os.path.join(final_archive_dir,d)
+            self.assertTrue(os.path.exists(d))
+        files = ("auto_process.info",
+                 "custom_SampleSheet.csv",
+                 "metadata.info",
+                 "projects.info",
+                 "SampleSheet.orig.csv")
+        for f in files:
+            f = os.path.join(final_archive_dir,f)
+            self.assertTrue(os.path.exists(f))

--- a/auto_process_ngs/test/commands/test_publish_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_publish_qc_cmd.py
@@ -42,6 +42,7 @@ class TestAutoProcessPublishQc(unittest.TestCase):
         mockdir = MockAnalysisDirFactory.bcl2fastq2(
             '160621_M00879_0087_000000000-AGEW9',
             'miseq',
+            metadata={ "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
         ap = AutoProcess(mockdir.dirn)
@@ -62,7 +63,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             '160621_K00879_0087_000000000-AGEW9',
             'hiseq',
             metadata={ "run_number": 87,
-                       "source": "local" },
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
         ap = AutoProcess(mockdir.dirn)
@@ -90,7 +92,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             '160621_K00879_0087_000000000-AGEW9',
             'hiseq',
             metadata={ "run_number": 87,
-                       "source": "local" },
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
         ap = AutoProcess(mockdir.dirn)
@@ -122,7 +125,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             '160621_K00879_0087_000000000-AGEW9',
             'hiseq',
             metadata={ "run_number": 87,
-                       "source": "local" },
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
         ap = AutoProcess(mockdir.dirn)
@@ -166,7 +170,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             '160621_K00879_0087_000000000-AGEW9',
             'hiseq',
             metadata={ "run_number": 87,
-                       "source": "local" },
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
         ap = AutoProcess(mockdir.dirn)
@@ -207,7 +212,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             '160621_K00879_0087_000000000-AGEW9',
             'hiseq',
             metadata={ "run_number": 87,
-                       "source": "local" },
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
         ap = AutoProcess(mockdir.dirn)
@@ -267,7 +273,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             '160621_K00879_0087_000000000-AGEW9',
             'hiseq',
             metadata={ "run_number": 87,
-                       "source": "local" },
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
         ap = AutoProcess(mockdir.dirn)
@@ -294,7 +301,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             '160621_K00879_0087_000000000-AGEW9',
             'hiseq',
             metadata={ "run_number": 87,
-                       "source": "local" },
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
         ap = AutoProcess(mockdir.dirn)
@@ -347,7 +355,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             '160621_K00879_0087_000000000-AGEW9',
             'hiseq',
             metadata={ "run_number": 87,
-                       "source": "local" },
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
         ap = AutoProcess(mockdir.dirn)
@@ -403,7 +412,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             '160621_K00879_0087_000000000-AGEW9',
             'hiseq',
             metadata={ "run_number": 87,
-                       "source": "local" },
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
         ap = AutoProcess(mockdir.dirn)
@@ -458,7 +468,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             '160621_K00879_0087_000000000-AGEW9',
             'hiseq',
             metadata={ "run_number": 87,
-                       "source": "local" },
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
         ap = AutoProcess(mockdir.dirn)
@@ -489,7 +500,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             '160621_K00879_0087_000000000-AGEW9',
             'hiseq',
             metadata={ "run_number": 87,
-                       "source": "local" },
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
         ap = AutoProcess(mockdir.dirn)
@@ -520,7 +532,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             '160621_K00879_0087_000000000-AGEW9',
             'hiseq',
             metadata={ "run_number": 87,
-                       "source": "local" },
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
         ap = AutoProcess(mockdir.dirn)
@@ -553,7 +566,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             '160621_K00879_0087_000000000-AGEW9',
             'hiseq',
             metadata={ "run_number": 87,
-                       "source": "local" },
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
         ap = AutoProcess(mockdir.dirn)
@@ -670,7 +684,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             '160621_K00879_0087_000000000-AGEW9',
             'hiseq',
             metadata={ "run_number": 87,
-                       "source": "local" },
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
         ap = AutoProcess(mockdir.dirn)
@@ -758,7 +773,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             '160621_K00879_0087_000000000-AGEW9',
             'hiseq',
             metadata={ "run_number": 87,
-                       "source": "local" },
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
         ap = AutoProcess(mockdir.dirn)

--- a/auto_process_ngs/test/commands/test_publish_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_publish_qc_cmd.py
@@ -623,7 +623,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             '160621_K00879_0087_000000000-AGEW9',
             'hiseq',
             metadata={ "run_number": 87,
-                       "source": "local" },
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
         ap = AutoProcess(mockdir.dirn)
@@ -639,7 +640,7 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                    use_hierarchy=True)
         # Check outputs
         final_dir = os.path.join(publication_dir,
-                                 "2017",
+                                 "2016",
                                  "hiseq")
         self.assertTrue(os.path.exists(final_dir))
         outputs = ["index.html",


### PR DESCRIPTION
PR to set the default year from the instrument datestamp in the `publish_qc` and `archive` commands.

Currently the default is the current year, but this can be problematic if runs are processed over the year boundary. For example:

* If the QC for a run is published using the 'hierarchical' option in December of one year, and again in January of the next, then it will be in two different locations
* If the run is staged for archive in December and finalised in the following January then it will also be in two different locations.

This PR should address this by making the default year consistent with the datestamp for the run.