### PR TITLE
[WIP] Add support for additional cellranger options in 10xGenomics processing

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1296,10 +1296,12 @@ class AutoProcess:
                     skip_fastq_generation=False,
                     only_fetch_primary_data=False,
                     create_empty_fastqs=None,runner=None,
-                    cellranger_jobmode=None,
+                    cellranger_jobmode="local",
                     cellranger_mempercore=None,
                     cellranger_maxjobs=None,
-                    cellranger_jobinterval=None):
+                    cellranger_jobinterval=None,
+                    cellranger_localcores=None,
+                    cellranger_localmem=None,):
         """Create and summarise FASTQ files
 
         Wrapper for operations related to FASTQ file generation and analysis.
@@ -1362,15 +1364,20 @@ class AutoProcess:
                                 (must have completed with zero exit status)
           runner              : (optional) specify a non-default job runner to use for
                                 fastq generation
-          cellranger_jobmode  : (optional) job mode to run cellranger in
-                                (10xGenomics Chromium SC data only)
+          cellranger_jobmode  : (optional) job mode to run cellranger in; defaults
+                                to "local" (10xGenomics Chromium SC data only)
           cellranger_mempercore: (optional) memory assumed per core (in Gbs)
                                 (10xGenomics Chromium SC data only)
           cellranger_maxjobs  : (optional) maxiumum number of concurrent jobs
                                 to run (10xGenomics Chromium SC data only)
           cellranger_jobinterval: (optional) how often jobs are submitted (in
                                 ms) (10xGenomics Chromium SC data only)
-
+          cellranger_localcores: (optional) maximum number of cores cellranger
+                                can request in jobmode 'local' (10xGenomics Chromium
+                                SC data only)
+          cellranger_localmem : (optional) maximum memory cellranger can request in
+                                jobmode 'local' (10xGenomics Chromium SC data
+                                only)
         """
         # Report protocol
         print "Protocol              : %s" % protocol
@@ -1588,6 +1595,8 @@ class AutoProcess:
                         cellranger_maxjobs=cellranger_maxjobs,
                         cellranger_mempercore=cellranger_mempercore,
                         cellranger_jobinterval=cellranger_jobinterval,
+                        cellranger_localcores=cellranger_localcores,
+                        cellranger_localmem=cellranger_localmem,
                         log_dir=self.log_dir)
                 except Exception,ex:
                     raise Exception("'cellranger mkfastq' stage failed: "

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1301,7 +1301,8 @@ class AutoProcess:
                     cellranger_maxjobs=None,
                     cellranger_jobinterval=None,
                     cellranger_localcores=None,
-                    cellranger_localmem=None,):
+                    cellranger_localmem=None,
+                    cellranger_ignore_dual_index=False):
         """Create and summarise FASTQ files
 
         Wrapper for operations related to FASTQ file generation and analysis.
@@ -1378,6 +1379,9 @@ class AutoProcess:
           cellranger_localmem : (optional) maximum memory cellranger can request in
                                 jobmode 'local' (10xGenomics Chromium SC data
                                 only)
+          cellranger_ignore_dual_index: (optional) on a dual-indexed flowcell where
+                                the second index was not used for the 10x sample,
+                                ignore it (10xGenomics Chromium SC data only)
         """
         # Report protocol
         print "Protocol              : %s" % protocol
@@ -1591,6 +1595,7 @@ class AutoProcess:
                         lanes=(None if lanes is None
                                else ','.join([str(l) for l in lanes])),
                         bases_mask=bases_mask,
+                        ignore_dual_index=cellranger_ignore_dual_index,
                         cellranger_jobmode=cellranger_jobmode,
                         cellranger_maxjobs=cellranger_maxjobs,
                         cellranger_mempercore=cellranger_mempercore,

--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python
 #
 #     archive_cmd.py: implement auto process archive command
