### PR TITLE
Reduce scheduler and pipeline polling interval to speed up unit tests

### DIFF
--- a/auto_process_ngs/commands/analyse_barcodes_cmd.py
+++ b/auto_process_ngs/commands/analyse_barcodes_cmd.py
@@ -144,7 +144,8 @@ def analyse_barcodes(ap,unaligned_dir=None,lanes=None,
     # Schedule the jobs needed to do counting
     sched = SimpleScheduler(
         runner=runner,
-        max_concurrent=ap.settings.general.max_concurrent_jobs)
+        max_concurrent=ap.settings.general.max_concurrent_jobs,
+        poll_interval=ap.settings.general.poll_interval)
     sched.start()
     # Do counting
     print "Getting counts from fastq files"

--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -2,7 +2,7 @@
 #!/usr/bin/env python
 #
 #     archive_cmd.py: implement auto process archive command
-#     Copyright (C) University of Manchester 2017-2018 Peter Briggs
+#     Copyright (C) University of Manchester 2017-2019 Peter Briggs
 #
 #########################################################################
 
@@ -220,7 +220,8 @@ def archive(ap,archive_dir=None,platform=None,year=None,
         # Setup a scheduler for multiple rsync jobs
         sched = simple_scheduler.SimpleScheduler(
             runner=runner,
-            max_concurrent=ap.settings.general.max_concurrent_jobs)
+            max_concurrent=ap.settings.general.max_concurrent_jobs,
+            poll_interval=ap.settings.general.poll_interval)
         sched.start()
         # Keep track of jobs
         archiving_jobs = []

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -514,7 +514,9 @@ def get_primary_data(ap,runner=None):
                              working_dir=os.getcwd())
     rsync_job.start()
     try:
-        rsync_job.wait()
+        rsync_job.wait(
+            poll_interval=ap.settings.general.poll_interval
+        )
     except KeyboardInterrupt:
         logger.warning("Keyboard interrupt, terminating primary data "
                        "rsync operation")
@@ -718,7 +720,9 @@ def bcl_to_fastq(ap,unaligned_dir,sample_sheet,primary_data_dir,
                                  working_dir=os.getcwd())
     bcl2fastq_job.start()
     try:
-        bcl2fastq_job.wait()
+        bcl2fastq_job.wait(
+            poll_interval=ap.settings.general.poll_interval
+        )
     except KeyboardInterrupt,ex:
         logger.warning("Keyboard interrupt, terminating bcl2fastq")
         bcl2fastq_job.terminate()
@@ -856,7 +860,9 @@ def fastq_statistics(ap,stats_file=None,per_lane_stats_file=None,
     )
     fastq_statistics_job.start()
     try:
-        fastq_statistics_job.wait()
+        fastq_statistics_job.wait(
+            poll_interval=ap.settings.general.poll_interval
+        )
     except KeyboardInterrupt as ex:
         logger.warning("Keyboard interrupt, terminating fastq_statistics")
         fastq_statistics_job.terminate()

--- a/auto_process_ngs/commands/merge_fastq_dirs_cmd.py
+++ b/auto_process_ngs/commands/merge_fastq_dirs_cmd.py
@@ -89,7 +89,9 @@ def merge_fastq_dirs(ap,primary_unaligned_dir,output_dir=None,
         runner.set_log_dir(ap.log_dir)
         sched = SimpleScheduler(
             runner=runner,
-            max_concurrent=ap.settings.general.max_concurrent_jobs)
+            max_concurrent=ap.settings.general.max_concurrent_jobs,
+            poll_interval=ap.settings.general.poll_interval
+        )
         sched.start()
         jobs = []
     # Top-level for undetermined reads

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     publish_qc_cmd.py: implement auto process publish_qc command
-#     Copyright (C) University of Manchester 2017-2018 Peter Briggs
+#     Copyright (C) University of Manchester 2017-2019 Peter Briggs
 #
 #########################################################################
 
@@ -14,7 +14,7 @@ import time
 import string
 import ast
 import auto_process_ngs.fileops as fileops
-import auto_process_ngs.simple_scheduler as simple_scheduler
+from auto_process_ngs.simple_scheduler import SimpleScheduler
 from auto_process_ngs.qc.illumina_qc import IlluminaQC
 from auto_process_ngs.qc.utils import verify_qc
 from auto_process_ngs.qc.utils import report_qc
@@ -345,7 +345,11 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
         ap.set_log_dir(ap.get_log_subdir('publish_qc'))
         runner = ap.settings.general.default_runner
         runner.set_log_dir(ap.log_dir)
-        sched = simple_scheduler.SimpleScheduler(runner=runner)
+        sched = SimpleScheduler(
+            runner=runner,
+            max_concurrent=ap.settings.general.max_concurrent_jobs,
+            poll_interval=ap.settings.general.poll_interval
+        )
         sched.start()
     else:
         sched = None

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -29,7 +29,8 @@ logger = logging.getLogger(__name__)
 def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
            fastq_screen_subset=100000,nthreads=1,
            runner=None,fastq_dir=None,qc_dir=None,
-           report_html=None,run_multiqc=True):
+           report_html=None,run_multiqc=True,
+           poll_interval=5):
     """Run QC pipeline script for projects
 
     Run the illumina_qc.sh script to perform QC on projects.
@@ -69,6 +70,8 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
         report (default: '<QC_DIR>_report.html')
       run_multiqc (bool): if True then run MultiQC at the end of
         the QC run (default)
+      poll_interval (float): specifies polling interval for
+        scheduler used for running QC (default: 5s)
 
     Returns:
       Integer: UNIX-style integer returncode where 0 = successful
@@ -140,5 +143,6 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
                        qc_runner=qc_runner,
                        verify_runner=default_runner,
                        report_runner=default_runner,
-                       max_jobs=max_jobs)
+                       max_jobs=max_jobs,
+                       poll_interval=poll_interval)
     return status

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -30,7 +30,7 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
            fastq_screen_subset=100000,nthreads=1,
            runner=None,fastq_dir=None,qc_dir=None,
            report_html=None,run_multiqc=True,
-           poll_interval=5):
+           poll_interval=None):
     """Run QC pipeline script for projects
 
     Run the illumina_qc.sh script to perform QC on projects.
