### PR TITLE
Fix 'archive' command to ignore .bak directories with 'fastqs' subdirectory

### DIFF
--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -210,16 +210,21 @@ def archive(ap,archive_dir=None,platform=None,year=None,
         archiving_jobs = []
         # If making fastqs read-only then transfer them separately
         if read_only_fastqs and final:
+            # Make sure excluded directories are excluded
+            extra_options =  [ex for ex in excludes]
+            # Set up to include only the fastq directories
+            extra_options.extend([
+                '--include=*/',
+                '--include=fastqs/**',
+                '--exclude=*'])
+            # Execute the rsync
             rsync_fastqs = applications.general.rsync(
                 "%s/" % ap.analysis_dir,
                 os.path.join(archive_dir,staging),
                 prune_empty_dirs=True,
                 dry_run=dry_run,
                 chmod='ugo-w',
-                extra_options=(
-                    '--include=*/',
-                    '--include=fastqs/**',
-                    '--exclude=*',))
+                extra_options=extra_options)
             print "Running %s" % rsync_fastqs
             rsync_fastqs_job = sched.submit(rsync_fastqs,
                                             name="rsync.archive_fastqs")

--- a/auto_process_ngs/test/commands/test_archive_cmd.py
+++ b/auto_process_ngs/test/commands/test_archive_cmd.py
@@ -12,6 +12,9 @@ from auto_process_ngs.auto_processor import AutoProcess
 from auto_process_ngs.mock import MockAnalysisDirFactory
 from auto_process_ngs.commands.archive_cmd import archive
 
+# Set to False to keep test output dirs
+REMOVE_TEST_OUTPUTS = True
+
 # Unit tests
 
 class TestArchiveCommand(unittest.TestCase):
@@ -36,7 +39,8 @@ class TestArchiveCommand(unittest.TestCase):
             os.chmod(os.path.dirname(name),0755)
             os.chmod(name,0655)
             os.remove(name)
-        shutil.rmtree(self.dirn,onerror=del_rw)
+        if REMOVE_TEST_OUTPUTS:
+            shutil.rmtree(self.dirn,onerror=del_rw)
 
     def test_archive_to_staging(self):
         """archive: test copying to staging archive dir
@@ -548,3 +552,60 @@ class TestArchiveCommand(unittest.TestCase):
                           read_only_fastqs=False,
                           final=True)
         self.assertFalse(os.path.exists(final_archive_dir))
+
+    def test_archive_to_staging_ignores_bak_projects(self):
+        """archive: check .bak directories are ignored
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901" },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Make a mock archive directory
+        archive_dir = os.path.join(self.dirn,"archive")
+        final_dir = os.path.join(archive_dir,
+                                 "2017",
+                                 "miseq")
+        os.makedirs(final_dir)
+        self.assertTrue(os.path.isdir(final_dir))
+        self.assertEqual(len(os.listdir(final_dir)),0)
+        # Make autoprocess instance and set required metadata
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        ap.set_metadata("source","testing")
+        ap.set_metadata("run_number","87")
+        # Add a .bak project directory
+        shutil.copytree(os.path.join(mockdir.dirn,"AB"),
+                        os.path.join(mockdir.dirn,"AB.bak"))
+        # Do archiving op
+        status = archive(ap,
+                         archive_dir=archive_dir,
+                         year='2017',platform='miseq',
+                         read_only_fastqs=False,
+                         final=False)
+        self.assertEqual(status,0)
+        # Check that staging dir exists
+        staging_dir = os.path.join(
+            final_dir,
+            "__170901_M00879_0087_000000000-AGEW9_analysis.pending")
+        self.assertTrue(os.path.exists(staging_dir))
+        self.assertEqual(len(os.listdir(final_dir)),1)
+        # Check contents
+        dirs = ("AB","CDE","logs","undetermined")
+        for d in dirs:
+            d = os.path.join(staging_dir,d)
+            self.assertTrue(os.path.exists(d))
+        files = ("auto_process.info",
+                 "custom_SampleSheet.csv",
+                 "metadata.info",
+                 "projects.info",
+                 "SampleSheet.orig.csv")
+        for f in files:
+            f = os.path.join(staging_dir,f)
+            self.assertTrue(os.path.exists(f))
+        # Check .bak directory wasn't copied
+        dirs = ("AB.bak",)
+        for d in dirs:
+            d = os.path.join(staging_dir,d)
+            self.assertFalse(os.path.exists(d))

