### PR TITLE
WIP update ICELL8 QC pipeline to use library code in 'qc/run.py'

### DIFF
--- a/auto_process_ngs/qc/runqc.py
+++ b/auto_process_ngs/qc/runqc.py
@@ -299,18 +299,26 @@ class ProjectQC(object):
         check_qc = jobs[0]
         logger.debug("Exit code: %s" % check_qc.exit_code)
         logger.debug("Log file: %s" % check_qc.log)
-        logger.debug("Log file contents:")
-        logger.debug("%s" % open(check_qc.log,'r').read())
-        self.verification_status = check_qc.exit_code
+        if check_qc.log is not None:
+            logger.debug("Log file contents:")
+            logger.debug("%s" % open(check_qc.log,'r').read())
+        else:
+            logger.warning("No log file output: can't list Fastqs with "
+                           "missing QC outputs")
+        if check_qc.exit_code is None:
+            self.verification_status = 1
+        else:
+            self.verification_status = check_qc.exit_code
         self.fastqs_missing_qc = list()
-        with open(check_qc.log,'r') as log:
-            for line in log:
-                if line.startswith(self.project.dirn):
-                    self.fastqs_missing_qc.append(line.rstrip())
-                    self.verification_status += 1
-        logger.debug("Fastqs with missing QC outputs:")
-        for fq in self.fastqs_missing_qc:
-            logger.debug("%s" % fq)
+        if check_qc.log is not None:
+            with open(check_qc.log,'r') as log:
+                for line in log:
+                    if line.startswith(self.project.dirn):
+                        self.fastqs_missing_qc.append(line.rstrip())
+                        self.verification_status += 1
+            logger.debug("Fastqs with missing QC outputs:")
+            for fq in self.fastqs_missing_qc:
+                logger.debug("%s" % fq)
 
     def setup_qc(self,sched,illumina_qc,qc_runner=None,
                  verify_runner=None,batch_size=None):

--- a/bin/process_icell8.py
+++ b/bin/process_icell8.py
@@ -1844,7 +1844,7 @@ if __name__ == "__main__":
         collect_filtered_failed_umis = CollectFiles(
             "Collect filtered fastqs (failed UMIs)",
             filter_dir,
-            filter_fastqs.output().patterns.assigned)
+            filter_fastqs.output().patterns.failed_umis)
         for task in (collect_filtered_fastqs,
                      collect_filtered_unassigned,
                      collect_filtered_failed_barcodes,


### PR DESCRIPTION
WIP PR to drop the current QC pipeline code from `process_icell8.py` and switch to using the new `RunQC` class from `qc/runqc.py` instead.

This should simplify the relevant parts of `process_icell8.py` and allow us to remove the relevant code; it will also mean that any future updates to the QC pipeline will automatically be available to the ICELL8 pipeline.