### PR TITLE
make_fastqs: update to work with bcl2fastq2 v2.20

### DIFF
--- a/auto_process_ngs/bcl2fastq_utils.py
+++ b/auto_process_ngs/bcl2fastq_utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     bcl2fastq_utils.py: utility functions for bcl2fastq conversion
-#     Copyright (C) University of Manchester 2013-2018 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2019 Peter Briggs
 #
 ########################################################################
 #
@@ -23,7 +23,8 @@ Utility functions for bcl to fastq conversion operations:
 - get_bases_mask: get a bases mask string
 - run_bcl2fastq_1_8: run bcl-to-fastq conversion from CASAVA/bcl2fastq 1.8.*
 - run_bcl2fastq_2_17: run bcl-to-fastq conversion from bcl2fastq 2.17.*
-
+- run_bcl2fastq_2_20: run bcl-to-fastq conversion from bcl2fastq 2.20.*
+- run_bcl2fastq_2: general wrapper for running bcl2fastq 2.*
 """
 
 #######################################################################
@@ -583,22 +584,44 @@ def run_bcl2fastq_1_8(basecalls_dir,sample_sheet,
         logging.error("make returned %s" % returncode)
     return returncode
 
-def run_bcl2fastq_2_17(basecalls_dir,sample_sheet,
-                       output_dir="Unaligned",
-                       mismatches=None,
-                       bases_mask=None,
-                       ignore_missing_bcl=False,
-                       no_lane_splitting=False,
-                       minimum_trimmed_read_length=None,
-                       mask_short_adapter_reads=None,
-                       loading_threads=None,
-                       demultiplexing_threads=None,
-                       processing_threads=None,
-                       writing_threads=None):
+def run_bcl2fastq_2_17(*args,**kws):
     """
     Wrapper for running bcl2fastq 2.17.*
 
     Runs the bcl2fastq 2.17.* software to generate fastq files
+       from bcl files.
+
+    Wrapper for the generic `run_bcl2fastq_2` function.
+    """
+    return run_bcl2fastq_2(*args,**kws)
+
+def run_bcl2fastq_2_20(*args,**kws):
+    """
+    Wrapper for running bcl2fastq 2.20.*
+
+    Runs the bcl2fastq 2.20.* software to generate fastq files
+       from bcl files.
+
+    Wrapper for the generic `run_bcl2fastq_2` function.
+    """
+    return run_bcl2fastq_2(*args,**kws)
+
+def run_bcl2fastq_2(basecalls_dir,sample_sheet,
+                    output_dir="Unaligned",
+                    mismatches=None,
+                    bases_mask=None,
+                    ignore_missing_bcl=False,
+                    no_lane_splitting=False,
+                    minimum_trimmed_read_length=None,
+                    mask_short_adapter_reads=None,
+                    loading_threads=None,
+                    demultiplexing_threads=None,
+                    processing_threads=None,
+                    writing_threads=None):
+    """
+    Wrapper for running bcl2fastq 2.*
+
+    Runs the bcl2fastq 2.* software to generate fastq files
        from bcl files.
 
     Arguments:
@@ -638,9 +661,8 @@ def run_bcl2fastq_2_17(basecalls_dir,sample_sheet,
 
     Returns:
       0 on success; if a problem is encountered then returns -1 for
-      errors within the function (e.g. missing Makefile) or the exit
-      code from the failed program.
-
+      errors within the function or if the exit code from the program
+      was non-zero.
     """
     # Set up and run bcl2fastq2
     bcl2fastq2_cmd = applications.bcl2fastq.bcl2fastq2(

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -819,7 +819,7 @@ class MockBcl2fastq2Exe(object):
     @staticmethod
     def create(path,exit_code=0,missing_fastqs=None,
                platform=None,assert_bases_mask=None,
-               version='2.17.1.14'):
+               version='2.20.0.422'):
         """
         Create a "mock" bcl2fastq executable
 

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -818,7 +818,8 @@ class MockBcl2fastq2Exe(object):
 
     @staticmethod
     def create(path,exit_code=0,missing_fastqs=None,
-               platform=None,assert_bases_mask=None):
+               platform=None,assert_bases_mask=None,
+               version='2.17.1.14'):
         """
         Create a "mock" bcl2fastq executable
 
@@ -835,6 +836,8 @@ class MockBcl2fastq2Exe(object):
           platform (str): platform for primary
             data (if it cannot be determined from
             the directory/instrument name)
+          version (str): version of bcl2fastq2
+            to imitate
         """
         path = os.path.abspath(path)
         print "Building mock executable: %s" % path
