### PR TITLE
Suppress screens for R1 Fastqs for single cell QC

### DIFF
--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -74,7 +74,7 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
         termination, non-zero indicates an error.
     """
     # Set up QC script
-    compatible_versions = ('1.3.0','1.3.1')
+    compatible_versions = ('1.3.2',)
     version = IlluminaQC().version()
     if version not in compatible_versions:
         logger.error("QC script version is %s, needs %s" %

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1078,7 +1078,7 @@ sys.exit(MockIlluminaQcSh(version=%s,
         p.add_argument("--no-ungzip",action="store_true")
         p.add_argument("--threads",action="store")
         p.add_argument("--subset",action="store")
-        p.add_argument("--no-screens",action="store")
+        p.add_argument("--no-screens",action="store_true")
         p.add_argument("--qc_dir",action="store")
         p.add_argument("fastq")
         args = p.parse_args(args)

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1055,7 +1055,7 @@ sys.exit(MockIlluminaQcSh(version=%s,
         Internal: configure the mock illumina_qc.sh
         """
         if version is None:
-            version = "1.3.1"
+            version = "1.3.2"
         self._version = str(version)
         self._fastq_screen = fastq_screen
         self._fastqc = fastqc
@@ -1078,6 +1078,7 @@ sys.exit(MockIlluminaQcSh(version=%s,
         p.add_argument("--no-ungzip",action="store_true")
         p.add_argument("--threads",action="store")
         p.add_argument("--subset",action="store")
+        p.add_argument("--no-screens",action="store")
         p.add_argument("--qc_dir",action="store")
         p.add_argument("fastq")
         args = p.parse_args(args)
@@ -1111,7 +1112,7 @@ fastqc\t/opt/apps/bin/fastqc\t0.11.3
                 with open(ungzipped_fastq,'w') as fp:
                     fp.write("uncompressed %s" % args.fastq)
         # Create FastQScreen outputs
-        if self._fastq_screen:
+        if self._fastq_screen and not args.no_screens:
             for screen in ("model_organisms",
                            "other_organisms",
                            "rRNA"):

--- a/auto_process_ngs/qc/illumina_qc.py
+++ b/auto_process_ngs/qc/illumina_qc.py
@@ -245,6 +245,9 @@ class IlluminaQC(object):
                 cmd.add_args('--subset',self.fastq_screen_subset)
             if qc_dir is not None:
                 cmd.add_args('--qc_dir',os.path.abspath(qc_dir))
+            if IlluminaFastqAttrs(fastq).read_number == 1:
+                # Screens for R2 only
+                cmd.add_args('--no-screens')
             cmds.append(cmd)
             # Strandedness (R2 only)
             if self.fastq_strand_conf is not None:
@@ -371,10 +374,11 @@ class IlluminaQC(object):
             # FastQC outputs
             expected.extend([os.path.join(qc_dir,f)
                              for f in fastqc_output(fastq)])
-            # Fastq_screen outputs
-            for name in FASTQ_SCREENS:
-                expected.extend([os.path.join(qc_dir,f)
-                                 for f in fastq_screen_output(fastq,name)])
+            # Fastq_screen outputs (R2 only)
+            if IlluminaFastqAttrs(fastq).read_number == 2:
+                for name in FASTQ_SCREENS:
+                    expected.extend([os.path.join(qc_dir,f)
+                                     for f in fastq_screen_output(fastq,name)])
             # Strand stats output (R2 only)
             if self.fastq_strand_conf:
                 if IlluminaFastqAttrs(fastq).read_number == 2:

--- a/auto_process_ngs/test/qc/test_illumina_qc.py
+++ b/auto_process_ngs/test/qc/test_illumina_qc.py
@@ -240,7 +240,8 @@ class TestIlluminaQC(unittest.TestCase):
                          "illumina_qc.sh "
                          "/path/to/fastqs/test_S1_R1.fastq.gz "
                          "--threads 1 "
-                         "--qc_dir /path/to/qc")
+                         "--qc_dir /path/to/qc "
+                         "--no-screens")
         self.assertEqual(str(cmds[1]),
                          "illumina_qc.sh "
                          "/path/to/fastqs/test_S1_R2.fastq.gz "
@@ -261,7 +262,8 @@ class TestIlluminaQC(unittest.TestCase):
                          "illumina_qc.sh "
                          "/path/to/fastqs/test_S1_R1.fastq.gz "
                          "--threads 1 "
-                         "--qc_dir /path/to/qc")
+                         "--qc_dir /path/to/qc "
+                         "--no-screens")
         self.assertEqual(str(cmds[1]),
                          "illumina_qc.sh "
                          "/path/to/fastqs/test_S1_R2.fastq.gz "
@@ -423,12 +425,6 @@ class TestIlluminaQC(unittest.TestCase):
         reference_outputs = ("/path/to/qc/test_S1_R1_fastqc",
                              "/path/to/qc/test_S1_R1_fastqc.html",
                              "/path/to/qc/test_S1_R1_fastqc.zip",
-                             "/path/to/qc/test_S1_R1_model_organisms_screen.png",
-                             "/path/to/qc/test_S1_R1_model_organisms_screen.txt",
-                             "/path/to/qc/test_S1_R1_other_organisms_screen.png",
-                             "/path/to/qc/test_S1_R1_other_organisms_screen.txt",
-                             "/path/to/qc/test_S1_R1_rRNA_screen.png",
-                             "/path/to/qc/test_S1_R1_rRNA_screen.txt",
                              "/path/to/qc/test_S1_R2_fastqc",
                              "/path/to/qc/test_S1_R2_fastqc.html",
                              "/path/to/qc/test_S1_R2_fastqc.zip",
@@ -457,12 +453,6 @@ class TestIlluminaQC(unittest.TestCase):
         reference_outputs = ("/path/to/qc/test_S1_R1_fastqc",
                              "/path/to/qc/test_S1_R1_fastqc.html",
                              "/path/to/qc/test_S1_R1_fastqc.zip",
-                             "/path/to/qc/test_S1_R1_model_organisms_screen.png",
-                             "/path/to/qc/test_S1_R1_model_organisms_screen.txt",
-                             "/path/to/qc/test_S1_R1_other_organisms_screen.png",
-                             "/path/to/qc/test_S1_R1_other_organisms_screen.txt",
-                             "/path/to/qc/test_S1_R1_rRNA_screen.png",
-                             "/path/to/qc/test_S1_R1_rRNA_screen.txt",
                              "/path/to/qc/test_S1_R2_fastqc",
                              "/path/to/qc/test_S1_R2_fastqc.html",
                              "/path/to/qc/test_S1_R2_fastqc.zip",
@@ -825,12 +815,6 @@ class TestIlluminaQC(unittest.TestCase):
         reference_outputs = ("test_S1_R1_fastqc",
                              "test_S1_R1_fastqc.html",
                              "test_S1_R1_fastqc.zip",
-                             "test_S1_R1_model_organisms_screen.png",
-                             "test_S1_R1_model_organisms_screen.txt",
-                             "test_S1_R1_other_organisms_screen.png",
-                             "test_S1_R1_other_organisms_screen.txt",
-                             "test_S1_R1_rRNA_screen.png",
-                             "test_S1_R1_rRNA_screen.txt",
                              "test_S1_R2_fastqc",
                              "test_S1_R2_fastqc.html",
                              "test_S1_R2_fastqc.zip",
@@ -867,12 +851,6 @@ class TestIlluminaQC(unittest.TestCase):
         reference_outputs = ("test_S1_R1_fastqc",
                              "test_S1_R1_fastqc.html",
                              "test_S1_R1_fastqc.zip",
-                             "test_S1_R1_model_organisms_screen.png",
-                             "test_S1_R1_model_organisms_screen.txt",
-                             "test_S1_R1_other_organisms_screen.png",
-                             "test_S1_R1_other_organisms_screen.txt",
-                             "test_S1_R1_rRNA_screen.png",
-                             "test_S1_R1_rRNA_screen.txt",
                              "test_S1_R2_fastqc",
                              "test_S1_R2_fastqc.html",
                              "test_S1_R2_fastqc.zip",
@@ -911,21 +889,15 @@ class TestIlluminaQC(unittest.TestCase):
         reference_outputs = ("test_S1_R1_fastqc",
                              "test_S1_R1_fastqc.html",
                              "test_S1_R1_fastqc.zip",
-                             "test_S1_R1_model_organisms_screen.png",
-                             "test_S1_R1_model_organisms_screen.txt",
-                             "test_S1_R1_other_organisms_screen.png",
-                             "test_S1_R1_other_organisms_screen.txt",
                              "test_S1_R2_fastqc",
                              "test_S1_R2_fastqc.html",
                              "test_S1_R2_fastqc.zip",
                              "test_S1_R2_model_organisms_screen.png",
                              "test_S1_R2_model_organisms_screen.txt",
                              "test_S1_R2_other_organisms_screen.png",
-                             "test_S1_R2_other_organisms_screen.txt",
-                             "test_S1_R2_rRNA_screen.png",
+                             "test_S1_R2_other_organisms_screen.txt",)
+        reference_missing = ("test_S1_R2_rRNA_screen.png",
                              "test_S1_R2_rRNA_screen.txt",)
-        reference_missing = ("test_S1_R1_rRNA_screen.png",
-                             "test_S1_R1_rRNA_screen.txt",)
         for r in reference_outputs:
             with open(os.path.join(qc_dir,r),'w') as fp:
                 fp.write("test")


### PR DESCRIPTION
PR which addresses issue #175, by suppressing the generation of screens (from `fastq_screen`) for the R1 Fastq files, when running the QC pipeline for single-cell datasets.

Requires the changes from https://github.com/fls-bioinformatics-core/genomics/pull/69.