@@ -70,8 +70,8 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
         report (default: '<QC_DIR>_report.html')
       run_multiqc (bool): if True then run MultiQC at the end of
         the QC run (default)
-      poll_interval (float): specifies polling interval for
-        scheduler used for running QC (default: 5s)
+      poll_interval (float): specifies non-default polling
+        interval for scheduler used for running QC
 
     Returns:
       Integer: UNIX-style integer returncode where 0 = successful
@@ -106,6 +106,9 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
         qc_runner = fetch_runner(runner)
     else:
         qc_runner = ap.settings.runners.qc
+    # Get scheduler parameters
+    if poll_interval is None:
+        poll_interval = ap.settings.general.poll_interval
     # Set up the QC for each project
     runqc = RunQC()
     for project in projects:

--- a/auto_process_ngs/config.py
+++ b/auto_process_ngs/config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     config: classes & funcs for configuring auto_process_ngs
-#     Copyright (C) University of Manchester 2014-2018 Peter Briggs
+#     Copyright (C) University of Manchester 2014-2019 Peter Briggs
 #
 ########################################################################
 #
@@ -64,6 +64,11 @@ class Config(SafeConfigParser):
         try:
             return SafeConfigParser.getint(self,section,option)
         except TypeError:
+            return default
+    def getfloat(self,section,option,default=None):
+        try:
+            return SafeConfigParser.getfloat(self,section,option)
+        except (TypeError,AttributeError):
             return default
     def getboolean(self,section,option,default=None):
         try:

