### PR TITLE
Fix 'run_qc.py' to respect --batch-size argument

### DIFF
--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -203,6 +203,7 @@ if __name__ == "__main__":
                        fastq_strand_indexes=
                        __settings.fastq_strand_indexes,
                        max_jobs=args.max_jobs,
+                       batch_size=args.batch_size,
                        runners={
                            'qc_runner': qc_runner,
                            'verify_runner': verify_runner,


### PR DESCRIPTION
PR that fixes the `run_qc.py` utility so that it respects the `--batch-size` argument (which was being ignored).