### PR TITLE
Defer bases mask determination from 'setup' to 'make_fastqs'

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -904,18 +904,8 @@ class AutoProcess:
             logging.warning("No element 'Assay' found in sample sheet")
             assay = None
         # Bases mask
-        bases_mask = self.params.bases_mask
-        if bases_mask is None:
-            print "Acquiring RunInfo.xml to determine bases mask..."
-            tmp_run_info = os.path.join(self.tmp_dir,'RunInfo.xml')
-            rsync = applications.general.rsync(os.path.join(data_dir,
-                                                            'RunInfo.xml'),
-                                               self.tmp_dir)
-            status = rsync.run_subprocess(log=self.log_path('rsync.run_info.log'))
-            bases_mask = bcl2fastq_utils.get_bases_mask(tmp_run_info,
-                                                        custom_sample_sheet)
-            os.remove(tmp_run_info)
-        print "Corrected bases mask: %s" % bases_mask
+        print "Bases mask set to 'auto' (will be determined at run time)"
+        bases_mask = "auto"
         # Generate and print predicted outputs and warnings
         print samplesheet_utils.predict_outputs(sample_sheet=sample_sheet)
         samplesheet_utils.check_and_warn(sample_sheet=sample_sheet)
@@ -1488,6 +1478,17 @@ class AutoProcess:
             print "Bcl format            : %s" % illumina_run.bcl_extension
             # Set platform in metadata
             self.metadata['platform'] = illumina_run.platform
+            # Bases mask
+            if bases_mask is not None:
+                self.params.bases_mask = bases_mask
+            else:
+                bases_mask = self.params.bases_mask
+            print "Bases mask setting    : %s" % bases_mask
+            if bases_mask == "auto":
+                print "Determining bases mask from RunInfo.xml"
+                bases_mask = bcl2fastq_utils.get_bases_mask(
+                    illumina_run.runinfo_xml,
+                    sample_sheet)
             # Do fastq generation according to protocol
             if protocol == 'icell8':
                 # ICell8 data

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1479,9 +1479,7 @@ class AutoProcess:
             # Set platform in metadata
             self.metadata['platform'] = illumina_run.platform
             # Bases mask
-            if bases_mask is not None:
-                self.params.bases_mask = bases_mask
-            else:
+            if bases_mask is None:
                 bases_mask = self.params.bases_mask
             print "Bases mask setting    : %s" % bases_mask
             if bases_mask == "auto":
@@ -1489,6 +1487,10 @@ class AutoProcess:
                 bases_mask = bcl2fastq_utils.get_bases_mask(
                     illumina_run.runinfo_xml,
                     sample_sheet)
+            if not bcl2fastq_utils.bases_mask_is_valid(bases_mask):
+                raise Exception("Invalid bases mask: '%s'" %
+                                bases_mask)
+            self.params.bases_mask = bases_mask
             # Do fastq generation according to protocol
             if protocol == 'icell8':
                 # ICell8 data
@@ -1500,6 +1502,10 @@ class AutoProcess:
                 bases_mask = IlluminaData.IlluminaRunInfo(
                     illumina_run.runinfo_xml).bases_mask
                 bases_mask = icell8_utils.get_icell8_bases_mask(bases_mask)
+                if not bcl2fastq_utils.bases_mask_is_valid(bases_mask):
+                    raise Exception("Invalid bases mask: '%s'" %
+                                    bases_mask)
+                self.params.bases_mask = bases_mask
                 # Switch to standard protocol
                 protocol = 'standard'
             if protocol == 'standard':

--- a/auto_process_ngs/bcl2fastq_utils.py
+++ b/auto_process_ngs/bcl2fastq_utils.py
@@ -325,8 +325,11 @@ def get_nmismatches(bases_mask):
       contain any index reads then returns zero.)
 
     """
+    # Check mask is valid
     if not bases_mask_is_valid(bases_mask):
         raise Exception("'%s': not a valid bases mask" % bases_mask)
+    # Total the length of all index reads
+    index_length = 0
     for read in bases_mask.upper().split(','):
         if read.startswith('I'):
             try:
@@ -335,15 +338,14 @@ def get_nmismatches(bases_mask):
             except ValueError:
                 pass
             try:
-                index_length = int(read[1:])
+                index_length += int(read[1:])
             except ValueError:
-                index_length = len(read)
-            if index_length >= 6:
-                return 1
-            else:
-                return 0
-    # Failed to find any indexed reads
-    return 0
+                index_length += len(read)
+    # Return number of mismatches
+    if index_length >= 6:
+        return 1
+    else:
+        return 0
 
 def check_barcode_collisions(sample_sheet_file,nmismatches):
     """