--- a/auto_process_ngs/qc/runqc.py
+++ b/auto_process_ngs/qc/runqc.py
@@ -94,7 +94,7 @@ class RunQC(object):
 
     def run(self,report_html=None,multiqc=False,qc_runner=None,
             verify_runner=None,report_runner=None,max_jobs=None,
-            batch_size=None):
+            poll_interval=5,batch_size=None):
         """
         Schedule and execute QC jobs
 
@@ -111,6 +111,8 @@ class RunQC(object):
             for QC reporting
           max_jobs (int): optional, specify maximum
             number of jobs to run concurrently
+          poll_interval (float): specify polling interval
+            for scheduler (default: 5s)
           batch_size (int): if set then run QC commands in
             batches, with each job running this many
             commands at a time
@@ -129,7 +131,8 @@ class RunQC(object):
         if report_runner is None:
             report_runner = verify_runner
         # Set up and start scheduler
-        self._sched = SimpleScheduler(max_concurrent=max_jobs)
+        self._sched = SimpleScheduler(max_concurrent=max_jobs,
+                                      poll_interval=poll_interval)
         self._sched.start()
         # Initial QC check for each project
         for project in self._projects:

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -109,6 +109,8 @@ class Settings(object):
                                                           'SimpleJobRunner')
         self.general['max_concurrent_jobs'] = config.getint('general',
                                                             'max_concurrent_jobs',12)
+        self.general['poll_interval'] = config.getfloat('general',
+                                                        'poll_interval',5)
         # modulefiles
         self.add_section('modulefiles')
         self.modulefiles['make_fastqs'] = config.get('modulefiles','make_fastqs')

--- a/auto_process_ngs/test/commands/test_analyse_barcodes_cmd.py
+++ b/auto_process_ngs/test/commands/test_analyse_barcodes_cmd.py
@@ -8,6 +8,7 @@ import shutil
 import os
 import gzip
 from bcftbx.IlluminaData import IlluminaData
+from auto_process_ngs.settings import Settings
 from auto_process_ngs.auto_processor import AutoProcess
 from auto_process_ngs.mock import MockAnalysisDirFactory
 from auto_process_ngs.commands.analyse_barcodes_cmd import analyse_barcodes
@@ -22,6 +23,15 @@ class TestAutoProcessAnalyseBarcodes(unittest.TestCase):
     def setUp(self):
         # Create a temp working dir
         self.wd = tempfile.mkdtemp(suffix='TestAutoProcessAnalyseBarcodes')
+        # Create settings instance
+        # This allows us to set the polling interval for the
+        # unit tests
+        settings_ini = os.path.join(self.wd,"settings.ini")
+        with open(settings_ini,'w') as s:
+            s.write("""[general]
+poll_interval = 0.5
+""")
+        self.settings = Settings(settings_ini)
         # Store original location
         self.pwd = os.getcwd()
         # Move to working dir
@@ -71,7 +81,8 @@ IIIIIHIIIGHHIIDGHIIIIIIHIIIIIIIIIIIH
         # Add data to Fastq files
         self._insert_fastq_reads(mockdir.dirn)
         # Analyse barcodes
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         analyse_barcodes(ap)
         # Check outputs
         analysis_dir = os.path.join(
@@ -120,7 +131,8 @@ IIIIIHIIIGHHIIDGHIIIIIIHIIIIIIIIIIIH
         # Add data to Fastq files
         self._insert_fastq_reads(mockdir.dirn)
         # Analyse barcodes
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         analyse_barcodes(ap)
         # Check outputs
         analysis_dir = os.path.join(

--- a/auto_process_ngs/test/commands/test_archive_cmd.py
+++ b/auto_process_ngs/test/commands/test_archive_cmd.py
@@ -8,6 +8,7 @@ import shutil
 import os
 import pwd
 import grp
+from auto_process_ngs.settings import Settings
 from auto_process_ngs.auto_processor import AutoProcess
 from auto_process_ngs.mock import MockAnalysisDirFactory
 from auto_process_ngs.mock import UpdateAnalysisProject
@@ -25,6 +26,15 @@ class TestArchiveCommand(unittest.TestCase):
     def setUp(self):
         # Create a temp working dir
         self.dirn = tempfile.mkdtemp(suffix='TestArchiveCommand')
+        # Create settings instance
+        # This allows us to set the polling interval for the
+        # unit tests
+        settings_ini = os.path.join(self.dirn,"settings.ini")
+        with open(settings_ini,'w') as s:
+            s.write("""[general]
+poll_interval = 0.5
+""")
+        self.settings = Settings(settings_ini)
         # Store original location so we can get back at the end
         self.pwd = os.getcwd()
         # Move to working dir
@@ -67,7 +77,8 @@ class TestArchiveCommand(unittest.TestCase):
         self.assertTrue(os.path.isdir(final_dir))
         self.assertEqual(len(os.listdir(final_dir)),0)
         # Make autoprocess instance and set required metadata
-        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=self.settings)
         ap.set_metadata("source","testing")
         ap.set_metadata("run_number","87")
         # Do archiving op
@@ -133,7 +144,8 @@ class TestArchiveCommand(unittest.TestCase):
         self.assertTrue(os.path.isdir(final_dir))
         self.assertEqual(len(os.listdir(final_dir)),0)
         # Make autoprocess instance and set required metadata
-        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=self.settings)
         ap.set_metadata("source","testing")
         ap.set_metadata("run_number","87")
         # Do archiving op
@@ -187,7 +199,8 @@ class TestArchiveCommand(unittest.TestCase):
         self.assertTrue(os.path.isdir(final_dir))
         self.assertEqual(len(os.listdir(final_dir)),0)
         # Make autoprocess instance and set required metadata
-        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=self.settings)
         ap.set_metadata("source","testing")
         ap.set_metadata("run_number","87")
         # Do archiving op
@@ -248,7 +261,8 @@ class TestArchiveCommand(unittest.TestCase):
         self.assertTrue(os.path.isdir(final_dir))
         self.assertEqual(len(os.listdir(final_dir)),0)
         # Make autoprocess instance and set required metadata
-        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=self.settings)
         ap.set_metadata("source","testing")
         ap.set_metadata("run_number","87")
         # Do archiving op
@@ -309,7 +323,8 @@ class TestArchiveCommand(unittest.TestCase):
         self.assertTrue(os.path.isdir(final_dir))
         self.assertEqual(len(os.listdir(final_dir)),0)
         # Make autoprocess instance and set required metadata
-        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=self.settings)
         ap.set_metadata("source","testing")
         ap.set_metadata("run_number","87")
         # Add additional fastq set for first project
@@ -386,7 +401,8 @@ class TestArchiveCommand(unittest.TestCase):
         self.assertTrue(os.path.isdir(final_dir))
         self.assertEqual(len(os.listdir(final_dir)),0)
         # Make autoprocess instance and set required metadata
-        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=self.settings)
         ap.set_metadata("source","testing")
         ap.set_metadata("run_number","87")
         # Do staging archiving op
@@ -449,7 +465,8 @@ class TestArchiveCommand(unittest.TestCase):
         self.assertTrue(os.path.isdir(final_dir))
         self.assertEqual(len(os.listdir(final_dir)),0)
         # Make autoprocess instance and set required metadata
-        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=self.settings)
         ap.set_metadata("source","testing")
         ap.set_metadata("run_number","87")
         ap.save_metadata()
@@ -526,7 +543,8 @@ class TestArchiveCommand(unittest.TestCase):
         self.assertTrue(os.path.isdir(final_dir))
         self.assertEqual(len(os.listdir(final_dir)),0)
         # Make autoprocess instance and set required metadata
-        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=self.settings)
         ap.set_metadata("source","testing")
         ap.set_metadata("run_number","87")
         # Do staging archiving op with no year
@@ -589,7 +607,8 @@ class TestArchiveCommand(unittest.TestCase):
         self.assertTrue(os.path.isdir(final_dir))
         self.assertEqual(len(os.listdir(final_dir)),0)
         # Make autoprocess instance and set required metadata
-        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=self.settings)
         ap.set_metadata("source","testing")
         ap.set_metadata("run_number","87")
         # Do staging archiving op with no year
@@ -657,7 +676,8 @@ class TestArchiveCommand(unittest.TestCase):
             final_dir,
             "170901_M00879_0087_000000000-AGEW9_analysis")
         # Make autoprocess instance and set required metadata
-        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=self.settings)
         ap.set_metadata("source","testing")
         ap.set_metadata("run_number","87")
         # Staging attempt should fail
@@ -718,7 +738,8 @@ class TestArchiveCommand(unittest.TestCase):
         self.assertTrue(os.path.isdir(final_dir))
         self.assertEqual(len(os.listdir(final_dir)),0)
         # Make autoprocess instance and set required metadata
-        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=self.settings)
         ap.set_metadata("source","testing")
         ap.set_metadata("run_number","87")
         # Add a .bak project directory
@@ -775,7 +796,8 @@ class TestArchiveCommand(unittest.TestCase):
         self.assertTrue(os.path.isdir(final_dir))
         self.assertEqual(len(os.listdir(final_dir)),0)
         # Make autoprocess instance and set required metadata
-        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=self.settings)
         ap.set_metadata("source","testing")
         ap.set_metadata("run_number","87")
         # Add a .bak project directory

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -6,6 +6,7 @@ import unittest
 import tempfile
 import shutil
 import os
+from auto_process_ngs.settings import Settings
 from auto_process_ngs.auto_processor import AutoProcess
 from bcftbx.mock import MockIlluminaRun
 from auto_process_ngs.mock import MockBcl2fastq2Exe
@@ -22,6 +23,15 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
     def setUp(self):
         # Create a temp working dir
         self.wd = tempfile.mkdtemp(suffix='TestAutoProcessMakeFastqs')
+        # Create settings instance
+        # This allows us to set the polling interval for the
+        # unit tests
+        settings_ini = os.path.join(self.wd,"settings.ini")
+        with open(settings_ini,'w') as s:
+            s.write("""[general]
+poll_interval = 0.5
+""")
+        self.settings = Settings(settings_ini)
         # Create a temp 'bin' dir
         self.bin = os.path.join(self.wd,"bin")
         os.mkdir(self.bin)
@@ -63,7 +73,7 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings)
         ap.setup(os.path.join(self.wd,
                               "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
@@ -117,7 +127,7 @@ class TestAutoProcessMakeFastqs(unittest.TestCase):
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings)
         ap.setup(os.path.join(self.wd,
                               "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
@@ -192,7 +202,7 @@ AB1,AB1,,,,,AB,
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings)
         ap.setup(os.path.join(self.wd,
                               "171020_NB500968_00002_AHGXXXX"),
                  sample_sheet=sample_sheet)
@@ -254,7 +264,7 @@ smpl4,smpl4,,,A007,SI-GA-D1,10xGenomics,
             top_dir=self.wd)
         illumina_run.create()
         # Do the test
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings)
         ap.setup(os.path.join(self.wd,
                               "171020_NB500968_00002_AHGXXXX"),
                  sample_sheet=sample_sheet)
@@ -280,7 +290,7 @@ smpl4,smpl4,,,A007,SI-GA-D1,10xGenomics,
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings)
         ap.setup(os.path.join(self.wd,
                               "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
@@ -333,7 +343,7 @@ smpl4,smpl4,,,A007,SI-GA-D1,10xGenomics,
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings)
         ap.setup(os.path.join(self.wd,
                               "171020_SN7001250_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
@@ -409,7 +419,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings)
         ap.setup(os.path.join(self.wd,
                               "171020_SN7001250_00002_AHGXXXX"),
                  sample_sheet=sample_sheet)
@@ -485,7 +495,7 @@ AB1,AB1,,,,,icell8,
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings)
         ap.setup(os.path.join(self.wd,
                               "171020_NB500968_00002_AHGXXXX"),
                  sample_sheet=sample_sheet)
@@ -532,7 +542,7 @@ AB1,AB1,,,,,icell8,
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings)
         ap.setup(os.path.join(self.wd,
                               "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
@@ -598,7 +608,7 @@ AB1,AB1,,,,,icell8,
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings)
         ap.setup(os.path.join(self.wd,
                               "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
@@ -660,7 +670,7 @@ AB1,AB1,,,,,icell8,
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings)
         ap.setup(os.path.join(self.wd,
                               "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
@@ -708,7 +718,7 @@ AB1,AB1,,,,,icell8,
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings)
         ap.setup(os.path.join(self.wd,
                               "171020_UNKNOWN_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
@@ -737,7 +747,7 @@ AB1,AB1,,,,,icell8,
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings)
         ap.setup(os.path.join(self.wd,
                               "171020_UNKNOWN_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
@@ -793,7 +803,7 @@ AB1,AB1,,,,,icell8,
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings)
         ap.setup(os.path.join(self.wd,
                               "171020_UNKNOWN_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
@@ -873,7 +883,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings)
         ap.setup(os.path.join(self.wd,
                               "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
@@ -924,7 +934,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings)
         ap.setup(os.path.join(self.wd,
                               "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
@@ -951,7 +961,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings)
         ap.setup(os.path.join(self.wd,
                               "171020_SN7001250_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)

--- a/auto_process_ngs/test/commands/test_merge_fastq_dirs_cmd.py
+++ b/auto_process_ngs/test/commands/test_merge_fastq_dirs_cmd.py
@@ -8,6 +8,7 @@ import shutil
 import os
 import gzip
 from auto_process_ngs.mock import MockAnalysisDir
+from auto_process_ngs.settings import Settings
 from auto_process_ngs.auto_processor import AutoProcess
 from auto_process_ngs.commands.merge_fastq_dirs_cmd import merge_fastq_dirs
 
@@ -35,6 +36,15 @@ class TestAutoProcessMergeFastqDirs(unittest.TestCase):
     def setUp(self):
         # Create a temp working dir
         self.dirn = tempfile.mkdtemp(suffix='TestAutoProcessMergeFastqDirs')
+        # Create settings instance
+        # This allows us to set the polling interval for the
+        # unit tests
+        settings_ini = os.path.join(self.dirn,"settings.ini")
+        with open(settings_ini,'w') as s:
+            s.write("""[general]
+poll_interval = 0.5
+""")
+        self.settings = Settings(settings_ini)
         # Store original location so we can get back at the end
         self.pwd = os.getcwd()
         # Move to working dir
@@ -185,7 +195,8 @@ class TestAutoProcessMergeFastqDirs(unittest.TestCase):
         """
         analysis_dir = self._setup_bcl2fastq2_no_lane_splitting()
         # Merge the unaligned dirs
