### PR TITLE
'AnalysisProject' and 'AnalysisSample' classes: remove QC-related methods which depend on qc.reporting

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     analysis: classes & funcs for handling analysis dirs and projects
-#     Copyright (C) University of Manchester 2018 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2019 Peter Briggs
 #
 ########################################################################
 #
@@ -40,8 +40,6 @@ from .metadata import AnalysisProjectInfo
 from .metadata import ProjectMetadataFile
 from .metadata import AnalysisProjectQCDirInfo
 from .fastq_utils import IlluminaFastqAttrs
-from qc.reporting import QCReporter
-from qc.reporting import QCSample
 from qc.illumina_qc import IlluminaQC
 from itertools import izip_longest
 
@@ -748,94 +746,25 @@ class AnalysisProject:
     def qc(self):
         """
         Return QCReporter instance for QC outputs
+
+        Not supported after version 0.15.0
+
+        Raises exception if invoked
         """
-        return QCReporter(self)
+        raise Exception("%s.qc method no longer supported"
+                        % self.__class__)
 
     def qc_report(self,title=None,report_html=None,qc_dir=None,
                   force=False):
         """
         Report QC outputs for project
 
-        Generates HTML and zipped QC reports.
+        Not supported after version 0.15.0
 
-        Arguments:
-          title (str): title text for the report
-          report_html (str): path for output HTML report file
-          qc_dir (str): path for QC output dir (if None then
-            use default QC directory)
-          force (bool): if True then force reports to be
-            regenerated (by default reports will not be
-            regenerated if they already exist)
-
-        Returns:
-          String: name of zip file, or None if there was a
-            problem.
+        Use the 'report_qc' function from qc.utils instead.
         """
-        if qc_dir is None:
-            qc_dir = self._qc_dir
-        elif not os.path.isabs(qc_dir):
-            qc_dir = os.path.join(self.dirn,qc_dir)
-        if not (force or self.verify_qc(qc_dir=qc_dir)):
-            logger.debug("Failed to generate QC report for %s: QC "
-                          "not verified and force not specified"
-                          % self.name)
-            return None
-        # Create HTML report
-        logger.debug("Creating HTML QC report for %s" % self.name)
-        try:
-            if not title:
-                if self.info.run is not None:
-                    title = "%s/%s: QC report" % (self.info.run,self.name)
-                else:
-                    title = "%s: QC report" % self.name
-            if report_html is None:
-                report_html = os.path.join(self.dirn,"qc_report.html")
-            self.qc.report(title=title,
-                           filename=report_html,
-                           qc_dir=qc_dir,
-                           relative_links=True)
-        except Exception as ex:
-            logger.error("Exception trying to generate QC report "
-                         "for %s: %s" % (self.name,ex))
-            return None
-        # Get a name for the zip file derived from the HTML
-        # report filename
-        zip_name = os.path.splitext(os.path.basename(report_html))[0]
-        # Create zip file
-        logger.debug("Creating zip archive of QC report for %s" %
-                      self.name)
-        try:
-            analysis_dir = os.path.basename(os.path.dirname(self.dirn))
-            report_zip = os.path.join(self.dirn,
-                                      "%s.%s.%s.zip" %
-                                      (zip_name,
-                                       self.name,
-                                       analysis_dir))
-            zip_file = ZipArchive(report_zip,relpath=self.dirn,
-                                  prefix="%s.%s.%s" %
-                                  (zip_name,
-                                   self.name,
-                                   analysis_dir))
-            # Add the HTML report
-            zip_file.add_file(report_html)
-            # Add the FastQC and screen files
-            illumina_qc = IlluminaQC()
-            for sample in self.qc.samples:
-                for fastqs in sample.fastq_pairs:
-                    for fq in fastqs:
-                        logger.debug("Adding QC outputs for %s" % fq)
-                        for f in illumina_qc.expected_outputs(fq,qc_dir):
-                            if f.endswith('.zip'):
-                                # Exclude .zip file
-                                continue
-                            if os.path.exists(f):
-                                zip_file.add(f)
-            # Finished
-            return report_zip
-        except Exception as ex:
-            logger.error("Exception trying to generate zip archive "
-                         "of QC report for %s: %s" % (self.name,ex))
-            return None
+        raise Exception("%s.qc_report method no longer supported"
+                        % self.__class__)
 
     @property
     def multiple_fastqs(self):
