### PR TITLE
'clone' command: reimplement functionality and move into 'commands' submodule

### DIFF
--- a/auto_process_ngs/commands/__init__.py
+++ b/auto_process_ngs/commands/__init__.py
@@ -17,3 +17,4 @@ from report_cmd import report
 from merge_fastq_dirs_cmd import merge_fastq_dirs
 from update_fastq_stats_cmd import update_fastq_stats
 from import_project_cmd import import_project
+from clone_cmd import clone

--- a/auto_process_ngs/commands/clone_cmd.py
+++ b/auto_process_ngs/commands/clone_cmd.py
@@ -54,6 +54,20 @@ def clone(ap,clone_dir,copy_fastqs=False):
     for f in (ap.metadata_file,ap.parameter_file):
         if os.path.exists(f):
             shutil.copy(f,os.path.join(clone_dir,os.path.basename(f)))
+    # Primary data directory
+    primary_data_dir = os.path.join(ap.analysis_dir,
+                                    ap.params.primary_data_dir)
+    if os.path.isdir(primary_data_dir):
+        clone_primary_data_dir = os.path.join(clone_dir,
+                                              os.path.basename(primary_data_dir))
+        print "[Primary data] making %s" % clone_primary_data_dir
+        bcf_utils.mkdir(clone_primary_data_dir)
+        data_dir = os.path.basename(ap.params.data_dir)
+        if os.path.exists(os.path.join(primary_data_dir,data_dir)):
+            clone_data_dir = os.path.join(clone_primary_data_dir,data_dir)
+            print "[Primary data] symlinking %s" % clone_data_dir
+            os.symlink(os.path.join(primary_data_dir,data_dir),
+                       clone_data_dir)
     # Link to or copy fastqs
     unaligned_dir = os.path.join(ap.analysis_dir,ap.params.unaligned_dir)
     if os.path.isdir(unaligned_dir):

--- a/auto_process_ngs/commands/clone_cmd.py
+++ b/auto_process_ngs/commands/clone_cmd.py
@@ -92,8 +92,12 @@ def clone(ap,clone_dir,copy_fastqs=False):
     # Copy additional files, if found
     for f in ("SampleSheet.orig.csv",
               ap.params.sample_sheet,
+              ap.params.project_metadata,
               ap.params.stats_file,
-              ap.params.project_metadata,):
+              ap.params.per_lane_stats_file,
+              "statistics_full.info",
+              "per_lane_sample_stats.info",
+              "processing_qc.html",):
         srcpath = os.path.join(ap.analysis_dir,f)
         if os.path.exists(srcpath):
             shutil.copy(srcpath,clone_dir)

