### PR TITLE
'setup' command: allow sample sheet to be specified via URL

### DIFF
--- a/auto_process_ngs/test/test_auto_processor.py
+++ b/auto_process_ngs/test/test_auto_processor.py
@@ -675,3 +675,66 @@ class TestAutoProcessSetup(unittest.TestCase):
             os.path.join(
                 self.dirn,
                 '160621_NB00879_0087_000000000-AGEW9_analysis')))
+
+    def test_autoprocess_setup_samplesheet_from_url(self):
+        """AutoProcess.setup works when samplesheet is a URL
+        """
+        # Create mock Illumina run directory
+        mock_illumina_run = MockIlluminaRun(
+            '151125_M00879_0001_000000000-ABCDE1',
+            'miseq',
+            top_dir=self.dirn)
+        mock_illumina_run.create()
+        # Copy samplesheet
+        sample_sheet = os.path.join(self.dirn,'samplesheet.csv')
+        with open(os.path.join(mock_illumina_run.dirn,
+                               'Data','Intensities','BaseCalls',
+                               'SampleSheet.csv'),'r') as fp1:
+            with open(sample_sheet,'w') as fp2:
+                fp2.write(fp1.read())
+        sample_sheet = "file://%s" % sample_sheet
+        print sample_sheet
+        # Set up autoprocessor
+        ap = AutoProcess()
+        ap.setup(mock_illumina_run.dirn,sample_sheet=sample_sheet)
+        analysis_dirn = "%s_analysis" % mock_illumina_run.name
+        # Check parameters
+        self.assertEqual(ap.analysis_dir,
+                         os.path.join(self.dirn,analysis_dirn))
+        self.assertEqual(ap.params.data_dir,mock_illumina_run.dirn)
+        self.assertEqual(ap.params.sample_sheet,
+                         os.path.join(self.dirn,analysis_dirn,
+                                      'custom_SampleSheet.csv'))
+        self.assertEqual(ap.params.bases_mask,'auto')
+        # Check metadata
+        self.assertEqual(ap.metadata.run_name,
+                         "151125_M00879_0001_000000000-ABCDE1")
+        self.assertEqual(ap.metadata.run_number,None)
+        self.assertEqual(ap.metadata.source,None)
+        self.assertEqual(ap.metadata.platform,"miseq")
+        self.assertEqual(ap.metadata.source,None)
+        self.assertEqual(ap.metadata.assay,"TruSeq HT")
+        self.assertEqual(ap.metadata.bcl2fastq_software,None)
+        self.assertEqual(ap.metadata.instrument_name,"M00879")
+        self.assertEqual(ap.metadata.instrument_datestamp,"151125")
+        self.assertEqual(ap.metadata.instrument_run_number,"1")
+        self.assertEqual(ap.metadata.instrument_flow_cell_id,
+                         "000000000-ABCDE1")
+        # Delete to force write of data to disk
+        del(ap)
+        # Check directory exists
+        self.assertTrue(os.path.isdir(analysis_dirn))
+        # Check files exists
+        for filen in ('SampleSheet.orig.csv',
+                      'custom_SampleSheet.csv',
+                      'auto_process.info',
+                      'metadata.info',):
+            self.assertTrue(os.path.exists(os.path.join(analysis_dirn,
+                                                        filen)),
+                            "Missing file: %s" % filen)
+        # Check subdirs have been created
+        for subdirn in ('ScriptCode',
+                        'logs',):
+            self.assertTrue(os.path.isdir(os.path.join(analysis_dirn,
+                                                       subdirn)),
+                            "Missing subdir: %s" % subdirn)

--- a/auto_process_ngs/test/test_fileops.py
+++ b/auto_process_ngs/test/test_fileops.py
@@ -24,6 +24,9 @@ class TestLocation(unittest.TestCase):
         self.assertEqual(location.server,'host.name')
         self.assertEqual(location.path,'/path/to/somewhere')
         self.assertTrue(location.is_remote)
+        self.assertFalse(location.is_url)
+        self.assertEqual(location.url,None)
+        self.assertEqual(location.protocol,None)
         self.assertEqual(str(location),'user@host.name:/path/to/somewhere')
     def test_location_server_path(self):
         """fileops.Location: handle host.name:/path/to/somewhere
@@ -33,6 +36,9 @@ class TestLocation(unittest.TestCase):
         self.assertEqual(location.server,'host.name')
         self.assertEqual(location.path,'/path/to/somewhere')
         self.assertTrue(location.is_remote)
+        self.assertFalse(location.is_url)
+        self.assertEqual(location.url,None)
+        self.assertEqual(location.protocol,None)
         self.assertEqual(str(location),'host.name:/path/to/somewhere')
     def test_location_path(self):
         """fileops.Location: handle /path/to/somewhere
@@ -42,7 +48,46 @@ class TestLocation(unittest.TestCase):
         self.assertEqual(location.server,None)
         self.assertEqual(location.path,'/path/to/somewhere')
         self.assertFalse(location.is_remote)
+        self.assertFalse(location.is_url)
+        self.assertEqual(location.url,None)
+        self.assertEqual(location.protocol,None)
         self.assertEqual(str(location),'/path/to/somewhere')
+    def test_location_http_url(self):
+        """fileops.Location: handle http://example.com/path/to/url
+        """
+        location = Location('http://example.com/path/to/url')
+        self.assertEqual(location.user,None)
+        self.assertEqual(location.server,'example.com')
+        self.assertEqual(location.path,'path/to/url')
+        self.assertFalse(location.is_remote)
+        self.assertTrue(location.is_url)
+        self.assertEqual(location.url,'http://example.com/path/to/url')
+        self.assertEqual(location.protocol,'http')
+        self.assertEqual(str(location),'http://example.com/path/to/url')
+    def test_location_https_url(self):
+        """fileops.Location: handle https://example.com/path/to/url
+        """
+        location = Location('https://example.com/path/to/url')
+        self.assertEqual(location.user,None)
+        self.assertEqual(location.server,'example.com')
+        self.assertEqual(location.path,'path/to/url')
+        self.assertFalse(location.is_remote)
+        self.assertTrue(location.is_url)
+        self.assertEqual(location.protocol,'https')
+        self.assertEqual(location.url,'https://example.com/path/to/url')
+        self.assertEqual(str(location),'https://example.com/path/to/url')
+    def test_location_file_url(self):
+        """fileops.Location: handle file:///path/to/file
+        """
+        location = Location('file:///path/to/file')
+        self.assertEqual(location.user,None)
+        self.assertEqual(location.server,None)
+        self.assertEqual(location.path,'/path/to/file')
+        self.assertFalse(location.is_remote)
+        self.assertTrue(location.is_url)
+        self.assertEqual(location.protocol,'file')
+        self.assertEqual(location.url,'file:///path/to/file')
+        self.assertEqual(str(location),'file:///path/to/file')
 
 class FileopsTestCase(unittest.TestCase):
     """Base class for fileops test cases


### PR DESCRIPTION
PR to enable the `setup` command to accept a sample sheet from a URL as well as a file on a local or remote filesystem (addresses issue #265).