### PR TITLE
Fix bugs in processing QC report when handling empty Fastqs

### DIFF
--- a/auto_process_ngs/qc/plots.py
+++ b/auto_process_ngs/qc/plots.py
@@ -379,7 +379,11 @@ def ustackedbar(data,outfile=None,inline=False,bbox=True,
     pixels = img.load()
     # Normalise the data
     total = float(sum(data))
-    ndata = [int(float(d)/total*float(length)) for d in data]
+    try:
+        ndata = [int(float(d)/total*float(length)) for d in data]
+    except ZeroDivisionError:
+        # Total was zero
+        ndata = [0 for d in data]
     # Reset the last value
     ndata[-1] = length - sum(ndata[:-1])
     # Create the plot

--- a/auto_process_ngs/qc/processing.py
+++ b/auto_process_ngs/qc/processing.py
@@ -17,12 +17,32 @@ from .plots import ustackedbar
 # Functions
 #######################################################################
 
+def get_absolute_file_path(p,base=None):
+    """
+    Get absolute path for supplied path
+
+    Arguments:
+      p (str): path
+      base (str): optional, base directory to
+        use if p is relative
+
+    Returns:
+      String: absolute path for p.
+    """
+    if not os.path.isabs(p):
+        if base is not None:
+            p = os.path.join(os.path.abspath(base),p)
+        else:
+            p = os.path.abspath(p)
+    return p
+
 def report_processing_qc(analysis_dir,html_file):
     """
     Generate HTML report for processing statistics
 
     Arguments:
-      analysis_dir (AnalysisDir): 
+      analysis_dir (AutoProcess): AutoProcess instance for
+        the directory to report the processing from
       html_file (str): destination path and file name for
         HTML report
     """
@@ -41,6 +61,8 @@ def report_processing_qc(analysis_dir,html_file):
     per_lane_stats_file = analysis_dir.params.per_lane_stats_file
     if per_lane_stats_file is None:
         per_lane_stats_file = "per_lane_statistics.info"
+    per_lane_stats_file = get_absolute_file_path(per_lane_stats_file,
+                                                 base=analysis_dir.analysis_dir)
     if os.path.exists(per_lane_stats_file):
         per_lane_stats = processing_qc.add_section(
             "Per-lane statistics",
@@ -66,7 +88,9 @@ def report_processing_qc(analysis_dir,html_file):
         per_lane_stats.add(tbl)
         toc_list.add_item(Link("Per-lane statistics",per_lane_stats))
     # Per lane by sample statistics
-    per_lane_sample_stats_file = "per_lane_sample_stats.info"
+    per_lane_sample_stats_file = get_absolute_file_path(
+        "per_lane_sample_stats.info",
+        base=analysis_dir.analysis_dir)
     if os.path.exists(per_lane_sample_stats_file):
         per_lane_sample_stats = processing_qc.add_section(
             "Per-lane statistics by sample",
@@ -74,7 +98,7 @@ def report_processing_qc(analysis_dir,html_file):
         lane_toc_list = List()
         per_lane_sample_stats.add(lane_toc_list)
         # Store the data for each lane
-        with open("per_lane_sample_stats.info") as stats:
+        with open(per_lane_sample_stats_file,'r') as stats:
             lane_data = []
             for line in stats:
                 if line.startswith("Lane "):
@@ -141,12 +165,15 @@ def report_processing_qc(analysis_dir,html_file):
                                per_lane_sample_stats),
                           lane_toc_list)
     # Per fastq statistics
-    stats_file = "statistics_full.info"
+    stats_file = get_absolute_file_path("statistics_full.info",
+                                        base=analysis_dir.analysis_dir)
     if not os.path.exists(stats_file):
         if analysis_dir.params.stats_file is not None:
             stats_file = analysis_dir.params.stats_file
         else:
             stats_file = "statistics.info"
+    stats_file = get_absolute_file_path(stats_file,
+                                        base=analysis_dir.analysis_dir)
     if os.path.exists(stats_file):
         per_file_stats = processing_qc.add_section(
             "Per-file statistics by project",

--- a/auto_process_ngs/qc/processing.py
+++ b/auto_process_ngs/qc/processing.py
@@ -98,8 +98,8 @@ def report_processing_qc(analysis_dir,html_file):
         lane_toc_list = List()
         per_lane_sample_stats.add(lane_toc_list)
         # Store the data for each lane
+        lane_data = list()
         with open(per_lane_sample_stats_file,'r') as stats:
-            lane_data = []
             for line in stats:
                 if line.startswith("Lane "):
                     lane = int(line.split(' ')[-1])
@@ -122,13 +122,17 @@ def report_processing_qc(analysis_dir,html_file):
         # Create a section and table for each lane
         for data in lane_data:
             lane = data['lane']
-            max_reads = max([d['nreads'] for d in data['samples']])
-            total_reads = data['total_reads']
             s = per_lane_sample_stats.add_subsection(
                 "Lane %d" % lane,
                 name="per_lane_sample_stats_lane%d" % lane
             )
             lane_toc_list.add_item(Link("Lane %d" % lane,s))
+            if not data['samples']:
+                # No samples reported
+                s.add("No samples reported for this lane")
+                continue
+            max_reads = max([d['nreads'] for d in data['samples']])
+            total_reads = data['total_reads']
             current_project = None
             tbl = Table(columns=('pname','sname',
                                  'nreads','percreads',

--- a/auto_process_ngs/qc/processing.py
+++ b/auto_process_ngs/qc/processing.py
@@ -189,8 +189,11 @@ def report_processing_qc(analysis_dir,html_file):
                 for l in subset_lanes:
                     data[l] = (pretty_print_reads(line[l])
                                if line[l] != '' else '')
-                barplot = ustackedbar(filter(lambda n: n != '',
-                                             [line[l] for l in subset_lanes]),
+                nreads = filter(lambda n: n != '',
+                                [line[l] for l in subset_lanes])
+                if not nreads:
+                    nreads = [0,]
+                barplot = ustackedbar(nreads,
                                       length=100,height=10,
                                       colors=('grey','lightgrey'),
                                       bbox=True,

--- a/auto_process_ngs/test/qc/test_processing.py
+++ b/auto_process_ngs/test/qc/test_processing.py
@@ -151,3 +151,62 @@ Undetermined_indices	undetermined	Undetermined_S0_R2_001.fastq.gz	24.0G	27596657
         self.assertFalse(os.path.exists(output_html))
         report_processing_qc(AutoProcess(analysis_dir),output_html)
         self.assertTrue(os.path.exists(output_html))
+
+    def test_report_processing_qc_empty_lane(self):
+        """report_processing_qc: report with empty lane
+        """
+        # Create test data
+        analysis_dir = os.path.join(self.wd,
+                                    "180430_K00311_0001_ABCDEFGHXX_analysis")
+        os.mkdir(analysis_dir)
+        per_lane_sample_stats = os.path.join(analysis_dir,
+                                             "per_lane_sample_stats.info")
+        with open(per_lane_sample_stats,'w') as fp:
+            fp.write("""
+Lane 1
+Total reads = 0
+
+Lane 2
+Total reads = 0114447328
+- CDE/CDE1	25058003	21.9%
+- CDE/CDE2	0	0.0%
+- CDE/CDE3	34509382	30.2%
+- CDE/CDE4	27283286	23.8%
+- Undetermined_indices/undetermined	27596657	24.1%
+""")
+        per_lane_statistics = os.path.join(analysis_dir,
+                                           "per_lane_statistics.info")
+        with open(per_lane_statistics,'w') as fp:
+            fp.write("""#Lane	Total reads	Assigned reads	Unassigned reads	%assigned	%unassigned
+Lane 1	0	0	0	0.0	0.0
+Lane 2	114447328	86850671	27596657	75.9	24.1
+""")
+        statistics_full = os.path.join(analysis_dir,
+                                       "statistics_full.info")
+        with open(statistics_full,'w') as fp:
+            fp.write("""#Project	Sample	Fastq	Size	Nreads	Paired_end	Read_number	L1	L2
+AB	AB1	AB1_S1_R1_001.fastq.gz	0.0K	0	Y	1		
+AB	AB1	AB1_S1_R2_001.fastq.gz	0.0K	0	Y	2		
+AB	AB2	AB2_S2_R1_001.fastq.gz	0.0K	0	Y	1		
+AB	AB2	AB2_S2_R2_001.fastq.gz	0.0K	0	Y	2		
+AB	AB3	AB3_S3_R1_001.fastq.gz	0.0K	0	Y	1		
+AB	AB3	AB3_S3_R2_001.fastq.gz	0.0k	0	Y	2		
+AB	AB4	AB4_S4_R1_001.fastq.gz	1.1G	0	Y	1		
+AB	AB4	AB4_S4_R2_001.fastq.gz	1.2G	0	Y	2		
+CDE	CDE1	CDE1_S5_R1_001.fastq.gz	1.0G	0	Y	1      		25058003
+CDE	CDE1	CDE1_S5_R2_001.fastq.gz	1.1G	0	Y	2		25058003
+CDE	CDE2	CDE2_S6_R1_001.fastq.gz	0.0K	0	Y	1		
+CDE	CDE2	CDE2_S6_R2_001.fastq.gz	0.0K	0	Y	2		
+CDE	CDE3	CDE3_S7_R1_001.fastq.gz	1.4G	34509382	Y	1		34509382
+CDE	CDE3	CDE3_S7_R2_001.fastq.gz	1.6G	34509382	Y	2		34509382
+CDE	CDE4	CDE4_S8_R1_001.fastq.gz	1.1G	27283286	Y	1		27283286
+CDE	CDE4	CDE4_S8_R2_001.fastq.gz	1.2G	27283286	Y	2		27283286
+Undetermined_indices	undetermined	Undetermined_S0_R1_001.fastq.gz	1.0K	0	Y	1	0	
+Undetermined_indices	undetermined	Undetermined_S0_R2_001.fastq.gz	1.0K	0	Y	2	0	
+""")
+        # Generate QC report
+        output_html = os.path.join(analysis_dir,
+                                   "processing_report.html")
+        self.assertFalse(os.path.exists(output_html))
+        report_processing_qc(AutoProcess(analysis_dir),output_html)
+        self.assertTrue(os.path.exists(output_html))

--- a/auto_process_ngs/test/qc/test_processing.py
+++ b/auto_process_ngs/test/qc/test_processing.py
@@ -1,0 +1,153 @@
+#######################################################################
+# Tests for qc/processing.py module
+#######################################################################
+
+import unittest
+import tempfile
+import shutil
+import os
+from auto_process_ngs.auto_processor import AutoProcess
+from auto_process_ngs.qc.processing import report_processing_qc
+
+# Set to False to keep test output dirs
+REMOVE_TEST_OUTPUTS = False
+
+class TestReportProcessingQC(unittest.TestCase):
+    """
+    Tests for report_processing_qc function
+    """
+    def setUp(self):
+        # Create a temp working dir
+        self.wd = tempfile.mkdtemp(suffix='TestReportProcessingQC')
+
+    def tearDown(self):
+        if REMOVE_TEST_OUTPUTS:
+            shutil.rmtree(self.wd)
+
+    def test_report_processing_qc(self):
+        """report_processing_qc: standard report
+        """
+        # Create test data
+        analysis_dir = os.path.join(self.wd,
+                                    "180430_K00311_0001_ABCDEFGHXX_analysis")
+        os.mkdir(analysis_dir)
+        per_lane_sample_stats = os.path.join(analysis_dir,
+                                             "per_lane_sample_stats.info")
+        with open(per_lane_sample_stats,'w') as fp:
+            fp.write("""
+Lane 1
+Total reads = 136778255
+- AB/AB1	25058003	18.3%
+- AB/AB2	22330927	16.3%
+- AB/AB3	34509382	25.2%
+- AB/AB4	27283286	19.9%
+- Undetermined_indices/undetermined	27596657	20.2%
+
+Lane 2
+Total reads = 136778255
+- CDE/CDE1	25058003	18.3%
+- CDE/CDE2	22330927	16.3%
+- CDE/CDE3	34509382	25.2%
+- CDE/CDE4	27283286	19.9%
+- Undetermined_indices/undetermined	27596657	20.2%
+""")
+        per_lane_statistics = os.path.join(analysis_dir,
+                                           "per_lane_statistics.info")  
+        with open(per_lane_statistics,'w') as fp:
+            fp.write("""#Lane	Total reads	Assigned reads	Unassigned reads	%assigned	%unassigned
+Lane 1	136778255	109181598	27596657	79.8	20.2
+Lane 2	136778255	109181598	27596657	79.8	20.2
+""")
+        statistics_full = os.path.join(analysis_dir,
+                                       "statistics_full.info")
+        with open(statistics_full,'w') as fp:
+            fp.write("""#Project	Sample	Fastq	Size	Nreads	Paired_end	Read_number	L1	L2
+AB	AB1	AB1_S1_R1_001.fastq.gz	1.0G	25058003	Y	1	25058003	
+AB	AB1	AB1_S1_R2_001.fastq.gz	1.1G	25058003	Y	2	25058003	
+AB	AB2	AB2_S2_R1_001.fastq.gz	941.7M	22330927	Y	1	22330927	
+AB	AB2	AB2_S2_R2_001.fastq.gz	1.0G	22330927	Y	2	22330927	
+AB	AB3	AB3_S3_R1_001.fastq.gz	1.4G	34509382	Y	1	34509382	
+AB	AB3	AB3_S3_R2_001.fastq.gz	1.6G	34509382	Y	2	34509382	
+AB	AB4	AB4_S4_R1_001.fastq.gz	1.1G	27283286	Y	1	27283286	
+AB	AB4	AB4_S4_R2_001.fastq.gz	1.2G	27283286	Y	2	27283286	
+CDE	CDE1	CDE1_S5_R1_001.fastq.gz	1.0G	25058003	Y	1		25058003
+CDE	CDE1	CDE1_S5_R2_001.fastq.gz	1.1G	25058003	Y	2		25058003
+CDE	CDE2	CDE2_S6_R1_001.fastq.gz	941.7M	22330927	Y	1		22330927
+CDE	CDE2	CDE2_S6_R2_001.fastq.gz	1.0G	22330927	Y	2		22330927
+CDE	CDE3	CDE3_S7_R1_001.fastq.gz	1.4G	34509382	Y	1		34509382
+CDE	CDE3	CDE3_S7_R2_001.fastq.gz	1.6G	34509382	Y	2		34509382
+CDE	CDE4	CDE4_S8_R1_001.fastq.gz	1.1G	27283286	Y	1		27283286
+CDE	CDE4	CDE4_S8_R2_001.fastq.gz	1.2G	27283286	Y	2		27283286
+Undetermined_indices	undetermined	Undetermined_S0_R1_001.fastq.gz	22.0G	27596657	Y	1	27596657	27596657
+Undetermined_indices	undetermined	Undetermined_S0_R2_001.fastq.gz	24.0G	27596657	Y	2	27596657	27596657
+""")
+        # Generate QC report
+        output_html = os.path.join(analysis_dir,
+                                   "processing_report.html")
+        self.assertFalse(os.path.exists(output_html))
+        report_processing_qc(AutoProcess(analysis_dir),output_html)
+        self.assertTrue(os.path.exists(output_html))
+
+    def test_report_processing_qc_empty_fastqs(self):
+        """report_processing_qc: report with empty Fastqs
+        """
+        # Create test data
+        analysis_dir = os.path.join(self.wd,
+                                    "180430_K00311_0001_ABCDEFGHXX_analysis")
+        os.mkdir(analysis_dir)
+        per_lane_sample_stats = os.path.join(analysis_dir,
+                                             "per_lane_sample_stats.info")
+        with open(per_lane_sample_stats,'w') as fp:
+            fp.write("""
+Lane 1
+Total reads = 79937946
+- AB/AB1	25058003	31.4%
+- AB/AB2	0	0.0%
+- AB/AB3	0	0.0%
+- AB/AB4	27283286	34.1%
+- Undetermined_indices/undetermined	27596657	34.5%
+
+Lane 2
+Total reads = 114447328
+- CDE/CDE1	25058003	21.9%
+- CDE/CDE2	0	0.0%
+- CDE/CDE3	34509382	30.2%
+- CDE/CDE4	27283286	23.8%
+- Undetermined_indices/undetermined	27596657	24.1%
+""")
+        per_lane_statistics = os.path.join(analysis_dir,
+                                           "per_lane_statistics.info")  
+        with open(per_lane_statistics,'w') as fp:
+            fp.write("""#Lane	Total reads	Assigned reads	Unassigned reads	%assigned	%unassigned
+Lane 1	79937946	52341289	27596657	65.5	35.5
+Lane 2	114447328	86850671	27596657	75.9	24.1
+""")
+        statistics_full = os.path.join(analysis_dir,
+                                       "statistics_full.info")
+        with open(statistics_full,'w') as fp:
+            fp.write("""#Project	Sample	Fastq	Size	Nreads	Paired_end	Read_number	L1	L2
+AB	AB1	AB1_S1_R1_001.fastq.gz	1.0G	25058003	Y	1	25058003	
+AB	AB1	AB1_S1_R2_001.fastq.gz	1.1G	25058003	Y	2	25058003	
+AB	AB2	AB2_S2_R1_001.fastq.gz	0.0K	0	Y	1		
+AB	AB2	AB2_S2_R2_001.fastq.gz	0.0K	0	Y	2		
+AB	AB3	AB3_S3_R1_001.fastq.gz	0.0K	0	Y	1		
+AB	AB3	AB3_S3_R2_001.fastq.gz	0.0k	0	Y	2		
+AB	AB4	AB4_S4_R1_001.fastq.gz	1.1G	27283286	Y	1	27283286	
+AB	AB4	AB4_S4_R2_001.fastq.gz	1.2G	27283286	Y	2	27283286	
+CDE	CDE1	CDE1_S5_R1_001.fastq.gz	1.0G	25058003	Y	1		25058003
+CDE	CDE1	CDE1_S5_R2_001.fastq.gz	1.1G	25058003	Y	2		25058003
+CDE	CDE2	CDE2_S6_R1_001.fastq.gz	0.0K	0	Y	1		
+CDE	CDE2	CDE2_S6_R2_001.fastq.gz	0.0K	0	Y	2		
+CDE	CDE3	CDE3_S7_R1_001.fastq.gz	1.4G	34509382	Y	1		34509382
+CDE	CDE3	CDE3_S7_R2_001.fastq.gz	1.6G	34509382	Y	2		34509382
+CDE	CDE4	CDE4_S8_R1_001.fastq.gz	1.1G	27283286	Y	1		27283286
+CDE	CDE4	CDE4_S8_R2_001.fastq.gz	1.2G	27283286	Y	2		27283286
+Undetermined_indices	undetermined	Undetermined_S0_R1_001.fastq.gz	22.0G	27596657	Y	1	27596657	27596657
+Undetermined_indices	undetermined	Undetermined_S0_R2_001.fastq.gz	24.0G	27596657	Y	2	27596657	27596657
+""")
+        # Generate QC report
+        output_html = os.path.join(analysis_dir,
+                                   "processing_report.html")
+        self.assertFalse(os.path.exists(output_html))
+        report_processing_qc(AutoProcess(analysis_dir),output_html)
+        self.assertTrue(os.path.exists(output_html))

--- a/auto_process_ngs/test/qc/test_processing.py
+++ b/auto_process_ngs/test/qc/test_processing.py
@@ -10,7 +10,7 @@ from auto_process_ngs.auto_processor import AutoProcess
 from auto_process_ngs.qc.processing import report_processing_qc
 
 # Set to False to keep test output dirs
-REMOVE_TEST_OUTPUTS = False
+REMOVE_TEST_OUTPUTS = True
 
 class TestReportProcessingQC(unittest.TestCase):
     """


### PR DESCRIPTION
PR to address bugs in the processing QC reporting when empty Fastqs are present, and when the `report_processing_qc` function is run outside of the target analysis directory.

Also adds some unit tests to cover these cases.