-        self.ap = AutoProcess(analysis_dir)
+        self.ap = AutoProcess(analysis_dir,
+                              settings=self.settings)
         merge_fastq_dirs(self.ap,"bcl2fastq.AB",output_dir="bcl2fastq")
         # Check outputs
         self._assert_dir_exists(os.path.join(analysis_dir,'save.bcl2fastq.AB'))
@@ -231,7 +242,8 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         """
         analysis_dir = self._setup_bcl2fastq2()
         # Merge the unaligned dirs
-        self.ap = AutoProcess(analysis_dir)
+        self.ap = AutoProcess(analysis_dir,
+                              settings=self.settings)
         merge_fastq_dirs(self.ap,
                          "bcl2fastq.lanes1-2",
                          output_dir="bcl2fastq")
@@ -333,7 +345,8 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         """
         analysis_dir = self._setup_bcl2fastq2_no_lane_splitting()
         # Merge the unaligned dirs
-        self.ap = AutoProcess(analysis_dir)
+        self.ap = AutoProcess(analysis_dir,
+                              settings=self.settings)
         merge_fastq_dirs(self.ap,"bcl2fastq.AB")
         # Check outputs
         self._assert_dir_exists(os.path.join(analysis_dir,'save.bcl2fastq.AB'))
@@ -378,7 +391,8 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         """
         analysis_dir = self._setup_bcl2fastq2()
         # Merge the unaligned dirs
-        self.ap = AutoProcess(analysis_dir)
+        self.ap = AutoProcess(analysis_dir,
+                              settings=self.settings)
         merge_fastq_dirs(self.ap,"bcl2fastq.lanes1-2")
         # Check outputs
         self._assert_dir_exists(os.path.join(analysis_dir,'save.bcl2fastq.lanes1-2'))
@@ -426,7 +440,8 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         """
         analysis_dir = self._setup_casava()
         # Merge the unaligned dirs
