### PR TITLE
Pipeliner: enable pipelines to be appended/merged & defer exit on task failure

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -746,6 +746,20 @@ class Pipeline(object):
             ranks.append(current_rank)
         return ranks
 
+    def get_dependent_tasks(self,task_id):
+        """
+        Return task ids that depend on supplied task id
+        """
+        dependents = set()
+        for id_ in self.task_list():
+            task,requires,kws = self.get_task(id_)
+            for req in requires:
+                if req.id() == task_id:
+                    dependents.update(self.get_dependent_tasks(id_))
+                    dependents.add(id_)
+                    break
+        return list(dependents)
+
     def run(self,working_dir=None,log_dir=None,scripts_dir=None,
             log_file=None,sched=None,default_runner=None,max_jobs=1):
         """

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -1198,7 +1198,6 @@ class PipelineTask(object):
                     f()
                 else:
                     f(*args,**kws)
-            self.report("done '%s'" % f.__name__)
             for line in output:
                 self.report("%s STDOUT: %s" % (f.__name__,line))
         except NotImplementedError:

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -170,7 +170,7 @@ class TestPipeline(unittest.TestCase):
 
     def test_pipeline_stops_on_task_failure(self):
         """
-        Pipeline: stops on task failure (IMMEDIATE mode)
+        Pipeline: immediate exit on task failure in 'immediate' mode
         """
         # Define a reusable task
         # Appends item to a list
@@ -224,7 +224,7 @@ class TestPipeline(unittest.TestCase):
 
     def test_pipeline_defers_task_failure(self):
         """
-        Pipeline: defer task failure (DEFERRED mode)
+        Pipeline: deferred exit on task failure in 'deferred' mode
         """
         # Define a reusable task
         # Appends item to a list
@@ -818,6 +818,9 @@ class TestPipelineCommand(unittest.TestCase):
             shutil.rmtree(self.working_dir)
 
     def test_pipelinecommand(self):
+        """
+        PipelineCommand: check command and wrapper script
+        """
         # Subclass PipelineCommand
         class EchoCmd(PipelineCommand):
             def init(self,txt):
@@ -853,6 +856,9 @@ class TestPipelineCommand(unittest.TestCase):
 class TestPipelineCommandWrapper(unittest.TestCase):
 
     def test_piplinecommandwrapper(self):
+        """
+        PipelineCommandWrapper: check generated command
+        """
         # Make a pipeline command wrapper
         cmd = PipelineCommandWrapper("Echo text","echo","hello")
         # Check name and generated command


### PR DESCRIPTION
PR which implements new functionality in the `Pipeline` class of the `pipeliner` module:

* Enable the contents of one pipeline to be appended to another (so that the appended tasks run after those already in the pipeline)
* Enable the contents of one pipeline to be merged into another (so that the tasks can be run 'in parallel' within the merged pipeline)
* Enable pipeline exit to be deferred when a task fails, so that all non-dependent tasks can complete

The changes include some under-the-hood refactoring of task dependency and scheduling management, and the monitoring/launch/failure handling loop - however these shouldn't change the existing functionality.

The new functionality should allow the QC pipelines to be reimplemented using the `pipeliner` module.