### PR TITLE
merge_fastq_dirs: add placeholders to preserve empty subdirs on rsync

### DIFF
--- a/auto_process_ngs/commands/merge_fastq_dirs_cmd.py
+++ b/auto_process_ngs/commands/merge_fastq_dirs_cmd.py
@@ -265,6 +265,10 @@ def merge_fastq_dirs(ap,primary_unaligned_dir,output_dir=None,
     if not dry_run and fmt == "bcl2fastq2":
         for dirn in ('Reports','Stats'):
             mkdir(os.path.join(merge_dir,dirn))
+            # Add a hidden placeholder to preserve these directories
+            # on rsync -m (prune empty dirs)
+            with open(os.path.join(merge_dir,dirn,'.placeholder'),'w') as fp:
+                fp.write("")
     # Wait for scheduler jobs to complete
     if not dry_run:
         sched.wait()


### PR DESCRIPTION
PR which updates the `merge_fastq_dirs` command to add empty placeholder files in the `Stats` and `Reports` subdirectories of the merged `bcl2fastq` directory, so that they will be preserved after `rsync -m` (which is used by the `archive` command, and which prunes empty directories).

(Without these directories the `IlluminaData` class from `bcftbx.IlluminaData` module doesn't recognise the directory as `bcl2fastq2` output.)