### PR TITLE
make_fastqs: stop if invalid characters found in sample sheet

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1416,7 +1416,13 @@ class AutoProcess:
         if invalid_barcodes:
             logging.error("Invalid barcodes detected")
             for line in invalid_barcodes:
-                logging.error("%s" % line)
+                logging.critical("%s" % line)
+        invalid_characters = samplesheet_utils.SampleSheetLinter(
+            sample_sheet_file=sample_sheet).has_invalid_characters()
+        if invalid_characters:
+            logging.critical("Invalid non-printing/non-ASCII characters "
+                             "detected")
+        if invalid_barcodes or invalid_characters:
             raise Exception("Errors detected in generated sample sheet")
         # Adjust verification settings for 10xGenomics Chromium SC
         # data if necessary

--- a/auto_process_ngs/test/test_auto_processor_make_fastqs.py
+++ b/auto_process_ngs/test/test_auto_processor_make_fastqs.py
@@ -617,3 +617,51 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
         self.assertTrue(ap.params.primary_data_dir is None)
         self.assertRaises(Exception,
                           ap.make_fastqs)
+
+    def test_make_fastqs_samplesheet_with_invalid_characters(self):
+        """make_fastqs: stop for invalid characters in sample sheet
+        """
+        # Create mock source data with samplesheet with backspace
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            sample_sheet_content="""[Header],,,,,,,,,
+IEMFileVersion,4
+Date,11/23/2015
+Workflow,GenerateFASTQ
+Application,FASTQ Only
+Assay,TruSeq HT
+Description,
+Chemistry,Amplicon
+
+[Reads]
+101
+101
+
+[Settings]
+ReverseComplement,0
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+Sample1,Sample1,,,D701,CGTGTAGG,D501,GACCTGTC,,\b
+Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
+""",
+            top_dir=self.wd)
+        illumina_run.create()
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 platform="miseq")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Do the test
+        ap = AutoProcess()
+        ap.setup(os.path.join(self.wd,
+                              "171020_M00879_00002_AHGXXXX"))
+        self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertRaises(Exception,
+                          ap.make_fastqs)


### PR DESCRIPTION
PR to address bug in issue #188, by exiting the `make_fastqs` command with an error if invalid (i.e. non-printing/non-ASCII) characters are found in the sample sheet.