### PR TITLE
[WIP] Add strandedness determination to QC pipeline

### DIFF
--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -241,7 +241,7 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                                               qc_dir=qc_dir,
                                               multiqc=True,
                                               log_dir=ap.log_dir)
-                    if report_status is not None:
+                    if report_status == 0:
                         print "...%s: (re)generated report" % qc_dir
                     else:
                         print "...%s: failed to (re)generate " \

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -200,6 +200,8 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
     # Collect QC for project directories
     print "Checking project directories"
     projects = ap.get_analysis_projects_from_dirs(pattern=project_pattern)
+    if projects:
+        ap.set_log_dir(ap.get_log_subdir('publish_qc'))
     project_qc = {}
     for project in projects:
         # Check qc subdirectories

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 #######################################################################
 
 def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
-           fastq_screen_subset=100000,nthreads=1,
-           runner=None,fastq_dir=None,qc_dir=None,
+           fastq_screen_subset=100000,fastq_strand_conf=None,
+           nthreads=1,runner=None,fastq_dir=None,qc_dir=None,
            report_html=None,run_multiqc=True):
     """Run QC pipeline script for projects
 
@@ -51,6 +51,8 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
       fastq_screen_subset (int): subset of reads to use in
         FastQScreen, set to zero or None to use all reads
         (default: 100000)
+      fastq_strand_conf (str): path to configuration file for
+        running fastq_strand.py for strand determination
       nthreads (int): specify number of threads to run the QC jobs
         with (default: 1)
       runner (str): specify a non-default job runner to use for
@@ -74,6 +76,7 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
     compatible_versions = ('1.3.0','1.3.1')
     illumina_qc = IlluminaQC(nthreads=nthreads,
                              fastq_screen_subset=fastq_screen_subset,
+                             fastq_strand_conf=fastq_strand_conf,
                              ungzip_fastqs=ungzip_fastqs)
     version = illumina_qc.version()
     if version not in compatible_versions:

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -74,11 +74,7 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
     """
     # Set up QC script
     compatible_versions = ('1.3.0','1.3.1')
-    illumina_qc = IlluminaQC(nthreads=nthreads,
-                             fastq_screen_subset=fastq_screen_subset,
-                             fastq_strand_conf=fastq_strand_conf,
-                             ungzip_fastqs=ungzip_fastqs)
-    version = illumina_qc.version()
+    version = IlluminaQC().version()
     if version not in compatible_versions:
         logger.error("QC script version is %s, needs %s" %
                      (version,'/'.join(compatible_versions)))
@@ -108,13 +104,19 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
     # Set up the QC for each project
     runqc = RunQC()
     for project in projects:
+        # Set up the QC command generator
+        illumina_qc = IlluminaQC(nthreads=nthreads,
+                                 fastq_screen_subset=fastq_screen_subset,
+                                 fastq_strand_conf=fastq_strand_conf,
+                                 ungzip_fastqs=ungzip_fastqs)
+        # Add the project
         runqc.add_project(project,
                           fastq_dir=fastq_dir,
                           sample_pattern=sample_pattern,
-                          qc_dir=qc_dir)
+                          qc_dir=qc_dir,
+                          illumina_qc=illumina_qc)
     # Run the QC