--- a/auto_process_ngs/test/commands/test_archive_cmd.py
+++ b/auto_process_ngs/test/commands/test_archive_cmd.py
@@ -36,9 +36,14 @@ class TestArchiveCommand(unittest.TestCase):
         def del_rw(action,name,excinfo):
             # Explicitly remove read only files/
             # dirs
-            os.chmod(os.path.dirname(name),0755)
-            os.chmod(name,0655)
-            os.remove(name)
+            if os.path.isfile(name):
+                os.chmod(os.path.dirname(name),0755)
+                os.chmod(name,0655)
+                os.remove(name)
+            elif os.path.isdir(name):
+                os.chmod(os.path.dirname(name),0755)
+                os.chmod(name,0755)
+                os.rmdir(name)
         if REMOVE_TEST_OUTPUTS:
             shutil.rmtree(self.dirn,onerror=del_rw)
 
@@ -554,7 +559,7 @@ class TestArchiveCommand(unittest.TestCase):
         self.assertFalse(os.path.exists(final_archive_dir))
 
     def test_archive_to_staging_ignores_bak_projects(self):
-        """archive: check .bak directories are ignored
+        """archive: check staging ignores .bak directories
         """
         # Make a mock auto-process directory
         mockdir = MockAnalysisDirFactory.bcl2fastq2(
@@ -608,4 +613,73 @@ class TestArchiveCommand(unittest.TestCase):
         dirs = ("AB.bak",)
         for d in dirs:
             d = os.path.join(staging_dir,d)
+            self.assertFalse(os.path.exists(d))
+
+    def test_archive_to_final_ignores_bak_projects(self):
+        """archive: check final archiving ignores .bak directories
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901" },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Make a mock archive directory
+        archive_dir = os.path.join(self.dirn,"archive")
+        final_dir = os.path.join(archive_dir,
+                                 "2017",
+                                 "miseq")
+        os.makedirs(final_dir)
+        self.assertTrue(os.path.isdir(final_dir))
+        self.assertEqual(len(os.listdir(final_dir)),0)
+        # Make autoprocess instance and set required metadata
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        ap.set_metadata("source","testing")
+        ap.set_metadata("run_number","87")
+        # Add a .bak project directory
+        shutil.copytree(os.path.join(mockdir.dirn,"AB"),
+                        os.path.join(mockdir.dirn,"AB.bak"))
+        # Do archiving op
+        status = archive(ap,
+                         archive_dir=archive_dir,
+                         year='2017',platform='miseq',
+                         read_only_fastqs=True,
+                         final=True)
+        self.assertEqual(status,0)
+        # Check that final dir exists
+        final_archive_dir = os.path.join(
+            final_dir,
+            "170901_M00879_0087_000000000-AGEW9_analysis")
+        self.assertTrue(os.path.exists(final_archive_dir))
+        self.assertEqual(len(os.listdir(final_dir)),1)
+        # Check contents
+        dirs = ("AB","CDE","logs","undetermined")
+        for d in dirs:
+            d = os.path.join(final_archive_dir,d)
+            self.assertTrue(os.path.exists(d))
+        files = ("auto_process.info",
+                 "custom_SampleSheet.csv",
+                 "metadata.info",
+                 "projects.info",
+                 "SampleSheet.orig.csv")
+        for f in files:
+            f = os.path.join(final_archive_dir,f)
+            self.assertTrue(os.path.exists(f))
+        # Check that Fastqs are not writable
+        for project in ("AB","CDE","undetermined"):
+            fq_dir = os.path.join(final_archive_dir,
+                                  project,
+                                  "fastqs")
+            self.assertTrue(os.path.exists(fq_dir))
+            fqs = os.listdir(fq_dir)
+            self.assertTrue(len(fqs) > 0)
+            for fq in fqs:
+                fq = os.path.join(fq_dir,fq)
+                self.assertTrue(os.access(fq,os.R_OK))
+                self.assertFalse(os.access(fq,os.W_OK))
+        # Check .bak directory wasn't copied
+        dirs = ("AB.bak",)
+        for d in dirs:
+            d = os.path.join(final_archive_dir,d)
             self.assertFalse(os.path.exists(d))


### PR DESCRIPTION
PR which fixes issue #195, whereby the `archive` command would effectively archive the `fastqs` directory (and any parent directories) regardless of whether these were project directories, when copying Fastqs to the final location in 'read-only' mode.