### PR TITLE
[WIP] Enable running Python functions as external jobs in pipelines

### DIFF
--- a/auto_process_ngs/applications.py
+++ b/auto_process_ngs/applications.py
@@ -237,7 +237,8 @@ class Command:
         return (status,output)
 
     def make_wrapper_script(self,shell=None,filen=None,fp=None,
-                            prologue=None,epilogue=None):
+                            prologue=None,epilogue=None,
+                            quote_spaces=False):
         """Wrap the command in a script
 
         Returns a string which can be injected into a file and
@@ -255,19 +256,33 @@ class Command:
             into the script before the command
           epilogue (str): optional, if set then will be written
             into the script after the command
+          quote_spaces (str): if True then arguments containing
+            whitespace will be wrapped in quotes
 
         Returns:
           String: the wrapper script contents.
         """
+        # Handle quoting of spaces
+        if quote_spaces:
+            args = []
+            for arg in self.command_line:
+                if (' ' in str(arg)):
+                    args.append("'%s'" % arg)
+                else:
+                    args.append(str(arg))
+        else:
+            args = [str(arg) for arg in self.command_line]
+        # Build script
         script = []
         if shell is not None:
             script.append("#!%s" % shell)
         if prologue is not None:
             script.append("%s" % prologue)
-        script.append(str(self))
+        script.append(' '.join(args))
         if epilogue is not None:
             script.append("%s" % epilogue)
         script = '\n'.join(script)