--- a/auto_process_ngs/commands/clone_cmd.py
+++ b/auto_process_ngs/commands/clone_cmd.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+#
+#     clone_cmd.py: implement auto process clone command
+#     Copyright (C) University of Manchester 2019 Peter Briggs
+#
+#########################################################################
+
+#######################################################################
+# Imports
+#######################################################################
+
+import os
+import logging
+import shutil
+from ..analysis import AnalysisProject
+from ..metadata import AnalysisDirParameters
+import bcftbx.utils as bcf_utils
+
+# Module specific logger
+logger = logging.getLogger(__name__)
+
+#######################################################################
+# Command functions
+#######################################################################
+
+def clone(ap,clone_dir,copy_fastqs=False):
+    """
+    Make a 'clone' (i.e. copy) of an analysis directory
+
+    Makes a copy of the analysis directory, including metadata
+    and parameters but ignoring any project subdirectories.
+
+    By default the 'unaligned' directory in the new directory is
+    simply a symlink from the original directory; set the
+    'copy_fastqs' to make copies instead.
+
+    Arguments
+      ap (AutoProcessor): autoprocessor pointing to the parent
+        analysis directory
+      clone_dir (str): path to the new directory to create as a
+        clone (must not already exist).
+      copy_fastqs (boolean): set to True to copy the Fastq files
+        (otherwise default behaviour is to make symlinks)
+    """
+    clone_dir = os.path.abspath(clone_dir)
+    if os.path.exists(clone_dir):
+        # Directory already exists
+        logger.critical("Target directory '%s' already exists" %
+                        clone_dir)
+        raise Exception("Clone failed: target directory '%s' "
+                        "already exists" % clone_dir)
+    bcf_utils.mkdir(clone_dir)
+    # Copy metadata and parameters
+    for f in (ap.metadata_file,ap.parameter_file):
+        if os.path.exists(f):
+            shutil.copy(f,os.path.join(clone_dir,os.path.basename(f)))
+    # Link to or copy fastqs
+    unaligned_dir = os.path.join(ap.analysis_dir,ap.params.unaligned_dir)
+    if os.path.isdir(unaligned_dir):
+        clone_unaligned_dir = os.path.join(clone_dir,
+                                           os.path.basename(unaligned_dir))
+        if not copy_fastqs:
+            # Link to unaligned dir
+            print "Symlinking %s" % clone_unaligned_dir
+            os.symlink(unaligned_dir,clone_unaligned_dir)
+        else:
+            # Copy unaligned dir
+            print "Copying %s" % clone_unaligned_dir
+            shutil.copytree(unaligned_dir,clone_unaligned_dir)
+    else:
+        print "No 'unaligned' dir found"
+    # Duplicate project directories
+    projects = ap.get_analysis_projects()
+    if projects:
+        print "Duplicating project directories:"
+        for project in ap.get_analysis_projects():
+            print "-- %s" % project.name
+            fastqs = project.fastqs
+            new_project = AnalysisProject(
+                project.name,
+                os.path.join(clone_dir,project.name),
+                user=project.info.user,
+                PI=project.info.PI,
+                library_type=project.info.library_type,
+                single_cell_platform=project.info.single_cell_platform,
+                organism=project.info.organism,
+                run=project.info.run,
+                comments=project.info.comments,
+                platform=project.info.platform)
+            new_project.create_directory(fastqs=fastqs,
+                                         link_to_fastqs=(not copy_fastqs))
+    # Copy additional files, if found
+    for f in ("SampleSheet.orig.csv",
+              ap.params.sample_sheet,
+              ap.params.stats_file,
+              ap.params.project_metadata,):
+        srcpath = os.path.join(ap.analysis_dir,f)
+        if os.path.exists(srcpath):
+            shutil.copy(srcpath,clone_dir)
+    # Create the basic set of subdirectories
+    for subdir in ('logs','ScriptCode',):
+        bcf_utils.mkdir(os.path.join(clone_dir,subdir))
+    # Update the settings
+    parameter_file = os.path.join(clone_dir,
+                                  os.path.basename(ap.parameter_file))
+    params = AnalysisDirParameters(filen=os.path.join(
+        clone_dir,
+        os.path.basename(ap.parameter_file)))
+    for s in ("sample_sheet",):
+        params[s] = os.path.join(clone_dir,
+                                 os.path.relpath(params[s],
+                                                 ap.analysis_dir))
+    params.save()

--- a/auto_process_ngs/commands/clone_cmd.py
+++ b/auto_process_ngs/commands/clone_cmd.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 # Command functions
 #######################################################################
 
-def clone(ap,clone_dir,copy_fastqs=False):
+def clone(ap,clone_dir,copy_fastqs=False,exclude_projects=False):
     """
     Make a 'clone' (i.e. copy) of an analysis directory
 
@@ -42,6 +42,8 @@ def clone(ap,clone_dir,copy_fastqs=False):
         clone (must not already exist).
       copy_fastqs (boolean): set to True to copy the Fastq files
         (otherwise default behaviour is to make symlinks)
+      exclude_projects (boolean): set to True to exclude any
+        projects from the parent analysis directory
     """
     clone_dir = os.path.abspath(clone_dir)
     print "Cloning into %s" % clone_dir
@@ -87,7 +89,7 @@ def clone(ap,clone_dir,copy_fastqs=False):
         print "[Unaligned] no 'unaligned' dir found"
     # Duplicate project directories
     projects = ap.get_analysis_projects()
-    if projects:
+    if projects and not exclude_projects:
         for project in ap.get_analysis_projects():
             print "[Projects] duplicating project '%s'" % project.name
             fastqs = project.fastqs

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -126,7 +126,8 @@ class MockAnalysisDir(MockIlluminaData):
                  top_dir=None,
                  metadata=None,
                  readme=None,
