### PR TITLE
Sort sample names into human readable order in QC reports

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -392,7 +392,8 @@ class AnalysisProject:
             sample.add_fastq(os.path.normpath(
                 os.path.join(self.fastq_dir,fq)))
         # Sort samples by name
-        self.samples.sort(cmp_sample_names)
+        self.samples = sorted(self.samples,
+                              key=lambda s: split_sample_name(s.name))
         logger.debug("Listing samples and files:")
         for sample in self.samples:
             logger.debug("* %s: %s" % (sample.name,sample.fastq))

--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -1095,29 +1095,3 @@ def split_sample_name(s):
         if part.isdigit():
             parts[i] = int(part)
     return parts
-
-def cmp_sample_names(a,b):
-    """Compare two sample names for sorting
-
-    Compares two sample names and returns an integer according
-    to the outcome.
-
-    Arguments:
-      a (str): first sample name
-      b (str): second sample name for comparison
-
-    Returns:
-      Integer: the return value is negative if a < b, zero if
-        a == b, and strictly positive if a > b.
-    """
-    for a,b in izip_longest(split_sample_name(a),
-                            split_sample_name(b),
-                            fillvalue=None):
-        if a is None:
-            return -1
-        elif b is None:
-            return 1
-        cmp_ = cmp(a,b)
-        if cmp_ != 0:
-            return cmp_
-    return 0

--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -391,6 +391,8 @@ class AnalysisProject:
                 self.samples.append(sample)
             sample.add_fastq(os.path.normpath(
                 os.path.join(self.fastq_dir,fq)))
+        # Sort samples by name
+        self.samples.sort(cmp_sample_names)
         logger.debug("Listing samples and files:")
         for sample in self.samples:
             logger.debug("* %s: %s" % (sample.name,sample.fastq))

--- a/auto_process_ngs/qc/processing.py
+++ b/auto_process_ngs/qc/processing.py
@@ -4,6 +4,7 @@
 
 import os
 from bcftbx.TabFile import TabFile
+from ..analysis import split_sample_name
 from ..docwriter import Document
 from ..docwriter import Table
 from ..docwriter import List
@@ -144,7 +145,12 @@ def report_processing_qc(analysis_dir,html_file):
                         barplot='',
                     )
             s.add(tbl)
-            for sample in data['samples']:
+            # Sort the sample data into order of sample name
+            samples = sorted([s for s in data['samples']],
+                             key=lambda s: split_sample_name(s['sname']))
+            # Write the table
+            for sample in samples:
+                print sample
                 pname = sample['pname']
                 sname = sample['sname']
                 nreads = sample['nreads']

--- a/auto_process_ngs/qc/processing.py
+++ b/auto_process_ngs/qc/processing.py
@@ -150,7 +150,6 @@ def report_processing_qc(analysis_dir,html_file):
                              key=lambda s: split_sample_name(s['sname']))
             # Write the table
             for sample in samples:
-                print sample
                 pname = sample['pname']
                 sname = sample['sname']
                 nreads = sample['nreads']

--- a/auto_process_ngs/qc/processing.py
+++ b/auto_process_ngs/qc/processing.py
@@ -194,17 +194,22 @@ def report_processing_qc(analysis_dir,html_file):
         lanes = filter(lambda c: c.startswith('L'),stats.header())
         sample = None
         for project in projects:
-            subset = filter(lambda d: d['Project'] == project,stats)
+            # Get subset of lines for this project
+            subset = sorted(filter(lambda d: d['Project'] == project,stats),
+                            key=lambda l: split_sample_name(l['Sample']))
+            # Work out which lanes are included
             subset_lanes = filter(lambda l:
                                   reduce(lambda x,y: x or bool(y),
                                          [d[l] for d in subset],
                                          False),
                                   lanes)
+            # Add a new section for this project
             s = per_file_stats.add_subsection(
                 "%s" % project,
                 name="per_file_stats_%s" % project
             )
             project_toc_list.add_item(Link("%s" % project,s))
+            # Build the data of data
             tbl = Table(columns=('Sample','Fastq','Size'))
             if subset_lanes:
                 tbl.append_columns(*subset_lanes)

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -713,6 +713,22 @@ class TestAnalysisProject(unittest.TestCase):
         project = AnalysisProject('PJB',os.path.join(self.dirn,'PJB'))
         self.assertEqual(project.sample_summary(),"No samples")
 
