### PR TITLE
Fix bug serialising MetadataDict using cloudpickle

### DIFF
--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -134,12 +134,6 @@ class MetadataDict(bcf_utils.AttributeDictionary):
                 extra_keys.sort()
                 self.__key_order.extend(extra_keys)
 
-    def __setitem__(self,key,value):
-        if key in self.__attributes:
-            bcf_utils.AttributeDictionary.__setitem__(self,key,value)
-        else:
-            raise AttributeError,"Key '%s' not defined" % key
-
     def __iter__(self):
         return iter(self.__key_order)
 

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -5,6 +5,8 @@
 import unittest
 import os
 import tempfile
+import pickle
+import cloudpickle
 from auto_process_ngs.metadata import *
 
 class TestMetadataDict(unittest.TestCase):
@@ -141,6 +143,48 @@ class TestMetadataDict(unittest.TestCase):
         self.assertEqual(metadata.salutation,'hello')
         self.assertEqual(metadata.valediction,'goodbye')
         self.assertEqual(metadata.chit_chat,'stuff')
+
+    def test_cloudpickle_metadata(self):
+        """Check Metadata object can be serialised with 'cloudpickle'
+        """
+        # Set up a metadata dictionary
+        metadata = MetadataDict(attributes={'chit_chat':'chit_chat',
+                                            'salutation':'salutation',
+                                            'valediction': 'valediction'})
+        metadata['salutation'] = "hello"
+        metadata['valediction'] = "goodbye"
+        metadata['chit_chat'] = "stuff"
+        self.assertEqual(metadata.salutation,'hello')
+        self.assertEqual(metadata.valediction,'goodbye')
+        self.assertEqual(metadata.chit_chat,'stuff')
+        # Pickle it
+        pickled = cloudpickle.dumps(metadata)
+        # Unpickle it
+        unpickled = cloudpickle.loads(pickled)
+        self.assertEqual(unpickled.salutation,'hello')
+        self.assertEqual(unpickled.valediction,'goodbye')
+        self.assertEqual(unpickled.chit_chat,'stuff')
+
+    def test_pickle_metadata(self):
+        """Check Metadata object can be serialised with 'pickle'
+        """
+        # Set up a metadata dictionary
+        metadata = MetadataDict(attributes={'chit_chat':'chit_chat',
+                                            'salutation':'salutation',
+                                            'valediction': 'valediction'})
+        metadata['salutation'] = "hello"
+        metadata['valediction'] = "goodbye"
+        metadata['chit_chat'] = "stuff"
+        self.assertEqual(metadata.salutation,'hello')
+        self.assertEqual(metadata.valediction,'goodbye')
+        self.assertEqual(metadata.chit_chat,'stuff')
+        # Pickle it
+        pickled = pickle.dumps(metadata)
+        # Unpickle it
+        unpickled = pickle.loads(pickled)
+        self.assertEqual(unpickled.salutation,'hello')
+        self.assertEqual(unpickled.valediction,'goodbye')
+        self.assertEqual(unpickled.chit_chat,'stuff')
 
 class TestAnalysisDirParameters(unittest.TestCase):
     """Tests for the AnalysisDirParameters class

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -63,17 +63,6 @@ class TestMetadataDict(unittest.TestCase):
                                             'valediction': 'Valediction'})
         self.assertRaises(AttributeError,lambda: metadata.conversation)
 
-    def test_set_non_existent_attribute(self):
-        """Check that setting non-existent attribute raises exception
-        """
-        metadata = MetadataDict(attributes={'salutation':'Salutation',
-                                            'valediction': 'Valediction'})
-        try:
-            metadata['conversation'] = 'hrm'
-            self.fail('AttributeError not raised')
-        except AttributeError,ex:
-            pass
-
     def test_specify_key_order(self):
         """Check that specified key ordering is respected
         """


### PR DESCRIPTION
PR which fixes a bug when trying to serialise instances of the `MetadataDict` class using the `cloudpickle` module: attempting to unpickle the pickled instances causes an error of the form:

    Traceback (most recent call last):
      File "XXXXXXXXXXXXXXX/auto_process_ngs/auto_process_ngs/test/test_analysis.py", line 754, in test_cloudpickle_analysis_project
        unpickled = cloudpickle.loads(pickled)
      File "XXXXXXXXXXXXXX/python/2.7.10/lib/python2.7/pickle.py", line 1382, in loads
        return Unpickler(file).load()
      File "XXXXXXXXXXXXXX/python/2.7.10/lib/python2.7/pickle.py", line 858, in load
        dispatch[key](self)
      File "XXXXXXXXXXXXXX/python2.7/pickle.py", line 1206, in load_setitems
        dict[stack[i]] = stack[i + 1]
      File "XXXXXXXXXXXXXX/auto_process_ngs/auto_process_ngs/metadata.py", line 138, in __setitem__
        if key in self.__attributes:
      File "XXXXXXXXXXXXXX/venv.ap/lib/python2.7/site-packages/bcftbx/utils.py", line 145, in __getattr__
        "attribute '%s'" % attr)
     AttributeError: 'AttributeDictionary' has no attribute '_MetadataDict__attributes'

The fix drops the implementation of the `__setitem__` built-in in `MetadataDict` which appears to cause this error; it also removes functionality which prevented attributes being set which were not in the metadata definition (so that check is no longer enforced) along with the unit test for that functionality.