@@ -187,7 +188,7 @@ def archive(ap,archive_dir=None,platform=None,year=None,
             excludes.append('--exclude=%s' % ap.params.unaligned_dir)
         # 10xgenomics products to exclude
         excludes.append('--exclude=*.mro')
-        excludes.append('--exclude="%s*"' %
+        excludes.append('--exclude=%s*' %
                         tenx_genomics_utils.flow_cell_id(ap.run_name))
         # Log dir
         log_dir = 'archive%s' % ('_final' if final else '_staging')

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -169,9 +169,11 @@ class Settings(object):
         self.add_section('10xgenomics')
         self['10xgenomics']['cellranger_jobmode'] = config.get('10xgenomics',
                                                                'cellranger_jobmode',
-                                                               None)
+                                                               'local')
         self['10xgenomics']['cellranger_mempercore'] = config.getint('10xgenomics','cellranger_mempercore',5)
         self['10xgenomics']['cellranger_jobinterval'] = config.getint('10xgenomics','cellranger_jobinterval',100)
+        self['10xgenomics']['cellranger_localmem'] = config.getint('10xgenomics','cellranger_localmem',5)
+        self['10xgenomics']['cellranger_localcores'] = config.getint('10xgenomics','cellranger_localcores',1)
         # 10xgenomics transcriptomes
         self.add_section('10xgenomics_transcriptomes')
         try:

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -169,7 +169,7 @@ class Settings(object):
         self.add_section('10xgenomics')
         self['10xgenomics']['cellranger_jobmode'] = config.get('10xgenomics',
                                                                'cellranger_jobmode',
-                                                               'sge')
+                                                               None)
         self['10xgenomics']['cellranger_mempercore'] = config.getint('10xgenomics','cellranger_mempercore',5)
         self['10xgenomics']['cellranger_jobinterval'] = config.getint('10xgenomics','cellranger_jobinterval',100)
         # 10xgenomics transcriptomes

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -395,10 +395,12 @@ def run_cellranger_mkfastq(sample_sheet,
                            output_dir,
                            lanes=None,
                            bases_mask=None,
-                           cellranger_jobmode=None,
+                           cellranger_jobmode="local",
                            cellranger_maxjobs=None,
                            cellranger_mempercore=None,
                            cellranger_jobinterval=None,
+                           cellranger_localcores=None,
+                           cellranger_localmem=None,
                            log_dir=None,
                            dry_run=False):
     """
@@ -452,7 +454,9 @@ def run_cellranger_mkfastq(sample_sheet,
                         jobmode=cellranger_jobmode,
                         mempercore=cellranger_mempercore,
                         maxjobs=cellranger_maxjobs,
-                        jobinterval=cellranger_jobinterval)
+                        jobinterval=cellranger_jobinterval,
+                        localcores=cellranger_localcores,
+                        localmem=cellranger_localmem)
     # Run the command
     print "Running %s" % cmd
     if not dry_run:
@@ -803,6 +807,8 @@ def add_cellranger_args(cellranger_cmd,
                         maxjobs=None,
                         mempercore=None,
                         jobinterval=None,
+                        localcores=None,
+                        localmem=None,
                         disable_ui=False):
     """
     Configure options for cellranger
