### PR TITLE
Enable default source metadata in settings

### DIFF
--- a/auto_process_ngs/commands/setup_cmd.py
+++ b/auto_process_ngs/commands/setup_cmd.py
@@ -213,6 +213,8 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
     # Bases mask
     print "Bases mask set to 'auto' (will be determined at run time)"
     bases_mask = "auto"
+    # Data source metadata
+    data_source = ap.settings.metadata.default_data_source
     # Generate and print predicted outputs and warnings
     if custom_sample_sheet is not None:
         sample_sheet_data = SampleSheet(custom_sample_sheet)
@@ -263,6 +265,7 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
     ap.metadata['instrument_run_number'] = run_number
     ap.metadata['instrument_flow_cell_id'] = flow_cell
     ap.metadata['assay'] = assay
+    ap.metadata['source'] = data_source
     # Make a 'projects.info' metadata file
     if unaligned_dir is not None:
         ap.make_project_metadata_file()

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -162,6 +162,10 @@ class Settings(object):
                 if platform not in self.platform:
                     self.platform[platform] = AttributeDictionary()
                 self.platform[platform]['bcl2fastq'] = bcl2fastq
+        # Metadata defaults
+        self.add_section('metadata')
+        self.metadata['default_data_source'] = config.get('metadata',
+                                                          'default_data_source')
         # icell8
         self.add_section('icell8')
         self.icell8['aligner'] = config.get('icell8','aligner')

--- a/auto_process_ngs/test/test_settings.py
+++ b/auto_process_ngs/test/test_settings.py
@@ -57,6 +57,8 @@ class TestSettings(unittest.TestCase):
         # QC reporting
         self.assertEqual(s.qc_web_server.dirn,None)
         self.assertEqual(s.qc_web_server.url,None)
+        # Metadata
+        self.assertEqual(s.metadata.default_data_source,None)
 
     def test_partial_settings_file(self):
         """Settings: load a partial settings.ini file

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -90,6 +90,10 @@ icell8 = SimpleJobRunner
 icell8_contaminant_filter = SimpleJobRunner
 icell8_statistics = SimpleJobRunner
 
+# Defaults for metadata
+[metadata]
+default_data_source = None
+
 # Settings for archiving analyses
 # dirn should be a directory in the form [[user@]host:]path
 [archive]

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -88,6 +88,25 @@ as follows:
 The instrument name can be derived from the name of the directories
 produced by the sequencer (see :ref:`run_and_fastq_naming_conventions`).
 
+----------------
+Default metadata
+----------------
+
+The ``metadata`` section of the configuration file allows defaults
+to be specified for metadata items associated with each run.
+
+Currently it is possible to set a default for the ``source``
+metadata item, which specifies where the data was received from,
+for example:
+
+::
+
+   [metadata]
+   default_data_source = "Local sequencing facility"
+
+If no default is set then the values can be updated using the
+``metadata`` command (see :ref:`commands_metadata`).
+
 .. _running_on_compute_cluster:
 
 ----------------------------


### PR DESCRIPTION
PR which adds a new `metadata` section to the `settings.ini` file with a new parameter `default_data_source`, which allows a default value to be set for the `source` metadata item (which records the facility where the data came from, e.g. the local sequencing facility).

The aim is to reduce the overhead of having to set the `source` metadata manually every time a new run is processed.