-        self.ap = AutoProcess(analysis_dir)
+        self.ap = AutoProcess(analysis_dir,
+                              settings=self.settings)
         merge_fastq_dirs(self.ap,"bcl2fastq.lanes1-2")
         # Check outputs
         self._assert_dir_exists(os.path.join(analysis_dir,'save.bcl2fastq.lanes1-2'))
@@ -474,7 +489,8 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         """
         analysis_dir = self._setup_bcl2fastq2_no_lane_splitting()
         # Merge the unaligned dirs
-        self.ap = AutoProcess(analysis_dir)
+        self.ap = AutoProcess(analysis_dir,
+                              settings=self.settings)
         merge_fastq_dirs(self.ap,"bcl2fastq.AB",dry_run=True)
         # Check outputs
         self._assert_dir_doesnt_exist(os.path.join(analysis_dir,'save.bcl2fastq.AB'))
@@ -491,7 +507,8 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         """
         analysis_dir = self._setup_bcl2fastq2()
         # Merge the unaligned dirs
-        self.ap = AutoProcess(analysis_dir)
+        self.ap = AutoProcess(analysis_dir,
+                              settings=self.settings)
         merge_fastq_dirs(self.ap,"bcl2fastq.lanes1-2",dry_run=True)
         # Check outputs
         self._assert_dir_doesnt_exist(os.path.join(analysis_dir,'save.bcl2fastq.lanes1-2'))
@@ -508,7 +525,8 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         """
         analysis_dir = self._setup_casava()
         # Merge the unaligned dirs
-        self.ap = AutoProcess(analysis_dir)
+        self.ap = AutoProcess(analysis_dir,
+                              settings=self.settings)
         merge_fastq_dirs(self.ap,"bcl2fastq.lanes1-2",dry_run=True)
         # Check outputs
         self._assert_dir_doesnt_exist(os.path.join(analysis_dir,'save.bcl2fastq.lanes1-2'))

--- a/auto_process_ngs/test/commands/test_publish_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_publish_qc_cmd.py
@@ -6,6 +6,7 @@ import unittest
 import tempfile
 import shutil
 import os
+from auto_process_ngs.settings import Settings
 from auto_process_ngs.auto_processor import AutoProcess
 from auto_process_ngs.mock import MockAnalysisDirFactory
 from auto_process_ngs.mock import UpdateAnalysisDir
@@ -23,6 +24,15 @@ class TestAutoProcessPublishQc(unittest.TestCase):
     def setUp(self):
         # Create a temp working dir
         self.dirn = tempfile.mkdtemp(suffix='TestAutoProcessPublishQc')
+        # Create settings instance
+        # This allows us to set the polling interval for the
+        # unit tests
+        settings_ini = os.path.join(self.dirn,"settings.ini")
+        with open(settings_ini,'w') as s:
+            s.write("""[general]
+poll_interval = 0.5
+""")
+        self.settings = Settings(settings_ini)
         # Create a temp 'bin' dir
         self.bin = os.path.join(self.dirn,"bin")
         os.mkdir(self.bin)
@@ -55,7 +65,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
             metadata={ "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Make a mock publication area
         publication_dir = os.path.join(self.dirn,'QC')
         os.mkdir(publication_dir)
@@ -77,7 +88,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing report
         UpdateAnalysisDir(ap).add_processing_report()
         # Make a mock publication area
@@ -106,7 +118,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing and barcode analysis reports
         UpdateAnalysisDir(ap).add_processing_report()
         UpdateAnalysisDir(ap).add_barcode_analysis()
@@ -139,7 +152,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing report and QC outputs
         UpdateAnalysisDir(ap).add_processing_report()
         for project in ap.get_analysis_projects():
@@ -184,7 +198,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing report and QC outputs
         UpdateAnalysisDir(ap).add_processing_report()
         for project in ap.get_analysis_projects():
@@ -224,7 +239,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing report and QC outputs
         UpdateAnalysisDir(ap).add_processing_report()
         for project in ap.get_analysis_projects():
@@ -278,7 +294,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing report and QC outputs
         UpdateAnalysisDir(ap).add_processing_report()
         for project in ap.get_analysis_projects():
@@ -334,7 +351,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing report
         UpdateAnalysisDir(ap).add_processing_report()
         # Add QC outputs for subset of projects
@@ -362,7 +380,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing report
         UpdateAnalysisDir(ap).add_processing_report()
         # Add QC outputs for subset of projects
@@ -414,7 +433,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing report
         UpdateAnalysisDir(ap).add_processing_report()
         # Add QC outputs for subset of projects
@@ -469,7 +489,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing report and QC outputs
         UpdateAnalysisDir(ap).add_processing_report()
         projects = ap.get_analysis_projects()
@@ -524,7 +545,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing and cellranger QC reports
         UpdateAnalysisDir(ap).add_processing_report()
         UpdateAnalysisDir(ap).add_cellranger_qc_output()
@@ -556,7 +578,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing and cellranger QC reports
         UpdateAnalysisDir(ap).add_processing_report()
         UpdateAnalysisDir(ap).add_cellranger_qc_output(lanes="45")
@@ -588,7 +611,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing and cellranger QC reports
         UpdateAnalysisDir(ap).add_processing_report()
         UpdateAnalysisDir(ap).add_cellranger_qc_output(lanes="45")
@@ -622,7 +646,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing and cellranger QC reports
         UpdateAnalysisDir(ap).add_processing_report()
         UpdateAnalysisDir(ap).add_cellranger_qc_output()
@@ -692,7 +717,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing report and QC outputs
         UpdateAnalysisDir(ap).add_processing_report()
         for project in ap.get_analysis_projects():
@@ -737,7 +763,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing report and QC outputs
         UpdateAnalysisDir(ap).add_processing_report()
         projects = ap.get_analysis_projects()
@@ -824,7 +851,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing report and QC outputs
         UpdateAnalysisDir(ap).add_processing_report()
         for project in ap.get_analysis_projects():
@@ -851,7 +879,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "20160621" },
             top_dir=self.dirn)
         mockdir.create()
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing report and QC outputs
         UpdateAnalysisDir(ap).add_processing_report()
         for project in ap.get_analysis_projects():
@@ -896,7 +925,8 @@ class TestAutoProcessPublishQc(unittest.TestCase):
                        "instrument_datestamp": "160621" },
             top_dir=self.dirn)
         mockdir.create()
-        ap = AutoProcess(mockdir.dirn)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
         # Add processing report and QC outputs
         UpdateAnalysisDir(ap).add_processing_report()
         for project in ap.get_analysis_projects():

--- a/auto_process_ngs/test/commands/test_run_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_run_qc_cmd.py
@@ -63,13 +63,19 @@ class TestAutoProcessRunQc(unittest.TestCase):
             metadata={ "instrument_datestamp": "170901" },
             top_dir=self.dirn)
         mockdir.create()
+        # Settings file with polling interval
+        settings_ini = os.path.join(self.dirn,"settings.ini")
+        with open(settings_ini,'w') as s:
+            s.write("""[general]
+poll_interval = 0.5
+""")
         # Make autoprocess instance
-        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=Settings(settings_ini))
         # Run the QC
         status = run_qc(ap,
                         run_multiqc=True,
-                        max_jobs=1,
-                        poll_interval=0.5)
+                        max_jobs=1)
         self.assertEqual(status,0)
         # Check output and reports
         for p in ("AB","CDE","undetermined"):
@@ -114,10 +120,14 @@ class TestAutoProcessRunQc(unittest.TestCase):
                                "CDE": { "Organism": "mouse", } },
             top_dir=self.dirn)
         mockdir.create()
-        # Settings file with fastq_strand indexes
+        # Settings file with fastq_strand indexes and
+        # polling interval
         settings_ini = os.path.join(self.dirn,"settings.ini")
         with open(settings_ini,'w') as s:
-            s.write("""[fastq_strand_indexes]
+            s.write("""[general]
+poll_interval = 0.5
+
+[fastq_strand_indexes]
 human = /data/genomeIndexes/hg38/STAR
 mouse = /data/genomeIndexes/mm10/STAR
 """)