+    def test_order_samples_by_name(self):
+        """AnalysisProject: sample_summary works for SE data
+        """
+        self.make_mock_project_dir(
+            'PJB',
+            ('PJB1_ACAGTG_L001_R1_001.fastq.gz',
+             'PJB2_ACAGTG_L001_R1_001.fastq.gz',
+             'PJB3_ACAGTG_L001_R1_001.fastq.gz',
+             'PJB10_ACAGTG_L001_R1_001.fastq.gz',
+             'PJB20_ACAGTG_L001_R1_001.fastq.gz',
+             'PJB21_ACAGTG_L001_R1_001.fastq.gz',))
+        project = AnalysisProject('PJB',os.path.join(self.dirn,'PJB'))
+        sample_names = [s.name for s in project.samples]
+        self.assertEqual(sample_names,
+                         ['PJB1','PJB2','PJB3','PJB10','PJB20','PJB21'])
+
     def test_pickle_analysis_project(self):
         """AnalysisProject: check serialisation with 'pickle'
         """

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -905,18 +905,3 @@ class TestSplitSampleNameFunction(unittest.TestCase):
         self.assertEqual(split_sample_name("PJB1"),["PJB",1])
         self.assertEqual(split_sample_name("PJB0001"),["PJB",1])
         self.assertEqual(split_sample_name("PJB_1-10"),["PJB_",1,"-",10])
-
-class TestCmpSampleNameFunction(unittest.TestCase):
-    """
-    Tests for the 'cmp_sample_names' function
-    """
-    def test_cmp_sample_name(self):
-        """cmp_sample_names: check names are compared correctly
-        """
-        self.assertEqual(cmp_sample_names("AB","CDE"),-1)
-        self.assertEqual(cmp_sample_names("CDE","AB"),1)
-        self.assertEqual(cmp_sample_names("CDE","CDE"),0)
-        self.assertEqual(cmp_sample_names("CDE01","CDE02"),-1)
-        self.assertEqual(cmp_sample_names("CDE02","CDE10"),-1)
-        self.assertEqual(cmp_sample_names("CDE_1_02","CDE_2_10"),-1)
-        self.assertEqual(cmp_sample_names("CDE_1","CDE_1_longer"),-1)

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -877,3 +877,30 @@ class TestAnalysisSample(unittest.TestCase):
         self.assertEqual(sample.fastq_subset(read_number=2),[fq_r2])
         self.assertTrue(sample.paired_end)
         self.assertEqual(str(sample),'PJB1-B')
+
+class TestSplitSampleNameFunction(unittest.TestCase):
+    """
+    Tests for the 'split_sample_name' function
+    """
+    def test_split_sample_name(self):
+        """split_sample_name: check names are split correctly
+        """
+        self.assertEqual(split_sample_name("PJB"),["PJB"])
+        self.assertEqual(split_sample_name("PJB1"),["PJB",1])
+        self.assertEqual(split_sample_name("PJB0001"),["PJB",1])
+        self.assertEqual(split_sample_name("PJB_1-10"),["PJB_",1,"-",10])
+
+class TestCmpSampleNameFunction(unittest.TestCase):
+    """
+    Tests for the 'cmp_sample_names' function
+    """
+    def test_cmp_sample_name(self):
+        """cmp_sample_names: check names are compared correctly
+        """
+        self.assertEqual(cmp_sample_names("AB","CDE"),-1)
+        self.assertEqual(cmp_sample_names("CDE","AB"),1)
+        self.assertEqual(cmp_sample_names("CDE","CDE"),0)
+        self.assertEqual(cmp_sample_names("CDE01","CDE02"),-1)
+        self.assertEqual(cmp_sample_names("CDE02","CDE10"),-1)
+        self.assertEqual(cmp_sample_names("CDE_1_02","CDE_2_10"),-1)
+        self.assertEqual(cmp_sample_names("CDE_1","CDE_1_longer"),-1)


### PR DESCRIPTION
PR which tries to sort the sample names into human readable order (so that e.g. `LF02` appears before `LF10` etc) in the QC reports.

Aims to address issue #150.