-                 project_metadata=None):
+                 project_metadata=None,
+                 include_stats_files=False):
         """
         Create a mock-up of an analysis directory
 
@@ -171,12 +172,16 @@ class MockAnalysisDir(MockIlluminaData):
             projects and values are dictionaries of
             metadata items, which will be written to
             the README.info file for that project
+          include_stats_files (bool): whether to
+            include (empty) stats files (default:
+            False, don't include stats files)
         """
         # Make a mock-up of an analysis dir
         self.run_name = os.path.basename(str(run_name))
         self.platform = str(platform).lower()
         self.bases_mask = bases_mask
         self.readme = readme
+        self.include_stats_files = include_stats_files
         # Store metadata
         self.metadata = { 'run_name': self.run_name,
                           'platform': self.platform, }
@@ -243,6 +248,14 @@ class MockAnalysisDir(MockIlluminaData):
             fp.write("sample_sheet\t%s/custom_SampleSheet.csv\n" % self.dirn)
             fp.write("stats_file\tstatistics.info\n")
             fp.write("unaligned_dir\tbcl2fastq\n")
+        # Add (empty) stats files
+        if self.include_stats_files:
+            for stats_file in ('statistics.info',
+                               'statistics_full.info',
+                               'per_lane_statistics.info',
+                               'per_lane_sample_stats.info',):
+                with open(os.path.join(self.dirn,stats_file),'w') as fp:
+                    fp.write('')
         # Add top-level README file
         if self.readme is not None:
             open(os.path.join(self.dirn,'README'),'w').write(self.readme)
@@ -710,7 +723,8 @@ class MockAnalysisDirFactory(object):
                    top_dir=None,
                    metadata=None,
                    project_metadata=None,
-                   bases_mask='auto'):
+                   bases_mask='auto',
+                   include_stats_files=False):
         """
         Basic analysis dir from bcl2fastq v2
         """
@@ -727,6 +741,7 @@ class MockAnalysisDirFactory(object):
                               lanes=lanes,
                               metadata=metadata,
                               project_metadata=project_metadata,
+                              include_stats_files=include_stats_files,
                               top_dir=top_dir)
         mad.add_fastq_batch('AB','AB1','AB1_S1',lanes=lanes)
         mad.add_fastq_batch('AB','AB2','AB2_S2',lanes=lanes)

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -241,12 +241,18 @@ class MockAnalysisDir(MockIlluminaData):
             fp.write("analysis_dir\t%s\n" % os.path.basename(self.dirn))
             fp.write("bases_mask\t%s\n" % self.bases_mask)
             fp.write("data_dir\t/mnt/data/%s\n" % self.run_name)
-            fp.write("per_lane_stats_file\tper_lane_statistics.info\n")
+            if self.include_stats_files:
+                fp.write("per_lane_stats_file\tper_lane_statistics.info\n")
+            else:
+                fp.write("per_lane_stats_file\t.\n")
             fp.write("primary_data_dir\t%s/primary_data/%s\n" % (self.dirn,
                                                                  self.run_name))
             fp.write("project_metadata\tprojects.info\n")
             fp.write("sample_sheet\t%s/custom_SampleSheet.csv\n" % self.dirn)
-            fp.write("stats_file\tstatistics.info\n")
+            if self.include_stats_files:
+                fp.write("stats_file\tstatistics.info\n")
+            else:
+                fp.write("stats_file\t.\n")
             fp.write("unaligned_dir\tbcl2fastq\n")
         # Add (empty) stats files
         if self.include_stats_files:

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -245,8 +245,7 @@ class MockAnalysisDir(MockIlluminaData):
                 fp.write("per_lane_stats_file\tper_lane_statistics.info\n")
             else:
                 fp.write("per_lane_stats_file\t.\n")
-            fp.write("primary_data_dir\t%s/primary_data/%s\n" % (self.dirn,
-                                                                 self.run_name))
+            fp.write("primary_data_dir\t%s/primary_data\n" % self.dirn)
             fp.write("project_metadata\tprojects.info\n")
             fp.write("sample_sheet\t%s/custom_SampleSheet.csv\n" % self.dirn)
             if self.include_stats_files:

--- a/auto_process_ngs/test/commands/test_clone_cmd.py
+++ b/auto_process_ngs/test/commands/test_clone_cmd.py
@@ -9,6 +9,7 @@ import os
 from auto_process_ngs.auto_processor import AutoProcess
 from auto_process_ngs.mock import MockAnalysisDirFactory
 from auto_process_ngs.mock import UpdateAnalysisDir
+from auto_process_ngs.metadata import AnalysisDirParameters
 from auto_process_ngs.commands.clone_cmd import clone
 
 # Set to False to keep test output dirs
@@ -86,6 +87,14 @@ class TestAutoProcessClone(unittest.TestCase):
         for proj in ('AB','CDE','undetermined'):
             d = os.path.join(clone_dir,proj)
             self.assertTrue(os.path.isdir(d),"Missing '%s'" % proj)
+        # Check parameters
+        params = AnalysisDirParameters(filen=os.path.join(
+            clone_dir,
+            'auto_process.info'))
+        self.assertEqual(params.sample_sheet,
+                         os.path.join(clone_dir,"custom_SampleSheet.csv"))
+        self.assertEqual(params.primary_data_dir,
+                         os.path.join(clone_dir,"primary_data"))
 
     def test_clone_analysis_dir_copy_fastqs(self):
         """
@@ -135,6 +144,14 @@ class TestAutoProcessClone(unittest.TestCase):
         for proj in ('AB','CDE','undetermined'):
             d = os.path.join(clone_dir,proj)
             self.assertTrue(os.path.isdir(d),"Missing '%s'" % proj)
+        # Check parameters
+        params = AnalysisDirParameters(filen=os.path.join(
+            clone_dir,
+            'auto_process.info'))
+        self.assertEqual(params.sample_sheet,
+                         os.path.join(clone_dir,"custom_SampleSheet.csv"))
+        self.assertEqual(params.primary_data_dir,
+                         os.path.join(clone_dir,"primary_data"))
 
     def test_clone_fails_if_target_dir_exists(self):
         """

--- a/auto_process_ngs/test/commands/test_clone_cmd.py
+++ b/auto_process_ngs/test/commands/test_clone_cmd.py
@@ -8,6 +8,7 @@ import shutil
 import os
 from auto_process_ngs.auto_processor import AutoProcess
 from auto_process_ngs.mock import MockAnalysisDirFactory
+from auto_process_ngs.mock import UpdateAnalysisDir
 from auto_process_ngs.commands.clone_cmd import clone
 
 # Set to False to keep test output dirs
@@ -50,10 +51,11 @@ class TestAutoProcessClone(unittest.TestCase):
             include_stats_files=True,
             top_dir=self.dirn)
         analysis_dir.create()
+        ap = AutoProcess(analysis_dir.dirn)
+        UpdateAnalysisDir(ap).add_processing_report()
         # Make a copy
         clone_dir = os.path.join(self.dirn,"190116_M01234_0002_AXYZ123_copy")
         self.assertFalse(os.path.exists(clone_dir))
-        ap = AutoProcess(analysis_dir.dirn)
         clone(ap,clone_dir)
         self.assertTrue(os.path.isdir(clone_dir))
         # Check contents
@@ -64,7 +66,11 @@ class TestAutoProcessClone(unittest.TestCase):
                       'custom_SampleSheet.csv',
                       'auto_process.info',
                       'metadata.info',
-                      'statistics.info',):
+                      'statistics.info',
+                      'statistics_full.info',
+                      'per_lane_statistics.info',
+                      'per_lane_sample_stats.info',
+                      'processing_qc.html',):
             f = os.path.join(clone_dir,filen)
             self.assertTrue(os.path.isfile(f),"Missing '%s'" % filen)
         # Check unassigned
@@ -88,10 +94,11 @@ class TestAutoProcessClone(unittest.TestCase):
             include_stats_files=True,
             top_dir=self.dirn)
         analysis_dir.create()
+        ap = AutoProcess(analysis_dir.dirn)
+        UpdateAnalysisDir(ap).add_processing_report()
         # Make a copy
         clone_dir = os.path.join(self.dirn,"190116_M01234_0002_AXYZ123_copy")
         self.assertFalse(os.path.exists(clone_dir))
-        ap = AutoProcess(analysis_dir.dirn)
         clone(ap,clone_dir,copy_fastqs=True)
         self.assertTrue(os.path.isdir(clone_dir))
         # Check contents
