### PR TITLE
make_fastqs: enable platform to be set explicitly (issue #156)

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1820,11 +1820,14 @@ class AutoProcess:
         if mask_short_adapter_reads is not None:
             bcl2fastq.add_args('--mask-short-adapter-reads',
                                mask_short_adapter_reads)
-        bcl2fastq.add_args('--bcl2fastq_path',
+        bcl2fastq.add_args('--platform',
+                           self.metadata.platform,
+                           '--bcl2fastq_path',
                            bcl2fastq_exe,
                            primary_data_dir,
                            bcl2fastq_dir,
                            tmp_sample_sheet)
+
         print "Running %s" % bcl2fastq
         bcl2fastq_job = simple_scheduler.SchedulerJob(runner,
                                                       bcl2fastq.command_line,

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1276,7 +1276,7 @@ class AutoProcess:
         undetermined_dir = os.path.join(self.analysis_dir,dirs[0])
         return utils.AnalysisProject(dirs[0],undetermined_dir)
         
-    def make_fastqs(self,protocol='standard',
+    def make_fastqs(self,protocol='standard',platform=None,
                     unaligned_dir=None,sample_sheet=None,lanes=None,
                     ignore_missing_bcl=False,ignore_missing_stats=False,
                     skip_rsync=False,remove_primary_data=False,
@@ -1313,6 +1313,9 @@ class AutoProcess:
           protocol            : if set then specifies the protocol to use
                                 for fastq generation, otherwise use the
                                 'standard' bcl2fastq protocol
+          platform            : if set then specifies the sequencing platform
+                                (otherwise platform will be determined from the
+                                primary data)
           unaligned_dir       : if set then use this as the output directory for
                                 bcl-to-fastq conversion. Default is 'bcl2fastq' (unless
                                 an alternative is already specified in the config file)
@@ -1449,6 +1452,9 @@ class AutoProcess:
                 raise Exception, "Failed to acquire primary data"
             if only_fetch_primary_data:
                 return
+        # Deal with platform information
+        if not platform:
+            platform = self.metadata.platform
         # Do fastq generation using the specified protocol
         if not skip_fastq_generation:
             # Set primary data location and report info
@@ -1456,9 +1462,22 @@ class AutoProcess:
                 self.params.primary_data_dir,
                 os.path.basename(self.params.data_dir))
             print "Primary data dir      : %s" % primary_data_dir
-            illumina_run = IlluminaData.IlluminaRun(primary_data_dir)
+            try:
+                illumina_run = IlluminaData.IlluminaRun(primary_data_dir,
+                                                        platform=platform)
+            except IlluminaData.IlluminaDataPlatformError as ex:
+                logging.critical("Error loading primary data: %s" % ex)
+                if platform is None:
+                    logging.critical("Try specifying platform using --platform?")
+                else:
+                    logging.critical("Check specified platform is valid (or "
+                                     "omit --platform")
+                raise Exception("Error determining sequencer platform")
             print "Platform              : %s" % illumina_run.platform
             print "Bcl format            : %s" % illumina_run.bcl_extension
+            # Set platform in metadata
+            self.metadata['platform'] = illumina_run.platform
+            # Do fastq generation according to protocol
             if protocol == 'icell8':
                 # ICell8 data
                 # Update bcl2fastq settings appropriately

--- a/auto_process_ngs/test/test_auto_processor_make_fastqs.py
+++ b/auto_process_ngs/test/test_auto_processor_make_fastqs.py
@@ -276,3 +276,115 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
             self.assertFalse(os.path.exists(
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
+
+    def test_make_fastqs_unknown_platform(self):
+        """make_fastqs: unknown platform raises exception
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_UNKNOWN_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Do the test
+        ap = AutoProcess()
+        ap.setup(os.path.join(self.wd,
+                              "171020_UNKNOWN_00002_AHGXXXX"))
+        self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertRaises(Exception,
+                          ap.make_fastqs,
+                          protocol="standard")
+
+    def test_make_fastqs_explicitly_specify_platform(self):
+        """make_fastqs: explicitly specify the platform
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_UNKNOWN_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 platform="miseq")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Do the test
+        ap = AutoProcess()
+        ap.setup(os.path.join(self.wd,
+                              "171020_UNKNOWN_00002_AHGXXXX"))
+        self.assertTrue(ap.params.sample_sheet is not None)
+        ap.make_fastqs(protocol="standard",
+                       platform="miseq")
+        # Check outputs
+        analysis_dir = os.path.join(
+            self.wd,
+            "171020_UNKNOWN_00002_AHGXXXX_analysis")
+        for subdir in (os.path.join("primary_data",
+                                    "171020_UNKNOWN_00002_AHGXXXX"),
+                       os.path.join("logs",
+                                    "002_make_fastqs"),
+                       "bcl2fastq"):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "projects.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    def test_make_fastqs_specify_platform_via_metadata(self):
+        """make_fastqs: implicitly specify the platform via metadata
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_UNKNOWN_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 platform="miseq")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Do the test
+        ap = AutoProcess()
+        ap.setup(os.path.join(self.wd,
+                              "171020_UNKNOWN_00002_AHGXXXX"))
+        self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertTrue(ap.metadata.platform is None)
+        ap.metadata["platform"] = "miseq"
+        ap.make_fastqs(protocol="standard")
+        # Check outputs
+        analysis_dir = os.path.join(
+            self.wd,
+            "171020_UNKNOWN_00002_AHGXXXX_analysis")
+        for subdir in (os.path.join("primary_data",
+                                    "171020_UNKNOWN_00002_AHGXXXX"),
+                       os.path.join("logs",
+                                    "002_make_fastqs"),
+                       "bcl2fastq"):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "projects.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -67,6 +67,7 @@ import subprocess
 import optparse
 import time
 import bcftbx.utils as bcf_utils
+import bcftbx.platforms
 from bcftbx.cmdparse import CommandParser
 from bcftbx.cmdparse import add_debug_option
 from bcftbx.cmdparse import add_no_save_option
@@ -238,6 +239,12 @@ def add_make_fastqs_command(cmdparser):
                                 help="explicitly set the output "
                                 "(sub)directory for bcl-to-fastq "
                                 "conversion (overrides default)")
+    fastq_generation.add_option('--platform',action="store",
+                                dest="platform",default=None,
+                                help="explicitly specify the sequencing "
+                                "platform. Only use this if the platform "
+                                "cannot be identified from the instrument "
+                                "name")
     fastq_generation.add_option('--use-bases-mask',action="store",
                                 dest="bases_mask",default=None,
                                 help="explicitly set the bases-mask string "
@@ -961,6 +968,7 @@ if __name__ == "__main__":
                     sample_sheet=options.sample_sheet,
                     bases_mask=options.bases_mask,
                     lanes=lanes,
+                    platform=options.platform,
                     no_lane_splitting=no_lane_splitting,
                     minimum_trimmed_read_length=options.minimum_trimmed_read_length,
                     mask_short_adapter_reads=options.mask_short_adapter_reads,

--- a/bin/bclToFastq.py
+++ b/bin/bclToFastq.py
@@ -124,6 +124,13 @@ def main():
                                 "with fewer ACGT bases will be completely "
                                 "masked with Ns (default: 22)")
     p.add_option_group(adapter_trimming)
+    # Advanced options
+    advanced = optparse.OptionGroup(p,'Advanced options')
+    advanced.add_option('--platform',action="store",
+                        dest="platform",default=None,
+                        help="Explicitly specify platform; only use this if "
+                        "the platform can't be read from the instrument name")
+    p.add_option_group(advanced)
 
     options,args = p.parse_args()
     if not (2 <= len(args) <=3):
@@ -167,7 +174,8 @@ def main():
         logging.error("%s: doesn't exist or is not a directory" %
                       illumina_run_dir)
         sys.exit(1)
-    illumina_run = IlluminaData.IlluminaRun(illumina_run_dir)
+    illumina_run = IlluminaData.IlluminaRun(illumina_run_dir,
+                                            options.platform)
     # Output directory
     output_dir = os.path.abspath(args[1].rstrip(os.sep))
     # Sample sheet


### PR DESCRIPTION
PR attempting to address issue #156 ("failure to identify platform name derails fastq creation").

With these changes, if the platform cannot be implicitly identified from the sequencer instrument name (because it's not in `platforms.py` in `genomics-bcftbx`) then it can be explicitly set by either:

* Specifying it via a new `--platform` option to the `make_fastqs` command, or
* Setting the `platform` in the `metadata.info` file (e.g. `auto_process.py metadata --set platform=miseq`)

These changes require version 1.2.0 or later of `genomics-bcftbx`, with the changes from https://github.com/fls-bioinformatics-core/genomics/pull/62