--- a/auto_process_ngs/test/test_auto_processor.py
+++ b/auto_process_ngs/test/test_auto_processor.py
@@ -510,8 +510,7 @@ class TestAutoProcessSetup(unittest.TestCase):
         self.assertEqual(ap.params.sample_sheet,
                          os.path.join(self.dirn,analysis_dirn,
                                       'custom_SampleSheet.csv'))
-        self.assertEqual(ap.params.bases_mask,
-                         'y101,I8,I8,y101')
+        self.assertEqual(ap.params.bases_mask,'auto')
         # Check metadata
         self.assertEqual(ap.metadata.run_name,
                          "151125_M00879_0001_000000000-ABCDE1")

--- a/auto_process_ngs/test/test_auto_processor.py
+++ b/auto_process_ngs/test/test_auto_processor.py
@@ -564,8 +564,7 @@ class TestAutoProcessSetup(unittest.TestCase):
         self.assertEqual(ap.params.sample_sheet,
                          os.path.join(self.dirn,analysis_dirn,
                                       'custom_SampleSheet.csv'))
-        self.assertEqual(ap.params.bases_mask,
-                         'y101,I8,I8,y101')
+        self.assertEqual(ap.params.bases_mask,'auto')
         # Check metadata
         self.assertEqual(ap.metadata.run_name,
                          "151125_M00879_0001")

