### PR TITLE
Commands use settings from the supplied AutoProcess instance

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -40,7 +40,7 @@ import bcl2fastq_utils
 import samplesheet_utils
 import icell8_utils
 import tenx_genomics_utils
-import settings
+from .settings import Settings
 from .qc.processing import report_processing_qc
 from .exceptions import MissingParameterFileException
 from auto_process_ngs import get_version
@@ -110,13 +110,18 @@ class AutoProcess:
     processing procedure for Illumina sequencing data
 
     """
-    def __init__(self,analysis_dir=None,allow_save_params=True):
+    def __init__(self,analysis_dir=None,settings=None,
+                 allow_save_params=True):
         """
         Create a new AutoProcess instance
 
         Arguments:
           analysis_dir (str): name/path for existing analysis
             directory
+          settings (Settings): optional, if supplied then should
+            be a Settings instance; otherwise use a default
+            instance populated from the installation-specific
+            'settings.ini' file
           allow_save_params (bool): if True then allow updates
             to parameters to be saved back to the parameter file
             (this is the default)
@@ -126,7 +131,9 @@ class AutoProcess:
         self._master_log_dir = "logs"
         self._log_dir = self._master_log_dir
         # Load configuration settings
-        self.settings = settings.Settings()
+        if settings is None:
+            settings = Settings()
+        self.settings = settings
         # Create empty parameter and metadata set
         self.params = metadata.AnalysisDirParameters()
         self.metadata = metadata.AnalysisDirMetadata()

--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -18,10 +18,6 @@ import auto_process_ngs.simple_scheduler as simple_scheduler
 import auto_process_ngs.tenx_genomics_utils as tenx_genomics_utils
 from bcftbx.JobRunner import fetch_runner
 
-# Fetch configuration settings
-import auto_process_ngs.settings
-__settings = auto_process_ngs.settings.Settings()
-
 # Module specific logger
 logger = logging.getLogger(__name__)
 

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -24,10 +24,6 @@ from ..docwriter import Para
 import bcftbx.utils as bcf_utils
 from auto_process_ngs import get_version
 
-# Fetch configuration settings
-import auto_process_ngs.settings
-__settings = auto_process_ngs.settings.Settings()
-
 # Module specific logger
 import logging
 logger = logging.getLogger(__name__)
@@ -134,7 +130,7 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
         project_pattern = projects
     # Get location to publish qc reports to
     if location is None:
-        location = fileops.Location(__settings.qc_web_server.dirn)
+        location = fileops.Location(ap.settings.qc_web_server.dirn)
     else:
         location = fileops.Location(location)
     if use_hierarchy:
@@ -315,7 +311,7 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
         # Make log directory and set up scheduler
         # to farm out the intensive operations to
         ap.set_log_dir(ap.get_log_subdir('publish_qc'))
-        runner = __settings.general.default_runner
+        runner = ap.settings.general.default_runner
         runner.set_log_dir(ap.log_dir)
         sched = simple_scheduler.SimpleScheduler(runner=runner)
         sched.start()
@@ -598,8 +594,8 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
     if sched is not None:
         sched.stop()
     # Print the URL if given
-    if __settings.qc_web_server.url is not None:
-        url = __settings.qc_web_server.url
+    if ap.settings.qc_web_server.url is not None:
+        url = ap.settings.qc_web_server.url
         if use_hierarchy:
             url = os.path.join(url,
                                year,

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -15,10 +15,6 @@ from auto_process_ngs.qc.illumina_qc import IlluminaQC
 from auto_process_ngs.qc.runqc import RunQC
 from bcftbx.JobRunner import fetch_runner
 
-# Fetch configuration settings
-import auto_process_ngs.settings
-__settings = auto_process_ngs.settings.Settings()
-
 # Module specific logger
 logger = logging.getLogger(__name__)
 
@@ -101,11 +97,11 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
         logger.warning("No projects found for QC analysis")
         return 1
     # Set up runners
-    default_runner = __settings.general.default_runner
+    default_runner = ap.settings.general.default_runner
     if runner is not None:
         qc_runner = fetch_runner(runner)
     else:
-        qc_runner = __settings.runners.qc
+        qc_runner = ap.settings.runners.qc
     # Set up the QC for each project
     runqc = RunQC()
     for project in projects:


### PR DESCRIPTION
PR updates the `run_qc`, `publish_qc` and `archive` commands to ensure that the configuration settings are taken from those in the supplied `AutoProcess` instance.

Also updates the `AutoProcess` class to allow configuration to be explicitly passed in via a populated `Settings` object.