### PR TITLE
process_icell8.py: explicitly set QC protocol to 'singlecell'

### DIFF
--- a/bin/process_icell8.py
+++ b/bin/process_icell8.py
@@ -433,6 +433,7 @@ if __name__ == "__main__":
         print "No organisms specified"
     # Set up the QC
     illumina_qc = IlluminaQC(
+        protocol="singlecell",
         nthreads=nprocessors['qc'],
         fastq_screen_subset=default_fastq_screen_subset,
         fastq_strand_conf=fastq_strand_conf)


### PR DESCRIPTION
PR which fixes a bug in the `process_icell8.py` script, where the QC protocol was implicitly set to the default `standardPE`. The protocol should be explicitly set to `singlecell`.