### PR TITLE
Update 'report' command for runs with no projects

### DIFF
--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -368,10 +368,11 @@ def report_summary(ap):
                           "the following data:\n" %
                           ap.params.unaligned_dir)
             for project in illumina_data.projects:
-                rows.append(("- '%s:'" % project.name,
+                rows.append(("- '%s':" % project.name,
                              "%s sample%s" % (len(project.samples),
                                               's' if len(project.samples) != 1
                                               else '')))
+            report.append(utils.pretty_print_rows(rows))
         except IlluminaData.IlluminaDataError as ex:
             report.append("No projects found")
     # Additional comments/notes

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -116,10 +116,14 @@ def report_info(ap):
     else:
         report.append("No information on source fastq data (no unaligned dir "
                       "found)")
-    projects = ap.get_analysis_projects()
-    report.append("\n%d analysis project%s:" % (len(projects),
-                                                "s" if len(projects) != 0
-                                                else ""))
+    try:
+        projects = ap.get_analysis_projects()
+        report.append("\n%d analysis project%s:" % (len(projects),
+                                                    "s" if len(projects) != 0
+                                                    else ""))
+    except Exception as ex:
+        projects = []
+        report.append("\nNo analysis projects found")
     for project in projects:
         info = project.info
         report.append("\n- %s" % project.name)

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -165,25 +165,41 @@ def report_concise(ap):
     """
     report = []
     analysis_dir = analysis.AnalysisDir(ap.analysis_dir)
-    for p in analysis_dir.projects:
-        samples = "%d sample%s" % (len(p.samples),
-                                   's' if len(p.samples) != 1
-                                   else '')
-        if p.info.number_of_cells is not None:
-            samples += "/%d cell%s" % (p.info.number_of_cells,
-                                       's' if p.info.number_of_cells != 1
+    if analysis_dir.projects:
+        for p in analysis_dir.projects:
+            samples = "%d sample%s" % (len(p.samples),
+                                       's' if len(p.samples) != 1
                                        else '')
-        report.append("'%s': %s, %s %s%s (PI: %s) (%s)" % \
-                      (p.name,
-                       p.info.user,
-                       p.info.organism,
-                       ('%s ' % p.info.single_cell_platform
-                        if p.info.single_cell_platform else ''),
-                       p.info.library_type,
-                       p.info.PI,
-                       samples
-                   ))
-    report = '; '.join(report)
+            if p.info.number_of_cells is not None:
+                samples += "/%d cell%s" % (p.info.number_of_cells,
+                                           's' if p.info.number_of_cells != 1
+                                           else '')
+            report.append("'%s': %s, %s %s%s (PI: %s) (%s)" % \
+                          (p.name,
+                           p.info.user,
+                           p.info.organism,
+                           ('%s ' % p.info.single_cell_platform
+                            if p.info.single_cell_platform else ''),
+                           p.info.library_type,
+                           p.info.PI,
+                           samples
+                          ))
+        report = '; '.join(report)
+    else:
+        # No projects - try loading data from unaligned dir
+        try:
+            illumina_data = ap.load_illumina_data()
+            for p in illumina_data.projects:
+                report.append("'%s' (%s sample%s)" %
+                              (p.name,
+                               len(p.samples),
+                               's' if len(p.samples) != 1 else ''))
+            report = ', '.join(report)
+            report = "no projects found; contents of '%s' are: %s" % \
+                     (ap.params.unaligned_dir,
+                      report)
+        except IlluminaData.IlluminaDataError as ex:
+            report = "no projects found"
     # Paired end run?
     if analysis_dir.paired_end:
         endedness = "Paired end"

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -211,6 +211,36 @@ Summary of data in 'bcl2fastq' dir:
                        expected.split('\n')):
             self.assertEqual(o,e)
 
+    def test_report_info_no_projects(self):
+        """report: report run with no projects in 'info' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "assay": "Nextera" },
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate concise report
+        expected = """Run reference: MISEQ_170901#87
+Directory    : %s
+Platform     : miseq
+Unaligned dir: bcl2fastq
+
+Summary of data in 'bcl2fastq' dir:
+
+- AB: AB1-2 (2 paired end samples)
+- CDE: CDE3-4 (2 paired end samples)
+
+No analysis projects found""" % mockdir.dirn
+        for o,e in zip(report_info(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
 class TestReportConcise(unittest.TestCase):
     """
     Tests for the 'report' command ('concise' mode)

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -499,9 +499,11 @@ Assay     : Nextera
 No projects found; 'bcl2fastq' directory contains the following data:
 
 - 'AB':  2 samples
-- 'CDE': 2 samples
-""" % mockdir.dirn
-        for o,e in zip(report_summary(ap).split('\n'),
+- 'CDE': 2 samples""" % mockdir.dirn
+        report = report_summary(ap)
+        self.assertEqual(len(report.split('\n')),
+                         len(expected.split('\n')))
+        for o,e in zip(report.split('\n'),
                        expected.split('\n')):
             self.assertEqual(o,e)
 

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -323,6 +323,24 @@ class TestReportConcise(unittest.TestCase):
         self.assertEqual(report_concise(ap),
                          "Paired end: 'AB': Alison Bell, Human ICELL8 scRNA-seq (PI: Audrey Bower) (2 samples/1311 cells); 'CDE': Charles David Edwards, Mouse ChIP-seq (PI: Colin Delaney Eccleston) (2 samples)")
 
+    def test_report_concise_no_projects(self):
+        """report: report run with no projects in 'concise' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "assay": "Nextera" },
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate concise report
+        self.assertEqual(report_concise(ap),
+                         "Paired end: no projects found; contents of 'bcl2fastq' are: 'AB' (2 samples), 'CDE' (2 samples)")
+
 class TestReportSummary(unittest.TestCase):
     """
     Tests for the 'report' command ('summary' mode)

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -631,6 +631,27 @@ MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\t
                        expected.split('\n')):
             self.assertEqual(o,e)
 
+    def test_report_no_projects(self):
+        """report: report run with no projects in 'projects' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "assay": "Nextera" },
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        # Make autoprocess instance and set required metadata
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate projects report
+        expected = """No projects found
+"""
+        for o,e in zip(report_projects(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
 class TestReport(unittest.TestCase):
     """
     Tests for the 'report' command invoked directly

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -466,6 +466,45 @@ Additional notes/comments:
                        expected.split('\n')):
             self.assertEqual(o,e)
 
+    def test_report_summary_no_projects(self):
+        """report: report run with no projects in 'summary' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "bcl2fastq_software":
+                       "('/usr/bin/bcl2fastq', 'bcl2fastq', '2.17.1.14')",
+                       "cellranger_software":
+                       "('/usr/bin/cellranger', 'cellranger', '3.0.1')",
+                       "assay": "Nextera" },
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate summary report
+        expected = """MISEQ run #87 datestamped 170901
+================================
+Run name  : 170901_M00879_0087_000000000-AGEW9
+Reference : MISEQ_170901#87
+Platform  : MISEQ
+Directory : %s
+Endedness : Paired end
+Bcl2fastq : bcl2fastq 2.17.1.14
+Cellranger: cellranger 3.0.1
+Assay     : Nextera
+
+No projects found; 'bcl2fastq' directory contains the following data:
+
+- 'AB':  2 samples
+- 'CDE': 2 samples
+""" % mockdir.dirn
+        for o,e in zip(report_summary(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
 class TestReportProjects(unittest.TestCase):
     """
     Tests for the 'report' command ('projects' mode)


### PR DESCRIPTION
PR which updates the `report` command to ensure that the different report formats can deal with runs which don't have any analysis projects (to complement PRs #306 and #307).