### PR TITLE
Improve sequencing platform determination and configuration

### DIFF
--- a/auto_process_ngs/config.py
+++ b/auto_process_ngs/config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     config: classes & funcs for configuring auto_process_ngs
-#     Copyright (C) University of Manchester 2014 Peter Briggs
+#     Copyright (C) University of Manchester 2014-2018 Peter Briggs
 #
 ########################################################################
 #
@@ -16,17 +16,19 @@ module.
 
 """
 
-from ConfigParser import ConfigParser,NoOptionError,NoSectionError
+from ConfigParser import SafeConfigParser
+from ConfigParser import NoOptionError
+from ConfigParser import NoSectionError
 from bcftbx.JobRunner import fetch_runner
 
 #######################################################################
 # Classes
 #######################################################################
 
-class Config(ConfigParser):
-    """Wraps ConfigParser to set defaults for missing options
+class Config(SafeConfigParser):
+    """Wraps SafeConfigParser to set defaults for missing options
 
-    Implements a wrapper for ConfigParser:
+    Implements a wrapper for SafeConfigParser:
 
     - 'get' and 'getint' methods take a 'default' argument, which
       is returned if the specified option is missing from the file
@@ -45,10 +47,11 @@ class Config(ConfigParser):
 
     """
     def __init__(self):
-        ConfigParser.__init__(self)
+        SafeConfigParser.__init__(self)
+        self.optionxform = str
     def get(self,section,option,default=None):
         try:
-            value = ConfigParser.get(self,section,option)
+            value = SafeConfigParser.get(self,section,option)
             if value == 'None' or value == '':
                 return default
             else:
@@ -59,12 +62,12 @@ class Config(ConfigParser):
             return default
     def getint(self,section,option,default=None):
         try:
-            return ConfigParser.getint(self,section,option)
+            return SafeConfigParser.getint(self,section,option)
         except TypeError:
             return default
     def getboolean(self,section,option,default=None):
         try:
-            return ConfigParser.getboolean(self,section,option)
+            return SafeConfigParser.getboolean(self,section,option)
         except (TypeError,AttributeError):
             return default
     def getrunner(self,section,option,default='SimpleJobRunner'):

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -133,6 +133,13 @@ class Settings(object):
                 self.fastq_strand_indexes[genome] = conf_file
         except NoSectionError:
             logging.warning("No strand stats conf files defined")
+        # Sequencers
+        self.add_section('sequencers')
+        try:
+            for instrument,platform in config.items('sequencers'):
+                self['sequencers'][instrument] = platform
+        except NoSectionError:
+            logging.warning("No sequencers defined")
         # Sequencing platform-specific defaults
         self.add_section('platform')
         for section in filter(lambda x: x.startswith('platform:'),

--- a/auto_process_ngs/test/test_config.py
+++ b/auto_process_ngs/test/test_config.py
@@ -23,6 +23,10 @@ other_value =
 
 [runners]
 my_runner = SimpleJobRunner
+
+[names]
+Name1 = Peter
+name1 = John
 """
 
 class TestConfig(unittest.TestCase):
@@ -42,7 +46,8 @@ class TestConfig(unittest.TestCase):
         """Check Config.get works with defaults
         """
         self.assertEqual(self.config.get('basic','salutation'),None)
-        self.assertEqual(self.config.get('basic','salutation','bonjour'),'bonjour')
+        self.assertEqual(self.config.get('basic','salutation','bonjour'),
+                         'bonjour')
 
     def test_getint(self):
         """Check Config.getint fetches integer value
@@ -75,9 +80,12 @@ class TestConfig(unittest.TestCase):
     def test_getrunner_with_default(self):
         """Check Config.getrunner works with defaults
         """
-        self.assertTrue(isinstance(self.config.getrunner('runners','your_runner'),
+        self.assertTrue(isinstance(self.config.getrunner('runners',
+                                                         'your_runner'),
                                    SimpleJobRunner))
-        self.assertTrue(isinstance(self.config.getrunner('runners','your_runner','GEJobRunner'),
+        self.assertTrue(isinstance(self.config.getrunner('runners',
+                                                         'your_runner',
+                                                         'GEJobRunner'),
                                    GEJobRunner))
 
     def test_get_with_None_value(self):
@@ -87,7 +95,13 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(self.config.get('none_types','some_value','something'),'something')
 
     def test_get_with_empty_value(self):
-        """Check Config.get works for parameters with no value set'
+        """Check Config.get works for parameters with no value set
         """
         self.assertEqual(self.config.get('none_types','other_value'),None)
         self.assertEqual(self.config.get('none_types','other_value','something'),'something')
+
+    def test_option_case_is_preserved(self):
+        """Check Config.get preserves option case
+        """
+        self.assertEqual(self.config.get('names','Name1'),'Peter')
+        self.assertEqual(self.config.get('names','name1'),'John')

--- a/auto_process_ngs/test/test_settings.py
+++ b/auto_process_ngs/test/test_settings.py
@@ -87,3 +87,19 @@ nprocessors = 8
         max_concurrent_jobs = s.general.max_concurrent_jobs
         self.assertEqual(s['general'].max_concurrent_jobs,
                          max_concurrent_jobs)
+
+    def test_preserve_option_case(self):
+        """Settings: case of option names is preserved
+        """
+        # Settings file
+        settings_file = os.path.join(self.dirn,"settings.ini")
+        with open(settings_file,'w') as s:
+            s.write("""[sequencers]
+SN7001251 = hiseq
+""")
+        # Load settings
+        s = Settings(settings_file)
+        # Check case of option
+        self.assertTrue('SN7001251' in s.sequencers)
+        self.assertEqual(s.sequencers['SN7001251'],'hiseq')
+        self.assertEqual(s.sequencers.SN7001251,'hiseq')

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -21,6 +21,12 @@ default_version = >=1.8.4
 no_lane_splitting = False
 create_empty_fastqs = True
 
+# Sequencers and platforms
+# Assign platforms to sequencer instrument names
+# These values will be specific to the local site
+[sequencers]
+#SN7001250 = hiseq
+
 # QC settings
 [qc]
 nprocessors = 1


### PR DESCRIPTION
PR which improves the sequencing platform determination used on analysis initialisation:

* Enables instrument names to be specified in a new `[sequencers]` section of the configuration file, which themselves specify which platform each instrument belongs to
* Use these settings to determine the platform for an instrument based on the instrument name (extracted from the run name, or supplied by the user).

These over-ride the existing method of using hardcoded values from the `bcftbx.platforms` module.