### PR TITLE
publish_qc: refactor the QC verification and reporting

### DIFF
--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -239,7 +239,9 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                 # Check if we need to (re)generate report
                 if (regenerate_reports or
                     not os.path.exists(qc_zip)):
-                    report_status = report_qc(qc_dir=qc_dir,
+                    report_status = report_qc(project,
+                                              qc_dir=qc_dir,
+                                              multiqc=True,
                                               log_dir=ap.log_dir)
                     if report_status is not None:
                         print "...%s: (re)generated report" % qc_dir

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -226,7 +226,8 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                 os.path.basename(fastq_dir)
             # Verify the QC and check for report
             verified = verify_qc(project,
-                qc_dir=os.path.join(project.dirn,qc_dir))
+                qc_dir=os.path.join(project.dirn,qc_dir),
+                                 log_dir=ap.log_dir)
             if verified:
                 print "...%s: verified QC" % qc_dir
                 # Check for an existing report
@@ -238,7 +239,9 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                 # Check if we need to (re)generate report
                 if (regenerate_reports or
                     not os.path.exists(qc_zip)):
-                    if report_qc(qc_dir=qc_dir) is not None:
+                    report_status = report_qc(qc_dir=qc_dir,
+                                              log_dir=ap.log_dir)
+                    if report_status is not None:
                         print "...%s: (re)generated report" % qc_dir
                     else:
                         print "...%s: failed to (re)generate " \

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     publish_qc_cmd.py: implement auto process publish_qc command
-#     Copyright (C) University of Manchester 2017 Peter Briggs
+#     Copyright (C) University of Manchester 2017-2018 Peter Briggs
 #
 #########################################################################
 
@@ -15,6 +15,8 @@ import string
 import ast
 import auto_process_ngs.fileops as fileops
 import auto_process_ngs.simple_scheduler as simple_scheduler
+from auto_process_ngs.qc.utils import verify_qc
+from auto_process_ngs.qc.utils import report_qc
 from ..docwriter import Document
 from ..docwriter import Table
 from ..docwriter import Link
@@ -223,7 +225,7 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
             print "...associated Fastq set '%s'" % \
                 os.path.basename(fastq_dir)
             # Verify the QC and check for report