@@ -102,7 +109,11 @@ class TestAutoProcessClone(unittest.TestCase):
                       'custom_SampleSheet.csv',
                       'auto_process.info',
                       'metadata.info',
-                      'statistics.info',):
+                      'statistics.info',
+                      'statistics_full.info',
+                      'per_lane_statistics.info',
+                      'per_lane_sample_stats.info',
+                      'processing_qc.html',):
             f = os.path.join(clone_dir,filen)
             self.assertTrue(os.path.isfile(f),"Missing '%s'" % filen)
         # Check unassigned
@@ -126,11 +137,12 @@ class TestAutoProcessClone(unittest.TestCase):
             include_stats_files=True,
             top_dir=self.dirn)
         analysis_dir.create()
+        ap = AutoProcess(analysis_dir.dirn)
+        UpdateAnalysisDir(ap).add_processing_report()
         # Make target dir
         clone_dir = os.path.join(self.dirn,"190116_M01234_0002_AXYZ123_copy")
         os.mkdir(clone_dir)
         # Try to copy source dir
-        ap = AutoProcess(analysis_dir.dirn)
         self.assertRaises(Exception,
                           clone,
                           ap,clone_dir)

--- a/auto_process_ngs/test/commands/test_clone_cmd.py
+++ b/auto_process_ngs/test/commands/test_clone_cmd.py
@@ -1,0 +1,138 @@
+#######################################################################
+# Tests for clone_cmd.py module
+#######################################################################
+
+import unittest
+import tempfile
+import shutil
+import os
+from auto_process_ngs.auto_processor import AutoProcess
+from auto_process_ngs.mock import MockAnalysisDirFactory
+from auto_process_ngs.commands.clone_cmd import clone
+
+# Set to False to keep test output dirs
+REMOVE_TEST_OUTPUTS = True
+
+class TestAutoProcessClone(unittest.TestCase):
+    """
+    Tests for AutoProcess.clone
+    """
+    def setUp(self):
+        # Create a temp working dir
+        self.dirn = tempfile.mkdtemp(suffix='TestAutoProcessClone')
+        # Store original location so we can get back at the end
+        self.pwd = os.getcwd()
+        # Move to working dir
+        os.chdir(self.dirn)
+        # Placeholders for test objects
+        self.ap = None
+
+    def tearDown(self):
+        # Delete autoprocessor object
+        if self.ap is not None:
+            del(self.ap)
+        # Return to original dir
+        os.chdir(self.pwd)
+        # Remove the temporary test directory
+        if REMOVE_TEST_OUTPUTS:
+            shutil.rmtree(self.dirn)
+
+    def test_clone_analysis_dir(self):
+        """
+        clone: copies an analysis directory using symlinks
+        """
+        # Make a source analysis dir
+        analysis_dir = MockAnalysisDirFactory.bcl2fastq2(
+            "190116_M01234_0002_AXYZ123",
+            platform="miseq",
+            paired_end=True,
+            no_lane_splitting=False,
+            include_stats_files=True,
+            top_dir=self.dirn)
+        analysis_dir.create()
+        # Make a copy
+        clone_dir = os.path.join(self.dirn,"190116_M01234_0002_AXYZ123_copy")
+        self.assertFalse(os.path.exists(clone_dir))
+        ap = AutoProcess(analysis_dir.dirn)
+        clone(ap,clone_dir)
+        self.assertTrue(os.path.isdir(clone_dir))
+        # Check contents
+        for subdir in ('logs','ScriptCode'):
+            d = os.path.join(clone_dir,subdir)
+            self.assertTrue(os.path.isdir(d),"Missing '%s'" % subdir)
+        for filen in ('SampleSheet.orig.csv',
+                      'custom_SampleSheet.csv',
+                      'auto_process.info',
+                      'metadata.info',
+                      'statistics.info',):
+            f = os.path.join(clone_dir,filen)
+            self.assertTrue(os.path.isfile(f),"Missing '%s'" % filen)
+        # Check unassigned
+        unassigned = os.path.join(clone_dir,'bcl2fastq')
+        self.assertTrue(os.path.islink(unassigned))
+        # Check projects
+        for proj in ('AB','CDE','undetermined'):
+            d = os.path.join(clone_dir,proj)
+            self.assertTrue(os.path.isdir(d),"Missing '%s'" % proj)
+
+    def test_clone_analysis_dir_copy_fastqs(self):
+        """
+        clone: copies an analysis directory
+        """
+        # Make a source analysis dir
+        analysis_dir = MockAnalysisDirFactory.bcl2fastq2(
+            "190116_M01234_0002_AXYZ123",
+            platform="miseq",
+            paired_end=True,
+            no_lane_splitting=False,
+            include_stats_files=True,
+            top_dir=self.dirn)
+        analysis_dir.create()
+        # Make a copy
+        clone_dir = os.path.join(self.dirn,"190116_M01234_0002_AXYZ123_copy")
+        self.assertFalse(os.path.exists(clone_dir))
+        ap = AutoProcess(analysis_dir.dirn)
+        clone(ap,clone_dir,copy_fastqs=True)
+        self.assertTrue(os.path.isdir(clone_dir))
+        # Check contents
+        for subdir in ('logs','ScriptCode'):
+            d = os.path.join(clone_dir,subdir)
+            self.assertTrue(os.path.isdir(d),"Missing '%s'" % subdir)
+        for filen in ('SampleSheet.orig.csv',
+                      'custom_SampleSheet.csv',
+                      'auto_process.info',
+                      'metadata.info',
+                      'statistics.info',):
+            f = os.path.join(clone_dir,filen)
+            self.assertTrue(os.path.isfile(f),"Missing '%s'" % filen)
+        # Check unassigned
+        unassigned = os.path.join(clone_dir,'bcl2fastq')
+        self.assertTrue(os.path.isdir(unassigned))
+        # Check projects
+        for proj in ('AB','CDE','undetermined'):
+            d = os.path.join(clone_dir,proj)
+            self.assertTrue(os.path.isdir(d),"Missing '%s'" % proj)
+
+    def test_clone_fails_if_target_dir_exists(self):
+        """
+        clone: raises an exception if target dir already exists 
+        """
+        # Make a source analysis dir
+        analysis_dir = MockAnalysisDirFactory.bcl2fastq2(
+            "190116_M01234_0002_AXYZ123",
+            platform="miseq",
+            paired_end=True,
+            no_lane_splitting=False,
+            include_stats_files=True,
+            top_dir=self.dirn)
+        analysis_dir.create()
+        # Make target dir
+        clone_dir = os.path.join(self.dirn,"190116_M01234_0002_AXYZ123_copy")
+        os.mkdir(clone_dir)
+        # Try to copy source dir
+        ap = AutoProcess(analysis_dir.dirn)
+        self.assertRaises(Exception,
+                          clone,
+                          ap,clone_dir)
+
+        