+        # Write to file
         if fp is not None:
             fp.write(script)
         if filen is not None:

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -1292,8 +1292,8 @@ class Dispatcher(object):
         # Generate command to run the function
         return Command("python",
                        "-c",
-                       "'from auto_process_ngs.pipeliner import Dispatcher ; "
-                       "Dispatcher().execute(\"%s\",\"%s\",\"%s\",\"%s\")'" %
+                       "from auto_process_ngs.pipeliner import Dispatcher ; "
+                       "Dispatcher().execute(\"%s\",\"%s\",\"%s\",\"%s\")" %
                        (pkl_func_file,
                         pkl_args_file,
                         pkl_kwds_file,

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -1077,7 +1077,8 @@ class PipelineCommand(object):
         self.cmd().make_wrapper_script(filen=script_file,
                                        shell=shell,
                                        prologue='\n'.join(prologue),
-                                       epilogue='\n'.join(epilogue))
+                                       epilogue='\n'.join(epilogue),
+                                       quote_spaces=True)
         return script_file
 
     def init(self):

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -382,7 +382,7 @@ import inspect
 import traceback
 import string
 ##import importlib
-import pickle
+import cloudpickle
 from collections import Iterator
 from cStringIO import StringIO
 from bcftbx.utils import mkdir
@@ -1167,12 +1167,16 @@ class Dispatcher(object):
     >>> cmd.run_subprocess()
 
     """
-    def __init__(self,working_dir=None):
+    def __init__(self,working_dir=None,pickler=None):
         """
         """
         if not working_dir:
             working_dir = str(uuid.uuid4())
         self._working_dir = os.path.abspath(working_dir)
+        if pickler is None:
+            self._pickler = cloudpickle
+        else:
+            self._picker = pickler
         # TO-DO: remove working dir using atexit
 
     @property
@@ -1249,14 +1253,14 @@ class Dispatcher(object):
         pickle_file = os.path.join(self.working_dir,
                                    str(uuid.uuid4()))
         with open(pickle_file,'wb') as fp:
-            fp.write(pickle.dumps(obj))
+            fp.write(self._pickler.dumps(obj))
         return pickle_file
 
     def _unpickle_object(self,pickle_file):
         """
         """
         with open(pickle_file,'rb') as fp:
-            return pickle.loads(fp.read())
+            return self._pickler.loads(fp.read())
 
 ######################################################################
 # Generic pipeline functions

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -249,7 +249,8 @@ as an external process, for example reimplementing the earlier
         def init(self,fastqs):
             self.counts = dict()
         def setup(self):
-            self.add_call(self.count_reads,
+            self.add_call("Count reads in Fastq",
+                          self.count_reads,
                           self.args.fastqs)
         def count_reads(self,fastqs):
             # Count reads in each Fastq

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -1366,7 +1366,7 @@ class Dispatcher(object):
             written
         """
         # Unpickle the components
-        print "Unpickling..."
+        print "Dispatcher: running 'execute'..."
         try:
             func = self._unpickle_object(pkl_func_file)
         except AttributeError as ex:
@@ -1377,13 +1377,13 @@ class Dispatcher(object):
             return 1
         args = self._unpickle_object(pkl_args_file)
         kwds = self._unpickle_object(pkl_kwds_file)
-        print "Executing:"
+        print "Dispatcher: executing:"
         print "-- function: %s" % func
         print "-- args    : %s" % (args,)
         print "-- kwds    : %s" % (kwds,)
         # Execute the function
         result = func(*args,**kwds)
-        print "Result: %s" % result
+        print "Dispatcher: result: %s" % (result,)
         # Pickle the result
         if pkl_result_file:
             self._pickle_object(result,pkl_result_file)

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -430,7 +430,6 @@ import uuid
 import inspect
 import traceback
 import string
-##import importlib
 import cloudpickle
 import atexit
 from collections import Iterator

--- a/auto_process_ngs/test/test_applications.py
+++ b/auto_process_ngs/test/test_applications.py
@@ -83,6 +83,15 @@ class TestCommand(unittest.TestCase):
         cmd.make_wrapper_script(fp=fp)
         self.assertEqual(fp.getvalue(),"echo hello")
 
+    def test_make_wrapper_script_handle_args_with_spaces(self):
+        """Check 'make_wrapper_script' method handles arguments with spaces
+        """
+        cmd = Command('echo','hello world')
+        self.assertEqual(cmd.make_wrapper_script(),
+                         "echo hello world")
+        self.assertEqual(cmd.make_wrapper_script(quote_spaces=True),
+                         "echo 'hello world'")
+
 class TestBcl2Fastq(unittest.TestCase):
 
     def test_configure_bcl_to_fastq(self):

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -622,7 +622,7 @@ class TestDispatcher(unittest.TestCase):
                             cmd.args)
         while runner.isRunning(job_id):
             time.sleep(0.1)
-        exit_code = cmd.run_subprocess()
+        exit_code = runner.exit_status(job_id)
         self.assertEqual(exit_code,0)
         result = d.get_result()
         self.assertEqual(result,"Hello World!")

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -522,7 +522,7 @@ class TestPipelineCommand(unittest.TestCase):
                          "echo \"#### HOSTNAME $HOSTNAME\"\n"
                          "echo \"#### USER $USER\"\n"
                          "echo \"#### START $(date)\"\n"
-                         "echo hello there\n"
+                         "echo 'hello there'\n"
                          "exit_code=$?\n"
                          "echo \"#### END $(date)\"\n"
                          "echo \"#### EXIT_CODE $exit_code\"\n"

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ for pattern in ('bin/*.py','bin/*.sh',):
 install_requires = ['pillow',
                     'matplotlib',
                     'pandas',
+                    'cloudpickle',
                     'genomics-bcftbx',
                     'nebulizer']
 # If we're on ReadTheDocs then we can reduce this


### PR DESCRIPTION
WIP PR which updates the `pipeliner` module to enable Python functions to be executed in external processes in pipeline tasks.

This is implemented by pickling the function and arguments and then passing these to a new Python process to be executed, before returning the output back in a similar way.

The immediate application for this new functionality is to enable computationally intensive setup of tasks in the ICELL8 pipeline to be farmed out to compute nodes when running in a cluster environment (for example, read assembly preparation - see issue #224).