### PR TITLE
Exclude stranded stats from per-pair QC reports if no 'fastq_strand' outputs are present

### DIFF
--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -488,10 +488,6 @@ class QCReport(Document):
         if relpath is not None:
             relpath = os.path.normpath(os.path.abspath(relpath))
         self.relpath = relpath
-        # Attributes to report for each sample
-        if report_attrs is None:
-            attrs = ('fastqc','fastq_screen','program_versions')
-        self.report_attrs = report_attrs
         # Field descriptions for summary table
         self.field_descriptions = { 'sample': 'Sample',
                                     'fastq' : 'Fastq',
@@ -525,6 +521,14 @@ class QCReport(Document):
                 if ('screens_%s' % read) in self.outputs:
                     summary_fields.append('screens_%s' % read)
         self.summary_fields = summary_fields
+        # Attributes to report for each sample
+        if report_attrs is None:
+            report_attrs = ['fastqc',
+                            'fastq_screen',
+                            'program_versions']
+            if 'strandedness' in self.outputs:
+                report_attrs.append('strandedness')
+        self.report_attrs = report_attrs
         # Initialise tables
         self.metadata_table = self._init_metadata_table()
         self.summary_table = self._init_summary_table()


### PR DESCRIPTION
Currently the QC reports produced by `reportqc.py`/`qc/reporting.py` will include a section in the per-pair Fastq QC report sections for strand statistics, even if no such statistics are present in the QC outputs.

This PR removes the strandedness section if no data is present, in a similar way to the removal of strandedness summary plots from the summary table.