@@ -847,7 +850,8 @@ from auto_process_ngs.mock import MockBcl2fastq2Exe
 sys.exit(MockBcl2fastq2Exe(exit_code=%s,
                            missing_fastqs=%s,
                            platform=%s,
-                           assert_bases_mask=%s).main(sys.argv[1:]))
+                           assert_bases_mask=%s,
+                           version='%s').main(sys.argv[1:]))
             """ % (exit_code,
                    missing_fastqs,
                    ("\"%s\"" % platform
@@ -855,7 +859,8 @@ sys.exit(MockBcl2fastq2Exe(exit_code=%s,
                     else None),
                    ("\"%s\"" % assert_bases_mask
                     if assert_bases_mask is not None
-                    else None)))
+                    else None),
+                   version))
             os.chmod(path,0775)
         with open(path,'r') as fp:
             print "bcl2fastq:"
@@ -865,7 +870,8 @@ sys.exit(MockBcl2fastq2Exe(exit_code=%s,
     def __init__(self,exit_code=0,
                  missing_fastqs=None,
                  platform=None,
-                 assert_bases_mask=None):
+                 assert_bases_mask=None,
+                 version=None):
         """
         Internal: configure the mock bcl2fastq2
         """
@@ -873,6 +879,7 @@ sys.exit(MockBcl2fastq2Exe(exit_code=%s,
         self._missing_fastqs = missing_fastqs
         self._platform = platform
         self._assert_bases_mask = assert_bases_mask
+        self._version = version
 
     def main(self,args):
         """
@@ -880,11 +887,13 @@ sys.exit(MockBcl2fastq2Exe(exit_code=%s,
         """
         # Build generic header
         header = """BCL to FASTQ file converter
-bcl2fastq v2.17.1.14
-Copyright (c) 2007-2015 Illumina, Inc.
-
-2015-12-17 14:08:00 [7fa113f3f780] Command-line invocation: bcl2fastq %s""" \
-    % ' '.join(args)
+bcl2fastq v%s
+""" % self._version
+        if self._version.startswith("2.17."):
+            header += \
+            "Copyright (c) 2007-2015 Illumina, Inc.\n\n2015-12-17 14:08:00 [7fa113f3f780] Command-line invocation: bcl2fastq %s" % ' '.join(args)
+        elif self._version.startswith("2.20."):
+            header += "Copyright (c) 2007-2017 Illumina, Inc.\n"
         # Handle version request
         if "--version" in args:
             print header
@@ -901,7 +910,8 @@ Copyright (c) 2007-2015 Illumina, Inc.
         p.add_argument("--ignore-missing-bcls",action="store_true")
         p.add_argument("--no-lane-splitting",action="store_true")
         p.add_argument("-r",action="store")
-        p.add_argument("-d",action="store")
+        if self._version.startswith("2.17."):
+            p.add_argument("-d",action="store")
         p.add_argument("-p",action="store")
         p.add_argument("-w",action="store")
         args = p.parse_args(args)

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -47,8 +47,8 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
             shutil.rmtree(self.wd)
             
     #@unittest.skip("Skipped")
-    def test_make_fastqs_standard_protocol(self):
-        """make_fastqs: standard protocol
+    def test_make_fastqs_standard_protocol_bcl2fastq_2_17(self):
+        """make_fastqs: standard protocol (bcl2fastq v2.17)
         """
         # Create mock source data
         illumina_run = MockIlluminaRun(
@@ -58,7 +58,62 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
         illumina_run.create()
         # Create mock bcl2fastq
         MockBcl2fastq2Exe.create(os.path.join(self.bin,
-                                              "bcl2fastq"))
+                                              "bcl2fastq"),
+                                 version='2.17.1.14')
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Do the test
+        ap = AutoProcess()
+        ap.setup(os.path.join(self.wd,
+                              "171020_M00879_00002_AHGXXXX"))
+        self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
+        make_fastqs(ap,protocol="standard")
+        # Check parameters
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(self.wd,
+                                      "171020_M00879_00002_AHGXXXX_analysis",
+                                      "primary_data"))
+        self.assertTrue(ap.params.acquired_primary_data)
+        # Check outputs
+        analysis_dir = os.path.join(
+            self.wd,
+            "171020_M00879_00002_AHGXXXX_analysis")
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       os.path.join("logs",
+                                    "002_make_fastqs"),
+                       "bcl2fastq"):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "projects.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_make_fastqs_standard_protocol_bcl2fastq_2_20(self):
+        """make_fastqs: standard protocol (bcl2fastq v2.20)
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 version="2.20.0.422")
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -220,6 +220,7 @@ AB1,AB1,,,,,AB,
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
 
+    #@unittest.skip("Skipped")
     def test_make_fastqs_standard_protocol_chromium_sc_indices(self):
         """make_fastqs: standard protocol with Chromium SC indices raises exception
         """
@@ -369,6 +370,7 @@ smpl4,smpl4,,,A007,SI-GA-D1,10xGenomics,
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
 
+    #@unittest.skip("Skipped")
     def test_make_fastqs_10x_chromium_sc_protocol(self):
         """make_fastqs: 10x_chromium_sc protocol
         """
@@ -933,7 +935,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
                           make_fastqs,
                           ap)
 
