### PR TITLE
Fix reportqc.py to use relative links when generating QC report

### DIFF
--- a/bin/reportqc.py
+++ b/bin/reportqc.py
@@ -219,7 +219,8 @@ def main():
         print "Writing QC report to %s" % out_file
         report_html= QCReporter(p).report(qc_dir=qc_dir,
                                           title=opts.title,
-                                          filename=out_file)
+                                          filename=out_file,
+                                          relative_links=True)
         # Generate ZIP archive
         if opts.zip:
             report_zip = zip_report(p,report_html,qc_dir)


### PR DESCRIPTION
PR which fixes a bug in `reportqc.py`, whereby references to external resources (i.e. `fastqc` and `fastq_screen` reports) in the generated QC report were specified as absolute rather than relative links (meaning that the resulting reports were not portable to another machine).