@@ -870,22 +799,13 @@ class AnalysisProject:
         """
         Check if QC run has completed successfully
 
-        Arguments:
-          qc_dir (str): path for QC output dir (if None then
-            use default QC directory)
+        Not supported after version 0.15.0
 
-        Returns:
-          Boolean: True if QC run is completed, False
-            if QC couldn't be verified.
+        Use the 'verify_qc' function from the qc.utils module
+        instead.
         """
-        if qc_dir is None:
-            qc_dir = self._qc_dir
-        elif not os.path.isabs(qc_dir):
-            qc_dir = os.path.join(self.dirn,qc_dir)
-        try:
-            return self.qc.verify(qc_dir=qc_dir)
-        except AttributeError:
-            return False
+        raise Exception("%s.qc_report method no longer supported"
+                        % self.__class__)
 
     def get_sample(self,name):
         """Return sample that matches 'name'
@@ -1026,27 +946,22 @@ class AnalysisSample:
     def qc_sample(self):
         """Fetch QCSample object for this sample
 
-        Returns:
-          Populated QCSample object.
+        Not supported after version 0.15.0
 
+        Raises exception if invoked
         """
-        return QCSample(self)
+        raise Exception("%s.qc_sample method no longer supported"
+                        % self.__class__)
 
     def verify_qc(self,qc_dir,fastq):
         """Check if QC completed for a fastq file
 
-        Arguments:
-          qc_dir: name of the QC directory
-          fastq : fastq file to get the QC information for
+        Not supported after version 0.15.0
 
-        Returns:
-          True if QC completed correctly, False otherwise.
-
+        Raises exception if invoked
         """
-        present,missing = IlluminaQC().check_outputs(fastq,qc_dir)
-        if missing:
-            return False
-        return True
+        raise Exception("%s.verify_qc method no longer supported"
+                        % self.__class__)
 
     def __repr__(self):
         """Implement __repr__ built-in

--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -40,7 +40,6 @@ from .metadata import AnalysisProjectInfo
 from .metadata import ProjectMetadataFile
 from .metadata import AnalysisProjectQCDirInfo
 from .fastq_utils import IlluminaFastqAttrs
-from qc.illumina_qc import IlluminaQC
 from itertools import izip_longest
 
 # Module specific logger

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     report_cmd.py: implement auto process 'report' command
-#     Copyright (C) University of Manchester 2018 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2019 Peter Briggs
 #
 #########################################################################
 
@@ -19,6 +19,7 @@ import bcftbx.utils as bcf_utils
 import auto_process_ngs.analysis as analysis
 import auto_process_ngs.utils as utils
 import auto_process_ngs.fileops as fileops
+from ..qc.utils import verify_qc
 
 # Module specific logger
 logger = logging.getLogger(__name__)
@@ -133,7 +134,7 @@ def report_info(ap):
         report.append("  #cells  : %s" % default_value(info.number_of_cells))
         report.append("  Samples : %s" % project.prettyPrintSamples())
         report.append("  QC      : %s" % ('ok'
-                                          if project.verify_qc()
+                                          if verify_qc(project)
                                           else 'not verified'))
         report.append("  Comments: %s" % (project.info.comments))
     return '\n'.join(report)

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -288,10 +288,14 @@ class MockAnalysisDir(MockIlluminaData):
                 project_name = 'undetermined'
             else:
                 project_name = project
+            project_metadata = { 'Run': self.run_name,
+                                 'Platform': self.platform }
             try:
-                project_metadata = self.project_metadata[project_name]
+                for item in self.project_metadata[project_name]:
+                    project_metadata[item] = \
+                                self.project_metadata[project_name][item]
             except KeyError:
-                project_metadata = dict()
+                pass
             project_dir = MockAnalysisProject(project_name,
                                               metadata=project_metadata)
             sample_names = []

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -57,19 +57,19 @@ def verify_qc(project,qc_dir=None,illumina_qc=None,runner=None,
     if runner is None:
         runner = Settings().general.default_runner
     # Set up QC project
-    project = ProjectQC(project,
-                        illumina_qc=illumina_qc,
-                        qc_dir=qc_dir,
-                        log_dir=log_dir)
+    project_ = ProjectQC(project,
+                         illumina_qc=illumina_qc,
+                         qc_dir=qc_dir,
+                         log_dir=log_dir)
     # Set up and start scheduler
     sched = SimpleScheduler()
     sched.start()
     # QC check for project
-    project.check_qc(sched,
-                     name="verify_qc",
-                     runner=runner)
+    project_.check_qc(sched,
+                      name="verify_qc",
+                      runner=runner)
     sched.wait()
-    return project.verify()
+    return project_.verify()
 
 def report_qc(project,qc_dir=None,illumina_qc=None,
               report_html=None,zip_outputs=True,multiqc=False,
@@ -103,18 +103,18 @@ def report_qc(project,qc_dir=None,illumina_qc=None,
     if runner is None:
         runner = Settings().general.default_runner
     # Set up QC project
-    project = ProjectQC(project,
-                        illumina_qc=illumina_qc,
-                        qc_dir=qc_dir,
-                        log_dir=log_dir)
+    project_ = ProjectQC(project,
+                         illumina_qc=illumina_qc,
+                         qc_dir=qc_dir,
+                         log_dir=log_dir)
     # Set up and start scheduler
     sched = SimpleScheduler()
     sched.start()
     # Generate QC for project
-    project.report_qc(sched,
-                      report_html=report_html,
-                      multiqc=multiqc,
-                      zip_outputs=zip_outputs,
-                      runner=runner)
+    project_.report_qc(sched,
+                       report_html=report_html,
+                       multiqc=multiqc,
+                       zip_outputs=zip_outputs,
+                       runner=runner)
     sched.wait()
-    return project.reporting_status
+    return project_.reporting_status

--- a/auto_process_ngs/test/commands/test_import_project.py
+++ b/auto_process_ngs/test/commands/test_import_project.py
@@ -7,8 +7,14 @@ import tempfile
 import shutil
 import os
 from auto_process_ngs.mock import MockAnalysisDirFactory
+from auto_process_ngs.mock import UpdateAnalysisProject
+from auto_process_ngs.mock import MockMultiQC
 from auto_process_ngs.auto_processor import AutoProcess
+from auto_process_ngs.analysis import AnalysisProject
 from auto_process_ngs.commands.import_project_cmd import import_project
+
+# Set to False to keep test output dirs
+REMOVE_TEST_OUTPUTS = True
 
 class TestAutoProcessImportProject(unittest.TestCase):
     """Tests for AutoProcess.import_project
@@ -16,6 +22,11 @@ class TestAutoProcessImportProject(unittest.TestCase):
     """
     def setUp(self):
         self.dirn = tempfile.mkdtemp(suffix='TestAutoProcessImportProject')
+        # Create a temp 'bin' dir
+        self.bin = os.path.join(self.dirn,"bin")
+        os.mkdir(self.bin)
+        # Store original PATH
+        self.path = os.environ['PATH']
         # Make a mock project
         project_dir = os.path.join(self.dirn,'NewProj')
         os.mkdir(project_dir)
@@ -37,8 +48,11 @@ Comments\t1% PhiX spike in
         self.new_project_dir = project_dir
 
     def tearDown(self):
+        # Restore PATH
+        os.environ['PATH'] = self.path
         # Remove the temporary test directory
-        shutil.rmtree(self.dirn)
+        if REMOVE_TEST_OUTPUTS:
+            shutil.rmtree(self.dirn)
 
     def test_import_project(self):
         """import_project: check project is imported
@@ -70,6 +84,51 @@ Comments\t1% PhiX spike in
         self.assertTrue('NewProj' in [p.name
                                       for p in ap2.get_analysis_projects_from_dirs()])
         self.assertTrue(os.path.exists(os.path.join(ap2.analysis_dir,'NewProj')))
+
+    def test_import_project_with_qc(self):
+        """import_project: check project with QC outputs is imported
+        """
+        # Make mock multiqc
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,os.environ['PATH'])
+        # Make an auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '160621_M00879_0087_000000000-AGEW9',
+            'miseq',
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add  QC outputs to the project to be imported
+        UpdateAnalysisProject(
+            AnalysisProject('NewProj',self.new_project_dir)).add_qc_outputs(
+                include_multiqc=False)
+        # Check that the project is not currently present
+        ap = AutoProcess(mockdir.dirn)
+        self.assertFalse('NewProj' in [p.name
+                                       for p in ap.get_analysis_projects()])
+        self.assertFalse('NewProj' in [p.name
+                                       for p in ap.get_analysis_projects_from_dirs()])
+        self.assertFalse(os.path.exists(os.path.join(ap.analysis_dir,'NewProj')))
+        # Import the project
+        import_project(ap,self.new_project_dir)
+        self.assertTrue('NewProj' in [p.name
+                                      for p in ap.get_analysis_projects()])
+        self.assertTrue('NewProj' in [p.name
+                                      for p in ap.get_analysis_projects_from_dirs()])
+        self.assertTrue(os.path.exists(os.path.join(ap.analysis_dir,'NewProj')))
+        # Verify via fresh AutoProcess object
+        ap2 = AutoProcess(mockdir.dirn)
+        self.assertTrue('NewProj' in [p.name
+                                      for p in ap2.get_analysis_projects()])
+        self.assertTrue('NewProj' in [p.name
+                                      for p in ap2.get_analysis_projects_from_dirs()])
+        self.assertTrue(os.path.exists(os.path.join(ap2.analysis_dir,'NewProj')))
+        # Check for QC report and ZIP file
+        print os.listdir(os.path.join(ap2.analysis_dir,'NewProj'))
+        for f in ("qc_report.html",
+                  "multiqc_report.html",
+                  "qc_report.NewProj.160621_M00879_0087_000000000-AGEW9_analysis.zip",):
+            f = os.path.join(ap2.analysis_dir,'NewProj',f)
+            self.assertTrue(os.path.exists(f),"Missing %s" % f)
 
     def test_import_project_already_in_metadata_file(self):
         """import_project: fails when project is already in projects.info

--- a/auto_process_ngs/test/commands/test_publish_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_publish_qc_cmd.py
@@ -13,6 +13,9 @@ from auto_process_ngs.mock import UpdateAnalysisProject
 from auto_process_ngs.mock import MockMultiQC
 from auto_process_ngs.commands.publish_qc_cmd import publish_qc
 
+# Set to False to keep test output dirs
+REMOVE_TEST_OUTPUTS = True
+
 class TestAutoProcessPublishQc(unittest.TestCase):
     """
     Tests for AutoProcess.publish_qc
@@ -39,7 +42,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
         # Return to original dir
         os.chdir(self.pwd)
         # Remove the temporary test directory
-        shutil.rmtree(self.dirn)
+        if REMOVE_TEST_OUTPUTS:
+            shutil.rmtree(self.dirn)
 
     def test_publish_qc_metadata_missing(self):
         """publish_qc: raise exception if metadata not set

--- a/bin/reportqc.py
+++ b/bin/reportqc.py
@@ -105,7 +105,7 @@ def zip_report(project,report_html,qc_dir=None,illumina_qc=None):
     # Add the QC outputs
     if illumina_qc is None:
         illumina_qc = IlluminaQC()
-    for sample in project.qc.samples:
+    for sample in QCReporter(project).samples:
         for fastqs in sample.fastq_pairs:
             for fq in fastqs:
                 logging.debug("Adding QC outputs for %s" % fq)


### PR DESCRIPTION
PR which removes the functionality of the following methods for classes in the `analysis` module, which depend in some form on classes from the `qc.reporting` module:

* `AnalysisProject`: the `qc`, `qc_report` and `verify_qc` methods
* `AnalysisSample`: the `qc_sample` and `verify_qc` methods

The methods are still present but invoking them raises an exception.

Classes and functions which previously used these method calls have been updated to use alternatives, either by creating their own `QCReporter` instances or by using the `verify_qc` and `report_qc` functions from the `qc.utils` module instead.

Removing the dependency on `qc.reporting` from the `analysis` module should give clearer separation between the functionality of the different modules and reduce issues with circular imports.