### PR TITLE
Report additional data items in project QC reports

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -1090,6 +1090,21 @@ def run_reference_id(run_name,platform=None,facility_run_number=None):
     Note that the instrument run number is only used if it differs
     from the facility run number.
 
+    If the platform isn't supplied then the instrument name is
+    used instead, e.g.:
+
+    'SN0123_140701/242#22'
+
+    If the run name can't be split into components then the
+    general form will be:
+
+    [PLATFORM_]RUN_NAME[#FACILITY_RUN_NUMBER]
+
+    depending on whether platform and/or facility run number have
+    been supplied. For example for a run called 'rag_05_2017':
+
+    'MISEQ_rag_05_2017#90'
+
     Arguments:
       run_name (str): the run name (can be a path)
       platform (str): the platform name (optional)
@@ -1126,16 +1141,18 @@ def run_reference_id(run_name,platform=None,facility_run_number=None):
         run_id = platform
         if datestamp is not None:
             run_id += "_%s" % datestamp
-        if run_number is not None:
-            try:
-                if run_number != facility_run_number:
-                    run_id += "/%s" % run_number
-            except ValueError:
-                run_id += "/%s" % run_number
-        if facility_run_number is not None:
-            run_id += "#%s" % facility_run_number
+        else:
+            run_id += "_%s" % run_name
     else:
         run_id = run_name
+    if run_number is not None:
+        try:
+            if run_number != facility_run_number:
+                run_id += "/%s" % run_number
+        except ValueError:
+            run_id += "/%s" % run_number
+    if facility_run_number is not None:
+        run_id += "#%s" % facility_run_number
     return run_id
 
 def split_sample_name(s):

--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -1111,6 +1111,8 @@ def run_reference_id(run_name,platform=None,facility_run_number=None):
     # Platform
     if platform is not None:
         platform = platform.upper()
+    else:
+        platform = instrument
     # Run number
     if run_number is not None:
         run_number = int(run_number)

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -670,23 +670,8 @@ class AutoProcess(object):
 
     @property
     def run_reference_id(self):
-        """Return a run reference id e.g. 'HISEQ_140701/242#22'
-
-        The run reference code is a code that identifies the sequencing
-        run, and has the general form:
-
-        PLATFORM_DATESTAMP[/INSTRUMENT_RUN_NUMBER]#FACILITY_RUN_NUMBER
-
-        - PLATFORM is always uppercased e.g. HISEQ, MISEQ, GA2X
-        - DATESTAMP is the YYMMDD code e.g. 140701
-        - INSTRUMENT_RUN_NUMBER is the run number that forms part of the
-          run directory e.g. for '140701_SN0123_0045_000000000-A1BCD'
-          it is '45'
-        - FACILITY_RUN_NUMBER is the run number that has been assigned
-          by the facility
-
-        Note that the instrument run number is only used if it differs
-        from the facility run number.
+        """
+        Return a run reference id (e.g. 'HISEQ_140701/242#22')
         """
         return analysis.run_reference_id(
             self.run_name,

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -687,54 +687,11 @@ class AutoProcess(object):
 
         Note that the instrument run number is only used if it differs
         from the facility run number.
-
         """
-        # Extract information from run name
-        run_name = self.run_name
-        try:
-            datestamp,instrument,run_number = IlluminaData.split_run_name(run_name)
-        except Exception, ex:
-            logging.warning("Unable to extract information from run name '%s'" \
-                            % run_name)
-            logging.warning("Exception: %s" % ex)
-            instrument = None
-            date_stamp = None
-            run_number = None
-        # Update items from metadata
-        if self.metadata.instrument_name:
-            instrument = self.metadata.instrument_name
-        if self.metadata.instrument_datestamp:
-            date_stamp = self.metadata.instrument_datestamp
-        if self.metadata.instrument_run_number:
-            run_number = self.metadata.instrument_run_number
-        if run_number is not None:
-            run_number = str(run_number).lstrip('0')
-        # Platform
-        if self.metadata.platform is not None:
-            platform = self.metadata.platform.upper()
-        else:
-            platform = None
-        # Facility run number
-        if self.metadata.run_number is not None:
-            facility_run_number = str(self.metadata.run_number)
-        else:
-            facility_run_number = None
-        # Construct the reference id
-        if platform is not None:
-            run_id = platform
-            if datestamp is not None:
-                run_id += "_%s" % datestamp
-            if run_number is not None:
-                try:
-                    if run_number != facility_run_number:
-                        run_id += "/%s" % run_number
-                except ValueError:
-                    run_id += "/%s" % run_number
-            if facility_run_number is not None:
-                run_id += "#%s" % facility_run_number
-        else:
-            run_id = run_name
-        return run_id
+        return analysis.run_reference_id(
+            self.run_name,
+            platform=self.metadata.platform,
+            facility_run_number=self.metadata.run_number)
 
     @property
     def parameter_file(self):

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -62,7 +62,7 @@ div.footer { font-style: italic;
 
 def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                regenerate_reports=False,force=False,use_hierarchy=False,
-               exclude_zip_files=False):
+               exclude_zip_files=False,legacy=False):
     """
     Copy the QC reports to the webserver
 
@@ -79,13 +79,21 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
     each Fastq set in each project:
 
     - QC report for standard QC
-    - MultiQC report
 
     Also if a project comprises ICell8 or 10xGenomics Chromium
     data:
 
     - ICell8 processing report, or
     - 'cellranger count' reports for each sample
+
+    In 'legacy' mode, the top-level report will also contain
+    explicit links for each project for the following (where
+    appropriate):
+
+    - MultiQC report
+
+    (These reports should now be accessible from the per-project
+    QC reports, regardless of whther 'legacy' mode is specified.)
 
     Raises an exception if:
 
@@ -116,6 +124,8 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
       exclude_zip_files (bool): if True then exclude any ZIP
         archives from publication (default is to include ZIP
         files)
+      legacy (bool): if True then operate in 'legacy' mode (i.e.
+        explicitly include MultiQC reports for each project)
     """
     # Turn off saving of parameters etc
     ap._save_params = False
