### PR TITLE
'setup' command: fix broken command-line

### DIFF
--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -916,11 +916,11 @@ if __name__ == "__main__":
             sys.stderr.write("Need to supply a data source location\n")
             sys.exit(1)
         d = AutoProcess()
-        if options.fastq_dir is None:
+        if options.unaligned_dir is None:
             d.setup(args[0],
                     analysis_dir=options.analysis_dir,
                     sample_sheet=options.sample_sheet,
-                    unaligned_dir=options.fastq_dir)
+                    unaligned_dir=options.unaligned_dir)
     elif cmd == 'clone':
         if len(args) != 2:
             sys.stderr.write("Need to supply an existing analysis dir and "


### PR DESCRIPTION
PR to fix bug in the `auto_process.py setup` command introduced in PR #277:

    $ auto_process.py setup ~/test_data/MiSEQ/150729_M00879_0087_000000000-AGEW9
     WARNING: No sequencers defined
    auto_process.py version 0.14.0
     WARNING: No sequencers defined
    Traceback (most recent call last):
      File "/home/pjb/scratchpad/test_auto_process_updates/venv.ap/bin/auto_process.py", line 919, in <module>
        if options.fastq_dir is None:
    AttributeError: Values instance has no attribute 'fastq_dir'