--- a/auto_process_ngs/test/test_auto_processor_make_fastqs.py
+++ b/auto_process_ngs/test/test_auto_processor_make_fastqs.py
@@ -63,7 +63,15 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
         ap.setup(os.path.join(self.wd,
                               "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
         ap.make_fastqs(protocol="standard")
+        # Check parameters
+        self.assertEqual(ap.params.bases_mask,"y101,I8,I8,y101")
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(self.wd,
+                                      "171020_M00879_00002_AHGXXXX_analysis",
+                                      "primary_data"))
         # Check outputs
         analysis_dir = os.path.join(
             self.wd,
@@ -107,7 +115,15 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
         ap.setup(os.path.join(self.wd,
                               "171020_SN7001250_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
         ap.make_fastqs(protocol="icell8")
+        # Check parameters
+        self.assertEqual(ap.params.bases_mask,"y25n76,I8,I8,y101")
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(self.wd,
+                                      "171020_SN7001250_00002_AHGXXXX_analysis",
+                                      "primary_data"))
         # Check outputs
         analysis_dir = os.path.join(
             self.wd,
@@ -152,6 +168,8 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
         ap.setup(os.path.join(self.wd,
                               "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
         self.assertRaises(Exception,
                           ap.make_fastqs,
                           protocol="standard",
@@ -206,8 +224,16 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
         ap.setup(os.path.join(self.wd,
                               "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
         ap.make_fastqs(protocol="standard",
                        create_empty_fastqs=True)
+        # Check parameters
+        self.assertEqual(ap.params.bases_mask,"y101,I8,I8,y101")
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(self.wd,
+                                      "171020_M00879_00002_AHGXXXX_analysis",
+                                      "primary_data"))
         # Check outputs
         analysis_dir = os.path.join(
             self.wd,
@@ -256,6 +282,8 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
         ap.setup(os.path.join(self.wd,
                               "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
         self.assertRaises(Exception,
                           ap.make_fastqs,
                           protocol="standard")
@@ -300,6 +328,8 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
         ap.setup(os.path.join(self.wd,
                               "171020_UNKNOWN_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
         self.assertRaises(Exception,
                           ap.make_fastqs,
                           protocol="standard")
@@ -324,8 +354,16 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
         ap.setup(os.path.join(self.wd,
                               "171020_UNKNOWN_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
         ap.make_fastqs(protocol="standard",
                        platform="miseq")
+        # Check parameters
+        self.assertEqual(ap.params.bases_mask,"y101,I8,I8,y101")
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(self.wd,
+                                      "171020_UNKNOWN_00002_AHGXXXX_analysis",
+                                      "primary_data"))
         # Check outputs
         analysis_dir = os.path.join(
             self.wd,
@@ -370,7 +408,16 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertTrue(ap.metadata.platform is None)
         ap.metadata["platform"] = "miseq"
+        self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
         ap.make_fastqs(protocol="standard")
+        # Check parameters
+        self.assertEqual(ap.params.bases_mask,"y101,I8,I8,y101")
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(self.wd,
+                                      "171020_UNKNOWN_00002_AHGXXXX_analysis",
+                                      "primary_data"))
         # Check outputs
         analysis_dir = os.path.join(
             self.wd,
@@ -436,7 +483,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
         ap.setup(os.path.join(self.wd,
                               "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
         self.assertRaises(Exception,
                           ap.make_fastqs)
-        #ap.make_fastqs()
-        #self.fail()

--- a/auto_process_ngs/test/test_bcl2fastq.py
+++ b/auto_process_ngs/test/test_bcl2fastq.py
@@ -570,6 +570,23 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(open(sample_sheet_out,'r').read(),
                          expected)
 
+class TestBasesMaskIsValid(unittest.TestCase):
+    """Tests for the bases_mask_is_valid function
+    """
+    def test_bases_mask_is_valid(self):
+        self.assertTrue(bases_mask_is_valid('y50'))
+        self.assertTrue(bases_mask_is_valid('y50,I4'))
+        self.assertTrue(bases_mask_is_valid('y50,I6'))
+        self.assertTrue(bases_mask_is_valid('y101,I6,y101'))
+        self.assertTrue(bases_mask_is_valid('y250,I8,I8,y250'))
+        self.assertTrue(bases_mask_is_valid('y250,I6nn,I6nn,y250'))
+        self.assertTrue(bases_mask_is_valid('y250,I6n2,I6n2,y250'))
+        self.assertTrue(bases_mask_is_valid('y25n76,I8,I8,y101'))
+        self.assertTrue(bases_mask_is_valid('y250,I16'))
+        self.assertTrue(bases_mask_is_valid('yyyyyyyyy,IIIIII'))
+        self.assertTrue(bases_mask_is_valid('yyyyyyyyy,IIIInn'))
+        self.assertFalse(bases_mask_is_valid(123))
+
 class TestGetNmismatches(unittest.TestCase):
     """Tests for the get_nmismatches function
 
@@ -583,4 +600,11 @@ class TestGetNmismatches(unittest.TestCase):
         self.assertEqual(get_nmismatches('y250,I6nn,I6nn,y250'),1)
         self.assertEqual(get_nmismatches('y250,I6n2,I6n2,y250'),1)
         self.assertEqual(get_nmismatches('y250,I16'),1)
+        self.assertEqual(get_nmismatches('yyyyyyyyy,IIIIII'),1)
+        self.assertEqual(get_nmismatches('yyyyyyyyy,IIIINN'),0)
+        self.assertEqual(get_nmismatches('yyyyyyyyy,IIII'),0)
+        self.assertEqual(get_nmismatches('yyyyyyyyy,IIIIN4'),0)
 
+    def test_n_mismatches_invalid_input(self):
+        self.assertRaises(Exception,get_nmismatches,'auto')
+        self.assertRaises(Exception,get_nmismatches,123)

--- a/auto_process_ngs/test/test_bcl2fastq.py
+++ b/auto_process_ngs/test/test_bcl2fastq.py
@@ -604,6 +604,7 @@ class TestGetNmismatches(unittest.TestCase):
         self.assertEqual(get_nmismatches('yyyyyyyyy,IIIINN'),0)
         self.assertEqual(get_nmismatches('yyyyyyyyy,IIII'),0)
         self.assertEqual(get_nmismatches('yyyyyyyyy,IIIIN4'),0)
+        self.assertEqual(get_nmismatches('y250,I4,I4,y250'),1)
 
     def test_n_mismatches_invalid_input(self):
         self.assertRaises(Exception,get_nmismatches,'auto')

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -250,7 +250,8 @@ def add_make_fastqs_command(cmdparser):
                                 help="explicitly set the bases-mask string "
                                 "to indicate how each cycle should be used "
                                 "in the bcl-to-fastq conversion (overrides "
-                                "default)")
+                                "default). Set to 'auto' to determine "
+                                "automatically")
     fastq_generation.add_option('--skip-fastq-generation',
                                 action='store_true',
                                 dest='skip_fastq_generation',default=False,


### PR DESCRIPTION
PR to address issue #120: moves initial determination of bases mask from the `setup` step to the `make_fastqs` step, with the option to force the mask to be reset automatically by specifying it as `auto`.