### PR TITLE
Fix issues with `--protocol=10x_chromium_sc` in make_fastqs command

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1482,14 +1482,15 @@ class AutoProcess:
             if bases_mask is None:
                 bases_mask = self.params.bases_mask
             print "Bases mask setting    : %s" % bases_mask
-            if bases_mask == "auto":
-                print "Determining bases mask from RunInfo.xml"
-                bases_mask = bcl2fastq_utils.get_bases_mask(
-                    illumina_run.runinfo_xml,
-                    sample_sheet)
-            if not bcl2fastq_utils.bases_mask_is_valid(bases_mask):
-                raise Exception("Invalid bases mask: '%s'" %
-                                bases_mask)
+            if protocol != '10x_chromium_sc':
+                if bases_mask == "auto":
+                    print "Determining bases mask from RunInfo.xml"
+                    bases_mask = bcl2fastq_utils.get_bases_mask(
+                        illumina_run.runinfo_xml,
+                        sample_sheet)
+                    if not bcl2fastq_utils.bases_mask_is_valid(bases_mask):
+                        raise Exception("Invalid bases mask: '%s'" %
+                                        bases_mask)
             self.params.bases_mask = bases_mask
             # Do fastq generation according to protocol
             if protocol == 'icell8':
@@ -1530,6 +1531,8 @@ class AutoProcess:
                     raise Exception("Bcl2fastq stage failed: '%s'" % ex)
             elif protocol == '10x_chromium_sc':
                 # 10xGenomics Chromium SC
+                if bases_mask == 'auto':
+                    bases_mask = None
                 try:
                     # Check we have cellranger
                     cellranger = bcf_utils.find_program('cellranger')

--- a/auto_process_ngs/bcl2fastq_utils.py
+++ b/auto_process_ngs/bcl2fastq_utils.py
@@ -34,6 +34,7 @@ import re
 import logging
 import auto_process_ngs.applications as applications
 import auto_process_ngs.utils as utils
+from .samplesheet_utils import barcode_is_10xgenomics
 import bcftbx.IlluminaData as IlluminaData
 import bcftbx.utils as bcf_utils
 
@@ -280,9 +281,13 @@ def get_bases_mask(run_info_xml,sample_sheet_file):
         IlluminaData.SampleSheet(sample_sheet_file).data[0])
     if example_barcode is None:
         example_barcode = ""
-    bases_mask = IlluminaData.fix_bases_mask(bases_mask,example_barcode)
-    print "Bases mask: %s (updated for barcode sequence '%s')" % (bases_mask,
-                                                                  example_barcode)
+    if barcode_is_10xgenomics(example_barcode):
+        print "Bases mask: barcode is 10xGenomics sample set ID"
+    else:
+        bases_mask = IlluminaData.fix_bases_mask(bases_mask,
+                                                 example_barcode)
+        print "Bases mask: %s (updated for barcode sequence '%s')" % \
+            (bases_mask,example_barcode)
     return bases_mask
 
 def bases_mask_is_valid(bases_mask):

