### PR TITLE
Handle organism names with spaces for strandedness QC and 10xGenomics count

### DIFF
--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -16,6 +16,7 @@ from ..qc.illumina_qc import IlluminaQC
 from ..qc.illumina_qc import determine_qc_protocol
 from ..qc.runqc import RunQC
 from ..qc.fastq_strand import build_fastq_strand_conf
+from ..utils import get_organism_list
 from bcftbx.JobRunner import fetch_runner
 
 # Module specific logger
@@ -109,7 +110,7 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
         protocol = determine_qc_protocol(project)
         # Set up conf file for strandedness determination
         try:
-            organisms = project.info.organism.lower().split(',')
+            organisms = get_organism_list(project.info.organism)
         except AttributeError:
             organisms = None
         fastq_strand_indexes = build_fastq_strand_conf(

--- a/auto_process_ngs/test/test_utils.py
+++ b/auto_process_ngs/test/test_utils.py
@@ -250,6 +250,32 @@ class TestBasesMaskIsPairedEnd(unittest.TestCase):
         self.assertTrue(bases_mask_is_paired_end('y101,I6n,y101'))
         self.assertTrue(bases_mask_is_paired_end('y101,I6,I6,y101'))
 
+class TestGetOrganismList(unittest.TestCase):
+    """Tests for the get_organism_list function
+    """
+
+    def test_get_organism_list(self):
+        """get_organism_list: handle standard names
+        """
+        self.assertEqual(get_organism_list("Human"),["human"])
+        self.assertEqual(get_organism_list("mouse"),["mouse"])
+        self.assertEqual(get_organism_list("Human,Mouse"),
+                         ["human","mouse"])
+
+    def test_get_organism_list_handle_names_with_spaces(self):
+        """get_organism_list: handle names with spaces
+        """
+        self.assertEqual(get_organism_list("Xenopus tropicalis"),
+                         ["xenopus_tropicalis"])
+        self.assertEqual(get_organism_list("Homo sapiens,Mus musculus"),
+                         ["homo_sapiens","mus_musculus"])
+
+    def test_get_organism_list_handle_extra_whitespace(self):
+        """get_organism_list: handle names with extra whitespace
+        """
+        self.assertEqual(get_organism_list("Homo sapiens, Mus  musculus "),
+                         ["homo_sapiens","mus_musculus"])
+
 class TestSplitUserHostDir(unittest.TestCase):
     """Tests for the split_user_host_dir function
 

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -22,6 +22,7 @@ Classes:
 Functions:
 
 - bases_mask_is_paired_end:
+- get_organism_list:
 - split_user_host_dir:
 - get_numbered_subdir:
 - find_executables:
@@ -39,6 +40,7 @@ Functions:
 
 import sys
 import os
+import re
 import logging
 import zipfile
 import pydoc
@@ -352,6 +354,33 @@ def bases_mask_is_paired_end(bases_mask):
     else:
         # An error?
         raise Exception, "Bad bases mask '%s'?" % bases_mask
+
+def get_organism_list(organisms):
+    """
+    Return a list of normalised organism names
+
+    Normalisation consists of converting names to
+    lower case and spaces to underscores.
+
+    E.g.
+
+    "Human,Mouse" -> ['human','mouse']
+    "Xenopus tropicalis" -> ['xenopus_tropicalis']
+
+    Arguments:
+      organisms (str): string with organism names
+        separated by commas
+
+    Returns:
+      List: list of normalised organism names
+    """
+    if not organisms:
+        return []
+    # Make lowercase, split on commas and replace whitespace
+    # with single underscore, then strip leading/trailing
+    # underscores
+    return [re.sub(r'\s+','_',x).strip('_')
+            for x in str(organisms).lower().split(',')]
 
 def split_user_host_dir(location):
     # Split a location of the form [[user@]host:]dir into its

--- a/bin/process_10xgenomics.py
+++ b/bin/process_10xgenomics.py
@@ -22,6 +22,7 @@ from bcftbx.utils import mkdirs
 from bcftbx.IlluminaData import IlluminaData
 from bcftbx.IlluminaData import IlluminaDataError
 from auto_process_ngs.utils import get_numbered_subdir
+from auto_process_ngs.utils import get_organism_list
 from auto_process_ngs.analysis import AnalysisProject
 from auto_process_ngs.analysis import ProjectMetadataFile
 from auto_process_ngs.tenx_genomics_utils import run_cellranger_mkfastq
@@ -323,10 +324,10 @@ if __name__ == "__main__":
                 transcriptome = args.transcriptome
                 if transcriptome is None:
                     try:
-                        organisms = AnalysisProject(
-                            os.path.basename(project),
-                            project).\
-                            info.organism.lower().split(',')
+                        organisms = get_organism_list(
+                            AnalysisProject(
+                                os.path.basename(project),
+                                project).info.organism)
                     except AttributeError:
                         organisms = None
                     if not organisms:

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -28,6 +28,7 @@ from auto_process_ngs.qc.illumina_qc import IlluminaQC
 from auto_process_ngs.qc.illumina_qc import determine_qc_protocol
 from auto_process_ngs.qc.runqc import RunQC
 from auto_process_ngs.qc.fastq_strand import build_fastq_strand_conf
+from auto_process_ngs.utils import get_organism_list
 import auto_process_ngs
 import auto_process_ngs.settings
 import auto_process_ngs.envmod as envmod
@@ -202,7 +203,7 @@ if __name__ == "__main__":
     if organism:
         print "Organisms: %s" % organism
         fastq_strand_indexes = build_fastq_strand_conf(
-            organism.lower().split(','),
+            get_organism_list(organism),
             __settings.fastq_strand_indexes)
         if fastq_strand_indexes:
             print "Setting up conf file for strandedness determination"


### PR DESCRIPTION
PR which addresses issue #226:

* Adds new `get_organism_list` function to produce list of standardised names from the project metadata
* Uses this in `process_10xgenomics.py count`, `auto_process.py run_qc`, and `run_qc.py` to get names to check against relevant parameters in the settings