### PR TITLE
make_fastqs command: skip primary data acquisition if already copied

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -940,6 +940,7 @@ class AutoProcess(object):
         self.params['analysis_dir'] = self.analysis_dir
         self.params['sample_sheet'] = custom_sample_sheet
         self.params['bases_mask'] = bases_mask
+        self.params['acquired_primary_data'] = False
         # Store the metadata
         self.metadata['run_name'] = self.run_name
         self.metadata['platform'] = platform

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -257,12 +257,14 @@ def make_fastqs(ap,protocol='standard',platform=None,
         log_dir += "_L%s" % ''.join([str(l) for l in sorted(lanes)])
     ap.set_log_dir(ap.get_log_subdir(log_dir))
     # Fetch primary data
-    if not skip_rsync:
+    if not skip_rsync and not ap.params.acquired_primary_data:
         if get_primary_data(ap) != 0:
             logger.error("Failed to acquire primary data")
-            raise Exception, "Failed to acquire primary data"
-        if only_fetch_primary_data:
-            return
+            raise Exception("Failed to acquire primary data")
+        else:
+            ap.params['acquired_primary_data'] = True
+    if only_fetch_primary_data:
+        return
     # Deal with platform information
     if not platform:
         platform = ap.metadata.platform

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -250,6 +250,7 @@ class AnalysisDirParameters(MetadataDict):
     bases_mask: bases mask string
     project_metadata: name of the project metadata file
     primary_data_dir: directory used to hold copies of primary data
+    acquired_primary_data: whether primary data has been copied
     unaligned_dir: output directory for bcl2fastq conversion
     barcode_analysis_dir: directory holding barcode analysis outputs
     stats_file: name of file with per-fastq statistics
@@ -272,6 +273,7 @@ class AnalysisDirParameters(MetadataDict):
                                   'bases_mask':'bases_mask',
                                   'project_metadata':'project_metadata',
                                   'primary_data_dir':'primary_data_dir',
+                                  'acquired_primary_data':'acquired_primary_data',
                                   'unaligned_dir':'unaligned_dir',
                                   'barcode_analysis_dir':'barcode_analysis_dir',
                                   'stats_file':'stats_file',

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -68,6 +68,7 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
         make_fastqs(ap,protocol="standard")
         # Check parameters
         self.assertEqual(ap.params.bases_mask,"y101,I8,I8,y101")
@@ -75,6 +76,7 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
                          os.path.join(self.wd,
                                       "171020_M00879_00002_AHGXXXX_analysis",
                                       "primary_data"))
+        self.assertTrue(ap.params.acquired_primary_data)
         # Check outputs
         analysis_dir = os.path.join(
             self.wd,
@@ -230,6 +232,7 @@ smpl4,smpl4,,,A007,SI-GA-D1,10xGenomics,
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
         make_fastqs(ap,protocol="icell8")
         # Check parameters
         self.assertEqual(ap.params.bases_mask,"y25n76,I8,I8,y101")
@@ -237,6 +240,7 @@ smpl4,smpl4,,,A007,SI-GA-D1,10xGenomics,
                          os.path.join(self.wd,
                                       "171020_SN7001250_00002_AHGXXXX_analysis",
                                       "primary_data"))
+        self.assertTrue(ap.params.acquired_primary_data)
         # Check outputs
         analysis_dir = os.path.join(
             self.wd,
@@ -304,6 +308,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
         make_fastqs(ap,protocol="10x_chromium_sc")
         # Check parameters
         self.assertEqual(ap.params.bases_mask,"auto")
@@ -311,6 +316,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
                          os.path.join(self.wd,
                                       "171020_SN7001250_00002_AHGXXXX_analysis",
                                       "primary_data"))
+        self.assertTrue(ap.params.acquired_primary_data)
         # Check outputs
         analysis_dir = os.path.join(
             self.wd,
@@ -424,11 +430,19 @@ AB1,AB1,,,,,icell8,
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
         self.assertRaises(Exception,
                           make_fastqs,
                           ap,
                           protocol="standard",
                           create_empty_fastqs=False)
+        # Check parameters
+        self.assertEqual(ap.params.bases_mask,"y101,I8,I8,y101")
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(self.wd,
+                                      "171020_M00879_00002_AHGXXXX_analysis",
+                                      "primary_data"))
+        self.assertTrue(ap.params.acquired_primary_data)
         # Check outputs
         analysis_dir = os.path.join(
             self.wd,
@@ -482,6 +496,7 @@ AB1,AB1,,,,,icell8,
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
         make_fastqs(ap,
                     protocol="standard",
                     create_empty_fastqs=True)
@@ -491,6 +506,7 @@ AB1,AB1,,,,,icell8,
                          os.path.join(self.wd,
                                       "171020_M00879_00002_AHGXXXX_analysis",
                                       "primary_data"))