@@ -273,15 +283,16 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
             else:
                 # Not verified
                 print "...%s: failed to verify QC" % qc_dir
-            # MultiQC report
-            multiqc_report = os.path.join(project.dirn,
-                                          "multi%s.html"
-                                          % qc_base)
-            if os.path.exists(multiqc_report):
-                print "...%s: found MultiQC report" % qc_dir
-                qc_artefacts['multiqc_report'] = multiqc_report
-            else:
-                print "...%s: no MultiQC report" % qc_dir
+            if legacy:
+                # MultiQC report
+                multiqc_report = os.path.join(project.dirn,
+                                              "multi%s.html"
+                                              % qc_base)
+                if os.path.exists(multiqc_report):
+                    print "...%s: found MultiQC report" % qc_dir
+                    qc_artefacts['multiqc_report'] = multiqc_report
+                else:
+                    print "...%s: no MultiQC report" % qc_dir
         # ICell8 pipeline report
         icell8_zip = os.path.join(project.dirn,
                                   "icell8_processing.%s.%s.zip" %

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -690,7 +690,7 @@ class QCReport(Document):
             outputs.append("strandedness")
             versions = set()
             for f in fastq_strand:
-                versions.add(FastqStrand(
+                versions.add(Fastqstrand(
                     os.path.join(self.qc_dir,f)).version)
             if versions:
                 software['fastq_strand'] = sorted(list(versions))

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -639,6 +639,13 @@ class QCReport(Document):
         logger.debug("fastq_strand: %s" % fastq_strand)
         if fastq_strand:
             outputs.append("strandedness")
+        # Look for MultiQC report
+        print "Checking for MultiQC report in %s" % self.project.dirn)
+        multiqc_report = os.path.join(self.project.dirn,
+                                      "multi%s_report.html"
+                                      % os.path.basename(self.qc_dir))
+        if os.path.isfile(multiqc_report):
+            outputs.append("multiqc")
         self.outputs = outputs
         return self.outputs
 
@@ -657,6 +664,8 @@ class QCReport(Document):
                           'organism',
                           'qc_protocol',
                           'comments',]
+        if 'multiqc' in self.outputs:
+            metadata_items.append('multiqc')
         metadata_titles = {
             'user': 'User',
             'PI': 'PI',
@@ -666,6 +675,7 @@ class QCReport(Document):
             'organism': 'Organism',
             'qc_protocol': 'QC protocol',
             'comments': 'Additional comments',
+            'multiqc': 'MultiQC report',
         }
         for item in metadata_items:
             # Acquire the value
@@ -678,6 +688,13 @@ class QCReport(Document):
             except KeyError:
                 if item == 'qc_protocol':
                     value = self.project.qc_info(self.qc_dir).protocol
+                elif item == 'multiqc':
+                    multiqc_report = os.path.join(self.project.dirn,
+                                                  "multi%s_report.html"
+                                                  % os.path.basename(
+                                                      self.qc_dir))
+                    value = Link(os.path.basename(multiqc_report),
+                                 multiqc_report)
                 else:
                     raise Exception("Unrecognised item to report: '%s'"
                                     % item)

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -52,7 +52,12 @@ logger = logging.getLogger(__name__)
 
 from .illumina_qc import FASTQ_SCREENS
 
-QC_REPORT_CSS_STYLES = """/* Headers */
+QC_REPORT_CSS_STYLES = """/* General styles */
+html { font-family: DejaVu Serif, serif; }
+p { font-size: 85%;
+    color: #808080; }
+/* Headers */
+h1, h2, h3, h4 { font-family: DejaVu Serif, serif; }
 h1 { background-color: #42AEC2;
      color: white;\n
      padding: 5px 10px; }
@@ -63,21 +68,23 @@ h2 { background-color: #8CC63F;
      margin: 0;
      border-top-left-radius: 20px;
      border-bottom-right-radius: 20px; }
- h3, h4 { background-color: grey;
-          color: white;
-          display: block;
-          padding: 5px 15px;
-          margin: 0;
-          border-top-left-radius: 20px;
-          border-bottom-right-radius: 20px; }
+h3, h4 { background-color: grey;
+         color: white;
+         display: block;
+         padding: 5px 15px;
+         margin: 0;
+         border-top-left-radius: 20px;
+         border-bottom-right-radius: 20px; }
 /* Summary section */
 div.summary { margin: 10 10;
               border: solid 2px #8CC63F;
               padding: 0;
               border-top-left-radius: 25px; }
 .info { padding: 5px 15px;
-        float: left; }
+        float: left;
+        font-size: 100%; }
 .info h3 { margin: 5px; }
+.info p { color: black; }
 /* Samples and Fastqs */
 .sample { margin: 10 10;
           border: solid 2px #8CC63F;
@@ -138,9 +145,6 @@ table.programs th { text-align: left;
                     padding: 2px 5px; }
 table.programs td { padding: 2px 5px;
                     border-bottom: solid 1px lightgray; }
-/* General styles */
-p { font-size: 85%;
-    color: #808080; }
 /* Rules for printing */
 @media print
 {

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -20,6 +20,7 @@ from bcftbx.qc.report import strip_ngs_extensions
 from bcftbx.utils import AttributeDictionary
 from bcftbx.utils import extract_prefix
 from bcftbx.utils import extract_index
+from ..analysis import run_reference_id
 from ..docwriter import Document
 from ..docwriter import Section
 from ..docwriter import Table
@@ -731,7 +732,9 @@ class QCReport(Document):
         Adds entries for the project metadata to the "metadata"
         table in the report
         """
-        metadata_items = ['user',
+        metadata_items = ['run',
+                          'run_id',
+                          'user',
                           'PI',
                           'library_type',
                           'single_cell_platform',
@@ -742,6 +745,8 @@ class QCReport(Document):
         if 'multiqc' in self.outputs:
             metadata_items.append('multiqc')
         metadata_titles = {
+            'run_id': 'Run ID',
+            'run': 'Run name',
             'user': 'User',
             'PI': 'PI',
             'library_type': 'Library type',
@@ -761,7 +766,13 @@ class QCReport(Document):
                     # No value set, skip this item
                     continue
             except KeyError:
-                if item == 'qc_protocol':
+                if item == 'run_id':
+                    value = run_reference_id(
+                        self.project.info['run'],
+                        platform=self.project.info['platform'],
+                        facility_run_number=
+                        self.run_metadata['run_number'])
+                elif item == 'qc_protocol':
                     value = self.project.qc_info(self.qc_dir).protocol
                 elif item == 'multiqc':
                     multiqc_report = "multi%s_report.html" \

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -640,7 +640,7 @@ class QCReport(Document):
         if fastq_strand:
             outputs.append("strandedness")
         # Look for MultiQC report
-        print "Checking for MultiQC report in %s" % self.project.dirn)
+        print "Checking for MultiQC report in %s" % self.project.dirn
         multiqc_report = os.path.join(self.project.dirn,
                                       "multi%s_report.html"
                                       % os.path.basename(self.qc_dir))

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -27,6 +27,7 @@ from ..docwriter import Table
 from ..docwriter import Img
 from ..docwriter import Link
 from ..docwriter import Target
+from ..docwriter import List
 from ..metadata import AnalysisDirMetadata
 from .fastqc import Fastqc
 from .fastq_screen import Fastqscreen
@@ -636,7 +637,13 @@ class QCReport(Document):
         # Add comments section
         comments = info.add_subsection("Comments")
         comments.add_css_classes("info")
-        comments.add(self.project.info.comments)
+        comments_list = List()
+        if self.project.info.comments:
+            for comment in self.project.info.comments.split(';'):
+                comments_list.add_item(comment.strip())
+        else:
+            comments_list.add_item("N/A")
+        comments.add(comments_list)
         # Add an empty section to clear HTML floats
         clear = summary.add_subsection()
         clear.add_css_classes("clear")

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -68,6 +68,14 @@ h2 { background-color: #8CC63F;
           margin: 0;
           border-top-left-radius: 20px;
           border-bottom-right-radius: 20px; }
+/* Summary section */
+div.summary { margin: 10 10;
+              border: solid 2px #8CC63F;
+              padding: 0;
+              border-top-left-radius: 25px; }
+.info { padding: 5px 15px;
+        float: left; }
+.info h3 { margin: 5px; }
 /* Samples and Fastqs */
 .sample { margin: 10 10;
           border: solid 2px #8CC63F;
@@ -610,8 +618,19 @@ class QCReport(Document):
         Associated name is 'summary'
         """
         summary = self.add_section("Summary",name='summary')
-        summary.add(self.metadata_table)
-        summary.add(self.software_table)
+        summary.add_css_classes("summary")
+        # Add subsections inside a container
+        info = summary.add_subsection()
+        general_info = info.add_subsection("General information")
+        general_info.add_css_classes("info")
+        general_info.add(self.metadata_table)
+        software_info = info.add_subsection("Software")
+        software_info.add_css_classes("info")
+        software_info.add(self.software_table)
+        # Add an empty section to clear HTML floats
+        clear = summary.add_subsection()
+        clear.add_css_classes("clear")
+        # Add the summary table
         summary.add("%d samples | %d fastqs" % (len(self.project.samples),
                                                 len(self.project.fastqs)))
         summary.add(self.summary_table)

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -631,6 +631,15 @@ class QCReport(Document):
         # Add an empty section to clear HTML floats
         clear = summary.add_subsection()
         clear.add_css_classes("clear")
+        # Add additional subsections for comments etc
+        info = summary.add_subsection()
+        # Add comments section
+        comments = info.add_subsection("Comments")
+        comments.add_css_classes("info")
+        comments.add(self.project.info.comments)
+        # Add an empty section to clear HTML floats
+        clear = summary.add_subsection()
+        clear.add_css_classes("clear")
         # Add the summary table
         summary.add("%d samples | %d fastqs" % (len(self.project.samples),
                                                 len(self.project.fastqs)))
@@ -740,8 +749,7 @@ class QCReport(Document):
                           'single_cell_platform',
                           'number_of_cells',
                           'organism',
-                          'qc_protocol',
-                          'comments',]
+                          'qc_protocol',]
         if 'multiqc' in self.outputs:
             metadata_items.append('multiqc')
         metadata_titles = {
@@ -754,7 +762,6 @@ class QCReport(Document):
             'number_of_cells': 'Number of cells',
             'organism': 'Organism',
             'qc_protocol': 'QC protocol',
-            'comments': 'Additional comments',
             'multiqc': 'MultiQC report',
         }
         for item in metadata_items:

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -851,7 +851,8 @@ class QCReport(Document):
             else:
                 idx = self.summary_table.add_row(sample="&nbsp;")
             fastq_pair.update_summary_table(self.summary_table,idx=idx,
-                                            fields=self.summary_fields)
+                                            fields=self.summary_fields,
+                                            relpath=self.relpath)
 
 class QCReportFastqPair(object):
     """
@@ -1072,7 +1073,8 @@ class QCReportFastqPair(object):
         clear = fastqs_report.add_subsection()
         clear.add_css_classes("clear")
 
-    def update_summary_table(self,summary_table,idx=None,fields=None):
+    def update_summary_table(self,summary_table,idx=None,fields=None,
+                             relpath=None):
         """
         Add a line to a summary table reporting a Fastq pair
 
@@ -1101,6 +1103,8 @@ class QCReportFastqPair(object):
             table row to update (if None then a new row is
             appended)
           fields (list): list of custom fields to report
+          relpath (str): if set then make link paths
+            relative to 'relpath'
         """
         # Fields to report
         if fields is None:
@@ -1140,16 +1144,23 @@ class QCReportFastqPair(object):
                         self.r1.fastqc.data.basic_statistics(
                             'Total Sequences'))
                 elif field == "read_lengths":
+                    read_lengths_r1 = Link(
+                        self.r1.fastqc.data.basic_statistics(
+                            'Sequence length'),
+                        self.r1.fastqc.summary.link_to_module(
+                            'Sequence Length Distribution',
+                            relpath=relpath))
                     if self.paired_end:
-                        read_lengths = "%s<br />%s" % \
-                                       (self.r1.fastqc.data.basic_statistics(
-                                           'Sequence length'),
-                                        self.r2.fastqc.data.basic_statistics(
-                                            'Sequence length'))
+                        read_lengths_r2 = Link(
+                            self.r2.fastqc.data.basic_statistics(
+                                'Sequence length'),
+                            self.r2.fastqc.summary.link_to_module(
+                                'Sequence Length Distribution',
+                                relpath=relpath))
+                        read_lengths = "%s<br />%s" % (read_lengths_r1,
+                                                       read_lengths_r2)
                     else:
-                        read_lengths = "%s" % \
-                                       self.r1.fastqc.data.basic_statistics(
-                                           'Sequence length')
+                        read_lengths = "%s" % read_lengths_r1
                     value = read_lengths
                 elif field == "boxplot_r1":
                     value = Img(self.r1.uboxplot(),

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -649,24 +649,42 @@ class QCReport(Document):
         Adds entries for the project metadata to the "metadata"
         table in the report
         """
-        metadata_items = ['user','PI','library_type','organism',]
-        if self.project.info.single_cell_platform is not None:
-            metadata_items.insert(3,'single_cell_platform')
+        metadata_items = ['user',
+                          'PI',
+                          'library_type',
+                          'single_cell_platform',
+                          'number_of_cells',
+                          'organism',
+                          'qc_protocol',
+                          'comments',]
         metadata_titles = {
             'user': 'User',
             'PI': 'PI',
             'library_type': 'Library type',
             'single_cell_platform': 'Single cell preparation platform',
+            'number_of_cells': 'Number of cells',
             'organism': 'Organism',
+            'qc_protocol': 'QC protocol',
+            'comments': 'Additional comments',
         }
         for item in metadata_items:
-            if self.project.info[item]:
-                self.metadata_table.add_row(
-                    item=metadata_titles[item],
-                    value=self.project.info[item])
-        self.metadata_table.add_row(
-            item='QC protocol',
-            value=self.project.qc_info(self.qc_dir).protocol)
+            # Acquire the value
+            try:
+                if self.project.info[item]:
+                    value = self.project.info[item]
+                else:
+                    # No value set, skip this item
+                    continue
+            except KeyError:
+                if item == 'qc_protocol':
+                    value = self.project.qc_info(self.qc_dir).protocol
+                else:
+                    raise Exception("Unrecognised item to report: '%s'"
+                                    % item)
+            # Add to the metadata table
+            self.metadata_table.add_row(
+                item=metadata_titles[item],
+                value=value)
 
     def report_sample(self,sample):
         """

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -689,12 +689,9 @@ class QCReport(Document):
                 if item == 'qc_protocol':
                     value = self.project.qc_info(self.qc_dir).protocol
                 elif item == 'multiqc':
-                    multiqc_report = os.path.join(self.project.dirn,
-                                                  "multi%s_report.html"
-                                                  % os.path.basename(
-                                                      self.qc_dir))
-                    value = Link(os.path.basename(multiqc_report),
-                                 multiqc_report)
+                    multiqc_report = "multi%s_report.html" \
+                                     % os.path.basename(self.qc_dir)
+                    value = Link(multiqc_report)
                 else:
                     raise Exception("Unrecognised item to report: '%s'"
                                     % item)

--- a/auto_process_ngs/test/commands/test_publish_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_publish_qc_cmd.py
@@ -206,8 +206,6 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
             outputs.append(os.path.join(project_qc,"qc"))
-            # MultiQC output
-            outputs.append("multiqc_report.%s.html" % project.name)
         for item in outputs:
             f = os.path.join(publication_dir,
                              "160621_K00879_0087_000000000-AGEW9_analysis",
@@ -262,8 +260,6 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
             outputs.append(os.path.join(project_qc,"qc"))
-            # MultiQC output
-            outputs.append("multiqc_report.%s.html" % project.name)
         for item in outputs:
             f = os.path.join(publication_dir,
                              "160621_K00879_0087_000000000-AGEW9_analysis",
@@ -312,8 +308,6 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
             outputs.append(os.path.join(project_qc,"qc"))
-            # MultiQC output
-            outputs.append("multiqc_report.%s.html" % project.name)
         # Additional QC for second fastq set in first project
         project_qc = "qc.extra_report.%s.%s" % (multi_fastqs_project.name,
                                                 os.path.basename(
@@ -322,9 +316,6 @@ class TestAutoProcessPublishQc(unittest.TestCase):
         outputs.append("%s.zip" % project_qc)
         outputs.append(os.path.join(project_qc,"qc.extra_report.html"))
         outputs.append(os.path.join(project_qc,"qc.extra"))
-        # MultiQC output
-        outputs.append("multiqc.extra_report.%s.html" %
-                       multi_fastqs_project.name)
         for item in outputs:
             f = os.path.join(publication_dir,
                              "160621_K00879_0087_000000000-AGEW9_analysis",
@@ -398,8 +389,6 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
             outputs.append(os.path.join(project_qc,"qc"))
-            # MultiQC output
-            outputs.append("multiqc_report.%s.html" % project.name)
         for item in outputs:
             f = os.path.join(publication_dir,
                              "160621_K00879_0087_000000000-AGEW9_analysis",
@@ -452,8 +441,6 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
             outputs.append(os.path.join(project_qc,"qc"))
-            # MultiQC output
-            outputs.append("multiqc_report.%s.html" % project.name)
         for item in outputs:
             f = os.path.join(publication_dir,
                              "160621_K00879_0087_000000000-AGEW9_analysis",
@@ -509,8 +496,6 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
             outputs.append(os.path.join(project_qc,"qc"))
-            # MultiQC output
-            outputs.append("multiqc_report.%s.html" % project.name)
         # ICell8 outputs
         icell8_dir = "icell8_processing.%s.%s" % (icell8_project.name,
                                                   os.path.basename(
@@ -667,8 +652,6 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
             outputs.append(os.path.join(project_qc,"qc"))
-            # MultiQC output
-            outputs.append("multiqc_report.%s.html" % project.name)
         # Cellranger count outputs
         cellranger_count_dir = "cellranger_count_report.%s.%s" % (
             tenxgenomics_project.name,
@@ -736,8 +719,6 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
             outputs.append(os.path.join(project_qc,"qc"))
-            # MultiQC output
-            outputs.append("multiqc_report.%s.html" % project.name)
         for item in outputs:
             f = os.path.join(final_dir,
                              "160621_K00879_0087_000000000-AGEW9_analysis",
@@ -787,8 +768,6 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             outputs.append(os.path.join(project_qc,"qc_report.html"))
             outputs.append(os.path.join(project_qc,"qc"))
             zip_files.append("%s.zip" % project_qc)
-            # MultiQC output
-            outputs.append("multiqc_report.%s.html" % project.name)
         # ICell8 outputs
         icell8_dir = "icell8_processing.%s.%s" % (icell8_project.name,
                                                   os.path.basename(
@@ -899,10 +878,50 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
             outputs.append(os.path.join(project_qc,"qc"))
-            # MultiQC output
-            outputs.append("multiqc_report.%s.html" % project.name)
         for item in outputs:
             f = os.path.join(final_dir,
                              "20160621_K00879_0087_000000000-AGEW9_analysis",
+                             item)
+            self.assertTrue(os.path.exists(f),"Missing %s" % f)
+
+    def test_publish_qc_with_projects_legacy_mode(self):
+        """publish_qc: projects with all QC outputs (legacy mode)
+        """
+        # Make an auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '160621_K00879_0087_000000000-AGEW9',
+            'hiseq',
+            metadata={ "run_number": 87,
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
+            top_dir=self.dirn)
+        mockdir.create()
+        ap = AutoProcess(mockdir.dirn)
+        # Add processing report and QC outputs
+        UpdateAnalysisDir(ap).add_processing_report()
+        for project in ap.get_analysis_projects():
+            UpdateAnalysisProject(project).add_qc_outputs()
+        # Make a mock publication area
+        publication_dir = os.path.join(self.dirn,'QC')
+        os.mkdir(publication_dir)
+        # Publish
+        publish_qc(ap,location=publication_dir,legacy=True)
+        # Check outputs
+        outputs = ["index.html",
+                   "processing_qc.html"]
+        for project in ap.get_analysis_projects():
+            # Standard QC outputs
+            project_qc = "qc_report.%s.%s" % (project.name,
+                                              os.path.basename(
+                                                  ap.analysis_dir))
+            outputs.append(project_qc)
+            outputs.append("%s.zip" % project_qc)
+            outputs.append(os.path.join(project_qc,"qc_report.html"))
+            outputs.append(os.path.join(project_qc,"qc"))
+            # MultiQC output
+            outputs.append("multiqc_report.%s.html" % project.name)
+        for item in outputs:
+            f = os.path.join(publication_dir,
+                             "160621_K00879_0087_000000000-AGEW9_analysis",
                              item)
             self.assertTrue(os.path.exists(f),"Missing %s" % f)

--- a/auto_process_ngs/test/commands/test_run_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_run_qc_cmd.py
@@ -6,6 +6,7 @@ import unittest
 import tempfile
 import shutil
 import os
+import zipfile
 from bcftbx.JobRunner import SimpleJobRunner
 from auto_process_ngs.auto_processor import AutoProcess
 from auto_process_ngs.mock import MockAnalysisDirFactory
@@ -80,6 +81,17 @@ class TestAutoProcessRunQc(unittest.TestCase):
                 self.assertTrue(os.path.exists(os.path.join(mockdir.dirn,
                                                             p,f)),
                                 "Missing %s in project '%s'" % (f,p))
+            # Check zip file has MultiQC report
+            zip_file = os.path.join(mockdir.dirn,p,
+                                    "qc_report.%s.%s_analysis.zip" % (
+                                        p,
+                                        '170901_M00879_0087_000000000-AGEW9'))
+            with zipfile.ZipFile(zip_file) as z:
+                multiqc = os.path.join(
+                    "qc_report.%s.%s_analysis" % (
+                        p,'170901_M00879_0087_000000000-AGEW9'),
+                    "multiqc_report.html")
+                self.assertTrue(multiqc in z.namelist())
 
     def test_run_qc_with_strandedness(self):
         """run_qc: standard QC run with strandedness determination
@@ -138,6 +150,17 @@ mouse = /data/genomeIndexes/mm10/STAR
                 self.assertTrue(os.path.exists(os.path.join(mockdir.dirn,
                                                             p,f)),
                                 "Missing %s in project '%s'" % (f,p))
+            # Check zip file has MultiQC report
+            zip_file = os.path.join(mockdir.dirn,p,
+                                    "qc_report.%s.%s_analysis.zip" % (
+                                        p,
+                                        '170901_M00879_0087_000000000-AGEW9'))
+            with zipfile.ZipFile(zip_file) as z:
+                multiqc = os.path.join(
+                    "qc_report.%s.%s_analysis" % (
+                        p,'170901_M00879_0087_000000000-AGEW9'),
+                    "multiqc_report.html")
+                self.assertTrue(multiqc in z.namelist())
 
     def test_run_qc_single_end_with_strandedness(self):
         """run_qc: single-end QC run with strandedness determination
@@ -197,6 +220,17 @@ mouse = /data/genomeIndexes/mm10/STAR
                 self.assertTrue(os.path.exists(os.path.join(mockdir.dirn,
                                                             p,f)),
                                 "Missing %s in project '%s'" % (f,p))
+            # Check zip file has MultiQC report
+            zip_file = os.path.join(mockdir.dirn,p,
+                                    "qc_report.%s.%s_analysis.zip" % (
+                                        p,
+                                        '170901_M00879_0087_000000000-AGEW9'))
+            with zipfile.ZipFile(zip_file) as z:
+                multiqc = os.path.join(
+                    "qc_report.%s.%s_analysis" % (
+                        p,'170901_M00879_0087_000000000-AGEW9'),
+                    "multiqc_report.html")
+                self.assertTrue(multiqc in z.namelist())
 
     def test_run_qc_single_cell_with_strandedness(self):
         """run_qc: single-cell QC run with strandedness determination
@@ -257,3 +291,14 @@ mouse = /data/genomeIndexes/mm10/STAR
                 self.assertTrue(os.path.exists(os.path.join(mockdir.dirn,
                                                             p,f)),
                                 "Missing %s in project '%s'" % (f,p))
+            # Check zip file has MultiQC report
+            zip_file = os.path.join(mockdir.dirn,p,
+                                    "qc_report.%s.%s_analysis.zip" % (
+                                        p,
+                                        '170901_M00879_0087_000000000-AGEW9'))
+            with zipfile.ZipFile(zip_file) as z:
+                multiqc = os.path.join(
+                    "qc_report.%s.%s_analysis" % (
+                        p,'170901_M00879_0087_000000000-AGEW9'),
+                    "multiqc_report.html")
+                self.assertTrue(multiqc in z.namelist())

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -996,11 +996,15 @@ class TestRunReferenceIdFunction(unittest.TestCase):
         self.assertEqual(run_reference_id("160621_M00879_0087_000000000-AGEW9",
                                           platform=None,
                                           facility_run_number=87),
-                         "160621_M00879_0087_000000000-AGEW9")
+                         "M00879_160621#87")
+        self.assertEqual(run_reference_id("160621_M00879_0087_000000000-AGEW9",
+                                          platform=None,
+                                          facility_run_number=88),
+                         "M00879_160621/87#88")
         self.assertEqual(run_reference_id("/data/160621_M00879_0087_000000000-AGEW9/",
                                           platform=None,
                                           facility_run_number=87),
-                         "160621_M00879_0087_000000000-AGEW9")
+                         "M00879_160621#87")
 
     def test_run_reference_id_no_facility_run_number(self):
         """run_reference_id: run name and platform (no facility run number)

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -974,6 +974,54 @@ class TestAnalysisSample(unittest.TestCase):
         self.assertTrue(sample.paired_end)
         self.assertEqual(str(sample),'PJB1-B')
 
+class TestRunReferenceIdFunction(unittest.TestCase):
+    """
+    Tests for the 'run_reference_id' function
+    """
+    def test_run_reference_id(self):
+        """run_reference_id: run name, platform and facility run number
+        """
+        self.assertEqual(run_reference_id("160621_M00879_0087_000000000-AGEW9",
+                                          platform="miseq",
+                                          facility_run_number=87),
+                         "MISEQ_160621#87")
+        self.assertEqual(run_reference_id("/data/160621_M00879_0087_000000000-AGEW9/",
+                                          platform="miseq",
+                                          facility_run_number=87),
+                         "MISEQ_160621#87")
+
+    def test_run_reference_id_no_platform(self):
+        """run_reference_id: run name and facility run number (no platform)
+        """
+        self.assertEqual(run_reference_id("160621_M00879_0087_000000000-AGEW9",
+                                          platform=None,
+                                          facility_run_number=87),
+                         "160621_M00879_0087_000000000-AGEW9")
+        self.assertEqual(run_reference_id("/data/160621_M00879_0087_000000000-AGEW9/",
+                                          platform=None,
+                                          facility_run_number=87),
+                         "160621_M00879_0087_000000000-AGEW9")
+
+    def test_run_reference_id_no_facility_run_number(self):
+        """run_reference_id: run name and platform (no facility run number)
+        """
+        self.assertEqual(run_reference_id("160621_M00879_0087_000000000-AGEW9",
+                                          platform="miseq",
+                                          facility_run_number=None),
+                         "MISEQ_160621/87")
+
+    def test_run_reference_id_facility_run_number_differs(self):
+        """run_reference_id: instrument and facility run numbers differ
+        """
+        self.assertEqual(run_reference_id("160621_M00879_0087_000000000-AGEW9",
+                                          platform="miseq",
+                                          facility_run_number=90),
+                         "MISEQ_160621/87#90")
+        self.assertEqual(run_reference_id("/data/160621_M00879_0087_000000000-AGEW9/",
+                                          platform="miseq",
+                                          facility_run_number=90),
+                         "MISEQ_160621/87#90")
+
 class TestSplitSampleNameFunction(unittest.TestCase):
     """
     Tests for the 'split_sample_name' function

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -1026,6 +1026,26 @@ class TestRunReferenceIdFunction(unittest.TestCase):
                                           facility_run_number=90),
                          "MISEQ_160621/87#90")
 