@@ -819,9 +825,16 @@ def add_cellranger_args(cellranger_cmd,
       maxjobs (int): if specified, will be passed to the
         --mempercore option
       mempercore (int): if specified, will be passed to
-        the --maxjobs option
+        the --maxjobs option (only if jobmode is not
+        "local")
       jobinterval (int):  if specified, will be passed to
         the --jobinterval option
+      localcores (int): if specified, will be passed to
+        the --localcores option (only if jobmode is
+        "local")
+      localmem (int): if specified, will be passed to the
+        the --localmem option (only if jobmode is
+        "local")
       disable_ui (bool): if True, add the --disable-ui
         option (default is not to add it)
 
@@ -831,8 +844,17 @@ def add_cellranger_args(cellranger_cmd,
     """
     if jobmode is not None:
         cellranger_cmd.add_args("--jobmode=%s" % jobmode)
-    if mempercore is not None:
-        cellranger_cmd.add_args("--mempercore=%s" % mempercore)
+    if jobmode == "local":
+        if localcores is not None:
+            cellranger_cmd.add_args("--localcores=%s" %
+                                    localcores)
+        if localmem is not None:
+            cellranger_cmd.add_args("--localmem=%s" %
+                                    localmem)
+    else:
+        if mempercore is not None:
+            cellranger_cmd.add_args("--mempercore=%s" %
+                                    mempercore)
     if maxjobs is not None:
         cellranger_cmd.add_args("--maxjobs=%s" % maxjobs)
     if jobinterval is not None:

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -395,7 +395,7 @@ def run_cellranger_mkfastq(sample_sheet,
                            output_dir,
                            lanes=None,
                            bases_mask=None,
-                           cellranger_jobmode="local",
+                           cellranger_jobmode='local',
                            cellranger_maxjobs=None,
                            cellranger_mempercore=None,
                            cellranger_jobinterval=None,
@@ -423,7 +423,7 @@ def run_cellranger_mkfastq(sample_sheet,
         bases mask setting (default is to let cellranger
         determine the bases mask automatically)
       cellranger_jobmode (str): specify the job mode to
-        pass to cellranger (default: None)
+        pass to cellranger (default: "local")
       cellranger_maxjobs (int): specify the maximum
         number of jobs to pass to cellranger (default:
         None)
@@ -433,6 +433,11 @@ def run_cellranger_mkfastq(sample_sheet,
       cellranger_jobinterval (int): specify the interval
         between launching jobs (in ms) to pass to
         cellranger (default: None)
+      cellranger_localcores (int): maximum number of cores
+        cellranger can request in jobmode 'local'
+        (default: None)
+      cellranger_localmem (int): maximum memory cellranger
+        can request in jobmode 'local' (default: None)
       log_dir (str): path to a directory to write logs
         (default: current working directory)
       dry_run (bool): if True then only report actions
@@ -503,10 +508,12 @@ def run_cellranger_mkfastq(sample_sheet,
 
 def run_cellranger_count(fastq_dir,
                          transcriptome,
-                         cellranger_jobmode='sge',
+                         cellranger_jobmode='local',
                          cellranger_maxjobs=None,
                          cellranger_mempercore=None,
                          cellranger_jobinterval=None,
+                         cellranger_localcores=None,
+                         cellranger_localmem=None,
                          max_jobs=4,
                          log_dir=None,
                          dry_run=False,
@@ -531,7 +538,7 @@ def run_cellranger_count(fastq_dir,
         compatible transcriptome reference data
         directory
       cellranger_jobmode (str): specify the job mode to
-        pass to cellranger (default: None)
+        pass to cellranger (default: "local")
       cellranger_maxjobs (int): specify the maximum
         number of jobs to pass to cellranger (default:
         None)
@@ -541,6 +548,11 @@ def run_cellranger_count(fastq_dir,
       cellranger_jobinterval (int): specify the interval
         between launching jobs (in ms) to pass to
         cellranger (default: None)
+      cellranger_localcores (int): maximum number of cores
+        cellranger can request in jobmode 'local'
+        (default: None)
+      cellranger_localmem (int): maximum memory cellranger
+        can request in jobmode 'local' (default: None)
       max_jobs (int): maxiumum number of concurrent
         count jobs to run; also used for maximum number
         of jobs each count pipeline can run at once
@@ -623,7 +635,9 @@ def run_cellranger_count(fastq_dir,
                                 jobmode=cellranger_jobmode,
                                 mempercore=cellranger_mempercore,
                                 maxjobs=cellranger_maxjobs,
-                                jobinterval=cellranger_jobinterval)
+                                jobinterval=cellranger_jobinterval,
+                                localcores=cellranger_localcores,
+                                localmem=cellranger_localmem)
             print "Running: %s" % cmd
             if not dry_run:
                 job = sched.submit(cmd,
@@ -733,10 +747,12 @@ def run_cellranger_count(fastq_dir,
 
 def run_cellranger_count_for_project(project_dir,
                                      transcriptome,
-                                     cellranger_jobmode='sge',
+                                     cellranger_jobmode='local',
                                      cellranger_maxjobs=None,
                                      cellranger_mempercore=None,
                                      cellranger_jobinterval=None,
+                                     cellranger_localcores=None,
+                                     cellranger_localmem=None,
                                      max_jobs=4,
                                      log_dir=None,
                                      dry_run=False,
@@ -756,7 +772,7 @@ def run_cellranger_count_for_project(project_dir,
         compatible transcriptome reference data
         directory
       cellranger_jobmode (str): specify the job mode to
-        pass to cellranger (default: None)
+        pass to cellranger (default: "local")
       cellranger_maxjobs (int): specify the maximum
         number of jobs to pass to cellranger (default:
         None)
@@ -766,6 +782,11 @@ def run_cellranger_count_for_project(project_dir,
       cellranger_jobinterval (int): specify the interval
         between launching jobs (in ms) to pass to
         cellranger (default: None)
+      cellranger_localcores (int): maximum number of cores
+        cellranger can request in jobmode 'local'
+        (default: None)
+      cellranger_localmem (int): maximum memory cellranger
+        can request in jobmode 'local' (default: None)
       max_jobs (int): maxiumum number of concurrent
         count jobs to run; also used for maximum number
         of jobs each count pipeline can run at once
@@ -792,6 +813,8 @@ def run_cellranger_count_for_project(project_dir,
         cellranger_maxjobs=cellranger_maxjobs,
         cellranger_mempercore=cellranger_mempercore,
         cellranger_jobinterval=cellranger_jobinterval,
+        cellranger_localcores=cellranger_localcores,
+        cellranger_localmem=cellranger_localmem,
         max_jobs=max_jobs,
         log_dir=log_dir,
         dry_run=dry_run,

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -54,6 +54,22 @@ import logging
 logger = logging.getLogger(__name__)
 
 #######################################################################
+# Data
+#######################################################################
+
+# Permissible values for cellranger count --chemistry option
+# See https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/count
+CELLRANGER_ASSAY_CONFIGS = {
+    'auto': 'autodetection',
+    'threeprime': 'Single Cell 3\'',
+    'fiveprime': 'Single Cell 5\'',
+    'SC3Pv1': 'Single Cell 3\' v1',
+    'SC3Pv2': 'Single Cell 3\' v2',
+    'SC5P-PE': 'Single Cell 5\' paired-end (both R1 and R2 are used for alignment)',
+    'SC5P-R2': 'Single Cell 5\' R2-only (where only R2 is used for alignment)',
+}
+
+#######################################################################
 # Classes
 #######################################################################
 

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -411,6 +411,7 @@ def run_cellranger_mkfastq(sample_sheet,
                            output_dir,
                            lanes=None,
                            bases_mask=None,
+                           ignore_dual_index=False,
                            cellranger_jobmode='local',
                            cellranger_maxjobs=None,
                            cellranger_mempercore=None,
@@ -438,6 +439,9 @@ def run_cellranger_mkfastq(sample_sheet,
       bases_mask (str): optional, specify an alternative
         bases mask setting (default is to let cellranger
         determine the bases mask automatically)
+      ignore_dual_index (bool): optional, on a dual-indexed
+        flowcell where the second index was not used for
+        the 10x sample, ignore it
       cellranger_jobmode (str): specify the job mode to
         pass to cellranger (default: "local")
       cellranger_maxjobs (int): specify the maximum
@@ -471,6 +475,8 @@ def run_cellranger_mkfastq(sample_sheet,
         cmd.add_args("--lanes=%s" % lanes)
     if bases_mask is not None:
         cmd.add_args("--use-bases-mask=%s" % bases_mask)
+    if ignore_dual_index:
+        cmd.add_args("--ignore-dual-index")
     add_cellranger_args(cmd,
                         jobmode=cellranger_jobmode,
                         mempercore=cellranger_mempercore,

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -508,6 +508,7 @@ def run_cellranger_mkfastq(sample_sheet,
 
 def run_cellranger_count(fastq_dir,
                          transcriptome,
+                         chemistry='auto',
                          cellranger_jobmode='local',
                          cellranger_maxjobs=None,
                          cellranger_mempercore=None,
@@ -537,6 +538,9 @@ def run_cellranger_count(fastq_dir,
       transcriptome (str): path to the cellranger
         compatible transcriptome reference data
         directory
+      chemistry (str): assay configuration (set to
+        'auto' to let cellranger determine this
+        automatically)
       cellranger_jobmode (str): specify the job mode to
         pass to cellranger (default: "local")
       cellranger_maxjobs (int): specify the maximum
@@ -630,7 +634,8 @@ def run_cellranger_count(fastq_dir,
                           "--id",sample,
                           "--fastqs",os.path.abspath(fastq_dir),
                           "--sample",sample,
-                          "--transcriptome",transcriptome)
+                          "--transcriptome",transcriptome,
+                          "--chemistry",chemistry)
             add_cellranger_args(cmd,
                                 jobmode=cellranger_jobmode,
                                 mempercore=cellranger_mempercore,
@@ -747,6 +752,7 @@ def run_cellranger_count(fastq_dir,
 
 def run_cellranger_count_for_project(project_dir,
                                      transcriptome,
+                                     chemistry='auto',
                                      cellranger_jobmode='local',
                                      cellranger_maxjobs=None,
                                      cellranger_mempercore=None,
@@ -771,6 +777,9 @@ def run_cellranger_count_for_project(project_dir,
       transcriptome (str): path to the cellranger
         compatible transcriptome reference data
         directory
+      chemistry (str): assay configuration (set to
+        'auto' to let cellranger determine this
+        automatically)
       cellranger_jobmode (str): specify the job mode to
         pass to cellranger (default: "local")
       cellranger_maxjobs (int): specify the maximum
@@ -809,6 +818,7 @@ def run_cellranger_count_for_project(project_dir,
     retval = run_cellranger_count(
         fastq_dir,
         transcriptome,
+        chemistry=chemistry,
         cellranger_jobmode=cellranger_jobmode,
         cellranger_maxjobs=cellranger_maxjobs,
         cellranger_mempercore=cellranger_mempercore,

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -411,9 +411,23 @@ def add_make_fastqs_command(cmdparser):
     cellranger.add_option("--mempercore",
                           dest="mem_per_core",
                           default=__settings['10xgenomics'].cellranger_mempercore,
-                          help="memory assumed per core (in Gbs; "
-                          "default: %s)" %
+                          help="memory assumed per core (in Gbs; default: "
+                          "%s); NB only used if jobmode is not 'local'" %
                           __settings['10xgenomics'].cellranger_mempercore)
+    cellranger.add_option("--localcores",
+                          dest="local_cores",
+                          default=__settings['10xgenomics'].cellranger_localcores,
+                          help="maximum cores cellranger can request at one"
+                          "time for jobmode 'local' (ignored for other "
+                          "jobmodes) (default: %s)" %
+                          __settings['10xgenomics'].cellranger_localcores)
+    cellranger.add_option("--localmem",
+                          dest="local_mem",
+                          default=__settings['10xgenomics'].cellranger_localmem,
+                          help="maximum total memory cellranger can request "
+                          "at one time for jobmode 'local' (ignored for other "
+                          "jobmodes) (in Gbs; default: %s)" %
+                          __settings['10xgenomics'].cellranger_localmem)
     cellranger.add_option("--maxjobs",type=int,
                           dest="max_jobs",
                           default=__settings.general.max_concurrent_jobs,
@@ -975,7 +989,9 @@ if __name__ == "__main__":
                     cellranger_jobmode=options.job_mode,
                     cellranger_mempercore=options.mem_per_core,
                     cellranger_maxjobs=options.max_jobs,
-                    cellranger_jobinterval=options.job_interval)
+                    cellranger_jobinterval=options.job_interval,
+                    cellranger_localcores=options.local_cores,
+                    cellranger_localmem=options.local_mem)
             except Exception as ex:
                 logging.fatal("make_fastqs: %s" % ex)
                 sys.exit(1)

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -440,6 +440,11 @@ def add_make_fastqs_command(cmdparser):
                           help="how often jobs are submitted (in ms; "
                           "default: %d)" %
                           __settings['10xgenomics'].cellranger_jobinterval)
+    cellranger.add_option("--ignore-dual-index",
+                          action="store_true",
+                          dest="ignore_dual_index",
+                          help="on a dual-indexed flowcell where the second "
+                          "index was not used for the 10x sample, ignore it")
     p.add_option_group(cellranger)
     # Statistics
     statistics = optparse.OptionGroup(p,'Statistics generation')
@@ -991,7 +996,8 @@ if __name__ == "__main__":
                     cellranger_maxjobs=options.max_jobs,
                     cellranger_jobinterval=options.job_interval,
                     cellranger_localcores=options.local_cores,
-                    cellranger_localmem=options.local_mem)
+                    cellranger_localmem=options.local_mem,
+                    cellranger_ignore_dual_index=options.ignore_dual_index)
             except Exception as ex:
                 logging.fatal("make_fastqs: %s" % ex)
                 sys.exit(1)

--- a/bin/process_10xgenomics.py
+++ b/bin/process_10xgenomics.py
@@ -38,6 +38,12 @@ import auto_process_ngs.settings
 __settings = auto_process_ngs.settings.Settings()
 
 ######################################################################
+# Data
+######################################################################
+
+from auto_process_ngs.tenx_genomics_utils import CELLRANGER_ASSAY_CONFIGS
+
+######################################################################
 # Functions
 ######################################################################
 
@@ -220,9 +226,10 @@ if __name__ == "__main__":
                               "transcriptome of interest")
     count_parser.add_argument("-c","--chemistry",
                               dest="chemistry",default="auto",
-                              help="assay configuration; if set to "
-                              "'auto' then cellranger will attempt to "
-                              "determine this automatically")
+                              choices=CELLRANGER_ASSAY_CONFIGS.keys(),
+                              help="assay configuration; if set to 'auto' "
+                              "(the default) then cellranger will attempt "
+                              "to determine this automatically")
     count_parser.add_argument("-a","--all-outputs",
                               action="store_true",
                               help="collect all outputs from 'cellranger "

--- a/bin/process_10xgenomics.py
+++ b/bin/process_10xgenomics.py
@@ -45,10 +45,12 @@ def cellranger_mkfastq(samplesheet,
                        primary_data_dir,
                        output_dir,
                        lanes=None,
-                       cellranger_jobmode='sge',
+                       cellranger_jobmode='local',
                        cellranger_maxjobs=None,
                        cellranger_mempercore=None,
                        cellranger_jobinterval=None,
+                       cellranger_localcores=None,
+                       cellranger_localmem=None,
                        log_dir=None,
                        dry_run=False,
                        project_metadata_file='projects.info'):
@@ -69,7 +71,7 @@ def cellranger_mkfastq(samplesheet,
         to process (default is to process all lanes
         in the run)
       cellranger_jobmode (str): specify the job mode to
-        pass to cellranger (default: None)
+        pass to cellranger (default: "local")
       cellranger_maxjobs (int): specify the maximum
         number of jobs to pass to cellranger (default:
         None)
@@ -79,6 +81,10 @@ def cellranger_mkfastq(samplesheet,
       cellranger_jobinterval (int): specify the interval
         between launching jobs (in ms) to pass to
         cellranger (default: None)
+      cellranger_localcores (int): maximum number of cores
+        cellranger can request in jobmode 'local'
+      cellranger_localmem (int): maximum memory cellranger
+        can request in jobmode 'local'
       log_dir (str): path to a directory to write logs
         (default: current working directory)
       dry_run (bool): if True then only report actions
@@ -260,6 +266,20 @@ if __name__ == "__main__":
                        help="how often jobs are submitted (in ms; "
                        "default: %d)"
                        % __settings['10xgenomics'].cellranger_jobinterval)
+        p.add_argument("--localcores",type=int,
+                       dest="local_cores",
+                       default=__settings['10xgenomics'].cellranger_localcores,
+                       help="maximum cores cellranger can request at one"
+                       "time for jobmode 'local' (ignored for other "
+                       "jobmodes) (default: %s)" %
+                       __settings['10xgenomics'].cellranger_localcores)
+        p.add_argument("--localmem",type=int,
+                       dest="local_mem",
+                       default=__settings['10xgenomics'].cellranger_localmem,
+                       help="maximum total memory cellranger can request "
+                       "at one time for jobmode 'local' (ignored for other "
+                       "jobmodes) (in Gbs; default: %s)" %
+                       __settings['10xgenomics'].cellranger_localmem)
         p.add_argument('--modulefiles',action='store',
                        dest='modulefiles',default=None,
                        help="comma-separated list of environment "
@@ -311,6 +331,8 @@ if __name__ == "__main__":
                            cellranger_maxjobs=args.max_jobs,
                            cellranger_mempercore=args.mem_per_core,
                            cellranger_jobinterval=args.job_interval,
+                           cellranger_localcores=args.local_cores,
+                           cellranger_localmem=args.local_mem,
                            dry_run=args.dry_run,
                            log_dir='logs',
                            project_metadata_file='projects.info')
@@ -355,6 +377,8 @@ if __name__ == "__main__":
                     cellranger_maxjobs=args.max_jobs,
                     cellranger_mempercore=args.mem_per_core,
                     cellranger_jobinterval=args.job_interval,
+                    cellranger_localcores=args.local_cores,
+                    cellranger_localmem=args.local_mem,
                     max_jobs=args.max_jobs,
                     dry_run=args.dry_run,
                     log_dir='logs')
@@ -365,6 +389,8 @@ if __name__ == "__main__":
                                  cellranger_maxjobs=args.max_jobs,
                                  cellranger_mempercore=args.mem_per_core,
                                  cellranger_jobinterval=args.job_interval,
+                                 cellranger_localcores=args.local_cores,
+                                 cellranger_localmem=args.local_mem,
                                  max_jobs=args.max_jobs,
                                  dry_run=args.dry_run,
                                  log_dir='logs')

--- a/bin/process_10xgenomics.py
+++ b/bin/process_10xgenomics.py
@@ -218,6 +218,11 @@ if __name__ == "__main__":
                               dest="transcriptome",default=None,
                               help="directory with reference data for "
                               "transcriptome of interest")
+    count_parser.add_argument("-c","--chemistry",
+                              dest="chemistry",default="auto",
+                              help="assay configuration; if set to "
+                              "'auto' then cellranger will attempt to "
+                              "determine this automatically")
     count_parser.add_argument("-a","--all-outputs",
                               action="store_true",
                               help="collect all outputs from 'cellranger "
@@ -373,6 +378,7 @@ if __name__ == "__main__":
                 run_cellranger_count_for_project(
                     project,
                     transcriptome,
+                    chemistry=args.chemistry,
                     cellranger_jobmode=args.job_mode,
                     cellranger_maxjobs=args.max_jobs,
                     cellranger_mempercore=args.mem_per_core,
@@ -385,6 +391,7 @@ if __name__ == "__main__":
         else:
             run_cellranger_count(args.unaligned_dir,
                                  args.transcriptome,
+                                 chemistry=args.chemistry,
                                  cellranger_jobmode=args.job_mode,
                                  cellranger_maxjobs=args.max_jobs,
                                  cellranger_mempercore=args.mem_per_core,

--- a/bin/process_10xgenomics.py
+++ b/bin/process_10xgenomics.py
@@ -208,6 +208,10 @@ if __name__ == "__main__":
                                 dest="lanes",default=None,
                                 help="comma-separated list of lanes "
                                 "(optional)")
+    mkfastq_parser.add_argument("--ignore-dual-index",
+                                help="on a dual-indexed flowcell where "
+                                "the second index was not used for the "
+                                "10x sample, ignore it (optional)")
     # 'count' parser
     count_parser = subparsers.add_parser("count",
                                          help="run 'cellranger count'")
@@ -339,6 +343,7 @@ if __name__ == "__main__":
                            args.run_dir,
                            args.output_dir,
                            lanes=args.lanes,
+                           ignore_dual_index=args.ignore_dual_index,
                            cellranger_jobmode=args.job_mode,
                            cellranger_maxjobs=args.max_jobs,
                            cellranger_mempercore=args.mem_per_core,

--- a/bin/process_10xgenomics.py
+++ b/bin/process_10xgenomics.py
@@ -384,7 +384,7 @@ if __name__ == "__main__":
                     except KeyError:
                         raise Exception("%s: no transcriptome found for "
                                         "organism '%s'; use -t/--transcriptome"
-                                        "option" % (project,organism[0]))
+                                        "option" % (project,organisms[0]))
                 print "Transcriptome: %s" % transcriptome
                 # Run single library analysis
                 run_cellranger_count_for_project(

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -43,8 +43,10 @@ nprocessors_contaminant_filter = 1
 nprocessors_statistics = 1
 
 # 10xGenomics settings
+# Set cellranger_jobmode to 'sge' to use SGE jobmanager
+# See https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/advanced/cluster-mode
 [10xgenomics]
-cellranger_jobmode = sge
+cellranger_jobmode = None
 cellranger_mempercore = 5
 cellranger_jobinterval = 100
 

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -43,12 +43,16 @@ nprocessors_contaminant_filter = 1
 nprocessors_statistics = 1
 
 # 10xGenomics settings
-# Set cellranger_jobmode to 'sge' to use SGE jobmanager
+# cellranger_jobmode defaults to 'local': set to 'sge' to use SGE jobmanager
 # See https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/advanced/cluster-mode
 [10xgenomics]
-cellranger_jobmode = None
+cellranger_jobmode = local
+# cellranger_mempercore only used if jobmode is not 'local'
 cellranger_mempercore = 5
 cellranger_jobinterval = 100
+# cellranger_localmem and cellranger_localcores only used if jobmode is 'local'
+cellranger_localmem = 5
+cellranger_localcores = 1
 
 # 10xGenomics transcriptomes
 # Assign organism name to path to cellranger

--- a/docs/source/10xgenomics.rst
+++ b/docs/source/10xgenomics.rst
@@ -247,6 +247,17 @@ The directory will also contain:
 Appendix: known issues
 ----------------------
 
+Fastq generation fails for single-indexed 10x data produced in dual-index flowcell
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the 10x data is single-indexed but has been produced in a dual-index
+flowcell (for example, if the samples were run in a subset of lanes on a
+HISeq instrument alongside standard libraries in other lanes), then
+``cellranger mkfastq`` will fail.
+
+Use the ``--ignore-dual-index`` option to force ``cellranger`` to process
+the data in this case.
+
 Single-library analyses fail for low read counts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -290,6 +301,9 @@ The ``mkfastq`` command supports the following options::
     -r : specify the location of the primary data for the run
     -l : optionally, specify the lane numbers
     -o : specify the output directory
+    --ignore-dual-index:
+         force cellranger to ignore dual indexing on runs
+         which have it
 
 See also :ref:`10xgenomics-additional-options`.
 

--- a/docs/source/10xgenomics.rst
+++ b/docs/source/10xgenomics.rst
@@ -247,6 +247,9 @@ The directory will also contain:
 Appendix: known issues
 ----------------------
 
+Single-library analyses fail for low read counts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 It has been observed that when the Fastq files produced by the ``mkfastq``
 command have very low read counts then the single-library analyses may
 fail, with ``cellranger count`` reporting an error of the form e.g.::
@@ -256,6 +259,22 @@ fail, with ``cellranger count`` reporting an error of the form e.g.::
     one of the chemistries.
 
 There is currently no workaround for this issue.
+
+Single-library analyses fail to detect chemistry automatically
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default ``cellranger count`` attempts to determine the chemistry used
+automatically, however this may fail if a low number of reads map to the
+reference genome and give an error of the form::
+
+    The chemistry was unable to be automatically determined. This can
+    happen if not enough reads originate from the given reference. Please
+    verify your choice of reference or explicitly specify the chemistry
+    via the --chemistry argument.
+
+If the reference data being used is correct then use the ``--chemistry``
+option to specify the appropriate assay configuration - see
+https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/count
 
 Appendix: options for 'process_10xgenomics.py'
 ----------------------------------------------
@@ -284,6 +303,7 @@ See also :ref:`10xgenomics-additional-options`.
     -u : specify the name of the output directory from 'mkfastq'
     -t : specify the path to the directory with the appropriate
          10xGenomics transcriptome data
+    -c : specify the assay configuration (aka chemistry)
 
 See also :ref:`10xgenomics-additional-options`.
 
@@ -296,13 +316,27 @@ The ``process_10xgenomics.py`` has a number of additional options for
 controlling how the ``cellranger`` pipeline is run::
 
     --jobmode JOB_MODE : job mode to run cellranger in
-    --mempercore MEM_PER_CORE : memory assumed per core (in Gbs)
-    --maxjobs MAX_JOBS : maxiumum number of concurrent jobs to run
     --jobinterval JOB_INTERVAL : how often jobs are submitted (in ms)
+    --maxjobs MAX_JOBS : maxiumum number of concurrent jobs to run
 
-These map onto the equivalent ``cellranger`` options.
+The default ``JOB_MODE`` is ``local``, which runs the ``cellranger``
+pipelines on the local system. In this case the following additional
+options can be used to control the resources used by the pipeline::
 
-There are also the following general options::
+    --localcores LOCAL_CORES : maximum number of cores the pipeline
+                               can request
+    --localmem LOCAL_MEM     : maximum memory the pipeline can
+                               request (in Gbs)
+
+If ``cellranger`` is configured to use additional job submission
+systems (e.g. Grid Engine) then ``JOB_MODE`` can specify one of these
+(e.g. ``sge``). In this case the following additional options can
+be used::
+
+    --mempercore MEM_PER_CORE : memory assumed per core (in Gbs)
+
+Note that all the above options  map onto the equivalent ``cellranger``
+options; there are also the following general non-``cellranger`` options::
 
    --modulefiles MODULEFILES : comma-separated list of environment
                                modules to load before executing commands


### PR DESCRIPTION
PR to add support for various `cellranger` options which were not previously accessible via the `auto_process` utilities.

The updates include:

**Job management**

* Implement explicit support for `--jobmode=local` (which is now the default) for running `cellranger` pipelines on the current host
* Add support for `--localcores` and `--localmem` options to control resource usage for `--jobmode=local`
* Only use `--mempercore`  option when jobmode is not `local` (e.g. running on a cluster)

**Fastq generation**

* Add support for `--ignore-dual-index` option for `cellranger mkfastq`

**Single library analysis**

* Add support for `--chemistry` option for `cellranger count`