### PR TITLE
setup.py: specify matplotlib version to be <=2.2.3 at install time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ for pattern in ('bin/*.py','bin/*.sh',):
 
 # Installation requirements
 install_requires = ['pillow',
-                    'matplotlib',
+                    'matplotlib<=2.2.3',
                     'pandas',
                     'cloudpickle',
                     'psutil',


### PR DESCRIPTION
PR which explicitly specifies the version of the `matplotlib` library to be <=2.2.3 at install time; later versions won't work with Python 2.