### PR TITLE
Updates to protocol handling in 'make_fastqs' command

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -45,6 +45,12 @@ from .exceptions import MissingParameterFileException
 from auto_process_ngs import get_version
 
 #######################################################################
+# Data
+#######################################################################
+
+MAKE_FASTQS_PROTOCOLS = ('standard','icell8','10x_chromium_sc')
+
+#######################################################################
 # Decorators
 #######################################################################
 
@@ -1389,8 +1395,10 @@ class AutoProcess:
         """
         # Report protocol
         print "Protocol              : %s" % protocol
-        if protocol not in ('standard','icell8','10x_chromium_sc'):
-            raise Exception("Unknown protocol: '%s'" % protocol)
+        if protocol not in MAKE_FASTQS_PROTOCOLS:
+            raise Exception("Unknown protocol: '%s' (must be one of "
+                            "%s)" % (protocol,
+                                     ','.join([MAKE_FASTQS_PROTOCOLS])))
         # Unaligned dir
         if unaligned_dir is not None:
             self.params['unaligned_dir'] = unaligned_dir

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -1452,12 +1452,20 @@ class AutoProcess:
         # Adjust verification settings for 10xGenomics Chromium SC
         # data if necessary
         verify_include_sample_dir = False
-        if protocol == '10x_chromium_sc':
-            if tenx_genomics_utils.has_chromium_sc_indices(sample_sheet):
+        if tenx_genomics_utils.has_chromium_sc_indices(sample_sheet):
+            if protocol == '10x_chromium_sc':
                 # Force inclusion of sample-name subdirectories
                 # when verifying Chromium SC data
                 print "Sample sheet includes Chromium SC indices"
                 verify_include_sample_dir = True
+            else:
+                # Chromium SC indices detected but not using
+                # 10x_chromium_sc protocol
+                raise Exception("Detected 10xGenomics Chromium SC indices "
+                                "in generated sample sheet but protocol "
+                                "'%s' has been specified; must use "
+                                "'10x_chromium_sc' for these indices" %
+                                protocol)
         # Check for pre-existing Fastq outputs
         if self.verify_fastq_generation(
                 unaligned_dir=self.params.unaligned_dir,

--- a/auto_process_ngs/test/test_auto_processor_make_fastqs.py
+++ b/auto_process_ngs/test/test_auto_processor_make_fastqs.py
@@ -159,6 +159,48 @@ AB1,AB1,,,,,AB,
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
 
+    def test_make_fastqs_standard_protocol_chromium_sc_indices(self):
+        """make_fastqs: standard protocol with Chromium SC indices raises exception
+        """
+        # Sample sheet with 10xGenomics Chromium SC indices
+        samplesheet_chromium_sc_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-GA-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
+smpl3,smpl3,,,A006,SI-GA-C1,10xGenomics,
+smpl4,smpl4,,,A007,SI-GA-D1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_chromium_sc_indices)
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        # Do the test
+        ap = AutoProcess()
+        ap.setup(os.path.join(self.wd,
+                              "171020_NB500968_00002_AHGXXXX"),
+                 sample_sheet=sample_sheet)
+        self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertRaises(Exception,
+                          ap.make_fastqs,
+                          protocol="10x_chromium_sc")
+
     def test_make_fastqs_icell8_protocol(self):
         """make_fastqs: icell8 protocol
         """


### PR DESCRIPTION
PR which makes the following updates to the `make_fastqs` command:

* If the samplesheet (or partial samplesheet, if processing a subset of lanes) contains 10xGenomics chromium SC indices, then raise an exception if the protocol is not `10x_chromium_sc`.
* Generally, if an invalid protocol name is supplied then print the list of valid protocols as part of the error message.