### PR TITLE
Fix setting of qc_dir in AnalysisProject when fastq set is switched

### DIFF
--- a/auto_process_ngs/test/test_utils.py
+++ b/auto_process_ngs/test/test_utils.py
@@ -855,6 +855,60 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertRaises(Exception,
                           project.use_fastq_dir,'fastqs.non_existant')
 
+    def test_analysis_project_switch_fastq_dir_preserves_qc_dir(self):
+        """Check AnalysisProject switch fastqs dirs preserves QC dir
+        """
+        # Construct test project with two fastq subdirectories
+        self.make_mock_project_dir(
+            'PJB',
+            ('PJB1-A_ACAGTG_L001_R1_001.fastq.gz',
+             'PJB1-B_ACAGTG_L002_R1_001.fastq.gz',))
+        self.make_mock_project_dir(
+            'PJB.untrimmed',
+            ('PJB1-A-untrimmed_ACAGTG_L001_R1_001.fastq.gz',
+             'PJB1-B-untrimmed_ACAGTG_L002_R1_001.fastq.gz',),
+            fastq_dir='fastqs.untrimmed')
+        shutil.move(os.path.join(self.dirn,
+                                 'PJB.untrimmed',
+                                 'fastqs.untrimmed'),
+                    os.path.join(self.dirn,'PJB'))
+        shutil.rmtree(os.path.join(self.dirn,'PJB.untrimmed'))
+        # Load and check AnalysisProject: default fastqs dir
+        dirn = os.path.join(self.dirn,'PJB')
+        project = AnalysisProject('PJB',dirn)
+        self.assertEqual(project.name,'PJB')
+        self.assertTrue(os.path.isdir(project.dirn))
+        self.assertFalse(project.multiple_fastqs)
+        self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.samples[0].name,'PJB1-A')
+        self.assertEqual(project.samples[1].name,'PJB1-B')
+        self.assertEqual(project.fastq_dir,
+                         os.path.join(project.dirn,'fastqs'))
+        self.assertEqual(project.fastq_dirs,
+                         ['fastqs','fastqs.untrimmed'])
+        self.assertEqual(project.qc_dir,
+                         os.path.join(project.dirn,'qc'))
+        # Set new QC dir
+        project.use_qc_dir('qc.new')
+        self.assertEqual(project.qc_dir,
+                         os.path.join(project.dirn,'qc.new'))
+        # Switch to alternative fastqs dir
+        project.use_fastq_dir('fastqs.untrimmed')
+        self.assertEqual(project.name,'PJB')
+        self.assertTrue(os.path.isdir(project.dirn))
+        self.assertFalse(project.multiple_fastqs)
+        self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.samples[0].name,'PJB1-A-untrimmed')
+        self.assertEqual(project.samples[1].name,'PJB1-B-untrimmed')
+        self.assertEqual(project.fastq_dir,
+                         os.path.join(project.dirn,'fastqs.untrimmed'))
+        self.assertEqual(project.info.samples,'2 samples (PJB1-A, PJB1-B)')
+        self.assertEqual(project.fastq_dirs,
+                         ['fastqs','fastqs.untrimmed'])
+        self.assertEqual(project.info.primary_fastq_dir,'fastqs')
+        self.assertEqual(project.qc_dir,
+                         os.path.join(project.dirn,'qc.new'))
+
     def test_sample_summary_single_ended(self):
         """AnalysisProject: sample_summary works for SE data
         """

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -584,6 +584,7 @@ class AnalysisProject:
         self.fastq_dirs = []
         self.fastq_format = None
         self.samples = []
+        self._qc_dir = None
         self.info = AnalysisProjectInfo()
         self.info_file = os.path.join(self.dirn,"README.info")
         # Function to use for getting Fastq information
@@ -677,8 +678,9 @@ class AnalysisProject:
         for sample in self.samples:
             paired_end = (paired_end and sample.paired_end)
         self.info['paired_end'] = paired_end
-        # Set the QC output dir
-        self.use_qc_dir('qc')
+        # Set the QC output dir, if not already set
+        if self.qc_dir is None:
+            self.use_qc_dir('qc')
 
     def find_fastqs(self,dirn):
         """


### PR DESCRIPTION
PR to fix a bug in the `AnalysisProject` class, when the Fastq directory/set is switched using `use_fastq_dir` the QC dir is automatically switched to `qc` and doesn't preserve any previously set value.