--- a/auto_process_ngs/samplesheet_utils.py
+++ b/auto_process_ngs/samplesheet_utils.py
@@ -256,8 +256,25 @@ def barcode_is_valid(s):
       Boolean: True if barcode is valid, False if not.
 
     """
-    return bool(re.match(r'^[ATGC]*$',s) or
-                re.match(r'^SI\-[A-Z0-9]+\-[A-Z0-9]+$',s))
+    return (bool(re.match(r'^[ATGC]*$',s))
+            or barcode_is_10xgenomics(s))
+
+def barcode_is_10xgenomics(s):
+    """
+    Check if sample sheet barcode is 10xGenomics sample set ID
+
+    10xGenomics sample set IDs of the form e.g. 'SI-P03-C9' or
+    'SI-GA-B3' are also considered to be valid.
+
+    Arguments:
+      s (str): barcode sequence to validate
+
+    Returns:
+      Boolean: True if barcode is 10xGenomics sample set ID,
+        False if not.
+
+    """
+    return bool(re.match(r'^SI\-[A-Z0-9]+\-[A-Z0-9]+$',s))
 
 def predict_outputs(sample_sheet=None,sample_sheet_file=None):
     """

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -797,7 +797,7 @@ def add_cellranger_args(cellranger_cmd,
                         maxjobs=None,
                         mempercore=None,
                         jobinterval=None,
-                        disable_ui=True):
+                        disable_ui=False):
     """
     Configure options for cellranger
 
@@ -817,7 +817,7 @@ def add_cellranger_args(cellranger_cmd,
       jobinterval (int):  if specified, will be passed to
         the --jobinterval option
       disable_ui (bool): if True, add the --disable-ui
-        option (default)
+        option (default is not to add it)
 
     Returns:
       Command: the original command updated with the

--- a/auto_process_ngs/test/test_bcl2fastq.py
+++ b/auto_process_ngs/test/test_bcl2fastq.py
@@ -845,6 +845,44 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index,i
         self.assertEqual(get_bases_mask(run_info_xml,sample_sheet),
                          "y101,nnnnnnnn,nnnnnnnn,y101")
 
+    def test_get_bases_mask_10xgenomics_sample_set(self):
+        """get_bases_mask: handle 10xGenomics sample set IDs
+        """
+        # Make a RunInfo.xml file
+        run_info_xml = os.path.join(self.wd,"RunInfo.xml")
+        with open(run_info_xml,'w') as fp:
+            fp.write(RunInfoXml.nextseq("171020_NB500968_00002_AHGXXXX"))
+        # Make a matching sample sheet
+        sample_sheet_content = """[Header]
+IEMFileVersion,4
+Date,4/24/2018
+Workflow,GenerateFASTQ
+Application,NextSeq FASTQ Only
+Assay,Nextera XT v2 Set A
+Description,
+Chemistry,Default
+
+[Reads]
+76
+76
+
+[Settings]
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+SL1,SL1,,,N701,SI-GA-A2,SL,
+SL2,SL2,,,N702,SI-GA-B2,SL,
+SL3,SL3,,,N703,SI-GA-C2,SL,
+SL4,SL4,,,N704,SI-GA-D2,SL,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(sample_sheet_content)
+        # Check the bases mask
+        self.assertEqual(get_bases_mask(run_info_xml,sample_sheet),
+                         "y76,I6,y76")
+
 class TestGetNmismatches(unittest.TestCase):
     """Tests for the get_nmismatches function
 

--- a/auto_process_ngs/test/test_samplesheet_utils.py
+++ b/auto_process_ngs/test/test_samplesheet_utils.py
@@ -12,6 +12,7 @@ from bcftbx.IlluminaData import SampleSheet
 from auto_process_ngs.samplesheet_utils import SampleSheetLinter
 from auto_process_ngs.samplesheet_utils import has_invalid_characters
 from auto_process_ngs.samplesheet_utils import barcode_is_valid
+from auto_process_ngs.samplesheet_utils import barcode_is_10xgenomics
 from auto_process_ngs.samplesheet_utils import get_close_names
 
 sample_sheet_header = """[Header]
@@ -288,6 +289,19 @@ a non-ASCII character here\x80
 - {}[]
 - \t\n
 """))
+
+class TestBarcodeIs10xGenomics(unittest.TestCase):
+    def test_barcode_is_10xgenomics(self):
+        """barcode_is_10xgenomics: identifies 10xGenomics 'barcodes'
+        """
+        self.assertTrue(barcode_is_10xgenomics("SI-GA-B3"))
+        self.assertTrue(barcode_is_10xgenomics("SI-GA-G1"))
+        self.assertTrue(barcode_is_10xgenomics("SI-GA-H1"))
+        self.assertTrue(barcode_is_10xgenomics("SI-P03-C9"))
+    def test_barcode_is_not_10xgenomics(self):
+        """barcode_is_10xgenomics: identifies non-10xGenomics barcodes
+        """
+        self.assertFalse(barcode_is_10xgenomics("TGACCAAT"))
 
 class TestBarcodeIsValidFunction(unittest.TestCase):
     def test_standard_barcodes(self):


### PR DESCRIPTION
PR to address two issues with the `make_fastqs` command for 10xGenomics data (`--protocol=10x_chromium_sc` option):

 1. The `--disable-ui` option doesn't seem to be correctly handled by cellranger 2.1.1's `mkfastq` command and causes `bcl2fastq2` to fail, so it needs to be removed
 2. Bases mask is set explicitly and incorrectly for `auto` mode

The changes in this PR aim to address both these issues.