### PR TITLE
Fix failing test case for qc/illumina_qc.py

### DIFF
--- a/auto_process_ngs/test/qc/test_illumina_qc.py
+++ b/auto_process_ngs/test/qc/test_illumina_qc.py
@@ -30,6 +30,10 @@ class TestIlluminaQC(unittest.TestCase):
         os.mkdir(self.bin)
         # Store original PATH
         self.path = os.environ['PATH']
+        # Update PATH
+        os.environ['PATH'] = self.bin + \
+                             os.pathsep + \
+                             os.environ['PATH']
 
     def tearDown(self):
         # Restore PATH


### PR DESCRIPTION
PR which fixes the failing test case for `IlluminaQC` (from the `qc/illumina_qc.py` module) (`TestIlluminaQC.test_illumina_qc_version`). This failure appered to be a false negative as the issue seems to be with the test environment rather than indicating a problem with the class under test.