-            verified = project.verify_qc(
+            verified = verify_qc(project,
                 qc_dir=os.path.join(project.dirn,qc_dir))
             if verified:
                 print "...%s: verified QC" % qc_dir
@@ -236,14 +238,11 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                 # Check if we need to (re)generate report
                 if (regenerate_reports or
                     not os.path.exists(qc_zip)):
-                    try:
-                        project.qc_report(qc_dir=qc_dir,
-                                          force=force)
+                    if report_qc(qc_dir=qc_dir) is not None:
                         print "...%s: (re)generated report" % qc_dir
-                    except Exception as ex:
+                    else:
                         print "...%s: failed to (re)generate " \
-                            "QC report: %s" \
-                            % (qc_dir,ex)
+                            "QC report" % qc_dir
                 # Add to the list of verified QC dirs
                 if os.path.exists(qc_zip):
                     qc_artefacts['qc_zip'] = qc_zip

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -570,8 +570,13 @@ class UpdateAnalysisProject(DirectoryUpdater):
         illumina_qc = IlluminaQC()
         for fq in self._project.fastqs:
             print "Adding outputs for %s" % fq
-            for f in illumina_qc.expected_outputs(fq,self._project.qc_dir):
-                self.add_file(f)
+            MockQCOutputs.fastqc_v0_11_2(fq,self._project.qc_dir)
+            for screen in ("model_organisms",
+                           "other_organisms",
+                           "rRNA"):
+                MockQCOutputs.fastq_screen_v0_9_2(fq,
+                                                  self._project.qc_dir,
+                                                  screen)
         # Make mock report
         fastq_set_name = os.path.basename(self._project.fastq_dir)[6:]
         qc_name = "qc%s_report" % fastq_set_name

--- a/auto_process_ngs/qc/runqc.py
+++ b/auto_process_ngs/qc/runqc.py
@@ -63,7 +63,8 @@ class RunQC(object):
         self._sched = None
 
     def add_project(self,project,fastq_dir=None,qc_dir=None,
-                    sample_pattern=None,ungzip_fastqs=False):
+                    log_dir=None,sample_pattern=None,
+                    ungzip_fastqs=False):
         """
         Add a project to run the QC for
 
@@ -72,11 +73,14 @@ class RunQC(object):
             to run the QC for
           fastq_dir (str): optional, specify the subdir
             with the Fastqs to be be used
+          qc_dir (str): optional, specify the subdir to
+            write the QC outputs to
+          log_dir (str): optional, specify a directory to
+            write logs to (default is to put logs in the
+            'logs' subdir of the QC directory)
           sample_pattern (str): optional, specify a
             glob-style pattern to use to select a subset
             of samples
-          qc_dir (str): optional, specify the subdir to
-            write the QC outputs to
           ungzip_fastqs (bool): if True then uncompress
             source Fastqs (default: False i.e. don't
             uncompress the Fastqs)
@@ -85,6 +89,7 @@ class RunQC(object):
                                         fastq_dir=fastq_dir,
                                         sample_pattern=sample_pattern,
                                         qc_dir=qc_dir,
+                                        log_dir=log_dir,
                                         ungzip_fastqs=ungzip_fastqs))
 
     def run(self,illumina_qc=None,report_html=None,multiqc=False,
@@ -183,7 +188,7 @@ class ProjectQC(object):
     Class for setting up QC jobs for a project
     """
     def __init__(self,project,fastq_dir=None,sample_pattern=None,
-                 qc_dir=None,ungzip_fastqs=False):
+                 qc_dir=None,log_dir=None,ungzip_fastqs=False):
         """
         Create a new ProjectQC instance
 
@@ -197,6 +202,9 @@ class ProjectQC(object):
             of samples
           qc_dir (str): optional, specify the subdir to
             write the QC outputs to
+          log_dir (str): optional, specify a directory to
+            write logs to (default is to put logs in the
+            'logs' subdir of the QC directory)
         """
         # Clone the supplied project
         self.project = utils.AnalysisProject(project.name,
@@ -211,7 +219,10 @@ class ProjectQC(object):
         self.fastq_dir = project.qc_info(project.qc_dir).fastq_dir
         project.use_fastq_dir(self.fastq_dir)
         # Log directory
-        self.log_dir = os.path.join(project.qc_dir,'logs')
+        if log_dir is not None:
+            self.log_dir = os.path.abspath(log_dir)
+        else:
+            self.log_dir = os.path.join(project.qc_dir,'logs')
         if not os.path.exists(self.log_dir):
             print "Making QC logs directory: %s" % self.log_dir
             fileops.mkdir(self.log_dir,recursive=True)

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -61,7 +61,7 @@ def verify_qc(project,qc_dir=None,runner=None):
     sched.start()
     # QC check for project
     project.check_qc(sched,
-                     name="verify_qc.%s" % project.title,
+                     name="verify_qc",
                      runner=runner)
     sched.wait()
     return project.verify()

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+#
+#     utils: utility classes and functions for QC
+#     Copyright (C) University of Manchester 2018 Peter Briggs
+#
+"""
+utils.py
+========
+
+Provides utility classes and functions for analysis project QC.
+
+Provides the following functions:
+
+- verify_qc: verify the QC run for a project
+- report_qc: generate report for the QC run for a project
+"""
+
+#######################################################################
+# Imports
+#######################################################################
+
+import os
+import logging
+import uuid
+import tempfile
+import shutil
+from .runqc import ProjectQC
+from auto_process_ngs.settings import Settings
+from auto_process_ngs.simple_scheduler import SimpleScheduler
+
+# Module-specific logger
+logger = logging.getLogger(__name__)
+
+#######################################################################
+# Functions
+#######################################################################
+
+def verify_qc(project,qc_dir=None,runner=None):
+    """
+    Verify the QC run for a project
+
+    Arguments:
+      project (AnalysisProject): analysis project
+        to verify the QC for
+      qc_dir (str): optional, specify the subdir with
+        the QC outputs being verified
+      runner (JobRunner): optional, job runner to use
+        for running the verification
+
+    Returns:
+      Boolean: True if QC passes verification, otherwise
+        False.
+    """
+    # Sort out runners
+    if runner is None:
+        runner = Settings().general.default_runner
+    # Set up QC project
+    project = ProjectQC(project,qc_dir=qc_dir)
+    # Set up and start scheduler
+    sched = SimpleScheduler()
+    sched.start()
+    # QC check for project
+    project.check_qc(sched,
+                     name="verify_qc.%s" % project.title,
+                     runner=runner)
+    sched.wait()
+    return project.verify()
+
+def report_qc(project,qc_dir=None,report_html=None,
+              zip_outputs=True,multiqc=False,runner=None):
+    """
+    Generate report for the QC run for a project
+
+    Arguments:
+      project (AnalysisProject): analysis project
+        to report the QC for
+      qc_dir (str): optional, specify the subdir with
+        the QC outputs being reported
+      report_html (str): optional, path to the name of
+        the output QC report
+      zip_outputs (bool): if True then also generate ZIP
+        archive with the report and QC outputs
+      multiqc (bool): if True then also generate MultiQC
+        report
+      runner (JobRunner): optional, job runner to use
+        for running the reporting
+
+    Returns:
+      Integer: exit code from reporting job (zero indicates
+        success, non-zero indicates a problem).
+    """
+    # Sort out runners
+    if runner is None:
+        runner = Settings().general.default_runner
+    # Set up QC project
+    project = ProjectQC(project,qc_dir=qc_dir)
+    # Set up and start scheduler
+    sched = SimpleScheduler()
+    sched.start()
+    # Generate QC for project
+    project.report_qc(sched,
+                      report_html=report_html,
+                      multiqc=multiqc,
+                      zip_outputs=zip_outputs,
+                      runner=runner)
+    sched.wait()
+    return project.reporting_status

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 # Functions
 #######################################################################
 
-def verify_qc(project,qc_dir=None,runner=None):
+def verify_qc(project,qc_dir=None,runner=None,log_dir=None):
     """
     Verify the QC run for a project
 
@@ -46,6 +46,8 @@ def verify_qc(project,qc_dir=None,runner=None):
         the QC outputs being verified
       runner (JobRunner): optional, job runner to use
         for running the verification
+      log_dir (str): optional, specify a directory to
+        write logs to
 
     Returns:
       Boolean: True if QC passes verification, otherwise
@@ -55,7 +57,8 @@ def verify_qc(project,qc_dir=None,runner=None):
     if runner is None:
         runner = Settings().general.default_runner
     # Set up QC project
-    project = ProjectQC(project,qc_dir=qc_dir)
+    project = ProjectQC(project,qc_dir=qc_dir,
+                        log_dir=log_dir)
     # Set up and start scheduler
     sched = SimpleScheduler()
     sched.start()
@@ -67,7 +70,8 @@ def verify_qc(project,qc_dir=None,runner=None):
     return project.verify()
 
 def report_qc(project,qc_dir=None,report_html=None,
-              zip_outputs=True,multiqc=False,runner=None):
+              zip_outputs=True,multiqc=False,runner=None,
+              log_dir=None):
     """
     Generate report for the QC run for a project
 
@@ -84,6 +88,8 @@ def report_qc(project,qc_dir=None,report_html=None,
         report
       runner (JobRunner): optional, job runner to use
         for running the reporting
+      log_dir (str): optional, specify a directory to
+        write logs to
 
     Returns:
       Integer: exit code from reporting job (zero indicates
@@ -93,7 +99,8 @@ def report_qc(project,qc_dir=None,report_html=None,
     if runner is None:
         runner = Settings().general.default_runner
     # Set up QC project
-    project = ProjectQC(project,qc_dir=qc_dir)
+    project = ProjectQC(project,qc_dir=qc_dir,
+                        log_dir=log_dir)
     # Set up and start scheduler
     sched = SimpleScheduler()
     sched.start()

--- a/auto_process_ngs/test/commands/test_publish_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_publish_qc_cmd.py
@@ -10,6 +10,7 @@ from auto_process_ngs.auto_processor import AutoProcess
 from auto_process_ngs.mock import MockAnalysisDirFactory
 from auto_process_ngs.mock import UpdateAnalysisDir
 from auto_process_ngs.mock import UpdateAnalysisProject
+from auto_process_ngs.mock import MockMultiQC
 from auto_process_ngs.commands.publish_qc_cmd import publish_qc
 
 class TestAutoProcessPublishQc(unittest.TestCase):
@@ -19,8 +20,13 @@ class TestAutoProcessPublishQc(unittest.TestCase):
     def setUp(self):
         # Create a temp working dir
         self.dirn = tempfile.mkdtemp(suffix='TestAutoProcessPublishQc')
+        # Create a temp 'bin' dir
+        self.bin = os.path.join(self.dirn,"bin")
+        os.mkdir(self.bin)
         # Store original location so we can get back at the end
         self.pwd = os.getcwd()
+        # Store original PATH
+        self.path = os.environ['PATH']
         # Move to working dir
         os.chdir(self.dirn)
         # Placeholders for test objects
@@ -231,6 +237,10 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             qc_reports.append("multiqc_report.html")
             for f in qc_reports:
                 os.remove(os.path.join(project.dirn,f))
+        # Make a mock multiqc
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
         # Make a mock publication area
         publication_dir = os.path.join(self.dirn,'QC')
         os.mkdir(publication_dir)

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -1,0 +1,192 @@
+#######################################################################
+# Unit tests for qc/utils.py
+#######################################################################
+
+import unittest
+import tempfile
+import shutil
+import os
+from bcftbx.JobRunner import SimpleJobRunner
+from auto_process_ngs.mock import MockAnalysisProject
+from auto_process_ngs.mock import UpdateAnalysisProject
+from auto_process_ngs.utils import AnalysisProject
+from auto_process_ngs.qc.utils import verify_qc
+from auto_process_ngs.qc.utils import report_qc
+
+# Set to False to keep test output dirs
+REMOVE_TEST_OUTPUTS = True
+
+class TestVerifyQCFunction(unittest.TestCase):
+    """
+    Tests for verify_qc function
+    """
+    def setUp(self):
+        # Create a temp working dir
+        self.wd = tempfile.mkdtemp(suffix='TestVerifyQCFunction')
+        # Create a temp 'bin' dir
+        self.bin = os.path.join(self.wd,"bin")
+        os.mkdir(self.bin)
+        # Store original location
+        self.pwd = os.getcwd()
+        # Store original PATH
+        self.path = os.environ['PATH']
+        # Move to working dir
+        os.chdir(self.wd)
+
+    def tearDown(self):
+        # Return to original dir
+        os.chdir(self.pwd)
+        # Restore PATH
+        os.environ['PATH'] = self.path
+        # Remove the temporary test directory
+        if REMOVE_TEST_OUTPUTS:
+            shutil.rmtree(self.wd)
+
+    def test_verify_qc_all_outputs(self):
+        """verify_qc: project with all QC outputs present
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"))
+        p.create(top_dir=self.wd)
+        # Add QC outputs
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        UpdateAnalysisProject(project).add_qc_outputs()
+        # Do verification
+        self.assertTrue(verify_qc(project))
+
+    def test_verify_qc_incomplete_outputs(self):
+        """verify_qc: project with some QC outputs missing
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"))
+        p.create(top_dir=self.wd)
+        # Add QC outputs
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        UpdateAnalysisProject(project).add_qc_outputs()
+        # Remove an output
+        os.remove(os.path.join(self.wd,
+                               "PJB",
+                               "qc",
+                               "PJB1_S1_R1_001_fastqc.html"))
+        # Do verification
+        self.assertFalse(verify_qc(project))
+
+    def test_verify_qc_no_outputs(self):
+        """verify_qc: project with no QC outputs
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"))
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        # Do verification
+        self.assertFalse(verify_qc(project))
+
+class TestReportQCFunction(unittest.TestCase):
+    """
+    Tests for report_qc function
+    """
+    def setUp(self):
+        # Create a temp working dir
+        self.wd = tempfile.mkdtemp(suffix='TestReportQCFunction')
+        # Create a temp 'bin' dir
+        self.bin = os.path.join(self.wd,"bin")
+        os.mkdir(self.bin)
+        # Store original location
+        self.pwd = os.getcwd()
+        # Store original PATH
+        self.path = os.environ['PATH']
+        # Move to working dir
+        os.chdir(self.wd)
+
+    def tearDown(self):
+        # Return to original dir
+        os.chdir(self.pwd)
+        # Restore PATH
+        os.environ['PATH'] = self.path
+        # Remove the temporary test directory
+        if REMOVE_TEST_OUTPUTS:
+            shutil.rmtree(self.wd)
+
+    def test_report_qc_all_outputs(self):
+        """report_qc: project with all QC outputs present
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"))
+        p.create(top_dir=self.wd)
+        # Add QC outputs
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        UpdateAnalysisProject(project).add_qc_outputs()
+        # Do reporting
+        self.assertEqual(report_qc(project),0)
+        # Check output and reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    def test_report_qc_incomplete_outputs(self):
+        """report_qc: project with some QC outputs missing
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"))
+        p.create(top_dir=self.wd)
+        # Add QC outputs
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        UpdateAnalysisProject(project).add_qc_outputs()
+        # Remove an output
+        os.remove(os.path.join(self.wd,
+                               "PJB",
+                               "qc",
+                               "PJB1_S1_R1_001_fastqc.html"))
+        # Do reporting
+        self.assertEqual(report_qc(project),1)
+        # Check output and reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    def test_report_qc_no_outputs(self):
+        """report_qc: project with no QC outputs
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"))
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        # Do reporting
+        self.assertEqual(report_qc(project),1)
+        # Check output and reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "multiqc_report.html"):
+            self.assertFalse(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Found %s (should be missing)" % f)


### PR DESCRIPTION
PR to update the `publish_qc` command to delegate the QC verification and reporting to external processes, to address issues #193  and #102 (and reduce the load on cluster login nodes, if the operation is being run on a compute cluster).