@@ -127,8 +137,7 @@ mouse = /data/genomeIndexes/mm10/STAR
         # Run the QC
         status = run_qc(ap,
                         run_multiqc=True,
-                        max_jobs=1,
-                        poll_interval=0.5)
+                        max_jobs=1)
         self.assertEqual(status,0)
         # Check the fastq_strand_conf files were created
         for p in ("AB","CDE"):
@@ -185,10 +194,14 @@ mouse = /data/genomeIndexes/mm10/STAR
                                "CDE": { "Organism": "mouse", } },
             top_dir=self.dirn)
         mockdir.create()
-        # Settings file with fastq_strand indexes
+        # Settings file with fastq_strand indexes and
+        # polling interval
         settings_ini = os.path.join(self.dirn,"settings.ini")
         with open(settings_ini,'w') as s:
-            s.write("""[fastq_strand_indexes]
+            s.write("""[general]
+poll_interval = 0.5
+
+[fastq_strand_indexes]
 human = /data/genomeIndexes/hg38/STAR
 mouse = /data/genomeIndexes/mm10/STAR
 """)
@@ -198,8 +211,7 @@ mouse = /data/genomeIndexes/mm10/STAR
         # Run the QC
         status = run_qc(ap,
                         run_multiqc=True,
-                        max_jobs=1,
-                        poll_interval=0.5)
+                        max_jobs=1)
         self.assertEqual(status,0)
         # Check the fastq_strand_conf files were created
         for p in ("AB","CDE"):
@@ -257,10 +269,14 @@ mouse = /data/genomeIndexes/mm10/STAR
                                         "Single cell platform": "ICELL8", } },
             top_dir=self.dirn)
         mockdir.create()
-        # Settings file with fastq_strand indexes
+        # Settings file with fastq_strand indexes and
+        # polling interval
         settings_ini = os.path.join(self.dirn,"settings.ini")
         with open(settings_ini,'w') as s:
-            s.write("""[fastq_strand_indexes]
+            s.write("""[general]
+poll_interval = 0.5
+
+[fastq_strand_indexes]
 human = /data/genomeIndexes/hg38/STAR
 mouse = /data/genomeIndexes/mm10/STAR
 """)
@@ -270,8 +286,7 @@ mouse = /data/genomeIndexes/mm10/STAR
         # Run the QC
         status = run_qc(ap,
                         run_multiqc=True,
-                        max_jobs=1,
-                        poll_interval=0.5)
+                        max_jobs=1)
         self.assertEqual(status,0)
         # Check the fastq_strand_conf files were created
         for p in ("AB","CDE"):

--- a/auto_process_ngs/test/commands/test_run_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_run_qc_cmd.py
@@ -68,7 +68,8 @@ class TestAutoProcessRunQc(unittest.TestCase):
         # Run the QC
         status = run_qc(ap,
                         run_multiqc=True,
-                        max_jobs=1)
+                        max_jobs=1,
+                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check output and reports
         for p in ("AB","CDE","undetermined"):
@@ -126,7 +127,8 @@ mouse = /data/genomeIndexes/mm10/STAR
         # Run the QC
         status = run_qc(ap,
                         run_multiqc=True,
-                        max_jobs=1)
+                        max_jobs=1,
+                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check the fastq_strand_conf files were created
         for p in ("AB","CDE"):
@@ -196,7 +198,8 @@ mouse = /data/genomeIndexes/mm10/STAR
         # Run the QC
         status = run_qc(ap,
                         run_multiqc=True,
-                        max_jobs=1)
+                        max_jobs=1,
+                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check the fastq_strand_conf files were created
         for p in ("AB","CDE"):
@@ -267,7 +270,8 @@ mouse = /data/genomeIndexes/mm10/STAR
         # Run the QC
         status = run_qc(ap,
                         run_multiqc=True,
-                        max_jobs=1)
+                        max_jobs=1,
+                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check the fastq_strand_conf files were created
         for p in ("AB","CDE"):

--- a/auto_process_ngs/test/qc/test_runqc.py
+++ b/auto_process_ngs/test/qc/test_runqc.py
@@ -67,6 +67,7 @@ class TestRunQC(unittest.TestCase):
                            qc_runner=SimpleJobRunner(),
                            verify_runner=SimpleJobRunner(),
                            report_runner=SimpleJobRunner(),
