### PR TITLE
docwriter: abstract name sanitization functionality

### DIFF
--- a/auto_process_ngs/docwriter.py
+++ b/auto_process_ngs/docwriter.py
@@ -256,8 +256,7 @@ class Section(object):
         if self._name is not None:
             return self._name
         if self._title is not None:
-            return filter(lambda c: c in VALID_CSS_ID_CHARS,
-                          str(self._title).replace(' ','_').replace('\t','_'))
+            return sanitize_css_string(self._title)
         else:
             return self._title
 
@@ -914,3 +913,22 @@ class Para(object):
         Para instance is True if has content, False otherwise
         """
         return bool(self._content)
+
+#######################################################################
+# Functions
+#######################################################################
+
+def sanitize_css_string(s):
+    """
+    Remove or replace invalid (non-CSS) characters in a string
+
+    Arguments:
+      s (str): string to be sanitized
+
+    Returns:
+      String: version of the original string with whitespace
+        converted to underscores, and all other invalid
+        characters removed.
+    """
+    return filter(lambda c: c in VALID_CSS_ID_CHARS,
+                  str(s).replace(' ','_').replace('\t','_'))

--- a/auto_process_ngs/test/test_docwriter.py
+++ b/auto_process_ngs/test/test_docwriter.py
@@ -14,6 +14,7 @@ from auto_process_ngs.docwriter import Img
 from auto_process_ngs.docwriter import Link
 from auto_process_ngs.docwriter import Target
 from auto_process_ngs.docwriter import Para
+from auto_process_ngs.docwriter import sanitize_css_string
 
 # Unit tests
 
@@ -598,3 +599,15 @@ class TestPara(unittest.TestCase):
         self.assertFalse(p)
         p.add("some text")
         self.assertTrue(p)
+
+class TestSanitizeCssStringFunction(unittest.TestCase):
+    """
+    Tests for the sanitize_css_string function
+    """
+    def test_sanitize_css_string(self):
+        self.assertEqual(sanitize_css_string("test"),"test")
+        self.assertEqual(sanitize_css_string("test123"),"test123")
+        self.assertEqual(sanitize_css_string("test 123"),"test_123")
+        self.assertEqual(sanitize_css_string("test\t 123"),"test__123")
+        self.assertEqual(sanitize_css_string("test123.gz"),"test123gz")
+        self.assertEqual(sanitize_css_string("test@123.90.10.3"),"test12390103")


### PR DESCRIPTION
PR which moves the name sanitization functionality within the `Section` class into its own function `sanitize_css_string`.