+        self.assertTrue(ap.params.acquired_primary_data)
         # Check outputs
         analysis_dir = os.path.join(
             self.wd,
@@ -590,6 +606,7 @@ AB1,AB1,,,,,icell8,
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
         self.assertRaises(Exception,
                           make_fastqs,
                           ap,
@@ -618,6 +635,7 @@ AB1,AB1,,,,,icell8,
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
         make_fastqs(ap,
                        protocol="standard",
                        platform="miseq")
@@ -627,6 +645,7 @@ AB1,AB1,,,,,icell8,
                          os.path.join(self.wd,
                                       "171020_UNKNOWN_00002_AHGXXXX_analysis",
                                       "primary_data"))
+        self.assertTrue(ap.params.acquired_primary_data)
         # Check outputs
         analysis_dir = os.path.join(
             self.wd,
@@ -675,6 +694,7 @@ AB1,AB1,,,,,icell8,
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
         make_fastqs(ap,protocol="standard")
         # Check parameters
         self.assertEqual(ap.params.bases_mask,"y101,I8,I8,y101")
@@ -682,6 +702,7 @@ AB1,AB1,,,,,icell8,
                          os.path.join(self.wd,
                                       "171020_UNKNOWN_00002_AHGXXXX_analysis",
                                       "primary_data"))
+        self.assertTrue(ap.params.acquired_primary_data)
         # Check outputs
         analysis_dir = os.path.join(
             self.wd,
@@ -750,6 +771,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
         self.assertRaises(Exception,
                           make_fastqs,
                           ap)
@@ -800,6 +822,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
         self.assertRaises(Exception,
                           make_fastqs,
                           ap)
@@ -826,12 +849,14 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
         make_fastqs(ap,protocol="10x_chromium_sc")
         # Check parameters
         self.assertEqual(ap.params.primary_data_dir,
                          os.path.join(self.wd,
                                       "171020_SN7001250_00002_AHGXXXX_analysis",
                                       "primary_data"))
+        self.assertTrue(ap.params.acquired_primary_data)
         # Check outputs
         analysis_dir = os.path.join(
             self.wd,

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -205,9 +205,6 @@ def add_make_fastqs_command(cmdparser):
                             dest='only_fetch_primary_data',default=False,
                             help="only fetch the primary data, don't perform any other "
                             "operations")
-    primary_data.add_option('--skip-rsync',action='store_true',
-                            dest='skip_rsync',default=False,
-                            help="don't rsync the primary data at the beginning of processing")
     primary_data.add_option('--remove-primary-data',action='store_true',
                             dest='remove_primary_data',default=False,
                             help="Delete the primary data at the end of processing (default "
@@ -476,6 +473,12 @@ def add_make_fastqs_command(cmdparser):
                           help="don't run the Fastq generation step "
                           "(deprecated: use the '--skip-fastq-generation' "
                           "option instead)")
+    deprecated.add_option('--skip-rsync',action='store_true',
+                          dest='skip_rsync',default=False,
+                          help="don't rsync the primary data at the beginning "
+                          "of processing (deprecated: primary data acquisition "
+                          "is skipped automatically if data has already been "
+                          "rsynced)")
     p.add_option_group(deprecated)
 
 def add_setup_analysis_dirs_command(cmdparser):

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -40,22 +40,16 @@ By default ``make_fastqs`` performs the following steps:
   project (``processing.html``).
 
 Various options are available to skip or control each of these stages;
-the most useful are:
-
-* ``--skip-rsync`` bypasses the primary data acquisition (useful if
-  rerunning having already fetched the data once)
-* ``--no-stats`` skips the generation of statistics and processing QC
-  reporting
-
-Information on other commonly used options can be found :ref:`below <make_fastqs-commonly-used-options>`.
-
-More detail on the different usage modes can be found in the
+more detail on the different usage modes can be found in the
 subsequent sections:
 
 * :ref:`make_fastqs-standard-protocol`
 * :ref:`make_fastqs-icell8-protocol`
 * :ref:`make_fastqs-10x_chromium_sc-protocol`
 * :ref:`make_fastqs-mixed-protocols`
+
+Information on other commonly used options can be found
+:ref:`below <make_fastqs-commonly-used-options>`.
 
 Advice on handling other unusual cases and problems can be found
 here:
@@ -91,6 +85,9 @@ Some of the most commonly used options are:
   from the instrument name it can be explicitly specified using
   this option (see :ref:`config_sequencer_platforms` for how to
   associate sequencers and platforms in the configuration)
+* ``--no-stats`` skips the generation of statistics and processing
+  QC reporting (helpful when handling runs requiring multiple
+  rounds of processing; see :ref:`make_fastqs-mixed-protocols`)
 
 The full set of options can be found in the
 :ref:`'make_fastqs' section of the command reference <commands_make_fastqs>`.
@@ -227,7 +224,6 @@ samples in lanes 5 and 6 had different barcode lengths:
             --lanes=5-6 \
             --output-dir=bcl2fastq.L56 \
             --use-bases-mask=auto \
-            --skip-rsync \
 	    --no-stats
 
 Alternatively if the data in these lanes were 10xGenomics
@@ -240,11 +236,7 @@ Chromium single cell data:
 	    --protocol=10x_chromium_sc \
             --output-dir=bcl2fastq.L56 \
             --use-bases-mask=auto \
-            --skip-rsync \
 	    --no-stats
-
-(Using ``--skip-rsync`` means that the processing doesn't try
-to fetch the raw data again.)
 
 The outputs from each subset of lanes can be merged into a
 single output directory using the ``merge_fastq_dirs`` command.


### PR DESCRIPTION
PR to address issue #117: adds a flag parameter to the `auto_process.info` parameter file to indicate when the primary data have been copied/rsync'ed, and only acquires the data if this parameter is not set on subsequent `make_fastqs` invocations.

Effectively this obsoletes the `--skip-rsync` option for the `make_fastqs` command.