### PR TITLE
process_icell8.py: fix collection of Fastqs with reads failing UMI quality check

### DIFF
--- a/bin/process_icell8.py
+++ b/bin/process_icell8.py
@@ -2126,7 +2126,7 @@ if __name__ == "__main__":
         collect_filtered_failed_umis = CollectFiles(
             "Collect filtered fastqs (failed UMIs)",
             filter_dir,
-            filter_fastqs.output().patterns.assigned)
+            filter_fastqs.output().patterns.failed_umis)
         for task in (collect_filtered_fastqs,
                      collect_filtered_unassigned,
                      collect_filtered_failed_barcodes,


### PR DESCRIPTION
PR to fix a bug introduced into `process_icell8.py` in commit id 2204b474, which changed the way that different classes of Fastq file were collected after the initial filtering stage.

The bug meant that instead of collecting files called `*.failed_umi.fastq`, the Fastqs with **assigned** reads were being gathered. This generated a final `failed_umi` R1/R2 Fastq pair which duplicated all the reads passing filtering (not the reads failing the UMI quality check).