### PR TITLE
Fix 'archive' command to handle multiple fastq sets in projects

### DIFF
--- a/auto_process_ngs/test/commands/test_archive_cmd.py
+++ b/auto_process_ngs/test/commands/test_archive_cmd.py
@@ -10,6 +10,7 @@ import pwd
 import grp
 from auto_process_ngs.auto_processor import AutoProcess
 from auto_process_ngs.mock import MockAnalysisDirFactory
+from auto_process_ngs.mock import UpdateAnalysisProject
 from auto_process_ngs.commands.archive_cmd import archive
 
 # Set to False to keep test output dirs
@@ -288,6 +289,83 @@ class TestArchiveCommand(unittest.TestCase):
                 fq = os.path.join(fq_dir,fq)
                 self.assertTrue(os.access(fq,os.R_OK))
                 self.assertFalse(os.access(fq,os.W_OK))
+
+    def test_archive_to_final_multiple_fastq_sets_read_only_fastqs(self):
+        """archive: test copying multiple fastq sets to final archive dir (read-only Fastqs)
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901" },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Make a mock archive directory
+        archive_dir = os.path.join(self.dirn,"archive")
+        final_dir = os.path.join(archive_dir,
+                                 "2017",
+                                 "miseq")
+        os.makedirs(final_dir)
+        self.assertTrue(os.path.isdir(final_dir))
+        self.assertEqual(len(os.listdir(final_dir)),0)
+        # Make autoprocess instance and set required metadata
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        ap.set_metadata("source","testing")
+        ap.set_metadata("run_number","87")
+        # Add additional fastq set for first project
+        multi_fastqs_project = ap.get_analysis_projects()[0]
+        UpdateAnalysisProject(multi_fastqs_project).add_fastq_set(
+            "fastqs.extra",
+            ("Alt1.r1.fastq.gz","Alt2.r1.fastq.gz"))
+        # Do archiving op
+        status = archive(ap,
+                         archive_dir=archive_dir,
+                         year='2017',platform='miseq',
+                         read_only_fastqs=True,
+                         final=True)
+        self.assertEqual(status,0)
+        # Check that final dir exists
+        final_archive_dir = os.path.join(
+            final_dir,
+            "170901_M00879_0087_000000000-AGEW9_analysis")
+        self.assertTrue(os.path.exists(final_archive_dir))
+        self.assertEqual(len(os.listdir(final_dir)),1)
+        # Check contents
+        dirs = ("AB","CDE","logs","undetermined")
+        for d in dirs:
+            d = os.path.join(final_archive_dir,d)
+            self.assertTrue(os.path.exists(d))
+        files = ("auto_process.info",
+                 "custom_SampleSheet.csv",
+                 "metadata.info",
+                 "projects.info",
+                 "SampleSheet.orig.csv")
+        for f in files:
+            f = os.path.join(final_archive_dir,f)
+            self.assertTrue(os.path.exists(f))
+        # Check that Fastqs are not writable
+        for project in ("AB","CDE","undetermined"):
+            fq_dir = os.path.join(final_archive_dir,
+                                  project,
+                                  "fastqs")
+            self.assertTrue(os.path.exists(fq_dir))
+            fqs = os.listdir(fq_dir)
+            self.assertTrue(len(fqs) > 0)
+            for fq in fqs:
+                fq = os.path.join(fq_dir,fq)
+                self.assertTrue(os.access(fq,os.R_OK))
+                self.assertFalse(os.access(fq,os.W_OK))
+        # Check additional Fastqs are not writable
+        fq_dir = os.path.join(final_archive_dir,
+                              multi_fastqs_project.name,
+                              "fastqs.extra")
+        self.assertTrue(os.path.exists(fq_dir))
+        fqs = os.listdir(fq_dir)
+        self.assertTrue(len(fqs) > 0)
+        for fq in fqs:
+            fq = os.path.join(fq_dir,fq)
+            self.assertTrue(os.access(fq,os.R_OK))
+            self.assertFalse(os.access(fq,os.W_OK))
 
     def test_archive_to_final_via_staging(self):
         """archive: test copying to staging then final archive dir


### PR DESCRIPTION
PR to address issue #194, where Fastq subdirectories with names other than `fastqs` in projects are not treated correctly: specifically if 'read-only' Fastqs are requested then this was not being honoured. These changes should fix this.