--- a/auto_process_ngs/test/commands/test_clone_cmd.py
+++ b/auto_process_ngs/test/commands/test_clone_cmd.py
@@ -53,6 +53,7 @@ class TestAutoProcessClone(unittest.TestCase):
         analysis_dir.create()
         ap = AutoProcess(analysis_dir.dirn)
         UpdateAnalysisDir(ap).add_processing_report()
+        ap.add_directory("primary_data/190116_M01234_0002_AXYZ123")
         # Make a copy
         clone_dir = os.path.join(self.dirn,"190116_M01234_0002_AXYZ123_copy")
         self.assertFalse(os.path.exists(clone_dir))
@@ -73,9 +74,14 @@ class TestAutoProcessClone(unittest.TestCase):
                       'processing_qc.html',):
             f = os.path.join(clone_dir,filen)
             self.assertTrue(os.path.isfile(f),"Missing '%s'" % filen)
-        # Check unassigned
-        unassigned = os.path.join(clone_dir,'bcl2fastq')
-        self.assertTrue(os.path.islink(unassigned))
+        # Check unaligned
+        unaligned = os.path.join(clone_dir,'bcl2fastq')
+        self.assertTrue(os.path.islink(unaligned))
+        # Check primary data
+        primary_data = os.path.join(clone_dir,
+                                    'primary_data',
+                                    '190116_M01234_0002_AXYZ123')
+        self.assertTrue(os.path.islink(primary_data))
         # Check projects
         for proj in ('AB','CDE','undetermined'):
             d = os.path.join(clone_dir,proj)