-    status = runqc.run(illumina_qc,
-                       multiqc=True,
+    status = runqc.run(multiqc=True,
                        qc_runner=qc_runner,
                        verify_runner=default_runner,
                        report_runner=default_runner,

--- a/auto_process_ngs/docwriter.py
+++ b/auto_process_ngs/docwriter.py
@@ -687,7 +687,7 @@ class Img(object):
 
     """
     def __init__(self,src,name=None,height=None,width=None,href=None,
-                 alt=None):
+                 alt=None,title=None):
         """
         Create a new Img instance
 
@@ -704,6 +704,8 @@ class Img(object):
           alt (str): if specified then used as the
             'alternative text' ('alt' attribute
             for <img.../> tag
+          title (str): if specified then assigned
+            to the <img../> tag's 'title' attribute
 
         """
         self._src = src
@@ -712,6 +714,7 @@ class Img(object):
         self._name = name
         self._target = href
         self._alt = alt
+        self._title = title
 
     @property
     def name(self):
@@ -738,6 +741,9 @@ class Img(object):
         # Optional alt text
         if self._alt:
             html.append("alt='%s'" % self._alt)
+        # Optional title
+        if self._title:
+            html.append("title='%s'" % self._title)
         # Close the tag
         html.append("/>")
         # Wrap in a hef

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -55,6 +55,7 @@ from bcftbx.mock import MockIlluminaData
 from bcftbx.IlluminaData import IlluminaRun
 from bcftbx.IlluminaData import IlluminaRunInfo
 from bcftbx.IlluminaData import SampleSheetPredictor
+from bcftbx.qc.report import strip_ngs_extensions
 from .analysis import AnalysisProject
 from .utils import ZipArchive
 from .qc.illumina_qc import IlluminaQC
@@ -1313,7 +1314,7 @@ sys.exit(MockFastqStrandPy(no_outputs=%s,
         if self._no_outputs:
             return self._exit_code
         # Create fake output file
-        basename = os.path.splitext(os.path.basename(args.fastqr1))[0]
+        basename = strip_ngs_extensions(os.path.basename(args.fastqr1))
         if args.outdir is not None:
             outfile = os.path.join(args.outdir,"%s_fastq_strand.txt" % basename)
         else:

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1315,9 +1315,9 @@ sys.exit(MockFastqStrandPy(no_outputs=%s,
         # Create fake output file
         basename = os.path.splitext(os.path.basename(args.fastqr1))[0]
         if args.outdir is not None:
-            outfile = os.path.join(args.outdir,"%s.txt" % basename)
+            outfile = os.path.join(args.outdir,"%s_fastq_strand.txt" % basename)
         else:
-            outfile = os.path.join(os.getcwd(),"%s.txt" % basename)
+            outfile = os.path.join(os.getcwd(),"%s_fastq_strand.txt" % basename)
         with open(outfile,'w') as fp:
             fp.write("""#fastq_strand version: %s	#Aligner: STAR	#Reads in subset: 1000
 #Genome	1st forward	2nd reverse

--- a/auto_process_ngs/qc/fastq_strand.py
+++ b/auto_process_ngs/qc/fastq_strand.py
@@ -94,3 +94,30 @@ class Fastqstrand(object):
         Data associated with the genomes
         """
         return self._genomes
+
+def build_fastq_strand_conf(organisms,indexes):
+    """
+    Construct a conf file for input into fastq_strand
+
+    Arguments:
+      organisms (list): list of organism names to
+        include
+      indexes (dict): mapping of organism names to
+        paths to STAR indexes
+
+    Returns:
+      String: contents of a fastq_strand conf file,
+        or None if there were no matching indexes.
+    """
+    if not organisms:
+        return None
+    conf = list()
+    for organism in organisms:
+        try:
+            conf.append('\t'.join([organism,indexes[organism]]))
+        except KeyError:
+            pass
+    if conf:
+        return '\n'.join(conf)
+    else:
+        return None

--- a/auto_process_ngs/qc/fastq_strand.py
+++ b/auto_process_ngs/qc/fastq_strand.py
@@ -51,9 +51,21 @@ class Fastqstrand(object):
                             self._fastq_strand_out)
         # Copy data to main object
         for line in tabfile:
-            self._genomes[line['Genome']] = AttributeDictionary()
-            self._genomes[line['Genome']]['forward'] = line['1st forward']
-            self._genomes[line['Genome']]['reverse'] = line['2nd reverse']
+            # Store the data
+            data = AttributeDictionary()
+            self._genomes[line['Genome']] = data
+            data['forward'] = line['1st forward']
+            data['reverse'] = line['2nd reverse']
+            # Additional processing
+            ratio = float(data.forward)/float(data.reverse)
+            if ratio < 0.1:
+                strandedness = "reverse"
+            elif ratio > 10:
+                strandedness = "forward"
+            else:
+                strandedness = "unstranded"
+            data['ratio'] = ratio
+            data['strandedness'] = strandedness
 
     @property
     def txt(self):

--- a/auto_process_ngs/qc/fastq_strand.py
+++ b/auto_process_ngs/qc/fastq_strand.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+#
+# fastq screens library
+import os
+from bcftbx.TabFile import TabFile
+from bcftbx.utils import AttributeDictionary
+
+"""
+Example fastq_strand file for 0.0.1:
+
+#fastq_strand version: 0.0.1	#Aligner: STAR	#Reads in subset: 3
+#Genome	1st forward	2nd reverse
+Genome1	13.13	93.21
+Genome2	13.13	93.21
+
+Example with count data:
+
+"#fastq_strand version: 0.0.1	#Aligner: STAR	#Reads in subset: 3
+#Genome	1st forward	2nd reverse	Unstranded	1st read strand aligned	2nd read strand aligned
+Genome1	13.13	93.21	391087	51339	364535
+"""
+
+class Fastqstrand(object):
+    """
+    Class representing data from a fastq_strand.py run
+
+    """
+    def __init__(self,fastq_strand_out):
+        """
+        Create a new Fastqstrand instance
+
+        """
+        self._fastq_strand_out = os.path.abspath(fastq_strand_out)
+        self._version = None
+        self._genomes = AttributeDictionary()
+        # Read in data
+        tabfile = None
+        with open(self._fastq_strand_out,'r') as fp:
+            for line in fp:
+                line = line.strip()
+                if line.startswith('#fastq_strand version:'):
+                    self._version = line.split()[2]
+                    continue
+                elif line.startswith('#Genome'):
+                    tabfile = TabFile(column_names=line[1:].split('\t'))
+                    continue
+                tabfile.append(tabdata=line)
+        # Check there is some data
+        if tabfile is None:
+            raise Exception("Unable to extract fastq_strand data from %s" %
+                            self._fastq_strand_out)
+        # Copy data to main object
+        for line in tabfile:
+            self._genomes[line['Genome']] = AttributeDictionary()
+            self._genomes[line['Genome']]['forward'] = line['1st forward']
+            self._genomes[line['Genome']]['reverse'] = line['2nd reverse']
+
+    @property
+    def txt(self):
+        """
+        Path of the fastq_strand output txt file
+        """
+        return self._fastq_strand_out
+
+    @property
+    def version(self):
+        """
+        Version of fastq_strand which produced the stats
+        """
+        return self._version
+
+    @property
+    def genomes(self):
+        """
+        List of genome names with strand stats
+        """
+        return sorted([g for g in self._genomes])
+
+    @property
+    def stats(self):
+        """
+        Data associated with the genomes
+        """
+        return self._genomes

--- a/auto_process_ngs/qc/fastq_strand.py
+++ b/auto_process_ngs/qc/fastq_strand.py
@@ -58,12 +58,12 @@ class Fastqstrand(object):
             data['reverse'] = line['2nd reverse']
             # Additional processing
             ratio = float(data.forward)/float(data.reverse)
-            if ratio < 0.1:
+            if ratio < 0.2:
                 strandedness = "reverse"
-            elif ratio > 10:
+            elif ratio > 5:
                 strandedness = "forward"
             else:
-                strandedness = "unstranded"
+                strandedness = "unstranded?"
             data['ratio'] = ratio
             data['strandedness'] = strandedness
 

--- a/auto_process_ngs/qc/illumina_qc.py
+++ b/auto_process_ngs/qc/illumina_qc.py
@@ -215,3 +215,22 @@ def fastqc_output(fastq):
     """
     base_name = "%s_fastqc" % strip_ngs_extensions(os.path.basename(fastq))
     return (base_name,base_name+'.html',base_name+'.zip')
+
+def fastq_strand_output(fastq):
+    """
+    Generate name for fastq_strand.py output
+
+    Given a Fastq file name, the output from fastq_strand.py
+    will look like:
+
+    - {FASTQ}_fastq_strand.txt
+
+    Arguments:
+       fastq (str): name of Fastq file
+
+    Returns:
+       tuple: fastq_strand.py output (without leading paths)
+
+    """
+    return "%s_fastq_strand.txt" % strip_ngs_extensions(
+        os.path.basename(fastq))

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -974,12 +974,14 @@ class QCReportFastq(object):
             png,txt = fastq_screen_output(fastq,name)
             png = os.path.join(qc_dir,png)
             txt = os.path.join(qc_dir,txt)
-            self.fastq_screen['names'].append(name)
-            self.fastq_screen[name] = AttributeDictionary()
-            self.fastq_screen[name]["description"] = name.replace('_',' ').title()
-            self.fastq_screen[name]["png"] = png
-            self.fastq_screen[name]["txt"] = txt
-            self.fastq_screen[name]["version"] = Fastqscreen(txt).version
+            if os.path.exists(png) and os.path.exists(txt):
+                self.fastq_screen['names'].append(name)
+                self.fastq_screen[name] = AttributeDictionary()
+                self.fastq_screen[name]["description"] = \
+                                        name.replace('_',' ').title()
+                self.fastq_screen[name]["png"] = png
+                self.fastq_screen[name]["txt"] = txt
+                self.fastq_screen[name]["version"] = Fastqscreen(txt).version
         # Program versions
         self.program_versions = AttributeDictionary()
         if self.fastqc is not None:
@@ -1055,6 +1057,9 @@ class QCReportFastq(object):
         screens_report = document.add_subsection("Screens",
                                                  name="fastq_screens_%s" %
                                                  self.safe_name)
+        if not self.fastq_screen.names:
+            screens_report.add("No screens found")
+            return screens_report
         raw_data = list()
         for name in self.fastq_screen.names:
             # Title for the screen

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -971,12 +971,14 @@ class QCReportFastqPair(object):
                 summary_table.set_value(idx,'fastqc_r1',
                                         Img(self.r1.ufastqcplot(),
                                             href="#fastqc_%s" %
-                                            self.r1.safe_name))
+                                            self.r1.safe_name,
+                                            title=self.r1.fastqc_summary()))
             elif field == "fastqc_r2":
                 summary_table.set_value(idx,'fastqc_r2',
                                         Img(self.r2.ufastqcplot(),
                                             href="#fastqc_%s" %
-                                            self.r2.safe_name))
+                                            self.r2.safe_name,
+                                            title=self.r2.fastqc_summary()))
             elif field == "screens_r1":
                 summary_table.set_value(idx,'screens_r1',
                                         Img(self.r1.uscreenplot(),
@@ -1188,6 +1190,16 @@ class QCReportFastq(object):
                          Version=self.program_versions.fastq_screen)
         versions.add(programs)
         return versions
+
+    def fastqc_summary(self):
+        """
+        Return plaintext version of the FastQC summary
+        """
+        output = []
+        for m in self.fastqc.summary.modules:
+            output.append("%s: %s" %
+                          (self.fastqc.summary.status(m),m))
+        return "\n".join(output)
 
     def uboxplot(self,inline=True):
         """

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -19,7 +19,6 @@ from bcftbx.qc.report import strip_ngs_extensions
 from bcftbx.utils import AttributeDictionary
 from bcftbx.utils import extract_prefix
 from bcftbx.utils import extract_index
-from ..applications import Command
 from ..docwriter import Document
 from ..docwriter import Section
 from ..docwriter import Table

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -60,7 +60,9 @@ def verify_qc(project,qc_dir=None,illumina_qc=None,runner=None,
     if runner is None:
         runner = Settings().general.default_runner
     # Set up QC project
-    project = ProjectQC(project,qc_dir=qc_dir,
+    project = ProjectQC(project,
+                        illumina_qc=illumina_qc,
+                        qc_dir=qc_dir,
                         log_dir=log_dir)
     # Set up and start scheduler
     sched = SimpleScheduler()
@@ -68,7 +70,6 @@ def verify_qc(project,qc_dir=None,illumina_qc=None,runner=None,
     # QC check for project
     project.check_qc(sched,
                      name="verify_qc",
-                     illumina_qc=illumina_qc,
                      runner=runner)
     sched.wait()
     return project.verify()
@@ -105,14 +106,15 @@ def report_qc(project,qc_dir=None,illumina_qc=None,
     if runner is None:
         runner = Settings().general.default_runner
     # Set up QC project
-    project = ProjectQC(project,qc_dir=qc_dir,
+    project = ProjectQC(project,
+                        illumina_qc=illumina_qc,
+                        qc_dir=qc_dir,
                         log_dir=log_dir)
     # Set up and start scheduler
     sched = SimpleScheduler()
     sched.start()
     # Generate QC for project
     project.report_qc(sched,
-                      illumina_qc=illumina_qc,
                       report_html=report_html,
                       multiqc=multiqc,
                       zip_outputs=zip_outputs,

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -35,7 +35,8 @@ logger = logging.getLogger(__name__)
 # Functions
 #######################################################################
 
-def verify_qc(project,qc_dir=None,runner=None,log_dir=None):
+def verify_qc(project,qc_dir=None,illumina_qc=None,runner=None,
+              log_dir=None):
     """
     Verify the QC run for a project
 
@@ -44,6 +45,8 @@ def verify_qc(project,qc_dir=None,runner=None,log_dir=None):
         to verify the QC for
       qc_dir (str): optional, specify the subdir with
         the QC outputs being verified
+      illumina_qc (IlluminaQC): optional, configured
+        IlluminaQC object to use for QC verification
       runner (JobRunner): optional, job runner to use
         for running the verification
       log_dir (str): optional, specify a directory to
@@ -65,13 +68,14 @@ def verify_qc(project,qc_dir=None,runner=None,log_dir=None):
     # QC check for project
     project.check_qc(sched,
                      name="verify_qc",
+                     illumina_qc=illumina_qc,
                      runner=runner)
     sched.wait()
     return project.verify()
 
-def report_qc(project,qc_dir=None,report_html=None,
-              zip_outputs=True,multiqc=False,runner=None,
-              log_dir=None):
+def report_qc(project,qc_dir=None,illumina_qc=None,
+              report_html=None,zip_outputs=True,multiqc=False,
+              runner=None,log_dir=None):
     """
     Generate report for the QC run for a project
 
@@ -80,6 +84,8 @@ def report_qc(project,qc_dir=None,report_html=None,
         to report the QC for
       qc_dir (str): optional, specify the subdir with
         the QC outputs being reported
+      illumina_qc (IlluminaQC): optional, configured
+        IlluminaQC object to use for QC reporting
       report_html (str): optional, path to the name of
         the output QC report
       zip_outputs (bool): if True then also generate ZIP
@@ -106,6 +112,7 @@ def report_qc(project,qc_dir=None,report_html=None,
     sched.start()
     # Generate QC for project
     project.report_qc(sched,
+                      illumina_qc=illumina_qc,
                       report_html=report_html,
                       multiqc=multiqc,
                       zip_outputs=zip_outputs,

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -60,6 +60,7 @@ import logging
 import bcftbx.JobRunner as JobRunner
 from bcftbx.utils import AttributeDictionary
 from config import Config
+from config import NoSectionError
 
 #######################################################################
 # Classes
@@ -123,7 +124,13 @@ class Settings(object):
         self.qc['fastq_screen_subset'] = config.getint('qc',
                                                        'fastq_screen_subset',
                                                        100000)
-        self.qc['fastq_strand_conf'] = config.get('qc','fastq_strand_conf')
+        # fastq_strand indexes
+        self.add_section('fastq_strand_indexes')
+        try:
+            for genome,conf_file in config.items('fastq_strand_indexes'):
+                self.fastq_strand_indexes[genome] = conf_file
+        except NoSectionError:
+            logging.warning("No strand stats conf files defined")
         # Sequencing platform-specific defaults
         self.add_section('platform')
         for section in filter(lambda x: x.startswith('platform:'),

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -112,6 +112,7 @@ class Settings(object):
         self.add_section('modulefiles')
         self.modulefiles['make_fastqs'] = config.get('modulefiles','make_fastqs')
         self.modulefiles['run_qc'] = config.get('modulefiles','run_qc')
+        self.modulefiles['publish_qc'] = config.get('modulefiles','publish_qc')
         self.modulefiles['process_icell8'] = config.get('modulefiles','process_icell8')
         # bcl2fastq
         self.add_section('bcl2fastq')

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -122,6 +122,7 @@ class Settings(object):
         self.qc['fastq_screen_subset'] = config.getint('qc',
                                                        'fastq_screen_subset',
                                                        100000)
+        self.qc['fastq_strand_conf'] = config.get('qc','fastq_strand_conf')
         # Sequencing platform-specific defaults
         self.add_section('platform')
         for section in filter(lambda x: x.startswith('platform:'),

--- a/auto_process_ngs/test/qc/test_fastq_strand.py
+++ b/auto_process_ngs/test/qc/test_fastq_strand.py
@@ -6,6 +6,7 @@ import unittest
 import tempfile
 
 from auto_process_ngs.qc.fastq_strand import Fastqstrand
+from auto_process_ngs.qc.fastq_strand import build_fastq_strand_conf
 
 class TestFastqstrand(unittest.TestCase):
     def setUp(self):
@@ -40,7 +41,7 @@ mm10	15.02	91.18
             os.remove(self.fastq_strand_txt)
         except Exception:
             pass
-    def test_handle_fastq_screen_0_0_1(self):
+    def test_handle_fastq_strand_0_0_1(self):
         """Fastqstrand handles output from version 0.0.1
         """
         fastq_strand = Fastqstrand(self.fastq_strand_txt)
@@ -51,3 +52,27 @@ mm10	15.02	91.18
         self.assertEqual(fastq_strand.stats['hg38'].reverse,93.21)
         self.assertEqual(fastq_strand.stats['mm10'].forward,15.02)
         self.assertEqual(fastq_strand.stats['mm10'].reverse,91.18)
+
+class TestBuildFastqStrandConfFunction(unittest.TestCase):
+    indexes = dict(human="/data/to/hg38/STAR",
+                   mouse="/data/to/mm10/STAR",)
+    def test_build_fastq_strand_conf_no_organism(self):
+        """build_fastq_strand_conf: no organisms
+        """
+        self.assertEqual(build_fastq_strand_conf(None,self.indexes),
+                         None)
+    def test_build_fastq_strand_conf_one_organism(self):
+        """build_fastq_strand_conf: one organism
+        """
+        self.assertEqual(build_fastq_strand_conf(("human",),self.indexes),
+                         "human\t/data/to/hg38/STAR")
+    def test_build_fastq_strand_conf_multiple_organisms(self):
+        """build_fastq_strand_conf: multiple organisms
+        """
+        self.assertEqual(build_fastq_strand_conf(("human","mouse"),self.indexes),
+                         "human\t/data/to/hg38/STAR\nmouse\t/data/to/mm10/STAR")
+    def test_build_fastq_strand_conf_unrecognised_organism(self):
+        """build_fastq_strand_conf: unrecognised organism
+        """
+        self.assertEqual(build_fastq_strand_conf(("zebrafish",),self.indexes),
+                         None)

--- a/auto_process_ngs/test/qc/test_fastq_strand.py
+++ b/auto_process_ngs/test/qc/test_fastq_strand.py
@@ -50,8 +50,16 @@ mm10	15.02	91.18
         self.assertEqual(fastq_strand.genomes,['hg38','mm10'])
         self.assertEqual(fastq_strand.stats['hg38'].forward,13.13)
         self.assertEqual(fastq_strand.stats['hg38'].reverse,93.21)
+        self.assertEqual("%.4f" % fastq_strand.stats['hg38'].ratio,
+                         "%.4f" % 0.140864714)
+        self.assertEqual(fastq_strand.stats['hg38'].strandedness,
+                         "reverse")
         self.assertEqual(fastq_strand.stats['mm10'].forward,15.02)
         self.assertEqual(fastq_strand.stats['mm10'].reverse,91.18)
+        self.assertEqual("%.4f" % fastq_strand.stats['mm10'].ratio,
+                         "%.4f" % 0.164729107)
+        self.assertEqual(fastq_strand.stats['mm10'].strandedness,
+                         "reverse")
 
 class TestBuildFastqStrandConfFunction(unittest.TestCase):
     indexes = dict(human="/data/to/hg38/STAR",

--- a/auto_process_ngs/test/qc/test_fastq_strand.py
+++ b/auto_process_ngs/test/qc/test_fastq_strand.py
@@ -1,0 +1,53 @@
+#######################################################################
+# Unit tests for qc/fastq_strand.py
+#######################################################################
+
+import unittest
+import tempfile
+
+from auto_process_ngs.qc.fastq_strand import Fastqstrand
+
+class TestFastqstrand(unittest.TestCase):
+    def setUp(self):
+        fastq_strand_text = ""
+        with tempfile.NamedTemporaryFile(delete=False) as fp:
+            self.fastq_strand_txt = fp.name
+            fp.write(fastq_strand_text)
+    def tearDown(self):
+        try:
+            os.remove(self.fastq_strand_txt)
+        except Exception:
+            pass
+    def test_fastq_screen_handle_empty_output_file(self):
+        """Fastqstrand handles empty output file
+        """
+        self.assertRaises(Exception,
+                          Fastqstrand,
+                          self.fastq_strand_txt)
+
+class TestFastqstrand_0_0_1(unittest.TestCase):
+    def setUp(self):
+        fastq_strand_text = """#fastq_strand version: 0.0.1	#Aligner: STAR	#Reads in subset: 3
+#Genome	1st forward	2nd reverse
+hg38	13.13	93.21
+mm10	15.02	91.18
+"""
+        with tempfile.NamedTemporaryFile(delete=False) as fp:
+            self.fastq_strand_txt = fp.name
+            fp.write(fastq_strand_text)
+    def tearDown(self):
+        try:
+            os.remove(self.fastq_strand_txt)
+        except Exception:
+            pass
+    def test_handle_fastq_screen_0_0_1(self):
+        """Fastqstrand handles output from version 0.0.1
+        """
+        fastq_strand = Fastqstrand(self.fastq_strand_txt)
+        self.assertEqual(fastq_strand.version,'0.0.1')
+        self.assertEqual(fastq_strand.txt,self.fastq_strand_txt)
+        self.assertEqual(fastq_strand.genomes,['hg38','mm10'])
+        self.assertEqual(fastq_strand.stats['hg38'].forward,13.13)
+        self.assertEqual(fastq_strand.stats['hg38'].reverse,93.21)
+        self.assertEqual(fastq_strand.stats['mm10'].forward,15.02)
+        self.assertEqual(fastq_strand.stats['mm10'].reverse,91.18)

--- a/auto_process_ngs/test/qc/test_illumina_qc.py
+++ b/auto_process_ngs/test/qc/test_illumina_qc.py
@@ -10,6 +10,7 @@ from auto_process_ngs.mock import MockIlluminaQcSh
 from auto_process_ngs.qc.illumina_qc import IlluminaQC
 from auto_process_ngs.qc.illumina_qc import fastq_screen_output
 from auto_process_ngs.qc.illumina_qc import fastqc_output
+from auto_process_ngs.qc.illumina_qc import fastq_strand_output
 
 # Set to False to keep test output dirs
 REMOVE_TEST_OUTPUTS = True
@@ -285,3 +286,17 @@ class TestFastqcOutputFunction(unittest.TestCase):
                          ('PB1_ATTAGG_L001_R1_001_fastqc',
                           'PB1_ATTAGG_L001_R1_001_fastqc.html',
                           'PB1_ATTAGG_L001_R1_001_fastqc.zip'))
+
+class TestFastqStrandOutputFunction(unittest.TestCase):
+    def test_fastq_strand_output(self):
+        """fastq_strand_output: handles .fastq file
+        """
+        self.assertEqual(fastq_strand_output(
+            '/data/PB/PB1_ATTAGG_L001_R1_001.fastq'),
+                         'PB1_ATTAGG_L001_R1_001_fastq_strand.txt')
+    def test_fastq_strand_output_fastqgz(self):
+        """fastq_strand_output: handles fastq.gz file
+        """
+        self.assertEqual(fastq_strand_output(
+            '/data/PB/PB1_ATTAGG_L001_R1_001.fastq.gz'),
+                         'PB1_ATTAGG_L001_R1_001_fastq_strand.txt')

--- a/auto_process_ngs/test/qc/test_illumina_qc.py
+++ b/auto_process_ngs/test/qc/test_illumina_qc.py
@@ -76,6 +76,33 @@ class TestIlluminaQC(unittest.TestCase):
                          "--threads 1 "
                          "--qc_dir /path/to/qc")
 
+    def test_illumina_qc_commands_for_fastq_pair_with_strandedness(self):
+        """IlluminaQC: generates commands for Fastq pair with strandedness
+        """
+        illumina_qc = IlluminaQC(
+            fastq_strand_conf="/path/to/fastq_strand.conf")
+        cmds = illumina_qc.commands(("/path/to/fastqs/test_S1_R1.fastq.gz",
+                                     "/path/to/fastqs/test_S1_R2.fastq.gz"),
+                                    "/path/to/qc")
+        self.assertEqual(len(cmds),3)
+        self.assertEqual(str(cmds[0]),
+                         "illumina_qc.sh "
+                         "/path/to/fastqs/test_S1_R1.fastq.gz "
+                         "--threads 1 "
+                         "--qc_dir /path/to/qc")
+        self.assertEqual(str(cmds[1]),
+                         "illumina_qc.sh "
+                         "/path/to/fastqs/test_S1_R2.fastq.gz "
+                         "--threads 1 "
+                         "--qc_dir /path/to/qc")
+        self.assertEqual(str(cmds[2]),
+                         "fastq_strand.py "
+                         "-n 1 "
+                         "--conf /path/to/fastq_strand.conf "
+                         "--outdir /path/to/qc "
+                         "/path/to/fastqs/test_S1_R1.fastq.gz "
+                         "/path/to/fastqs/test_S1_R2.fastq.gz")
+
     def test_illumina_qc_commands_for_index_read(self):
         """IlluminaQC: generates empty command list for index read Fastq
         """

--- a/auto_process_ngs/test/qc/test_illumina_qc.py
+++ b/auto_process_ngs/test/qc/test_illumina_qc.py
@@ -176,6 +176,73 @@ class TestIlluminaQC(unittest.TestCase):
             self.assertTrue(r in expected_outputs,
                             "'%s' should be predicted" % r)
 
+    def test_illumina_qc_expected_outputs_for_input_pair(self):
+        """IlluminaQC: generates correct expected outputs for Fastq R1/R2 pair
+        """
+        illumina_qc = IlluminaQC()
+        expected_outputs = illumina_qc.expected_outputs(
+            ("/path/to/fastqs/test_S1_R1.fastq.gz",
+             "/path/to/fastqs/test_S1_R2.fastq.gz"),
+            "/path/to/qc")
+        reference_outputs = ("/path/to/qc/test_S1_R1_fastqc",
+                             "/path/to/qc/test_S1_R1_fastqc.html",
+                             "/path/to/qc/test_S1_R1_fastqc.zip",
+                             "/path/to/qc/test_S1_R1_model_organisms_screen.png",
+                             "/path/to/qc/test_S1_R1_model_organisms_screen.txt",
+                             "/path/to/qc/test_S1_R1_other_organisms_screen.png",
+                             "/path/to/qc/test_S1_R1_other_organisms_screen.txt",
+                             "/path/to/qc/test_S1_R1_rRNA_screen.png",
+                             "/path/to/qc/test_S1_R1_rRNA_screen.txt",
+                             "/path/to/qc/test_S1_R2_fastqc",
+                             "/path/to/qc/test_S1_R2_fastqc.html",
+                             "/path/to/qc/test_S1_R2_fastqc.zip",
+                             "/path/to/qc/test_S1_R2_model_organisms_screen.png",
+                             "/path/to/qc/test_S1_R2_model_organisms_screen.txt",
+                             "/path/to/qc/test_S1_R2_other_organisms_screen.png",
+                             "/path/to/qc/test_S1_R2_other_organisms_screen.txt",
+                             "/path/to/qc/test_S1_R2_rRNA_screen.png",
+                             "/path/to/qc/test_S1_R2_rRNA_screen.txt",)
+        for e in expected_outputs:
+            self.assertTrue(e in reference_outputs,
+                            "'%s' shouldn't be predicted" % e)
+        for r in reference_outputs:
+            self.assertTrue(r in expected_outputs,
+                            "'%s' should be predicted" % r)
+
+    def test_illumina_qc_expected_outputs_for_input_pair_incl_strand(self):
+        """IlluminaQC: generates correct expected outputs for Fastq R1/R2 pair (with strand)
+        """
+        illumina_qc = IlluminaQC(fastq_strand_conf=True)
+        expected_outputs = illumina_qc.expected_outputs(
+            ("/path/to/fastqs/test_S1_R1.fastq.gz",
+             "/path/to/fastqs/test_S1_R2.fastq.gz"),
+            "/path/to/qc")
+        reference_outputs = ("/path/to/qc/test_S1_R1_fastqc",
+                             "/path/to/qc/test_S1_R1_fastqc.html",
+                             "/path/to/qc/test_S1_R1_fastqc.zip",
+                             "/path/to/qc/test_S1_R1_model_organisms_screen.png",
+                             "/path/to/qc/test_S1_R1_model_organisms_screen.txt",
+                             "/path/to/qc/test_S1_R1_other_organisms_screen.png",
+                             "/path/to/qc/test_S1_R1_other_organisms_screen.txt",
+                             "/path/to/qc/test_S1_R1_rRNA_screen.png",
+                             "/path/to/qc/test_S1_R1_rRNA_screen.txt",
+                             "/path/to/qc/test_S1_R2_fastqc",
+                             "/path/to/qc/test_S1_R2_fastqc.html",
+                             "/path/to/qc/test_S1_R2_fastqc.zip",
+                             "/path/to/qc/test_S1_R2_model_organisms_screen.png",
+                             "/path/to/qc/test_S1_R2_model_organisms_screen.txt",
+                             "/path/to/qc/test_S1_R2_other_organisms_screen.png",
+                             "/path/to/qc/test_S1_R2_other_organisms_screen.txt",
+                             "/path/to/qc/test_S1_R2_rRNA_screen.png",
+                             "/path/to/qc/test_S1_R2_rRNA_screen.txt",
+                             "/path/to/qc/test_S1_R1_fastq_strand.txt",)
+        for e in expected_outputs:
+            self.assertTrue(e in reference_outputs,
+                            "'%s' shouldn't be predicted" % e)
+        for r in reference_outputs:
+            self.assertTrue(r in expected_outputs,
+                            "'%s' should be predicted" % r)
+
     def test_illumina_qc_expected_outputs_index_read(self):
         """IlluminaQC: predicts no outputs for index read Fastq
         """
@@ -238,6 +305,141 @@ class TestIlluminaQC(unittest.TestCase):
         illumina_qc = IlluminaQC()
         present,missing = illumina_qc.check_outputs(
             "/path/to/fastqs/test_S1_R1.fastq.gz",qc_dir)
+        # Check present
+        for p in present:
+            self.assertTrue(os.path.dirname(p),qc_dir)
+            self.assertTrue(os.path.basename(p) in reference_outputs,
+                            "'%s' shouldn't be found" % p)
+        for r in reference_outputs:
+            self.assertTrue(os.path.join(qc_dir,r) in present,
+                            "'%s' should exist" % r)
+        # Check missing
+        for m in missing:
+            self.assertTrue(os.path.dirname(m),qc_dir)
+            self.assertTrue(os.path.basename(m) in reference_missing,
+                            "'%s' shouldn't be found" % m)
+        for r in reference_missing:
+            self.assertTrue(os.path.join(qc_dir,r) in missing,
+                            "'%s' should exist" % r)
+
+    def test_illumina_qc_check_outputs_all_present_for_pair(self):
+        """IlluminaQC: check expected outputs when all present for R1/R2 pair
+        """
+        # Make QC dir and (empty) reference files
+        qc_dir = os.path.join(self.wd,"qc")
+        os.mkdir(qc_dir)
+        reference_outputs = ("test_S1_R1_fastqc",
+                             "test_S1_R1_fastqc.html",
+                             "test_S1_R1_fastqc.zip",
+                             "test_S1_R1_model_organisms_screen.png",
+                             "test_S1_R1_model_organisms_screen.txt",
+                             "test_S1_R1_other_organisms_screen.png",
+                             "test_S1_R1_other_organisms_screen.txt",
+                             "test_S1_R1_rRNA_screen.png",
+                             "test_S1_R1_rRNA_screen.txt",
+                             "test_S1_R2_fastqc",
+                             "test_S1_R2_fastqc.html",
+                             "test_S1_R2_fastqc.zip",
+                             "test_S1_R2_model_organisms_screen.png",
+                             "test_S1_R2_model_organisms_screen.txt",
+                             "test_S1_R2_other_organisms_screen.png",
+                             "test_S1_R2_other_organisms_screen.txt",
+                             "test_S1_R2_rRNA_screen.png",
+                             "test_S1_R2_rRNA_screen.txt",)
+        for r in reference_outputs:
+            with open(os.path.join(qc_dir,r),'w') as fp:
+                fp.write("test")
+        # Get lists of present and missing files
+        illumina_qc = IlluminaQC()
+        present,missing = illumina_qc.check_outputs(
+            ("/path/to/fastqs/test_S1_R1.fastq.gz",
+             "/path/to/fastqs/test_S1_R2.fastq.gz"),qc_dir)
+        print missing
+        self.assertEqual(len(missing),0)
+        for p in present:
+            self.assertTrue(os.path.dirname(p),qc_dir)
+            self.assertTrue(os.path.basename(p) in reference_outputs,
+                            "'%s' shouldn't be found" % p)
+        for r in reference_outputs:
+            self.assertTrue(os.path.join(qc_dir,r) in present,
+                            "'%s' should exist" % r)
+
+    def test_illumina_qc_check_outputs_all_present_for_pair_with_strand(self):
+        """IlluminaQC: check expected outputs when all present for R1/R2 pair (with strand)
+        """
+        # Make QC dir and (empty) reference files
+        qc_dir = os.path.join(self.wd,"qc")
+        os.mkdir(qc_dir)
+        reference_outputs = ("test_S1_R1_fastqc",
+                             "test_S1_R1_fastqc.html",
+                             "test_S1_R1_fastqc.zip",
+                             "test_S1_R1_model_organisms_screen.png",
+                             "test_S1_R1_model_organisms_screen.txt",
+                             "test_S1_R1_other_organisms_screen.png",
+                             "test_S1_R1_other_organisms_screen.txt",
+                             "test_S1_R1_rRNA_screen.png",
+                             "test_S1_R1_rRNA_screen.txt",
+                             "test_S1_R2_fastqc",
+                             "test_S1_R2_fastqc.html",
+                             "test_S1_R2_fastqc.zip",
+                             "test_S1_R2_model_organisms_screen.png",
+                             "test_S1_R2_model_organisms_screen.txt",
+                             "test_S1_R2_other_organisms_screen.png",
+                             "test_S1_R2_other_organisms_screen.txt",
+                             "test_S1_R2_rRNA_screen.png",
+                             "test_S1_R2_rRNA_screen.txt",
+                             "test_S1_R1_fastq_strand.txt",)
+        for r in reference_outputs:
+            with open(os.path.join(qc_dir,r),'w') as fp:
+                fp.write("test")
+        # Get lists of present and missing files
+        illumina_qc = IlluminaQC(fastq_strand_conf=True)
+        present,missing = illumina_qc.check_outputs(
+            ("/path/to/fastqs/test_S1_R1.fastq.gz",
+             "/path/to/fastqs/test_S1_R2.fastq.gz"),qc_dir)
+        print missing
+        self.assertEqual(len(missing),0)
+        for p in present:
+            self.assertTrue(os.path.dirname(p),qc_dir)
+            self.assertTrue(os.path.basename(p) in reference_outputs,
+                            "'%s' shouldn't be found" % p)
+        for r in reference_outputs:
+            self.assertTrue(os.path.join(qc_dir,r) in present,
+                            "'%s' should exist" % r)
+
+    def test_illumina_qc_check_outputs_for_pair_some_missing(self):
+        """IlluminaQC: check expected outputs for R1/R2 pair when some are missing
+        """
+        # Make QC dir and (empty) reference files
+        qc_dir = os.path.join(self.wd,"qc")
+        os.mkdir(qc_dir)
+        reference_outputs = ("test_S1_R1_fastqc",
+                             "test_S1_R1_fastqc.html",
+                             "test_S1_R1_fastqc.zip",
+                             "test_S1_R1_model_organisms_screen.png",
+                             "test_S1_R1_model_organisms_screen.txt",
+                             "test_S1_R1_other_organisms_screen.png",
+                             "test_S1_R1_other_organisms_screen.txt",
+                             "test_S1_R2_fastqc",
+                             "test_S1_R2_fastqc.html",
+                             "test_S1_R2_fastqc.zip",
+                             "test_S1_R2_model_organisms_screen.png",
+                             "test_S1_R2_model_organisms_screen.txt",
+                             "test_S1_R2_other_organisms_screen.png",
+                             "test_S1_R2_other_organisms_screen.txt",
+                             "test_S1_R2_rRNA_screen.png",
+                             "test_S1_R2_rRNA_screen.txt",)
+        reference_missing = ("test_S1_R1_rRNA_screen.png",
+                             "test_S1_R1_rRNA_screen.txt",)
+        for r in reference_outputs:
+            with open(os.path.join(qc_dir,r),'w') as fp:
+                fp.write("test")
+        # Get lists of present and missing files
+        illumina_qc = IlluminaQC()
+        present,missing = illumina_qc.check_outputs(
+            ("/path/to/fastqs/test_S1_R1.fastq.gz",
+             "/path/to/fastqs/test_S1_R2.fastq.gz"),
+            qc_dir)
         # Check present
         for p in present:
             self.assertTrue(os.path.dirname(p),qc_dir)

--- a/auto_process_ngs/test/qc/test_runqc.py
+++ b/auto_process_ngs/test/qc/test_runqc.py
@@ -96,11 +96,11 @@ class TestRunQC(unittest.TestCase):
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = RunQC()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")))
         illumina_qc=IlluminaQC(fastq_strand_conf="fastq_strand.conf")
-        status = runqc.run(illumina_qc=illumina_qc,
-                           multiqc=True,
+        runqc.add_project(AnalysisProject("PJB",
+                                          os.path.join(self.wd,"PJB")),
+                          illumina_qc=illumina_qc)
+        status = runqc.run(multiqc=True,
                            qc_runner=SimpleJobRunner(),
                            verify_runner=SimpleJobRunner(),
                            report_runner=SimpleJobRunner(),
@@ -134,11 +134,11 @@ class TestRunQC(unittest.TestCase):
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = RunQC()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")))
         illumina_qc=IlluminaQC(fastq_strand_conf="fastq_strand.conf")
-        status = runqc.run(illumina_qc=illumina_qc,
-                           multiqc=True,
+        runqc.add_project(AnalysisProject("PJB",
+                                          os.path.join(self.wd,"PJB")),
+                          illumina_qc=illumina_qc)
+        status = runqc.run(multiqc=True,
                            qc_runner=SimpleJobRunner(),
                            verify_runner=SimpleJobRunner(),
                            report_runner=SimpleJobRunner(),

--- a/auto_process_ngs/test/test_docwriter.py
+++ b/auto_process_ngs/test/test_docwriter.py
@@ -526,6 +526,12 @@ class TestImg(unittest.TestCase):
         self.assertEqual(img.html(),
                          "<a href='http://awesome.pix.com/'>"
                          "<img src='picture.png' /></a>")
+
+    def test_img_with_title(self):
+        img = Img('picture.png',title="An awesome picture")
+        self.assertEqual(img.html(),
+                         "<img src='picture.png' "
+                         "title='An awesome picture' />")
         
 class TestLink(unittest.TestCase):
     """

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -1017,8 +1017,6 @@ if __name__ == "__main__":
                                max_jobs=options.max_jobs,
                                ungzip_fastqs=options.ungzip_fastqs,
                                fastq_screen_subset=options.subset,
-                               fastq_strand_conf=
-                               __settings.qc.fastq_strand_conf,
                                nthreads=options.nthreads,
                                fastq_dir=options.fastq_dir,
                                qc_dir=options.qc_dir,

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -1017,6 +1017,8 @@ if __name__ == "__main__":
                                max_jobs=options.max_jobs,
                                ungzip_fastqs=options.ungzip_fastqs,
                                fastq_screen_subset=options.subset,
+                               fastq_strand_conf=
+                               __settings.qc.fastq_strand_conf,
                                nthreads=options.nthreads,
                                fastq_dir=options.fastq_dir,
                                qc_dir=options.qc_dir,

--- a/bin/process_icell8.py
+++ b/bin/process_icell8.py
@@ -2070,9 +2070,28 @@ if __name__ == "__main__":
 
     # Run the QC
     print "Running the QC"
+    # Set up conf file for strandedness determination
+    fastq_strand_conf = None
+    if analysis_project.info.organism:
+        print "Organisms: %s" % analysis_project.info.organism
+        fastq_strand_indexes = build_fastq_strand_conf(
+            analysis_project.info.organism.lower().split(','),
+            __settings.fastq_strand_indexes)
+        if fastq_strand_indexes:
+            print "Setting up conf file for strandedness determination"
+            fastq_strand_conf = os.path.join(analysis_project.dirn,
+                                             "fastq_strand.conf")
+            with open(fastq_strand_conf,'w') as fp:
+                fp.write("%s\n" % fastq_strand_indexes)
+        else:
+            print "No matching indexes for strandedness determination"
+    else:
+        print "No organisms specified"
+    # Set up the QC
     illumina_qc = IlluminaQC(
         nthreads=nprocessors['qc'],
-        fastq_screen_subset=default_fastq_screen_subset)
+        fastq_screen_subset=default_fastq_screen_subset,
+        fastq_strand_conf=fastq_strand_conf)
     runqc = RunQC()
     runqc.add_project(analysis_project,
                       fastq_dir="fastqs.samples",

--- a/bin/process_icell8.py
+++ b/bin/process_icell8.py
@@ -2076,12 +2076,13 @@ if __name__ == "__main__":
     runqc = RunQC()
     runqc.add_project(analysis_project,
                       fastq_dir="fastqs.samples",
-                      qc_dir="qc.samples")
+                      qc_dir="qc.samples",
+                      illumina_qc=illumina_qc)
     runqc.add_project(analysis_project,
                       fastq_dir="fastqs.barcodes",
-                      qc_dir="qc.barcodes")
-    exit_status = runqc.run(illumina_qc,
-                            multiqc=True,
+                      qc_dir="qc.barcodes"
+                      illumina_qc=illumina_qc)
+    exit_status = runqc.run(multiqc=True,
                             qc_runner=runners['qc'],
                             report_runner=default_runner,
                             max_jobs=max_jobs,

--- a/bin/reportqc.py
+++ b/bin/reportqc.py
@@ -21,9 +21,6 @@ from auto_process_ngs.qc.reporting import QCReporter
 from auto_process_ngs.fastq_utils import pair_fastqs_by_name
 from auto_process_ngs import get_version
 
-# Module specific logger
-logger = logging.getLogger(__name__)
-
 __version__ = get_version()
 
 """
@@ -107,7 +104,7 @@ def zip_report(project,report_html,qc_dir=None):
     for sample in project.qc.samples:
         for fastqs in sample.fastq_pairs:
             for fq in fastqs:
-                logger.debug("Adding QC outputs for %s" % fq)
+                logging.debug("Adding QC outputs for %s" % fq)
                 for f in illumina_qc.expected_outputs(fq,qc_dir):
                     if f.endswith('.zip'):
                         # Exclude .zip file
@@ -177,8 +174,8 @@ def main():
     # Check for MultiQC if required
     if opts.multiqc:
         if find_program("multiqc") is None:
-            logger.critical("MultiQC report requested but 'multiqc' "
-                            "not available")
+            logging.critical("MultiQC report requested but 'multiqc' "
+                             "not available")
             sys.exit(1)
 
     # Examine projects i.e. supplied directories
@@ -200,8 +197,8 @@ def main():
         qc_info = p.qc_info(qc_dir)
         if qc_info.fastq_dir is not None and \
            os.path.join(p.dirn,qc_info.fastq_dir) != p.fastq_dir:
-            logger.warning("Stored fastq dir mismatch (%s != %s)" %
-                           (p.fastq_dir,qc_info.fastq_dir))
+            logging.warning("Stored fastq dir mismatch (%s != %s)" %
+                            (p.fastq_dir,qc_info.fastq_dir))
         print "QC output dir: %s" % qc_dir
         print "-"*(len('Project: ')+len(p.name))
         print "%d samples | %d fastqs" % (len(p.samples),len(p.fastqs))

--- a/bin/reportqc.py
+++ b/bin/reportqc.py
@@ -232,6 +232,7 @@ def main():
             out_file = os.path.join(p.dirn,out_file)
         print "Writing QC report to %s" % out_file
         report_html= QCReporter(p).report(qc_dir=qc_dir,
+                                          illumina_qc=illumina_qc,
                                           title=opts.title,
                                           filename=out_file,
                                           relative_links=True)

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -26,6 +26,7 @@ from bcftbx.JobRunner import fetch_runner
 from auto_process_ngs.analysis import AnalysisProject
 from auto_process_ngs.qc.illumina_qc import IlluminaQC
 from auto_process_ngs.qc.runqc import RunQC
+from auto_process_ngs.qc.fastq_strand import build_fastq_strand_conf
 import auto_process_ngs
 import auto_process_ngs.settings
 import auto_process_ngs.envmod as envmod
@@ -93,6 +94,11 @@ if __name__ == "__main__":
                    "subset of samples to run the QC on. If specified "
                    "then only FASTQs with sample names matching "
                    "PATTERN will be examined.")
+    p.add_argument('--organism',metavar='ORGANISM',
+                   action='store',dest='organism',default=None,
+                   help="explicitly specify organism (e.g. 'human', "
+                   "'mouse'). Multiple organisms should be separated "
+                   "by commas (e.g. 'human,mouse')")
     p.add_argument('--fastq_screen_subset',metavar='SUBSET',
                    action='store',dest='fastq_screen_subset',
                    default=__settings.qc.fastq_screen_subset,type=int,
@@ -177,10 +183,14 @@ if __name__ == "__main__":
 
     # Handle strand stats
     fastq_strand_conf = None
-    if project.info.organism:
-        print "Organisms: %s" % project.info.organism
+    if args.organism:
+        organism = args.organism
+    else:
+        organism = project.info.organism
+    if organism:
+        print "Organisms: %s" % organism
         fastq_strand_indexes = build_fastq_strand_conf(
-            project.info.organism.lower().split(','),
+            organism.lower().split(','),
             __settings.fastq_strand_indexes)
         if fastq_strand_indexes:
             print "Setting up conf file for strandedness determination"

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -59,7 +59,7 @@ def announce(title):
     >>> announce("Hello!")
     ... ======
     ... Hello!
-    .... ======
+    ... ======
 
     Arguments:
       title (str): string to print
@@ -175,11 +175,29 @@ if __name__ == "__main__":
         if not os.path.isabs(out_file):
             out_file = os.path.join(project.dirn,out_file)
 
+    # Handle strand stats
+    fastq_strand_conf = None
+    if project.info.organism:
+        print "Organisms: %s" % project.info.organism
+        fastq_strand_indexes = build_fastq_strand_conf(
+            project.info.organism.lower().split(','),
+            __settings.fastq_strand_indexes)
+        if fastq_strand_indexes:
+            print "Setting up conf file for strandedness determination"
+            fastq_strand_conf = os.path.join(project.dirn,
+                                             "fastq_strand.conf")
+            with open(fastq_strand_conf,'w') as fp:
+                fp.write("%s\n" % fastq_strand_indexes)
+        else:
+            print "No matching indexes for strandedness determination"
+    else:
+        print "No organisms specified"
+
     # Set up QC script
     illumina_qc = IlluminaQC(
         nthreads=args.nthreads,
         fastq_screen_subset=args.fastq_screen_subset,
-        fastq_strand_conf=__settings.qc.fastq_strand_conf,
+        fastq_strand_conf=fastq_strand_conf,
         ungzip_fastqs=False)
 
     # Run the QC

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -188,9 +188,9 @@ if __name__ == "__main__":
     runqc.add_project(project,
                       fastq_dir=args.fastq_dir,
                       sample_pattern=args.sample_pattern,
-                      qc_dir=args.qc_dir)
-    status = runqc.run(illumina_qc,
-                       report_html=out_file,
+                      qc_dir=args.qc_dir,
+                      illumina_qc=illumina_qc)
+    status = runqc.run(report_html=out_file,
                        multiqc=args.run_multiqc,
                        qc_runner=qc_runner,
                        verify_runner=default_runner,

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -179,6 +179,7 @@ if __name__ == "__main__":
     illumina_qc = IlluminaQC(
         nthreads=args.nthreads,
         fastq_screen_subset=args.fastq_screen_subset,
+        fastq_strand_conf=__settings.qc.fastq_strand_conf,
         ungzip_fastqs=False)
 
     # Run the QC

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -23,6 +23,7 @@ create_empty_fastqs = True
 [qc]
 nprocessors = 1
 fastq_screen_subset = 100000
+fastq_strand_conf = None
 
 # icell8 settings
 [icell8]

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -10,6 +10,7 @@ max_concurrent_jobs = 12
 [modulefiles]
 make_fastqs = None
 run_qc = None
+publish_qc = None
 process_icell8 = None
 
 # bcl2fastq settings

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -24,7 +24,13 @@ create_empty_fastqs = True
 [qc]
 nprocessors = 1
 fastq_screen_subset = 100000
-fastq_strand_conf = None
+
+# Strandedness
+# Assign organism name to path to STAR index to use
+# for that organism in fastq_strand
+[fastq_strand_indexes]
+#human = /data/genomeIndexes/hg38/STAR/
+#mouse = /data/genomeIndexes/mm10/STAR/
 
 # icell8 settings
 [icell8]


### PR DESCRIPTION
PR adds strandedness determination to the QC pipeline by running and reporting the results from the `fastq_strand.py` utility from `genomics-bcftbx`. Addresses issue #176.