-    #@unittest.skip("Not implemented")
+    #@unittest.skip("Skipped")
     def test_make_fastqs_10x_chromium_sc_protocol(self):
         """make_fastqs: 10x_chromium_sc protocol
         """

--- a/auto_process_ngs/test/test_bcl2fastq.py
+++ b/auto_process_ngs/test/test_bcl2fastq.py
@@ -177,6 +177,17 @@ class MockBcl2fastq:
         self._make_exe('bcl2fastq','2.17.1.14','bin','bcl2fastq',
                        content="#!/bin/bash\nif [ \"$1\" == \"--version\" ] ; then cat >&2 <<EOF\nBCL to FASTQ file converter\nbcl2fastq v2.17.1.14\nCopyright (c) 2007-2015 Illumina, Inc.\n\n2015-12-17 14:08:00 [7fa113f3f780] Command-line invocation: bcl2fastq --version\nEOF\nfi")
 
+    def bcl2fastq_220(self):
+        """
+        Add a mock bcl2fastq 2.20 installation
+
+        """
+        # bcl2fastq 2.20.0.422
+        self._makedirs('bcl2fastq','2.20.0.422','bin')
+        self._makedirs('bcl2fastq','2.20.0.422','etc','bcl2fastq-2.20.0.422')
+        self._make_exe('bcl2fastq','2.20.0.422','bin','bcl2fastq',
+                       content="#!/bin/bash\nif [ \"$1\" == \"--version\" ] ; then cat >&2 <<EOF\nBCL to FASTQ file converter\nbcl2fastq v2.20.0.422\nCopyright (c) 2007-2017 Illumina, Inc.\n\nEOF\nfi")
+
 class TestGetSequencerPlatform(unittest.TestCase):
     """
     Tests for the get_sequencer_platform function
@@ -552,6 +563,20 @@ class TestBclToFastqInfo(unittest.TestCase):
         self.assertEqual(path,exe)
         self.assertEqual(name,'bcl2fastq')
         self.assertEqual(version,'2.17.1.14')
+
+    def test_bcl2fastq_2_20_0_422(self):
+        """
+        Collect info for bcl2fastq 2.20.0.422
+
+        """
+        # bcl2fastq 2.20.0.422
+        self.mockbcl2fastq.bcl2fastq_220()
+        self.mockbcl2fastq.set_path()
+        exe = self.mockbcl2fastq.exes[0]
+        path,name,version = bcl_to_fastq_info()
+        self.assertEqual(path,exe)
+        self.assertEqual(name,'bcl2fastq')
+        self.assertEqual(version,'2.20.0.422')
 
     def test_bcl2fastq_1_8_4_supplied_exe(self):
         """


### PR DESCRIPTION
PR which updates the bcl2fastq code to work `bcl2fastq2` v2.20(.0.422), while maintaining compatible with older versions.