@@ -96,6 +102,7 @@ class TestAutoProcessClone(unittest.TestCase):
         analysis_dir.create()
         ap = AutoProcess(analysis_dir.dirn)
         UpdateAnalysisDir(ap).add_processing_report()
+        ap.add_directory("primary_data/190116_M01234_0002_AXYZ123")
         # Make a copy
         clone_dir = os.path.join(self.dirn,"190116_M01234_0002_AXYZ123_copy")
         self.assertFalse(os.path.exists(clone_dir))
@@ -116,9 +123,14 @@ class TestAutoProcessClone(unittest.TestCase):
                       'processing_qc.html',):
             f = os.path.join(clone_dir,filen)
             self.assertTrue(os.path.isfile(f),"Missing '%s'" % filen)
-        # Check unassigned
-        unassigned = os.path.join(clone_dir,'bcl2fastq')
-        self.assertTrue(os.path.isdir(unassigned))
+        # Check unaligned
+        unaligned = os.path.join(clone_dir,'bcl2fastq')
+        self.assertTrue(os.path.isdir(unaligned))
+        # Check primary data
+        primary_data = os.path.join(clone_dir,
+                                    'primary_data',
+                                    '190116_M01234_0002_AXYZ123')
+        self.assertTrue(os.path.islink(primary_data))
         # Check projects
         for proj in ('AB','CDE','undetermined'):
             d = os.path.join(clone_dir,proj)
@@ -139,6 +151,7 @@ class TestAutoProcessClone(unittest.TestCase):
         analysis_dir.create()
         ap = AutoProcess(analysis_dir.dirn)
         UpdateAnalysisDir(ap).add_processing_report()
+        ap.add_directory("primary_data/190116_M01234_0002_AXYZ123")
         # Make target dir
         clone_dir = os.path.join(self.dirn,"190116_M01234_0002_AXYZ123_copy")
         os.mkdir(clone_dir)

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -705,6 +705,9 @@ def add_clone_command(cmdparser):
     p.add_option('--copy-fastqs',action='store_true',dest='copy_fastqs',default=False,
                  help="Copy fastq.gz files from DIR into CLONE_DIR (default is "
                  "to make a link to the bcl-to-fastq directory)")
+    p.add_option('--exclude-projects',action='store_true',
+                 dest='exclude_projects',default=False,
+                 help="Exclude (i.e. don't copy) project directories from DIR")
     add_debug_option(p)
 
 def add_analyse_barcodes_command(cmdparser):
@@ -924,7 +927,9 @@ if __name__ == "__main__":
                              "directory for the copy\n")
             sys.exit(1)
         d = AutoProcess(args[0],allow_save_params=False)
-        d.clone(args[1],copy_fastqs=options.copy_fastqs)
+        d.clone(args[1],
+                copy_fastqs=options.copy_fastqs,
+                exclude_projects=options.exclude_projects)
     elif cmd == 'import_project':
         if len(args) == 0 or len(args) > 2:
             sys.stderr.write("Need to supply a project directory to import\n")

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -700,13 +700,11 @@ def add_clone_command(cmdparser):
     """
     p = cmdparser.add_command('clone',help="Make a copy of an analysis directory",
                               usage="%prog clone [OPTIONS] DIR CLONE_DIR",
-                              description="Make a copy of an existing auto_processed analysis "
-                              "directory DIR, in a new directory CLONE_DIR. The clone will "
-                              "not include any project directories, but will copy the "
-                              "projects.info file.")
+                              description="Make a copy of an existing "
+                              "directory DIR in a new directory CLONE_DIR.")
     p.add_option('--copy-fastqs',action='store_true',dest='copy_fastqs',default=False,
-                 help="Copy fastq.gz files from DIR into DIR2 (default is to make a "
-                 "link to the bcl-to-fastq directory)")
+                 help="Copy fastq.gz files from DIR into CLONE_DIR (default is "
+                 "to make a link to the bcl-to-fastq directory)")
     add_debug_option(p)
 
 def add_analyse_barcodes_command(cmdparser):


### PR DESCRIPTION
PR which moves the functionality of the `clone` command out of the `AutoProcess` class and into the `commands` submodule, and adds new unit tests for checking.