+                           poll_interval=0.5,
                            max_jobs=1)
         # Check output and reports
         self.assertEqual(status,0)
@@ -104,6 +105,7 @@ class TestRunQC(unittest.TestCase):
                            qc_runner=SimpleJobRunner(),
                            verify_runner=SimpleJobRunner(),
                            report_runner=SimpleJobRunner(),
+                           poll_interval=0.5,
                            max_jobs=1)
         # Check output and reports
         self.assertEqual(status,0)
@@ -142,6 +144,7 @@ class TestRunQC(unittest.TestCase):
                            qc_runner=SimpleJobRunner(),
                            verify_runner=SimpleJobRunner(),
                            report_runner=SimpleJobRunner(),
+                           poll_interval=0.5,
                            max_jobs=1)
         # Check output and reports
         self.assertEqual(status,1)
@@ -176,6 +179,7 @@ class TestRunQC(unittest.TestCase):
                            qc_runner=SimpleJobRunner(),
                            verify_runner=SimpleJobRunner(),
                            report_runner=SimpleJobRunner(),
+                           poll_interval=0.5,
                            max_jobs=1)
         # Check output and reports
         self.assertEqual(status,0)
@@ -213,6 +217,7 @@ class TestRunQC(unittest.TestCase):
                            qc_runner=SimpleJobRunner(),
                            verify_runner=SimpleJobRunner(),
                            report_runner=SimpleJobRunner(),
+                           poll_interval=0.5,
                            max_jobs=1)
         # Check output and reports
         self.assertEqual(status,1)
@@ -248,6 +253,7 @@ class TestRunQC(unittest.TestCase):
                            qc_runner=SimpleJobRunner(),
                            verify_runner=SimpleJobRunner(),
                            report_runner=SimpleJobRunner(),
+                           poll_interval=0.5,
                            max_jobs=1)
         # Check output and reports
         self.assertEqual(status,1)
@@ -282,6 +288,7 @@ class TestRunQC(unittest.TestCase):
                            qc_runner=SimpleJobRunner(),
                            verify_runner=SimpleJobRunner(),
                            report_runner=SimpleJobRunner(),
+                           poll_interval=0.5,
                            max_jobs=1)
         # Check output and reports
         self.assertEqual(status,1)
@@ -320,6 +327,7 @@ class TestRunQC(unittest.TestCase):
                            qc_runner=SimpleJobRunner(),
                            verify_runner=SimpleJobRunner(),
                            report_runner=SimpleJobRunner(),
+                           poll_interval=0.5,
                            max_jobs=1)
         # Check output and reports
         self.assertEqual(status,0)
@@ -353,6 +361,7 @@ class TestRunQC(unittest.TestCase):
                            qc_runner=SimpleJobRunner(),
                            verify_runner=SimpleJobRunner(),
                            report_runner=SimpleJobRunner(),
+                           poll_interval=0.5,
                            max_jobs=1)
         # Check output and reports
         self.assertEqual(status,0)
@@ -392,6 +401,7 @@ class TestRunQC(unittest.TestCase):
                            qc_runner=SimpleJobRunner(),
                            verify_runner=SimpleJobRunner(),
                            report_runner=SimpleJobRunner(),
+                           poll_interval=0.5,
                            max_jobs=1)
         # Check output and reports
         self.assertEqual(status,0)
@@ -432,6 +442,7 @@ class TestRunQC(unittest.TestCase):
                            qc_runner=SimpleJobRunner(),
                            verify_runner=SimpleJobRunner(),
                            report_runner=SimpleJobRunner(),
+                           poll_interval=0.5,
                            max_jobs=1)
         # Check output and reports
         self.assertEqual(status,0)
@@ -468,6 +479,7 @@ class TestRunQC(unittest.TestCase):
                            qc_runner=SimpleJobRunner(),
                            verify_runner=SimpleJobRunner(),
                            report_runner=SimpleJobRunner(),
+                           poll_interval=0.5,
                            max_jobs=1)
         # Check output and reports
         self.assertEqual(status,0)
@@ -503,6 +515,7 @@ class TestRunQC(unittest.TestCase):
                            verify_runner=SimpleJobRunner(),
                            report_runner=SimpleJobRunner(),
                            max_jobs=1,
+                           poll_interval=0.5,
                            batch_size=3)
         # Check output and reports
         self.assertEqual(status,0)
@@ -540,6 +553,7 @@ class TestRunQC(unittest.TestCase):
                            verify_runner=SimpleJobRunner(),
                            report_runner=SimpleJobRunner(),
                            max_jobs=1,
+                           poll_interval=0.5,
                            batch_size=3)
         # Check output and reports
         self.assertEqual(status,1)
@@ -578,6 +592,7 @@ class TestRunQC(unittest.TestCase):
                            qc_runner=SimpleJobRunner(),
                            verify_runner=SimpleJobRunner(),
                            report_runner=SimpleJobRunner(),
+                           poll_interval=0.5,
                            max_jobs=1)
         # Check output and reports
         self.assertEqual(status,0)

--- a/auto_process_ngs/test/test_config.py
+++ b/auto_process_ngs/test/test_config.py
@@ -60,6 +60,17 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(self.config.getint('advanced','p'),None)
         self.assertEqual(self.config.getint('advanced','p',11),11)
 
+    def test_getfloat(self):
+        """Check Config.getfloat fetches float value
+        """
+        self.assertEqual(self.config.getfloat('advanced','m'),42.0)
+
+    def test_getfloat_with_default(self):
+        """Check Config.getfloat works with defaults
+        """
+        self.assertEqual(self.config.getfloat('advanced','p'),None)
+        self.assertEqual(self.config.getfloat('advanced','p',5.0),5.0)
+
     def test_getboolean(self):
         """Check Config.getboolean fetches boolean value
         """

--- a/auto_process_ngs/test/test_fileops.py
+++ b/auto_process_ngs/test/test_fileops.py
@@ -9,7 +9,6 @@ import shutil
 import pwd
 import grp
 from bcftbx.JobRunner import SimpleJobRunner
