### PR TITLE
qc/fastq_screen.py: Fastqscreen class raises exception for empty input file

### DIFF
--- a/auto_process_ngs/qc/fastq_screen.py
+++ b/auto_process_ngs/qc/fastq_screen.py
@@ -62,6 +62,7 @@ class Fastqscreen(TabFile):
         self._version = None
         self._no_hits = None
         # Read in data
+        tabfile = None
         with open(self._screen_file,'r') as fp:
             for line in fp:
                 line = line.strip()
@@ -80,6 +81,10 @@ class Fastqscreen(TabFile):
                    line.startswith('%'):
                     continue
                 tabfile.append(tabdata=line)
+        # Check there is some data
+        if tabfile is None:
+            raise Exception("Unable to extract Fastq_screen data from %s" %
+                            self._screen_file)
         # Handle different terminology for different versions
         if tabfile.header()[0] == 'Library':
             library = 'Library'

--- a/auto_process_ngs/test/qc/test_fastq_screen.py
+++ b/auto_process_ngs/test/qc/test_fastq_screen.py
@@ -7,6 +7,24 @@ import tempfile
 
 from auto_process_ngs.qc.fastq_screen import Fastqscreen
 
+class TestFastqscreen(unittest.TestCase):
+    def setUp(self):
+        screen_text = ""
+        with tempfile.NamedTemporaryFile(delete=False) as fp:
+            self.fastq_screen_txt = fp.name
+            fp.write(screen_text)
+    def tearDown(self):
+        try:
+            os.remove(self.fastq_screen_txt)
+        except Exception:
+            pass
+    def test_fastq_screen_handle_empty_output_file(self):
+        """FastqScreen handles empty output file
+        """
+        self.assertRaises(Exception,
+                          Fastqscreen,
+                          self.fastq_screen_txt)
+
 class TestFastqscreen_v0_4_1(unittest.TestCase):
     def setUp(self):
         screen_text = """#Fastq_screen version: 0.4.1


### PR DESCRIPTION
PR to update the `Fastqscreen` class in `qc/fastq_screen.py` to raise an explicit exception if the input file is empty.