### PR TITLE
Enable settings file to be specified via environment variable

### DIFF
--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -1,7 +1,7 @@
 #!/bin/env python
 #
 #     settings.py: handle configuration settings for autoprocessing
-#     Copyright (C) University of Manchester 2014-2018 Peter Briggs
+#     Copyright (C) University of Manchester 2014-2019 Peter Briggs
 #
 #########################################################################
 #
@@ -429,9 +429,11 @@ def locate_settings_file(name='settings.ini',create_from_sample=True):
     Look for a configuration settings file (default name
     'settings.ini'). The search path is:
 
-    1. current directory
-    2. 'config' subdir of installation location
-    3. top-level installation location
+    1. file specified by the AUTO_PROCESS_CONF environment
+       variable (if it exists)
+    2. current directory
+    3. 'config' subdir of installation location
+    4. top-level installation location
 
     The first file with a matching name is returned.
 
@@ -445,6 +447,14 @@ def locate_settings_file(name='settings.ini',create_from_sample=True):
     found.
 
     """
+    # Check for environment variable
+    try:
+        settings_file = os.environ['AUTO_PROCESS_CONF']
+        if os.path.exists(settings_file):
+            return settings_file
+    except KeyError:
+        pass
+    # Check locations
     install_dir = get_install_dir()
     config_dir = get_config_dir()
     config_file_dirs = (os.getcwd(),

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -13,9 +13,11 @@ The autoprocessor reads its global settings for the local system from a
 ``settings.ini`` file, which it looks for in order in the following
 locations:
 
-1. The current directory
-2. The ``config`` subdirectory of the installation directory
-3. The installation directory (for legacy installations only)
+1. The file specified by the ``AUTO_PROCESS_CONF`` environment
+   variable (if set)
+2. The current directory
+3. The ``config`` subdirectory of the installation directory
+4. The installation directory (for legacy installations only)
 
 To create a ``settings.ini`` file for a new installation, use the command
 


### PR DESCRIPTION
PR to address issue #170: updates the `locate_settings_file` in the `settings.py` module to look for a configuration file specified by the `AUTO_PROCESS_CONF` environment variable, before searching the other directories.
