### PR TITLE
Fix QC reporting to handle strandedness edge cases

### DIFF
--- a/auto_process_ngs/qc/fastq_strand.py
+++ b/auto_process_ngs/qc/fastq_strand.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 #
-# fastq screens library
+# fastq strand library
 import os
+import logging
 from bcftbx.TabFile import TabFile
 from bcftbx.utils import AttributeDictionary
+
+# Module specific logger
+logger = logging.getLogger(__name__)
 
 """
 Example fastq_strand file for 0.0.1:
@@ -57,13 +61,21 @@ class Fastqstrand(object):
             data['forward'] = line['1st forward']
             data['reverse'] = line['2nd reverse']
             # Additional processing
-            ratio = float(data.forward)/float(data.reverse)
-            if ratio < 0.2:
-                strandedness = "reverse"
-            elif ratio > 5:
-                strandedness = "forward"
+            if data.reverse > 0.0:
+                ratio = float(data.forward)/float(data.reverse)
+            elif data.forward > 0.0:
+                ratio = float("+inf")
             else:
-                strandedness = "unstranded?"
+                ratio = None
+            if ratio is not None:
+                if ratio < 0.2:
+                    strandedness = "reverse"
+                elif ratio > 5 or ratio == float("+inf"):
+                    strandedness = "forward"
+                else:
+                    strandedness = "unstranded?"
+            else:
+                strandedness = "undetermined"
             data['ratio'] = ratio
             data['strandedness'] = strandedness
 

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -791,11 +791,15 @@ class QCReportFastqPair(object):
         strandedness = Fastqstrand(txt)
         output = []
         for genome in strandedness.genomes:
-            output.append("%s: F%.2f%% | R%.2f%% (%.2f)" %
+            try:
+                ratio = "%.2f" % strandedness.stats[genome].ratio
+            except TypeError:
+                ratio = "NaN"
+            output.append("%s: F%.2f%% | R%.2f%% (%s)" %
                           (genome,
                            strandedness.stats[genome].forward,
                            strandedness.stats[genome].reverse,
-                           strandedness.stats[genome].ratio))
+                           ratio))
         return "\n".join(output)
 
     def ustrandplot(self):
@@ -842,16 +846,21 @@ class QCReportFastqPair(object):
                                      strand="Strandedness *")
             strandedness_tbl.add_css_classes("summary")
             for genome in strandedness.genomes:
+                try:
+                    ratio = "%.2f" % strandedness.stats[genome].ratio
+                except TypeError:
+                    ratio = "NaN"
                 strandedness_tbl.add_row(
                     genome=genome,
                     forward=strandedness.stats[genome].forward,
                     reverse=strandedness.stats[genome].reverse,
-                    ratio=("%.2f" % strandedness.stats[genome].ratio),
+                    ratio=ratio,
                     strand=strandedness.stats[genome].strandedness)
             strandedness_report.add(strandedness_tbl)
             strandedness_report.add("* Strandedness is 'reverse' if "
                                     "ratio &lt;0.2, 'forward' if ratio "
-                                    "is &gt;5, 'unstranded' otherwise")
+                                    "is &gt;5, 'unstranded' otherwise "
+                                    "(or undetermined if 'NaN')")
         return strandedness_report
 
     def report(self,sample_report,attrs=None,relpath=None):


### PR DESCRIPTION
PR which updates the strandedness reporting in the QC to handle edge cases, for example:

* No reads are mapped (so both forward and reverse read counts are zero)
* Only forward reads are mapped (so reverse read counts are zero)

As the strandedness ratio is (forward_counts/reverse_counts), zero reverse read counts causes division by zero errors, so this PR handles these cases.