### PR TITLE
Detect invalid barcodes in samplesheets

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1419,6 +1419,15 @@ class AutoProcess:
         bcl2fastq_utils.make_custom_sample_sheet(self.params.sample_sheet,
                                                  sample_sheet,
                                                  lanes=lanes)
+        # Check the temporary sample sheet
+        print "Checking temporary sample sheet"
+        invalid_barcodes = samplesheet_utils.SampleSheetLinter(
+            sample_sheet_file=sample_sheet).has_invalid_barcodes()
+        if invalid_barcodes:
+            logging.error("Invalid barcodes detected")
+            for line in invalid_barcodes:
+                logging.error("%s" % line)
+            raise Exception("Errors detected in generated sample sheet")
         # Adjust verification settings for 10xGenomics Chromium SC
         # data if necessary
         verify_include_sample_dir = False

--- a/auto_process_ngs/samplesheet_utils.py
+++ b/auto_process_ngs/samplesheet_utils.py
@@ -30,11 +30,14 @@ Helper functions:
 # Imports
 #######################################################################
 
-import logging
 import difflib
 import re
 from bcftbx.IlluminaData import SampleSheet
 from bcftbx.IlluminaData import SampleSheetPredictor
+
+# Initialise logging
+import logging
+logger = logging.getLogger(__name__)
 
 #######################################################################
 # Classes
@@ -343,23 +346,23 @@ def check_and_warn(sample_sheet=None,sample_sheet_file=None):
     # Do checks
     warnings = False
     if linter.close_project_names():
-        logging.warning("Some projects have similar names: check for typos")
+        logger.warning("Some projects have similar names: check for typos")
         warnings = True
     if linter.samples_with_multiple_barcodes():
-        logging.warning("Some samples have more than one barcode assigned")
+        logger.warning("Some samples have more than one barcode assigned")
         warnings = True
     if linter.samples_in_multiple_projects():
-        logging.warning("Some samples appear in more than one project")
+        logger.warning("Some samples appear in more than one project")
         warnings = True
     if linter.has_invalid_characters():
-        logging.warning("Sample sheet file contains invalid characters "
-                        "(non-printing ASCII or non-ASCII)")
+        logger.warning("Sample sheet file contains invalid characters "
+                       "(non-printing ASCII or non-ASCII)")
         warnings = True
     if linter.has_invalid_barcodes():
-        logging.warning("Some samples have invalid barcodes")
+        logger.warning("Some samples have invalid barcodes")
         warnings = True
     if linter.has_invalid_lines():
-        logging.warning("Sample sheet has one or more invalid lines")
+        logger.warning("Sample sheet has one or more invalid lines")
         warnings = True
     return warnings
 

--- a/auto_process_ngs/samplesheet_utils.py
+++ b/auto_process_ngs/samplesheet_utils.py
@@ -323,6 +323,7 @@ def check_and_warn(sample_sheet=None,sample_sheet_file=None):
     - samples associated with more than one project
     - invalid lines
     - invalid characters
+    - invalid barcodes
 
     Arguments:
       sample_sheet (SampleSheet): if supplied then must be a
@@ -353,6 +354,9 @@ def check_and_warn(sample_sheet=None,sample_sheet_file=None):
     if linter.has_invalid_characters():
         logging.warning("Sample sheet file contains invalid characters "
                         "(non-printing ASCII or non-ASCII)")
+        warnings = True
+    if linter.has_invalid_barcodes():
+        logging.warning("Some samples have invalid barcodes")
         warnings = True
     if linter.has_invalid_lines():
         logging.warning("Sample sheet has one or more invalid lines")

--- a/auto_process_ngs/test/test_auto_processor_make_fastqs.py
+++ b/auto_process_ngs/test/test_auto_processor_make_fastqs.py
@@ -388,3 +388,51 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
+
+    def test_make_fastqs_invalid_barcodes(self):
+        """make_fastqs: stop for invalid barcodes
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            sample_sheet_content="""[Header],,,,,,,,,
+IEMFileVersion,4
+Date,11/23/2015
+Workflow,GenerateFASTQ
+Application,FASTQ Only
+Assay,TruSeq HT
+Description,
+Chemistry,Amplicon
+
+[Reads]
+101
+101
+
+[Settings]
+ReverseComplement,0
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+Sample1,Sample1,,,D701,CGTGTAGG,D501,GACCTGNN,,
+Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
+""",
+            top_dir=self.wd)
+        illumina_run.create()
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 platform="miseq")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Do the test
+        ap = AutoProcess()
+        ap.setup(os.path.join(self.wd,
+                              "171020_M00879_00002_AHGXXXX"))
+        self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertRaises(Exception,
+                          ap.make_fastqs)
+        #ap.make_fastqs()
+        #self.fail()

--- a/auto_process_ngs/test/test_auto_processor_make_fastqs.py
+++ b/auto_process_ngs/test/test_auto_processor_make_fastqs.py
@@ -10,6 +10,9 @@ from bcftbx.mock import MockIlluminaRun
 from auto_process_ngs.mock import MockBcl2fastq2Exe
 from auto_process_ngs.auto_processor import AutoProcess
 
+# Set to False to keep test output dirs
+REMOVE_TEST_OUTPUTS = True
+
 class TestAutoProcessMakeFastqs(unittest.TestCase):
     """
     Tests for AutoProcess.make_fastqs
@@ -38,7 +41,8 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
         # Restore PATH
         os.environ['PATH'] = self.path
         # Remove the temporary test directory
-        ##shutil.rmtree(self.wd)
+        if REMOVE_TEST_OUTPUTS:
+            shutil.rmtree(self.wd)
 
     def test_make_fastqs_standard_protocol(self):
         """make_fastqs: standard protocol


### PR DESCRIPTION
PR to address issue #56: adds barcode verification functionality to the `SampleSheetLinter` class in `samplesheet_utils.py` and invokes this as part of the `check_and_warn` function.

Also updates the `make_fastqs` command to stop with an error if the sample sheet contains invalid barcde sequences.