### PR TITLE
'publish_qc': handle 4 digit year in instrument datestamp

### DIFF
--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -135,7 +135,16 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
     else:
         location = fileops.Location(location)
     if use_hierarchy:
-        year = "20%s" % str(ap.metadata.instrument_datestamp)[0:2]
+        datestamp = str(ap.metadata.instrument_datestamp)
+        if len(datestamp) == 6:
+            # Assume YYMMDD datestamp format
+            year = "20%s" % datestamp[0:2]
+        elif len(datestamp) == 8:
+            # Assume YYYYMMDD datestamp format
+            year = datestamp[0:4]
+        else:
+            raise Exception("Invalid datestamp '%s' (use "
+                            "--year option)" % datestamp)
         platform = ap.metadata.platform
     # Check the settings
     if location.is_remote:


### PR DESCRIPTION
PR which fixes the `publish_qc` command so that it can handle 4-digit years (i.e. `2018`) in instrument datestamps (for example for the iSeq instrument).