### PR TITLE
'archive' command: tidy internals and help text

### DIFF
--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -158,15 +158,13 @@ def archive(ap,archive_dir=None,platform=None,year=None,
                                   "(staging)")
     # Check if final archive already exists
     if fileops.exists(os.path.join(archive_dir,final_dest)):
-        logging.fatal("Final archive already exists, stopping")
-        return 1
+        raise Exception("Final archive already exists, stopping")
     # Check metadata
     check_metadata = ap.check_metadata(('source','run_number'))
     if not check_metadata:
         if not force or not is_staging:
-            logging.fatal("Some metadata items not set, stopping")
-            return 1
-        logging.warning("Some metadata items not set, proceeding")
+            raise Exception("Some metadata items not set, stopping")
+        logger.warning("Some metadata items not set, proceeding")
     if not is_staging:
         # Are there any projects to archive?
         projects = ap.get_analysis_projects()

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -611,8 +611,8 @@ def add_archive_command(cmdparser):
                  help="specify the year e.g. '2014' (default is the current year)")
     default_group = __settings.archive.group
     p.add_option('--group',action='store',dest='group',default=default_group,
-                 help="specify the name of group for the archived files NB only works "
-                 "when the archive is a local directory (default: %s)" % default_group)
+                 help="specify the name of group for the archived files "
+                 "(default: %s)" % default_group)
     default_chmod = __settings.archive.chmod
     p.add_option('--chmod',action='store',dest='permissions',
                  default=default_chmod,

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -614,9 +614,11 @@ def add_archive_command(cmdparser):
                  help="specify the name of group for the archived files NB only works "
                  "when the archive is a local directory (default: %s)" % default_group)
     default_chmod = __settings.archive.chmod
-    p.add_option('--chmod',action='store',dest='chmod',default=default_chmod,
-                 help="specify chmod operations for the archived files (default: "
-                 "%s)" % default_chmod)
+    p.add_option('--chmod',action='store',dest='permissions',
+                 default=default_chmod,
+                 help="specify permissions for the archived files. "
+                 "PERMISSIONS should be a string recognised by the 'chmod' "
+                 "command (e.g. 'o-rwX') (default: %s)" % default_chmod)
     p.add_option('--final',action='store_true',dest='final',default=False,
                  help="copy data to final archive location (default is to "
                  "copy to staging area)")
@@ -1089,7 +1091,7 @@ if __name__ == "__main__":
                                 platform=options.platform,
                                 year=options.year,
                                 group=options.group,
-                                perms=options.chmod,
+                                perms=options.permissions,
                                 final=options.final,
                                 force=options.force,
                                 dry_run=options.dry_run)


### PR DESCRIPTION
PR to tidy up some internals of the `archive_cmd` code, and update the help text seen by the user.