### PR TITLE
archive command: enable archiving to be forced when there are no projects

### DIFF
--- a/docs/source/using/archive.rst
+++ b/docs/source/using/archive.rst
@@ -63,5 +63,16 @@ and the final location would be
 
    /mnt/archive/2018/miseq/180817_M00123_0001_000000000-BV1X2_analysis
 
+---------------------
+Archiving failed runs
+---------------------
 
+By default it is not possible to archive an analysis directory
+which doesn't have any project directories.
 
+However in some cases it might be desirable to archive an incomplete
+analysis directory, for example if the original run had failed.
+
+In this case the ``--force`` option of the ``archive`` command
+can be used to force archiving of the analysis directory, provided
+that a ``bcl2fastq`` output subdirectory (or similar) also exists.


### PR DESCRIPTION
PR which enables the `archive` command to be forced to perform archiving for analysis directories which have a `bcl2fastq` or similar output directory but no projects (by specifying the `--force` option).

This would allow the archiving of failed runs where no analysis of individual projects was undertaken.