-from auto_process_ngs.simple_scheduler import SimpleScheduler
 from auto_process_ngs.utils import ZipArchive
 from auto_process_ngs.fileops import *
 

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -34,7 +34,7 @@ class TestPipeline(unittest.TestCase):
 
     def _get_scheduler(self):
         # Set up a scheduler
-        self.sched = SimpleScheduler(poll_interval=0.5)
+        self.sched = SimpleScheduler(poll_interval=0.01)
         self.sched.start()
         return self.sched
 
@@ -65,7 +65,8 @@ class TestPipeline(unittest.TestCase):
         task2 = Append("Append 2",task1.output.list,"item2")
         ppl.add_task(task2,requires=(task1,))
         # Run the pipeline
-        exit_status = ppl.run(working_dir=self.working_dir)
+        exit_status = ppl.run(working_dir=self.working_dir,
+                              poll_interval=0.1)
         # Check the outputs
         self.assertEqual(exit_status,0)
         self.assertEqual(task1.output.list,["item1"])
@@ -92,7 +93,8 @@ class TestPipeline(unittest.TestCase):
         task2 = Echo("Write item2",task1.output.file,"item2")
         ppl.add_task(task2,requires=(task1,))
         # Run the pipeline
-        exit_status = ppl.run(working_dir=self.working_dir)
+        exit_status = ppl.run(working_dir=self.working_dir,
+                              poll_interval=0.1)
         # Check the outputs
         self.assertEqual(exit_status,0)
         out_file = os.path.join(self.working_dir,"out.txt")
@@ -124,7 +126,8 @@ class TestPipeline(unittest.TestCase):
         self._get_scheduler()
         # Run the pipeline
         exit_status = ppl.run(sched=self.sched,
-                              working_dir=self.working_dir)
+                              working_dir=self.working_dir,
+                              poll_interval=0.1)
         # Check the outputs
         self.assertEqual(exit_status,0)
         out_file = os.path.join(self.working_dir,"out.txt")
@@ -160,7 +163,8 @@ class TestPipeline(unittest.TestCase):
         task2 = Print("Print item2",task1.output.file,"item2")
         ppl.add_task(task2,requires=(task1,))
         # Run the pipeline
-        exit_status = ppl.run(working_dir=self.working_dir)
+        exit_status = ppl.run(working_dir=self.working_dir,
+                              poll_interval=0.1)
         # Check the outputs
         self.assertEqual(exit_status,0)
         out_file = os.path.join(self.working_dir,"out.txt")
@@ -203,6 +207,7 @@ class TestPipeline(unittest.TestCase):
         ppl.add_task(task3_2,requires=(task3_1,))
         # Run the pipeline
         exit_status = ppl.run(working_dir=self.working_dir,
+                              poll_interval=0.1,
                               exit_on_failure=PipelineFailure.IMMEDIATE)
         # Check the outputs
         self.assertEqual(exit_status,1)
@@ -257,6 +262,7 @@ class TestPipeline(unittest.TestCase):
         ppl.add_task(task3_2,requires=(task3_1,))
         # Run the pipeline
         exit_status = ppl.run(working_dir=self.working_dir,
+                              poll_interval=0.1,
                               exit_on_failure=PipelineFailure.DEFERRED)
         # Check the outputs
         self.assertEqual(exit_status,1)
@@ -467,7 +473,7 @@ class TestPipelineTask(unittest.TestCase):
 
     def setUp(self):
         # Set up a scheduler
-        self.sched = SimpleScheduler(poll_interval=0.5)
+        self.sched = SimpleScheduler(poll_interval=0.01)
         self.sched.start()
         # Make a temporary working dir
         self.working_dir = tempfile.mkdtemp(
@@ -780,6 +786,7 @@ class TestPipelineTask(unittest.TestCase):
         # Run the task
         task.run(sched=self.sched,
                  working_dir=self.working_dir,
+                 poll_interval=0.2,
                  async=False)
         # Check final state
         self.assertTrue(task.completed)
@@ -830,6 +837,7 @@ class TestPipelineFunctionTask(unittest.TestCase):
         # Run the task
         task.run(sched=self.sched,
                  working_dir=self.working_dir,
+                 poll_interval=0.1,
                  async=False)
         # Check final state
         self.assertTrue(task.completed)
@@ -861,6 +869,7 @@ class TestPipelineFunctionTask(unittest.TestCase):
         # Run the task
         task.run(sched=self.sched,
                  working_dir=self.working_dir,
+                 poll_interval=0.1,
                  async=False)
         # Check final state
         self.assertTrue(task.completed)

--- a/auto_process_ngs/test/test_settings.py
+++ b/auto_process_ngs/test/test_settings.py
@@ -34,6 +34,7 @@ class TestSettings(unittest.TestCase):
         # General settings
         self.assertTrue(isinstance(s.general.default_runner,SimpleJobRunner))
         self.assertEqual(s.general.max_concurrent_jobs,12)
+        self.assertEqual(s.general.poll_interval,5.0)
         self.assertEqual(s.modulefiles.make_fastqs,None)
         self.assertEqual(s.modulefiles.run_qc,None)
         # Bcl2fastq
@@ -75,6 +76,7 @@ nprocessors = 8
         # General settings
         self.assertTrue(isinstance(s.general.default_runner,SimpleJobRunner))
         self.assertEqual(s.general.max_concurrent_jobs,12)
+        self.assertEqual(s.general.poll_interval,5.0)
         self.assertEqual(s.modulefiles.make_fastqs,None)
         self.assertEqual(s.modulefiles.run_qc,None)
         # Fastq_stats

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -4,6 +4,7 @@
 [general]
 default_runner = SimpleJobRunner
 max_concurrent_jobs = 12
+poll_interval = 5
 
 # Explicitly specify modulefiles to load for each step
 # Specify modulefiles as a comma-separated list


### PR DESCRIPTION
PR which addresses issue #292 by exposing the `poll_interval` scheduler parameter to allow a lower interval to be set from within the unit tests, resulting in quicker run times (e.g.  on Travis-CI the full set of tests originally ran in ~50 minutes; with these changes it is 16-17 minutes).