+    def test_run_reference_id_bad_run_name(self):
+        """run_reference_id: handle 'bad' run name (cannot be split)
+        """
+        self.assertEqual(run_reference_id("rag_05_2017",
+                                          platform=None,
+                                          facility_run_number=None),
+                         "rag_05_2017")
+        self.assertEqual(run_reference_id("rag_05_2017",
+                                          platform="miseq",
+                                          facility_run_number=None),
+                         "MISEQ_rag_05_2017")
+        self.assertEqual(run_reference_id("rag_05_2017",
+                                          platform=None,
+                                          facility_run_number=90),
+                         "rag_05_2017#90")
+        self.assertEqual(run_reference_id("rag_05_2017",
+                                          platform="miseq",
+                                          facility_run_number=90),
+                         "MISEQ_rag_05_2017#90")
+
 class TestSplitSampleNameFunction(unittest.TestCase):
     """
     Tests for the 'split_sample_name' function

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -609,6 +609,10 @@ def add_publish_qc_command(cmdparser):
                  dest='force',default=False,
                  help="force generation of QC reports for all projects even "
                  "if verification has failed")
+    p.add_option('--legacy',action='store_true',
+                 dest='legacy_mode',default=False,
+                 help="legacy mode: include links to MultiQC reports in the "
+                 "top-level index page")
     add_debug_option(p)
 
 def add_archive_command(cmdparser):
@@ -1140,7 +1144,7 @@ if __name__ == "__main__":
                          exclude_zip_files=(options.exclude_zip_files == 'yes'),
                          ignore_missing_qc=options.ignore_missing_qc,
                          regenerate_reports=options.regenerate_reports,
-                         force=options.force)
+                         force=options.force,legacy=options.legacy_mode)
         elif cmd == 'report':
             if options.logging:
                 mode = ReportingMode.CONCISE

--- a/bin/reportqc.py
+++ b/bin/reportqc.py
@@ -251,9 +251,9 @@ def main():
             # Check if we need to rerun MultiQC
             if os.path.exists(multiqc_report) and not opts.force:
                 run_multiqc = False
-                multiqc_mtime = os.stat(multiqc_report).st_mtime
+                multiqc_mtime = os.path.getmtime(multiqc_report)
                 for f in os.listdir(qc_dir):
-                    if os.stat(os.path.join(qc_dir,f)).st_mtime > \
+                    if os.path.getmtime(os.path.join(qc_dir,f)) > \
                        multiqc_mtime:
                         # Input is newer than report
                         run_multiqc = True


### PR DESCRIPTION
PR which addresses the following issues:

* Issue #187: reports additional data items (number of single cells, for single cell projects) and any comments associated with the project.
* Issue #182: links to MultiQC reports from QC reports (and includes the MultiQC reports in the ZIP files)
* Issue #261: adds the run reference ID to the report summary
* Adds a new top-level summary table reporting the versions of processing and QC software, if available)