### PR TITLE
Enable modulefiles and transcriptomes to be specified in settings for process_10xgenomics.py

### DIFF
--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -115,6 +115,8 @@ class Settings(object):
         self.modulefiles['run_qc'] = config.get('modulefiles','run_qc')
         self.modulefiles['publish_qc'] = config.get('modulefiles','publish_qc')
         self.modulefiles['process_icell8'] = config.get('modulefiles','process_icell8')
+        self.modulefiles['process_10xgenomics'] = config.get('modulefiles',
+                                                             'process_10xgenomics')
         # bcl2fastq
         self.add_section('bcl2fastq')
         self.bcl2fastq = self.get_bcl2fastq_config('bcl2fastq',config)

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -1,7 +1,7 @@
 #!/bin/env python
 #
 #     settings.py: handle configuration settings for autoprocessing
-#     Copyright (C) University of Manchester 2014-15 Peter Briggs
+#     Copyright (C) University of Manchester 2014-2018 Peter Briggs
 #
 #########################################################################
 #
@@ -172,6 +172,13 @@ class Settings(object):
                                                                'sge')
         self['10xgenomics']['cellranger_mempercore'] = config.getint('10xgenomics','cellranger_mempercore',5)
         self['10xgenomics']['cellranger_jobinterval'] = config.getint('10xgenomics','cellranger_jobinterval',100)
+        # 10xgenomics transcriptomes
+        self.add_section('10xgenomics_transcriptomes')
+        try:
+            for genome,transcriptome in config.items('10xgenomics_transcriptomes'):
+                self['10xgenomics_transcriptomes'][genome] = transcriptome
+        except NoSectionError:
+            logging.warning("No 10xgenomics transcriptomes defined")
         # fastq_stats
         self.add_section('fastq_stats')
         self.fastq_stats['nprocessors'] = config.getint('fastq_stats','nprocessors',1)

--- a/bin/process_10xgenomics.py
+++ b/bin/process_10xgenomics.py
@@ -272,11 +272,17 @@ if __name__ == "__main__":
     args = parser.parse_args()
     print "command: %s" % args.command
 
-    # Deal with module files
+    # Deal with environment modules
     if args.command in ("mkfastq","count"):
-        if args.modulefiles is not None:
-            modulefiles = args.modulefiles.split(',')
-            for modulefile in modulefiles:
+        modulefiles = args.modulefiles
+        if modulefiles is None:
+            try:
+                modulefiles = __settings.modulefiles['process_10xgenomics']
+            except KeyError:
+                # No environment modules specified
+                pass
+        if modulefiles is not None:
+            for modulefile in modulefiles.split(','):
                 envmod.load(modulefile)
 
     # Check for underlying programs

--- a/bin/process_10xgenomics.py
+++ b/bin/process_10xgenomics.py
@@ -22,7 +22,7 @@ from bcftbx.utils import mkdirs
 from bcftbx.IlluminaData import IlluminaData
 from bcftbx.IlluminaData import IlluminaDataError
 from auto_process_ngs.utils import get_numbered_subdir
-from auto_process_ngs.utils import ProjectMetadataFile
+from auto_process_ngs.analysis import ProjectMetadataFile
 from auto_process_ngs.tenx_genomics_utils import run_cellranger_mkfastq
 from auto_process_ngs.tenx_genomics_utils import run_cellranger_count
 from auto_process_ngs.tenx_genomics_utils import run_cellranger_count_for_project

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -12,6 +12,7 @@ make_fastqs = None
 run_qc = None
 publish_qc = None
 process_icell8 = None
+process_10xgenomics = None
 
 # bcl2fastq settings
 [bcl2fastq]

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -48,6 +48,14 @@ cellranger_jobmode = sge
 cellranger_mempercore = 5
 cellranger_jobinterval = 100
 
+# 10xGenomics transcriptomes
+# Assign organism name to path to cellranger
+# transcriptome reference data to use for that
+# organism in single library analysis
+[10xgenomics_transcriptomes]
+#human = /data/cellranger/refdata-cellranger-GRCh38-1.2.0
+#mouse = /data/cellranger/refdata-cellranger-mm10-1.2.0
+
 # Platform specific settings
 # Make sections [platform:NAME] and add parameters to
 # override the default bcl2fastq settings (i.e. number of


### PR DESCRIPTION
PR updates the code for handling 10xGenomics data via `process_10xgenomics.py`:

* Enable default environment module files to be specified in `settings.ini`, which are then picked up in `process_10xgenomics.py`
* Enable transcriptomes to be specified for organisms in `settings.ini` for the single library analyses, and pick these up automatically in `process_10xgenomics.py count`