### PR TITLE
Updates to distinguish task name versus task ID in 'pipeliner' module

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -1149,7 +1149,7 @@ class PipelineFunctionTask(PipelineTask):
              passed to the function when invoked
         """
         d = Dispatcher()
-        cmd = d.dispatch_function(f,*args,**kwds)
+        cmd = d.dispatch_function_cmd(f,*args,**kwds)
         self.add_cmd(PipelineCommandWrapper(name,
                                             *cmd.command_line))
         self._dispatchers.append(d)
@@ -1331,7 +1331,7 @@ class Dispatcher(object):
     Example usage:
 
     >>> d = Dispatcher()
-    >>> cmd = d.dispatch_function(bcftbx.utils.list_dirs,os.get_cwd())
+    >>> cmd = d.dispatch_function_cmd(bcftbx.utils.list_dirs,os.get_cwd())
     >>> cmd.run_subprocess()
     >>> result = d.get_result()
 
@@ -1427,7 +1427,7 @@ class Dispatcher(object):
             self._pickle_object(result,pkl_result_file)
         return 0
 
-    def dispatch_function(self,func,*args,**kwds):
+    def dispatch_function_cmd(self,func,*args,**kwds):
         """
         Generate a command to execute the function externally
 
@@ -1446,7 +1446,6 @@ class Dispatcher(object):
         print "-- args    : %s" % (args,)
         print "-- kwds    : %s" % (kwds,)
         # Pickle the components
-        print "Pickling..."
         pkl_func_file = self._pickle_object(func)
         pkl_args_file = self._pickle_object(args)
         pkl_kwds_file = self._pickle_object(kwds)

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -656,7 +656,7 @@ class TestDispatcher(unittest.TestCase):
         d = Dispatcher(working_dir=dispatcher_wd)
         def hello(name):
             return "Hello %s!" % name
-        cmd = d.dispatch_function(hello,"World")
+        cmd = d.dispatch_function_cmd(hello,"World")
         exit_code = cmd.run_subprocess(log=os.path.join(self.working_dir,
                                                         "dispatcher.log"))
         self.assertEqual(exit_code,0)
@@ -672,7 +672,7 @@ class TestDispatcher(unittest.TestCase):
         d = Dispatcher(working_dir=dispatcher_wd)
         def hello(name):
             return "Hello %s!" % name
-        cmd = d.dispatch_function(hello,"World")
+        cmd = d.dispatch_function_cmd(hello,"World")
         runner = SimpleJobRunner(log_dir=self.working_dir)
         job_id = runner.run("Hello world",
                             self.working_dir,


### PR DESCRIPTION
PR which makes the difference between task names (e.g. `Generate processing report`) and task IDs (e.g. 'generate_processing_report.9059d42c-8b44-47ee-8c5c-5d8525159124`) within `PipelineTask` classes in the `pipeliner` module:

* `PipelineTask.name` method now returns the name (previously it returned the ID)
* New `PipelineTask.id` method returns the ID

Reporting now uses the task name and only reports the ID on task startup and failure.