### PR TITLE
ICELL8 pipeline: use 'PipelineFunctionTasks' to remove work from main process

### DIFF
--- a/auto_process_ngs/icell8/pipeline.py
+++ b/auto_process_ngs/icell8/pipeline.py
@@ -1829,7 +1829,7 @@ class UpdateProjectData(PipelineTask):
         print "Primary fastq dir: %s" % project.info.primary_fastq_dir
         print "Number of cells  : %s" % project.info.number_of_cells
 
-class CleanupDirectory(PipelineTask):
+class CleanupDirectory(PipelineFunctionTask):
     """
     Remove a directory and all its contents
     """
@@ -1847,12 +1847,12 @@ class CleanupDirectory(PipelineTask):
         if not os.path.isdir(dirn):
             self.report("No directory '%s'" % self.args.dirn)
         else:
-            self.add_cmd(
-                PipelineCommandWrapper(
-                    "Clean up directory '%s'" % dirn,
-                    "rm","-f","%s" % os.path.join(dirn,'*'),
-                    "&&",
-                    "rmdir","%s" % dirn))
+            self.add_call("Clean up directory '%s'" % dirn,
+                          self.cleanup_directory,
+                          dirn)
+    def cleanup_directory(self,dirn):
+        # Remove a directory and all its contents
+        shutil.rmtree(dirn)
 
 ######################################################################
 # Functions

--- a/auto_process_ngs/icell8/pipeline.py
+++ b/auto_process_ngs/icell8/pipeline.py
@@ -1714,7 +1714,7 @@ class CheckICell8Barcodes(PipelineTask):
             bad_barcodes=self.bad_barcodes
         )
 
-class ConvertStatsToXLSX(PipelineTask):
+class ConvertStatsToXLSX(PipelineFunctionTask):
     """
     Convert the stats file to XLSX format
     """
@@ -1728,10 +1728,17 @@ class ConvertStatsToXLSX(PipelineTask):
         """
         pass
     def setup(self):
-        convert_to_xlsx(self.args.stats_file,
-                        self.args.xlsx_file,
-                        title="ICell8 stats",
-                        freeze_header=True)
+        self.add_call("Convert stats file to XLSX",
+                      self.convert_stats_to_xlsx,
+                      self.args.stats_file,
+                      self.args.xlsx_file,
+                      title="ICELL8 stats",
+                      freeze_header=True)
+    def convert_stats_to_xlsx(self,stats_file,xlsx_file,
+                              title=None,freeze_header=False):
+        # Convert the TSV stats file to XLSX format
+        convert_to_xlsx(stats_file,xlsx_file,title=title,
+                        freeze_header=freeze_header)
     def output(self):
         """Returns object pointing to output files
 


### PR DESCRIPTION
PR which makes use of the `PipelineFunctionTask` class introduced in PR #231, to move functionality out of the `setup` methods of a number of existing tasks into new tasks which can be executed outside of the main process. This should help to address issue #224 and reduce the load on the login node when the pipeline is run on a compute cluster.

These include:

* New `PairFastqs` task: given lists of Fastqs, assembles them into R1/R2 pairs. Removed the pairing functionality from the `setup` methods of a number of tasks and updated them to take a list of pairs as direct input.
* `MergeBarcodeFastqs` task: move the grouping of Fastqs by barcode from the `setup` method into a new `GroupFastqsByBarcode` task, and use `PairFastqs` to prepare the lists of unassigned and failed barcode/UMI Fastqs.
* `MergeSampleFastqs` task: move the grouping and pairing of Fastqs by barcode from the `setup` method into a new `GroupFastqsBySample` task.

Other updates include refactoring the following tasks into Python functions, to simplify their implementation:

* `CollectFiles`
* `CleanupDirectory`
* `ConvertStatsToXLSX`
* `CheckICell8Barcodes`