### PR TITLE
Update process_icell8.py to farm out file collection to external tasks

### DIFF
--- a/auto_process_ngs/qc/illumina_qc.py
+++ b/auto_process_ngs/qc/illumina_qc.py
@@ -105,6 +105,9 @@ class QCReporter:
             then use relative paths for links in the report
             (default is to use absolute paths)
 
+        Returns:
+          String: filename of the HTML report.
+
         """
         # Set title and output destination
         if title is None:
@@ -306,6 +309,8 @@ class QCReporter:
                 clear.add_css_classes("clear")
         # Write the report
         report.write(filename)
+        # Return the output filename
+        return filename
 
     def _report_fastq(self,fq,read_id,summary,idx,report,
                       qc_dir=None,relpath=None):

--- a/bin/process_icell8.py
+++ b/bin/process_icell8.py
@@ -501,7 +501,7 @@ class CollectFiles(PipelineTask):
                 "ls","-1",
                 "%s" % (os.path.join(self.args.dirn,
                                      self.args.pattern)),
-                "2>1",
+                "2>&1",
                 ";","echo","-n"))
     def finish(self):
         # Process the output from the 'ls' command which

--- a/bin/process_icell8.py
+++ b/bin/process_icell8.py
@@ -1271,7 +1271,7 @@ class CollectFastqsForQC(PipelineTask):
             PipelineCommandWrapper(
                 "Generate QC report for project '%s'" %
                 os.path.basename(self.args.project_dir),
-                "qcreporter2.py",
+                "reportqc.py",
                 "--fastq_dir",self.args.fastq_dir,
                 "--qc_dir",self.args.qc_dir,
                 "--verify",
@@ -1390,7 +1390,7 @@ class ReportQC(PipelineTask):
             PipelineCommandWrapper(
                 "Generate QC report for project '%s'" %
                 os.path.basename(self.args.project_dir),
-                "qcreporter2.py",
+                "reportqc.py",
                 "--fastq_dir",self.args.fastq_dir,
                 "--qc_dir",self.args.qc_dir,
                 "--title","'%s'" % self.title,

--- a/bin/qcreporter2.py
+++ b/bin/qcreporter2.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     qcreporter2.py: generate report file for Illumina NGS qc runs
-#     Copyright (C) University of Manchester 2015 Peter Briggs
+#     Copyright (C) University of Manchester 2015-2018 Peter Briggs
 #
 
 #######################################################################
@@ -11,14 +11,94 @@
 import sys
 import os
 import optparse
+import logging
 from auto_process_ngs.utils import AnalysisProject
+from auto_process_ngs.utils import ZipArchive
 from auto_process_ngs.qc.illumina_qc import QCReporter
+from auto_process_ngs.qc.illumina_qc import expected_qc_outputs
 from auto_process_ngs import get_version
+
+# Module specific logger
+logger = logging.getLogger(__name__)
 
 """
 qc_reporter2
 
 """
+
+#######################################################################
+# Functions
+#######################################################################
+
+def verify_qc(project,qc_dir=None):
+    """
+    Get list of fastqs in project failing verification
+
+    Arguments:
+      project (AnalysisProject): project object
+      qc_dir (str): optional name of subdirectory
+        containing QC outputs (defaults to default
+        QC subdir from the project)
+
+    Returns:
+      List: list of Fastqs (including path) which
+        don't pass the verification check.
+    """
+    if qc_dir is None:
+        qc_dir = self.qc_dir
+    fastqs = []
+    for sample in project.samples:
+        for fq in sample.fastq:
+            if not sample.verify_qc(qc_dir,fq):
+                fastqs.append(fq)
+    return fastqs
+
+def zip_report(project,report_html,qc_dir=None):
+    """
+    Create ZIP archive for a QC report
+
+    Arguments:
+      project (AnalysisProject): project object
+      report_html (str): HTML QC report
+      qc_dir (str): optional name of subdirectory
+        containing QC outputs (defaults to default
+        QC subdir from the project)
+
+    Returns:
+      String: path to the output ZIP file.
+    """
+    # Name for ZIP file
+    basename = os.path.splitext(os.path.basename(report_html))[0]
+    analysis_dir = os.path.basename(os.path.dirname(project.dirn))
+    # Create ZIP archive
+    report_zip = os.path.join(project.dirn,
+                              "%s.%s.%s.zip" %
+                              (basename,
+                               project.name,
+                               analysis_dir))
+    zip_file = ZipArchive(report_zip,relpath=project.dirn,
+                          prefix="%s.%s.%s" %
+                          (basename,
+                           project.name,
+                           analysis_dir))
+    # Get QC dir if not set
+    if qc_dir is None:
+        qc_dir = self.qc_dir
+    # Add the HTML report
+    zip_file.add_file(report_html)
+    # Add the FastQC and screen files
+    for sample in project.qc.samples:
+        for fastqs in sample.fastq_pairs:
+            for fq in fastqs:
+                logger.debug("Adding QC outputs for %s" % fq)
+                for f in expected_qc_outputs(fq,qc_dir):
+                    if f.endswith('.zip'):
+                        # Exclude .zip file
+                        continue
+                    if os.path.exists(f):
+                        zip_file.add(f)
+    # Finished
+    return report_zip
 
 #######################################################################
 # Main program
@@ -30,53 +110,100 @@ def main():
                               version="%prog "+get_version(),
                               description="Generate QC report for each directory "
                               "DIR")
+    p.add_option('--fastq_dir',
+                 action='store',dest='fastq_dir',default=None,
+                 help="explicitly specify subdirectory of DIRs with "
+                 "Fastq files to run the QC on.")
     p.add_option('--qc_dir',action='store',dest='qc_dir',default='qc',
                  help="explicitly specify QC output directory (nb if "
                  "supplied then the same QC_DIR will be used for each "
                  "DIR. Non-absolute paths are assumed to be relative to "
                  "DIR). Default: 'qc'")
-    p.add_option('-f','--filename',action='store',dest='filename',
-                 default=None,
-                 help="file name for output QC report (default: "
-                 "<DIR>/<QC_DIR>_report.html)")
-    p.add_option('--verify',action='store_true',dest='verify',
-                 help="verify the QC products only (don't write the "
-                 "report)")
+    reporting = optparse.OptionGroup(p,'Reporting options')
+    reporting.add_option('-t','--title',action='store',dest='title',
+                         default=None,
+                         help="title for output QC report")
+    reporting.add_option('-f','--filename',
+                         action='store',dest='filename',default=None,
+                 help="file name for output HTML QC report (default: "
+                         "<DIR>/<QC_DIR>_report.html)")
+    reporting.add_option('--zip',action='store_true',
+                         dest='zip',default=False,
+                         help="make ZIP archive for the QC report")
+    reporting.add_option('--force',action='store_true',
+                         dest='force',default=False,
+                         help="force generation of reports even if "
+                         "verification fails")
+    p.add_option_group(reporting)
+    verification = optparse.OptionGroup(p,'Verification options')
+    verification.add_option('--verify',action='store_true',dest='verify',
+                            help="verify the QC products only (don't "
+                            "write the report)")
+    verification.add_option('-l','--list-unverified',action='store_true',
+                            dest='list_unverified',default=False,
+                            help="list the Fastqs that failed "
+                            "verification")
+    p.add_option_group(verification)
     opts,args = p.parse_args()
     if len(args) < 1:
         p.error("Need to supply at least one directory")
 
     # Examine projects i.e. supplied directories
+    retval = 0
     for d in args:
         project_name = os.path.basename(d)
         dir_path = os.path.abspath(d)
-        p = AnalysisProject(project_name,dir_path)
+        p = AnalysisProject(project_name,dir_path,
+                            fastq_dir=opts.fastq_dir)
         print "Project: %s" % p.name
+        print "Fastqs : %s" % p.fastq_dir
         if opts.qc_dir is None:
             qc_dir = p.qc_dir
         else:
             qc_dir = opts.qc_dir
         if not os.path.isabs(qc_dir):
             qc_dir = os.path.join(p.dirn,qc_dir)
+        # Warning if there is a mismatch
+        qc_info = p.qc_info(qc_dir)
+        if qc_info.fastq_dir is not None and \
+           os.path.join(p.dirn,qc_info.fastq_dir) != p.fastq_dir:
+            logger.warning("Stored fastq dir mismatch (%s != %s)" %
+                           (p.fastq_dir,qc_info.fastq_dir))
         print "QC output dir: %s" % qc_dir
         print "-"*(len('Project: ')+len(p.name))
         print "%d samples | %d fastqs" % (len(p.samples),len(p.fastqs))
-        if opts.verify:
-            if not QCReporter(p).verify(qc_dir=qc_dir):
-                print "Verification: FAILED"
-            else:
-                print "Verification: OK"
+        # Verification step
+        unverified = verify_qc(p,qc_dir)
+        if unverified:
+            if opts.list_unverified:
+                for fq in unverified:
+                    print fq
+            print "Verification: FAILED"
+            retval = 1
+            if not opts.force:
+                continue
         else:
-            qc_base = os.path.basename(qc_dir)
-            if opts.filename is None:
-                out_file = '%s_report.html' % qc_base
-            else:
-                out_file = opts.filename
-            if not os.path.isabs(out_file):
-                out_file = os.path.join(p.dirn,out_file)
-            print "Writing QC report to %s" % out_file
-            qc = QCReporter(p).report(qc_dir=qc_dir,
-                                      filename=out_file)
+            print "Verification: OK"
+            if opts.verify:
+                continue
+        # Report generation
+        qc_base = os.path.basename(qc_dir)
+        if opts.filename is None:
+            out_file = '%s_report.html' % qc_base
+        else:
+            out_file = opts.filename
+        if not os.path.isabs(out_file):
+            out_file = os.path.join(p.dirn,out_file)
+        print "Writing QC report to %s" % out_file
+        report_html= QCReporter(p).report(qc_dir=qc_dir,
+                                          title=opts.title,
+                                          filename=out_file)
+        # Generate ZIP archive
+        if opts.zip:
+            report_zip = zip_report(p,qc_dir,report_html)
+            print "ZIP archive: %s" % report_zip
+    # Finish with appropriate exit code
+    sys.exit(retval)
 
 if __name__ == '__main__':
     main()

--- a/bin/reportqc.py
+++ b/bin/reportqc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-#     qcreporter2.py: generate report file for Illumina NGS qc runs
+#     reportqc.py: generate report file for Illumina NGS qc runs
 #     Copyright (C) University of Manchester 2015-2018 Peter Briggs
 #
 
@@ -22,8 +22,10 @@ from auto_process_ngs import get_version
 logger = logging.getLogger(__name__)
 
 """
-qc_reporter2
+reportqc
 
+Utility to verify and report on QC outputs from
+auto_process pipeline.
 """
 
 #######################################################################


### PR DESCRIPTION
PR to address issue #152: adds a `CollectFiles` task which replaces the use of the `FileCollector` class for gathering lists of output files.

It also modifies/updates `qcreporter2.py` and uses this in new `CollectFastqsForQC` and `ReportQC` taks to farm the QC checking and reporting to external processes.