### PR TITLE
make_fastqs: only store bases mask if explicitly supplied via command line

### DIFF
--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -289,8 +289,9 @@ def make_fastqs(ap,protocol='standard',platform=None,
         # Set platform in metadata
         ap.metadata['platform'] = illumina_run.platform
         # Bases mask
-        if bases_mask is None:
-            bases_mask = ap.params.bases_mask
+        if bases_mask is not None:
+            ap.params['bases_mask'] = bases_mask
+        bases_mask = ap.params.bases_mask
         print "Bases mask setting    : %s" % bases_mask
         if protocol != '10x_chromium_sc':
             if bases_mask == "auto":
@@ -300,7 +301,6 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 if not bases_mask_is_valid(bases_mask):
                     raise Exception("Invalid bases mask: '%s'" %
                                     bases_mask)
-        ap.params.bases_mask = bases_mask
         # Do fastq generation according to protocol
         if protocol == 'icell8':
             # ICell8 data
@@ -316,7 +316,6 @@ def make_fastqs(ap,protocol='standard',platform=None,
             if not bases_mask_is_valid(bases_mask):
                 raise Exception("Invalid bases mask: '%s'" %
                                 bases_mask)
-            ap.params.bases_mask = bases_mask
             # Switch to standard protocol
             protocol = 'standard'
         if protocol == 'standard':
@@ -582,8 +581,6 @@ def bcl_to_fastq(ap,unaligned_dir,sample_sheet,primary_data_dir,
     # Bases mask
     if bases_mask is None:
         bases_mask = ap.params.bases_mask
-    else:
-        ap.params['bases_mask'] = bases_mask
     # Check for basic information needed to do bcl2fastq conversion
     if ap.params.data_dir is None:
         raise Exception("No source data directory")

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -118,6 +118,7 @@ class MockAnalysisDir(MockIlluminaData):
                  platform,
                  unaligned_dir='bcl2fastq',
                  fmt='bcl2fastq2',
+                 bases_mask='auto',
                  paired_end=True,
                  lanes=None,
                  no_lane_splitting=False,
@@ -139,6 +140,8 @@ class MockAnalysisDir(MockIlluminaData):
           fmt (str): format of the outputs (can be
             'casava' or 'bcl2fastq2'; default is
             'bcl2fastq')
+          bases_mask (str): bases mask string to
+            put into 'auto_process.info'
           paired_end (bool): whether run should be
             paired end (set True, default) or single
             end (set False)
@@ -172,6 +175,7 @@ class MockAnalysisDir(MockIlluminaData):
         # Make a mock-up of an analysis dir
         self.run_name = os.path.basename(str(run_name))
         self.platform = str(platform).lower()
+        self.bases_mask = bases_mask
         self.readme = readme
         # Store metadata
         self.metadata = { 'run_name': self.run_name,
@@ -230,7 +234,7 @@ class MockAnalysisDir(MockIlluminaData):
         # Add auto_process.info file
         with open(os.path.join(self.dirn,'auto_process.info'),'w') as fp:
             fp.write("analysis_dir\t%s\n" % os.path.basename(self.dirn))
-            fp.write("bases_mask\ty76,I8,I8,y76\n")
+            fp.write("bases_mask\t%s\n" % self.bases_mask)
             fp.write("data_dir\t/mnt/data/%s\n" % self.run_name)
             fp.write("per_lane_stats_file\tper_lane_statistics.info\n")
             fp.write("primary_data_dir\t%s/primary_data/%s\n" % (self.dirn,
@@ -705,7 +709,8 @@ class MockAnalysisDirFactory(object):
                    no_lane_splitting=True,
                    top_dir=None,
                    metadata=None,
-                   project_metadata=None):
+                   project_metadata=None,
+                   bases_mask='auto'):
         """
         Basic analysis dir from bcl2fastq v2
         """
@@ -716,6 +721,7 @@ class MockAnalysisDirFactory(object):
         mad = MockAnalysisDir(run_name,platform,
                               unaligned_dir='bcl2fastq',
                               fmt='bcl2fastq2',
+                              bases_mask=bases_mask,
                               paired_end=paired_end,
                               no_lane_splitting=no_lane_splitting,
                               lanes=lanes,

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -70,7 +70,7 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
         self.assertTrue(ap.params.primary_data_dir is None)
         make_fastqs(ap,protocol="standard")
         # Check parameters
-        self.assertEqual(ap.params.bases_mask,"y101,I8,I8,y101")
+        self.assertEqual(ap.params.bases_mask,"auto")
         self.assertEqual(ap.params.primary_data_dir,
                          os.path.join(self.wd,
                                       "171020_M00879_00002_AHGXXXX_analysis",
@@ -207,6 +207,57 @@ smpl4,smpl4,,,A007,SI-GA-D1,10xGenomics,
                           protocol="standard")
 
     #@unittest.skip("Skipped")
+    def test_make_fastqs_standard_protocol_stores_bases_mask(self):
+        """make_fastqs: standard protocol stores supplied bases mask
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Do the test
+        ap = AutoProcess()
+        ap.setup(os.path.join(self.wd,
+                              "171020_M00879_00002_AHGXXXX"))
+        self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
+        make_fastqs(ap,protocol="standard",bases_mask="y101,I8,I8,y101")
+        # Check parameters
+        self.assertEqual(ap.params.bases_mask,"y101,I8,I8,y101")
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(self.wd,
+                                      "171020_M00879_00002_AHGXXXX_analysis",
+                                      "primary_data"))
+        # Check outputs
+        analysis_dir = os.path.join(
+            self.wd,
+            "171020_M00879_00002_AHGXXXX_analysis")
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       os.path.join("logs",
+                                    "002_make_fastqs"),
+                       "bcl2fastq"):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "projects.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
     def test_make_fastqs_icell8_protocol(self):
         """make_fastqs: icell8 protocol
         """
@@ -232,7 +283,7 @@ smpl4,smpl4,,,A007,SI-GA-D1,10xGenomics,
         self.assertTrue(ap.params.primary_data_dir is None)
         make_fastqs(ap,protocol="icell8")
         # Check parameters
-        self.assertEqual(ap.params.bases_mask,"y25n76,I8,I8,y101")
+        self.assertEqual(ap.params.bases_mask,"auto")
         self.assertEqual(ap.params.primary_data_dir,
                          os.path.join(self.wd,
                                       "171020_SN7001250_00002_AHGXXXX_analysis",
@@ -486,7 +537,7 @@ AB1,AB1,,,,,icell8,
                     protocol="standard",
                     create_empty_fastqs=True)
         # Check parameters
-        self.assertEqual(ap.params.bases_mask,"y101,I8,I8,y101")
+        self.assertEqual(ap.params.bases_mask,"auto")
         self.assertEqual(ap.params.primary_data_dir,
                          os.path.join(self.wd,
                                       "171020_M00879_00002_AHGXXXX_analysis",
@@ -622,7 +673,7 @@ AB1,AB1,,,,,icell8,
                        protocol="standard",
                        platform="miseq")
         # Check parameters
-        self.assertEqual(ap.params.bases_mask,"y101,I8,I8,y101")
+        self.assertEqual(ap.params.bases_mask,"auto")
         self.assertEqual(ap.params.primary_data_dir,
                          os.path.join(self.wd,
                                       "171020_UNKNOWN_00002_AHGXXXX_analysis",
@@ -677,7 +728,7 @@ AB1,AB1,,,,,icell8,
         self.assertTrue(ap.params.primary_data_dir is None)
         make_fastqs(ap,protocol="standard")
         # Check parameters
-        self.assertEqual(ap.params.bases_mask,"y101,I8,I8,y101")
+        self.assertEqual(ap.params.bases_mask,"auto")
         self.assertEqual(ap.params.primary_data_dir,
                          os.path.join(self.wd,
                                       "171020_UNKNOWN_00002_AHGXXXX_analysis",

--- a/auto_process_ngs/test/test_auto_processor_analyse_barcodes.py
+++ b/auto_process_ngs/test/test_auto_processor_analyse_barcodes.py
@@ -56,8 +56,58 @@ GCATACTCAGCTTTAGTAATAAGTGTGATTCTGGTA
 IIIIIHIIIGHHIIDGHIIIIIIHIIIIIIIIIIIH
 """)
 
-    def test_analyse_barcodes(self):
-        """analyse_barcodes: test with defaults
+    def test_analyse_barcodes_with_stored_bases_mask(self):
+        """analyse_barcodes: test with stored bases mask
+        """
+        # Make an auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '160621_M00879_0087_000000000-AGEW9',
+            'miseq',
+            bases_mask='y76,I6,y76',
+            metadata={ "instrument_datestamp": "160621" },
+            top_dir=self.wd)
+        mockdir.create(no_project_dirs=True)
+        # Add data to Fastq files
+        self._insert_fastq_reads(mockdir.dirn)
+        # Analyse barcodes
+        ap = AutoProcess(mockdir.dirn)
+        ap.analyse_barcodes()
+        # Check outputs
+        analysis_dir = os.path.join(
+            self.wd,
+            "160621_M00879_0087_000000000-AGEW9_analysis")
+        self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,"barcode_analysis")),
+                            "Missing dir: barcode_analysis")
+        self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,"barcode_analysis","counts")),
+                            "Missing dir: barcode_analysis/counts")
+        for f in ("AB.AB1_S1_R1_001.fastq.gz.counts",
+                  "AB.AB2_S2_R1_001.fastq.gz.counts",
+                  "CDE.CDE3_S3_R1_001.fastq.gz.counts",
+                  "CDE.CDE4_S4_R1_001.fastq.gz.counts",
+                  "undetermined.Undetermined_S0_R1_001.fastq.gz.counts"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,"barcode_analysis","counts",f)),
+                            "Missing file: %s" % f)
+        self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,
+                             "barcode_analysis",
+                             "barcodes.report")),
+                        "Missing file: barcodes.report")
+        self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,
+                             "barcode_analysis",
+                             "barcodes.xls")),
+                        "Missing file: barcodes.xls")
+        self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,
+                             "barcode_analysis",
+                             "barcodes.html")),
+                        "Missing file: barcodes.html")
+
+    def test_analyse_barcodes_no_stored_bases_mask(self):
+        """analyse_barcodes: test with no stored bases mask
         """
         # Make an auto-process directory
         mockdir = MockAnalysisDirFactory.bcl2fastq2(


### PR DESCRIPTION
PR to address issue #256 and only store/update the bases mask setting if the value was explicitly supplied via the command line (i.e. the `--use-bases-mask` option of the `make_fastqs` command).

This was partially implemented as part of changes in PR #215 but this should complete the job by handling an issue with the `analyse_barcodes` command, when the bases mask value is `auto` or `None`.