### PR TITLE
Set maximum concurrent jobs when creating new SimpleScheduler instances

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -2320,7 +2320,9 @@ class AutoProcess:
             self.set_log_dir(self.get_log_subdir('merge_fastq_dirs'))
             runner = self.settings.general.default_runner
             runner.set_log_dir(self.log_dir)
-            sched = simple_scheduler.SimpleScheduler(runner=runner)
+            sched = simple_scheduler.SimpleScheduler(
+                runner=runner,
+                max_concurrent=self.settings.general.max_concurrent_jobs)
             sched.start()
             jobs = []
         # Top-level for undetermined reads

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -537,7 +537,10 @@ def run_cellranger_count(fastq_dir,
       cellranger_jobinterval (int): specify the interval
         between launching jobs (in ms) to pass to
         cellranger (default: None)
-      max_jobs (int):
+      max_jobs (int): maxiumum number of concurrent
+        count jobs to run; also used for maximum number
+        of jobs each count pipeline can run at once
+        (default: 4)
       log_dir (str): path to a directory to write logs
         (default: current working directory)
       dry_run (bool): if True then only report actions
@@ -759,7 +762,10 @@ def run_cellranger_count_for_project(project_dir,
       cellranger_jobinterval (int): specify the interval
         between launching jobs (in ms) to pass to
         cellranger (default: None)
-      max_jobs (int):
+      max_jobs (int): maxiumum number of concurrent
+        count jobs to run; also used for maximum number
+        of jobs each count pipeline can run at once
+        (default: 4)
       log_dir (str): path to a directory to write logs
         (default: current working directory)
       dry_run (bool): if True then only report actions

--- a/bin/process_10xgenomics.py
+++ b/bin/process_10xgenomics.py
@@ -355,7 +355,7 @@ if __name__ == "__main__":
                     cellranger_maxjobs=args.max_jobs,
                     cellranger_mempercore=args.mem_per_core,
                     cellranger_jobinterval=args.job_interval,
-                    max_jobs=4,
+                    max_jobs=args.max_jobs,
                     dry_run=args.dry_run,
                     log_dir='logs')
         else:
@@ -365,7 +365,7 @@ if __name__ == "__main__":
                                  cellranger_maxjobs=args.max_jobs,
                                  cellranger_mempercore=args.mem_per_core,
                                  cellranger_jobinterval=args.job_interval,
-                                 max_jobs=4,
+                                 max_jobs=args.max_jobs,
                                  dry_run=args.dry_run,
                                  log_dir='logs')
     elif args.command == "update_projects":


### PR DESCRIPTION
PR which address issue #221 by updating the relevant code to ensure that the `max_concurrent` jobs is explicitly set when creating `SimpleScheduler` instances.