### PR TITLE
import_projects: move functionality from AutoProcess class to 'commands' submodule

### DIFF
--- a/auto_process_ngs/commands/__init__.py
+++ b/auto_process_ngs/commands/__init__.py
@@ -16,3 +16,4 @@ from archive_cmd import archive
 from report_cmd import report
 from merge_fastq_dirs_cmd import merge_fastq_dirs
 from update_fastq_stats_cmd import update_fastq_stats
+from import_project_cmd import import_project

--- a/auto_process_ngs/commands/import_project_cmd.py
+++ b/auto_process_ngs/commands/import_project_cmd.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#
+#     import_project_cmd.py: implement auto process import_project command
+#     Copyright (C) University of Manchester 2019 Peter Briggs
+#
+#########################################################################
+
+#######################################################################
+# Imports
+#######################################################################
+
+import os
+import logging
+from ..applications import general as applications_general
+from ..analysis import AnalysisProject
+
+# Module specific logger
+logger = logging.getLogger(__name__)
+
+#######################################################################
+# Command functions
+#######################################################################
+
+def import_project(ap,project_dir):
+    """
+    Import a project directory into this analysis directory
+
+    Arguments:
+      ap (AutoProcessor): autoprocessor pointing to the parent
+        analysis directory
+      project_dir (str): path to project directory to be
+        imported
+    """
+    # Check that target directory exists
+    project_dir = os.path.abspath(project_dir)
+    # Check that project doesn't already exist
+    project_name = os.path.basename(project_dir)
+    project_metadata = ap.load_project_metadata()
+    if project_name in [p['Project'] for p in project_metadata] or \
+       AnalysisProject(project_name,
+                       os.path.join(ap.analysis_dir,
+                                    project_name)).exists:
+        raise Exception("Project called '%s' already exists" %
+                        project_name)
+    # Load target as a project
+    project = AnalysisProject(project_name,project_dir)
+    # Rsync the project directory
+    print "Importing project directory contents for '%s'" % project_name
+    try:
+        excludes = ['--exclude=tmp.*',
+                    '--exclude=qc_report.*']
+        rsync = applications_general.rsync(project_dir,
+                                           ap.analysis_dir,
+                                           extra_options=excludes)
+        print "Running %s" % rsync
+        status = rsync.run_subprocess(log=ap.log_path('import_project.rsync.log'))
+    except Exception as ex:
+        logger.error("Exception importing project: %s" % ex)
+        raise ex
+    if status != 0:
+        raise Exception("Failed to import project from %s (status %s)" %
+                        (project_dir,status))
+    # Update the projects.info metadata file
+    print "Updating projects.info file with imported project"
+    project_metadata = ap.load_project_metadata()
+    sample_names = [s.name for s in project.samples]
+    project_metadata.add_project(project_name,
+                                 sample_names,
+                                 user=project.info.user,
+                                 library_type=project.info.library_type,
+                                 single_cell_platform=project.info.single_cell_platform,
+                                 organism=project.info.organism,
+                                 PI=project.info.PI,
+                                 comments=project.info.comments)
+    project_metadata.save()
+    # Report
+    print "Projects now in metadata file:"
+    for p in project_metadata:
+        print "- %s" % p['Project']
+    # Update the QC report
+    try:
+        project = ap.get_analysis_projects(pattern=project_name)[0]
+    except Exception as ex:
+        logger.error("Exception when trying to acquire project %s: %s"
+                      % (project_name,ex))
+        return
+    if project.qc is None:
+        print "No QC for %s" % project_name
+    else:
+        if project.qc.verify():
+            try:
+                project.qc_report()
+                print "Updated QC report for %s" % project_name
+            except Exception, ex:
+                logger.error("import_project: failed to generate QC "
+                             "report for %s" % project_name)

--- a/auto_process_ngs/test/commands/test_import_project.py
+++ b/auto_process_ngs/test/commands/test_import_project.py
@@ -8,6 +8,7 @@ import shutil
 import os
 from auto_process_ngs.mock import MockAnalysisDirFactory
 from auto_process_ngs.auto_processor import AutoProcess
+from auto_process_ngs.commands.import_project_cmd import import_project
 
 class TestAutoProcessImportProject(unittest.TestCase):
     """Tests for AutoProcess.import_project
@@ -40,7 +41,7 @@ Comments\t1% PhiX spike in
         shutil.rmtree(self.dirn)
 
     def test_import_project(self):
-        """Check AutoProcess.import_project imports a project
+        """import_project: check project is imported
         """
         # Make an auto-process directory
         mockdir = MockAnalysisDirFactory.bcl2fastq2(
@@ -56,7 +57,7 @@ Comments\t1% PhiX spike in
                                        for p in ap.get_analysis_projects_from_dirs()])
         self.assertFalse(os.path.exists(os.path.join(ap.analysis_dir,'NewProj')))
         # Import the project
-        ap.import_project(self.new_project_dir)
+        import_project(ap,self.new_project_dir)
         self.assertTrue('NewProj' in [p.name
                                       for p in ap.get_analysis_projects()])
         self.assertTrue('NewProj' in [p.name
@@ -71,7 +72,7 @@ Comments\t1% PhiX spike in
         self.assertTrue(os.path.exists(os.path.join(ap2.analysis_dir,'NewProj')))
 
     def test_import_project_already_in_metadata_file(self):
-        """AutoProcess.import_project fails if project exists in projects.info
+        """import_project: fails when project is already in projects.info
         """
         # Make an auto-process directory
         mockdir = MockAnalysisDirFactory.bcl2fastq2(
@@ -86,10 +87,12 @@ Comments\t1% PhiX spike in
         # Import the project
         ap = AutoProcess(mockdir.dirn)
         self.assertRaises(Exception,
-                          ap.import_project,self.new_project_dir)
+                          import_project,
+                          ap,
+                          self.new_project_dir)
 
     def test_import_project_directory_already_exists(self):
-        """AutoProcess.import_project fails if directory already exists
+        """import_project: fails if project directory already exists
         """
         # Make an auto-process directory
         mockdir = MockAnalysisDirFactory.bcl2fastq2(
@@ -102,4 +105,6 @@ Comments\t1% PhiX spike in
         # Import the project
         ap = AutoProcess(mockdir.dirn)
         self.assertRaises(Exception,
-                          ap.import_project,self.new_project_dir)
+                          import_project,
+                          ap,
+                          self.new_project_dir)


### PR DESCRIPTION
PR which moves the functionality for the `import_projects` command out of the `AutoProcess` class and into the `commands` submodule.