### PR TITLE
Add support for handling 10xGenomics single cell ATAC-seq

### DIFF
--- a/auto_process_ngs/bcl2fastq_utils.py
+++ b/auto_process_ngs/bcl2fastq_utils.py
@@ -311,37 +311,37 @@ def get_required_samplesheet_format(bcl2fastq_version):
         raise NotImplementedError('unknown version: %s' %
                                   bcl2fastq_version)
 
-def get_bases_mask(run_info_xml,sample_sheet_file):
+def get_bases_mask(run_info_xml,sample_sheet_file=None):
     """
     Get bases mask string
 
     Generates initial bases mask based on data in RunInfo.xml (which
     says how many reads there are, how many cycles in each read, and
-    which are index reads). Then updates this using the barcode
-    information in the sample sheet file.
+    which are index reads), and optionally updates this using the
+    barcode information in the sample sheet file.
 
     Arguments:
       run_info_xml: name and path of RunInfo.xml file from the
         sequencing run
-      sample_sheet_file: name and path of sample sheet file.
+      sample_sheet_file: (optional) path to sample sheet file
 
     Returns:
       Bases mask string e.g. 'y101,I6'. 
-
     """
     # Get initial bases mask
     bases_mask = IlluminaData.IlluminaRunInfo(run_info_xml).bases_mask
     print "Bases mask: %s (from RunInfo.xml)" % bases_mask
-    # Update bases mask from sample sheet
-    example_barcode = IlluminaData.samplesheet_index_sequence(
-        IlluminaData.SampleSheet(sample_sheet_file).data[0])
-    if example_barcode is None:
-        example_barcode = ""
-    if barcode_is_10xgenomics(example_barcode):
-        print "Bases mask: barcode is 10xGenomics sample set ID"
-    else:
-        bases_mask = IlluminaData.fix_bases_mask(bases_mask,
-                                                 example_barcode)
+    if sample_sheet_file is not None:
+        # Update bases mask from sample sheet
+        example_barcode = IlluminaData.samplesheet_index_sequence(
+            IlluminaData.SampleSheet(sample_sheet_file).data[0])
+        if example_barcode is None:
+            example_barcode = ""
+        if barcode_is_10xgenomics(example_barcode):
+            print "Bases mask: barcode is 10xGenomics sample set ID"
+        else:
+            bases_mask = IlluminaData.fix_bases_mask(bases_mask,
+                                                     example_barcode)
         print "Bases mask: %s (updated for barcode sequence '%s')" % \
             (bases_mask,example_barcode)
     return bases_mask

--- a/auto_process_ngs/fastq_utils.py
+++ b/auto_process_ngs/fastq_utils.py
@@ -274,46 +274,6 @@ class IlluminaFastqAttrs(BaseFastqAttrs):
 
     def __repr__(self):
         """Implement __repr__ built-in
-
-        """
-        # Reconstruct name
-        fq = ["%s" % self.sample_name]
-        if self.sample_number is not None:
-            fq.append("S%d" % self.sample_number)
-        if self.barcode_sequence is not None:
-            fq.append("%s" % self.barcode_sequence)
-        if self.lane_number is not None:
-            fq.append("L%03d" % self.lane_number)
-        if self.read_number is not None:
-            if self.delimiter == '.':
-                fq.append("r%d" % self.read_number)
-            elif self.is_index_read:
-                fq.append("I%d" % self.read_number)
-            else:
-                fq.append("R%d" % self.read_number)
-            for f in field.split('-'):
-                for c in f:
-                    is_tag = is_tag and c in 'ACGTN'
-            if is_tag:
-                self.barcode_sequence = field
-                fields = fields[:-1]
-                ##logger.debug("Identified barcode sequence as %s" % self.barcode_sequence)
-            else:
-                # Alternatively might be the sample number
-                if field.startswith('S'):
-                    try:
-                        if field[1:].isdigit():
-                            self.sample_number = int(field[1:])
-                            fields = fields[:-1]
-                    except IndexError:
-                        pass
-        # What's left is the name
-        ##logger.debug("Remaining fields: %s" % fields)
-        self.sample_name = '_'.join(fields)
-        assert(self.sample_name != '')
-
-    def __repr__(self):
-        """Implement __repr__ built-in
         """
         # Reconstruct name
         fq = ["%s" % self.sample_name]

--- a/auto_process_ngs/qc/constants.py
+++ b/auto_process_ngs/qc/constants.py
@@ -17,7 +17,8 @@ Provides the following constants for the QC pipeline:
 # QC protocols
 PROTOCOLS = ('standardPE',
              'standardSE',
-             'singlecell')
+             'singlecell',
+             '10x_scATAC')
 
 # Screen names
 FASTQ_SCREENS = ('model_organisms',

--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -22,7 +22,7 @@ import os
 from bcftbx.qc.report import strip_ngs_extensions
 import logging
 from .constants import FASTQ_SCREENS
-from ..fastq_utils import pair_fastqs_by_name
+from ..fastq_utils import group_fastqs_by_name
 from ..fastq_utils import remove_index_fastqs
 
 # Module specific logger
@@ -180,14 +180,14 @@ def check_fastq_strand_outputs(project,qc_dir,fastq_strand_conf,
         # No conf file, nothing to check
         return list()
     fastq_pairs = set()
-    for fq_pair in pair_fastqs_by_name(
+    for fq_group in group_fastqs_by_name(
             remove_index_fastqs(project.fastqs,
                                 project.fastq_attrs),
             fastq_attrs=project.fastq_attrs):
         # Strand stats output
         if qc_protocol == 'singlecell':
             # Strand stats output based on R2
-            fq_pair = (fq_pair[1],)
+            fq_pair = (fq_group[1],)
         output = os.path.join(qc_dir,
                               fastq_strand_output(fq_pair[0]))
         if not os.path.exists(output):
@@ -244,7 +244,7 @@ def expected_outputs(project,qc_dir,fastq_strand_conf=None,
                         for f in fastq_screen_output(fastq,screen)]:
                 outputs.add(output)
     if fastq_strand_conf and os.path.exists(fastq_strand_conf):
-        for fq_pair in pair_fastqs_by_name(
+        for fq_group in group_fastqs_by_name(
                 remove_index_fastqs(project.fastqs,
                                     project.fastq_attrs),
                 fastq_attrs=project.fastq_attrs):
@@ -252,10 +252,10 @@ def expected_outputs(project,qc_dir,fastq_strand_conf=None,
             if qc_protocol == 'singlecell':
                 # Strand stats output based on R2
                 output = os.path.join(qc_dir,
-                                      fastq_strand_output(fq_pair[1]))
+                                      fastq_strand_output(fq_group[1]))
             else:
                 # Strand stats output based on R1
                 output = os.path.join(qc_dir,
-                                      fastq_strand_output(fq_pair[0]))
+                                      fastq_strand_output(fq_group[0]))
             outputs.add(output)
     return sorted(list(outputs))

--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -192,9 +192,16 @@ def check_fastq_strand_outputs(project,qc_dir,fastq_strand_conf,
         if qc_protocol == '10x_scATAC':
             # Strand stats output based on R1/R3 pair
             fq_pair = (fq_group[0],fq_group[2])
-        if qc_protocol == 'singlecell':
+        elif qc_protocol == 'singlecell':
             # Strand stats output based on R2
             fq_pair = (fq_group[1],)
+        else:
+            # All other protocols use R1 (single-end)
+            # or R1/R2 (paired-end)
+            if len(fq_group) > 1:
+                fq_pair = (fq_group[0],fq_group[1])
+            else:
+                fq_pair = (fq_group[0],)
         output = os.path.join(qc_dir,
                               fastq_strand_output(fq_pair[0]))
         if not os.path.exists(output):

--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -121,6 +121,10 @@ def check_illumina_qc_outputs(project,qc_dir,qc_protocol=None):
     fastqs = set()
     for fastq in remove_index_fastqs(project.fastqs,
                                      project.fastq_attrs):
+        if qc_protocol == '10x_scATAC':
+            if project.fastq_attrs(fastq).read_number == 2:
+                # Ignore the R2 reads for 10x single-cell ATAC
+                continue
         # FastQC
         for output in [os.path.join(qc_dir,f)
                        for f in fastqc_output(fastq)]:
@@ -185,6 +189,9 @@ def check_fastq_strand_outputs(project,qc_dir,fastq_strand_conf,
                                 project.fastq_attrs),
             fastq_attrs=project.fastq_attrs):
         # Strand stats output
+        if qc_protocol == '10x_scATAC':
+            # Strand stats output based on R1/R3 pair
+            fq_pair = (fq_group[0],fq_group[2])
         if qc_protocol == 'singlecell':
             # Strand stats output based on R2
             fq_pair = (fq_group[1],)
@@ -230,6 +237,10 @@ def expected_outputs(project,qc_dir,fastq_strand_conf=None,
     outputs = set()
     for fastq in remove_index_fastqs(project.fastqs,
                                      project.fastq_attrs):
+        if qc_protocol == '10x_scATAC' and \
+           project.fastq_attrs(fastq).read_number == 2:
+            # No outputs for R2 for 10x single cell ATAC-seq
+            continue
         # FastQC
         for output in [os.path.join(qc_dir,f)
                        for f in fastqc_output(fastq)]:

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -40,12 +40,19 @@ def determine_qc_protocol(project):
     Return:
       String: QC protocol for the project
     """
+    # Standard protocols
     if project.info.paired_end:
         protocol = "standardPE"
     else:
         protocol = "standardSE"
+    # Single cell protocols
     if project.info.single_cell_platform is not None:
+        # Default
         protocol = "singlecell"
+        # 10xGenomics scATAC-seq
+        if project.info.single_cell_platform == "10xGenomics Chromium 3'v2" \
+           and project.info.library_type == "scATAC-seq":
+            protocol = "10x_scATAC"
     return protocol
 
 def verify_qc(project,qc_dir=None,fastq_dir=None,qc_protocol=None,

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -194,6 +194,13 @@ class Settings(object):
                 self['10xgenomics_transcriptomes'][genome] = transcriptome
         except NoSectionError:
             logging.debug("No 10xgenomics transcriptomes defined")
+        # 10xgenomics scATAC-seq genome references
+        self.add_section('10xgenomics_atac_genome_references')
+        try:
+            for genome,reference in config.items('10xgenomics_atac_genome_references'):
+                self['10xgenomics_atac_genome_references'][genome] = reference
+        except NoSectionError:
+            logging.debug("No 10xgenomics scATAC-seq genome references defined")
         # fastq_stats
         self.add_section('fastq_stats')
         self.fastq_stats['nprocessors'] = config.getint('fastq_stats','nprocessors',1)

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -196,6 +196,12 @@ def has_chromium_sc_indices(sample_sheet):
 
     e.g. 'SI-GA-B11'
 
+    For scATAC-seq the indices are of the form:
+
+    SI-NA-[A-H][1-12]
+
+    e.g. 'SI-NA-G9'
+
     Arguments:
       sample_sheet (str): path to the sample sheet CSV
         file to check

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -425,6 +425,7 @@ def run_cellranger_mkfastq(sample_sheet,
                            lanes=None,
                            bases_mask=None,
                            ignore_dual_index=False,
+                           cellranger_exe='cellranger',
                            cellranger_jobmode='local',
                            cellranger_maxjobs=None,
                            cellranger_mempercore=None,
@@ -441,6 +442,11 @@ def run_cellranger_mkfastq(sample_sheet,
     generate Fastqs from bcl files for Chromium single-cell
     data.
 
+    To run the 'mkfastq' command using a different version
+    of cellranger (e.g. cellranger-atac), specify the
+    cellranger executable using the 'cellranger_exe'
+    argument.
+
     Arguments:
       sample_sheet (str): path to input samplesheet with
         10xGenomics barcode indices
@@ -456,6 +462,8 @@ def run_cellranger_mkfastq(sample_sheet,
       ignore_dual_index (bool): optional, on a dual-indexed
         flowcell where the second index was not used for
         the 10x sample, ignore it
+      cellranger_exe (str): optional, name or path to
+        cellranger executable (default: "cellranger")
       cellranger_jobmode (str): specify the job mode to
         pass to cellranger (default: "local")
       cellranger_maxjobs (int): specify the maximum
@@ -506,7 +514,8 @@ def run_cellranger_mkfastq(sample_sheet,
             logger.warning("Removing existing mro file: %s" % mro_file)
             os.remove(mro_file)
     # Construct the cellranger command
-    cmd = Command("cellranger","mkfastq",
+    cmd = Command(cellranger_exe,
+                  "mkfastq",
                   "--samplesheet",sample_sheet,
                   "--run",primary_data_dir,
                   "--output-dir",output_dir,

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -88,6 +88,24 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
         self.assertEqual(determine_qc_protocol(project),
                          "singlecell")
 
+    def test_determine_qc_protocol_10xchromium3v2_atac_seq(self):
+        """determine_qc_protocol: single-cell ATAC-seq (10xGenomics Chromium 3'v2)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={'Single cell platform':
+                                          "10xGenomics Chromium 3'v2",
+                                          'Library type':
+                                          "scATAC-seq"})
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        self.assertEqual(determine_qc_protocol(project),
+                         "10x_scATAC")
+
 class TestVerifyQCFunction(unittest.TestCase):
     """
     Tests for verify_qc function

--- a/auto_process_ngs/test/test_bcl2fastq.py
+++ b/auto_process_ngs/test/test_bcl2fastq.py
@@ -1010,6 +1010,26 @@ SL4,SL4,,,N704,SI-GA-D2,SL,
         self.assertEqual(get_bases_mask(run_info_xml,sample_sheet),
                          "y76,I6,y76")
 
+    def test_get_bases_mask_single_index_no_sample_sheet(self):
+        """get_bases_mask: handle single index (no samplesheet)
+        """
+        # Make a single index RunInfo.xml file
+        run_info_xml = os.path.join(self.wd,"RunInfo.xml")
+        with open(run_info_xml,'w') as fp:
+            fp.write(RunInfoXml.nextseq("171020_NB500968_00002_AHGXXXX"))
+        # Check the bases mask
+        self.assertEqual(get_bases_mask(run_info_xml),"y76,I6,y76")
+
+    def test_get_bases_mask_dual_index_no_sample_sheet(self):
+        """get_bases_mask: handle dual index (no samplesheet)
+        """
+        # Make a RunInfo.xml file
+        run_info_xml = os.path.join(self.wd,"RunInfo.xml")
+        with open(run_info_xml,'w') as fp:
+            fp.write(RunInfoXml.hiseq("171020_SN7001250_00002_AHGXXXX"))
+        # Check the bases mask
+        self.assertEqual(get_bases_mask(run_info_xml),"y101,I8,I8,y101")
+
 class TestGetNmismatches(unittest.TestCase):
     """Tests for the get_nmismatches function
 

--- a/auto_process_ngs/test/test_fastq_utils.py
+++ b/auto_process_ngs/test/test_fastq_utils.py
@@ -14,6 +14,7 @@ from auto_process_ngs.fastq_utils import get_read_number
 from auto_process_ngs.fastq_utils import get_read_count
 from auto_process_ngs.fastq_utils import pair_fastqs
 from auto_process_ngs.fastq_utils import pair_fastqs_by_name
+from auto_process_ngs.fastq_utils import group_fastqs_by_name
 from auto_process_ngs.fastq_utils import remove_index_fastqs
 
 # Test data
@@ -717,6 +718,121 @@ class TestPairFastqsByNameFunction(unittest.TestCase):
                          [("/data/PJB1_S1_R1_001.fastq.gz",
                            "/data/PJB1_S1_R2_001.fastq.gz"),
                           ("/data/PJB2_S2_R2_001.fastq.gz",)])
+
+# group_fastqs_by_name
+class TestGroupFastqsByNameFunction(unittest.TestCase):
+    """
+    Tests for the group_fastqs_by_name function
+    """
+    def test_group_fastqs_by_name_SE(self):
+        """
+        group_fastqs_by_name: single-end fastqs
+        """
+        fastqs = ("/data/PJB1_S1_R1_001.fastq.gz",
+                  "/data/PJB2_S2_R1_001.fastq.gz")
+        self.assertEqual(group_fastqs_by_name(fastqs),
+                         [["/data/PJB1_S1_R1_001.fastq.gz",],
+                          ["/data/PJB2_S2_R1_001.fastq.gz",]])
+
+    def test_group_fastqs_by_name_PE(self):
+        """
+        group_fastqs_by_name: paired-end fastqs
+        """
+        fastqs = ("/data/PJB1_S1_R1_001.fastq.gz",
+                  "/data/PJB1_S1_R2_001.fastq.gz",
+                  "/data/PJB2_S2_R1_001.fastq.gz",
+                  "/data/PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(group_fastqs_by_name(fastqs),
+                         [["/data/PJB1_S1_R1_001.fastq.gz",
+                           "/data/PJB1_S1_R2_001.fastq.gz"],
+                          ["/data/PJB2_S2_R1_001.fastq.gz",
+                           "/data/PJB2_S2_R2_001.fastq.gz"]])
+
+    def test_group_fastqs_by_name_PE_with_index_read(self):
+        """
+        group_fastqs_by_name: paired-end fastqs with index reads
+        """
+        fastqs = ("/data/PJB1_S1_R1_001.fastq.gz",
+                  "/data/PJB1_S1_R2_001.fastq.gz",
+                  "/data/PJB1_S1_I1_001.fastq.gz",
+                  "/data/PJB2_S2_R1_001.fastq.gz",
+                  "/data/PJB2_S2_R2_001.fastq.gz",
+                  "/data/PJB2_S2_I1_001.fastq.gz")
+        self.assertEqual(group_fastqs_by_name(fastqs),
+                         [["/data/PJB1_S1_R1_001.fastq.gz",
+                           "/data/PJB1_S1_R2_001.fastq.gz",
+                           "/data/PJB1_S1_I1_001.fastq.gz",],
+                          ["/data/PJB2_S2_R1_001.fastq.gz",
+                           "/data/PJB2_S2_R2_001.fastq.gz",
+                           "/data/PJB2_S2_I1_001.fastq.gz",]])
+
+    def test_group_fastqs_by_name_PE_with_index_read_pair(self):
+        """
+        group_fastqs_by_name: paired-end fastqs with index read pair
+        """
+        fastqs = ("/data/PJB1_S1_R1_001.fastq.gz",
+                  "/data/PJB1_S1_R2_001.fastq.gz",
+                  "/data/PJB1_S1_I1_001.fastq.gz",
+                  "/data/PJB1_S1_I2_001.fastq.gz",
+                  "/data/PJB2_S2_R1_001.fastq.gz",
+                  "/data/PJB2_S2_R2_001.fastq.gz",
+                  "/data/PJB2_S2_I1_001.fastq.gz",
+                  "/data/PJB2_S2_I2_001.fastq.gz")
+        self.assertEqual(group_fastqs_by_name(fastqs),
+                         [["/data/PJB1_S1_R1_001.fastq.gz",
+                           "/data/PJB1_S1_R2_001.fastq.gz",
+                           "/data/PJB1_S1_I1_001.fastq.gz",
+                           "/data/PJB1_S1_I2_001.fastq.gz",],
+                          ["/data/PJB2_S2_R1_001.fastq.gz",
+                           "/data/PJB2_S2_R2_001.fastq.gz",
+                           "/data/PJB2_S2_I1_001.fastq.gz",
+                           "/data/PJB2_S2_I2_001.fastq.gz",]])
+
+    def test_group_fastqs_by_name_with_R3_and_index_read(self):
+        """
+        group_fastqs_by_name: R1, R2 and R3 fastqs with index reads
+        """
+        fastqs = ("/data/PJB1_S1_R1_001.fastq.gz",
+                  "/data/PJB1_S1_R2_001.fastq.gz",
+                  "/data/PJB1_S1_R3_001.fastq.gz",
+                  "/data/PJB1_S1_I1_001.fastq.gz",
+                  "/data/PJB2_S2_R1_001.fastq.gz",
+                  "/data/PJB2_S2_R2_001.fastq.gz",
+                  "/data/PJB2_S2_R3_001.fastq.gz",
+                  "/data/PJB2_S2_I1_001.fastq.gz")
+        self.assertEqual(group_fastqs_by_name(fastqs),
+                         [["/data/PJB1_S1_R1_001.fastq.gz",
+                           "/data/PJB1_S1_R2_001.fastq.gz",
+                           "/data/PJB1_S1_R3_001.fastq.gz",
+                           "/data/PJB1_S1_I1_001.fastq.gz",],
+                          ["/data/PJB2_S2_R1_001.fastq.gz",
+                           "/data/PJB2_S2_R2_001.fastq.gz",
+                           "/data/PJB2_S2_R3_001.fastq.gz",
+                           "/data/PJB2_S2_I1_001.fastq.gz",]])
+
+    def test_group_fastqs_by_name_mixed_SE_and_PE(self):
+        """
+        group_fastqs_by_name: mixture of single- and paired-end fastqs
+        """
+        fastqs = ("/data/PJB1_S1_R1_001.fastq.gz",
+                  "/data/PJB1_S1_R2_001.fastq.gz",
+                  "/data/PJB2_S2_R1_001.fastq.gz")
+        self.assertEqual(group_fastqs_by_name(fastqs),
+                         [["/data/PJB1_S1_R1_001.fastq.gz",
+                           "/data/PJB1_S1_R2_001.fastq.gz"],
+                          ["/data/PJB2_S2_R1_001.fastq.gz",]])
+
+    def test_group_fastqs_by_name_unpaired_R2(self):
+        """
+        group_fastqs_by_name: handle unpaired R2 fastqs
+        """
+        fastqs = ("/data/PJB1_S1_R1_001.fastq.gz",
+                  "/data/PJB1_S1_R2_001.fastq.gz",
+                  "/data/PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(group_fastqs_by_name(fastqs),
+                         [["/data/PJB1_S1_R1_001.fastq.gz",
+                           "/data/PJB1_S1_R2_001.fastq.gz"],
+                          ["/data/PJB2_S2_R2_001.fastq.gz",]])
 
 # get_read_number
 class TestGetReadNumber(unittest.TestCase):

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -142,13 +142,47 @@ class TestCellrangerInfo(unittest.TestCase):
             fp.write("#!/bin/bash\ncat <<EOF\ncellranger $1  (2.0.1)\nCopyright (c) 2017 10x Genomics, Inc.  All rights reserved.\n-------------------------------------------------------------------------------\n\nUsage:\n    cellranger mkfastq\n\n    cellranger count\n    cellranger aggr\n    cellranger reanalyze\n    cellranger mkloupe\n    cellranger mat2csv\n\n    cellranger mkgtf\n    cellranger mkref\n\n    cellranger vdj\n\n    cellranger mkvdjref\n\n    cellranger testrun\n    cellranger upload\n    cellranger sitecheckEOF")
         os.chmod(cellranger_201,0775)
         return cellranger_201
-            
+    def _make_mock_cellranger_atac_101(self):
+        # Make a fake cellranger-atac 1.0.1 executable
+        cellranger_atac_101 = os.path.join(self.wd,"cellranger-atac")
+        with open(cellranger_atac_101,'w') as fp:
+            fp.write("#!/bin/bash\ncat <<EOF\ncellranger-atac  (1.0.1)\nCopyright (c) 2018 10x Genomics, Inc.  All rights reserved.\n-------------------------------------------------------------------------------\n\nUsage:\n    cellranger-atac mkfastq\n\n    cellranger-atac count\n\n    cellranger-atac testrun\n    cellranger-atac upload\n    cellranger-atac sitecheckEOF")
+        os.chmod(cellranger_atac_101,0775)
+        return cellranger_atac_101
+
     def test_cellranger_201(self):
         """cellranger_info: collect info for cellranger 2.0.1
         """
         cellranger = self._make_mock_cellranger_201()
         self.assertEqual(cellranger_info(path=cellranger),
                          (cellranger,'cellranger','2.0.1'))
+
+    def test_cellranger_201_on_path(self):
+        """cellranger_info: collect info for cellranger 2.0.1 from PATH
+        """
+        os.environ['PATH'] = "%s%s%s" % (os.environ['PATH'],
+                                         os.pathsep,
+                                         self.wd)
+        cellranger = self._make_mock_cellranger_201()
+        self.assertEqual(cellranger_info(name='cellranger'),
+                         (cellranger,'cellranger','2.0.1'))
+
+    def test_cellranger_atac_101(self):
+        """cellranger_info: collect info for cellranger-atac 1.0.1
+        """
+        cellranger_atac = self._make_mock_cellranger_atac_101()
+        self.assertEqual(cellranger_info(path=cellranger_atac),
+                         (cellranger_atac,'cellranger-atac','1.0.1'))
+
+    def test_cellranger_atac_101_on_path(self):
+        """cellranger_info: collect info for cellranger-atac 1.0.1 from PATH
+        """
+        os.environ['PATH'] = "%s%s%s" % (os.environ['PATH'],
+                                         os.pathsep,
+                                         self.wd)
+        cellranger_atac = self._make_mock_cellranger_atac_101()
+        self.assertEqual(cellranger_info(name='cellranger-atac'),
+                         (cellranger_atac,'cellranger-atac','1.0.1'))
 
 class TestMetricsSummary(unittest.TestCase):
     """

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -303,6 +303,57 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
         self.assertTrue(os.path.isfile("cellranger_qc_summary.html"))
         self.assertTrue(os.path.isdir(output_dir))
 
+    def test_run_cellranger_mkfastq_atac(self):
+        """run_cellranger_mkfastq: check cellranger-atac is executed
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_SN7001250_00002_AHGXXXX",
+            "hiseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        # Mock sample sheet with chromium scATAC-seq indices
+        sample_sheet_file = os.path.join(self.wd,"samplesheet.csv")
+        with open(sample_sheet_file,'w') as fp:
+            fp.write("""[Header]
+IEMFileVersion,4
+
+[Reads]
+76
+76
+
+[Settings]
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+1,smpl1,smpl1,,,A001,SI-NA-A1,10xGenomics,
+2,smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
+3,smpl3,smpl3,,,A006,SI-NA-C1,10xGenomics,
+4,smpl4,smpl4,,,A007,SI-NA-D1,10xGenomics,
+""")
+        # Create mock bcl2fastq and cellranger-atac executables
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,"bcl2fastq"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger-atac"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Output dir
+        output_dir = "bcl2fastq"
+        self.assertFalse(os.path.exists("HGXXXX"))
+        self.assertFalse(os.path.exists("cellranger_qc_summary.html"))
+        self.assertFalse(os.path.exists(output_dir))
+        # Run 'cellranger mkfastq'
+        exit_code = run_cellranger_mkfastq(sample_sheet_file,
+                                           illumina_run.dirn,
+                                           output_dir,
+                                           cellranger_exe="cellranger-atac")
+        # Check outputs
+        self.assertEqual(exit_code,0)
+        self.assertTrue(os.path.isdir("HGXXXX"))
+        self.assertTrue(os.path.isfile("cellranger_qc_summary.html"))
+        self.assertTrue(os.path.isdir(output_dir))
+
     def test_run_cellranger_mkfastq_subset_of_lanes(self):
         """run_cellranger_mkfastq: check cellranger is executed for subset of lanes
         """

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -7,6 +7,7 @@ import tempfile
 import os
 import shutil
 from bcftbx.mock import MockIlluminaRun
+from bcftbx.mock import RunInfoXml
 from auto_process_ngs.mock import MockBcl2fastq2Exe
 from auto_process_ngs.mock import MockCellrangerExe
 from auto_process_ngs.tenx_genomics_utils import *
@@ -144,6 +145,53 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
         s = self._make_sample_sheet(
             self.sample_sheet_mixed_indices)
         self.assertTrue(has_chromium_sc_indices(s))
+
+class TestGetBasesMask10xAtac(unittest.TestCase):
+    """
+    Tests for the 'get_bases_mask_10x_atac' function
+    """
+    def setUp(self):
+        # Create a temporary working dir
+        self.wd = tempfile.mkdtemp()
+
+    def tearDown(self):
+        # Remove working dir
+        if self.wd is not None:
+            shutil.rmtree(self.wd)
+
+    def test_get_bases_mask_10x_atac_I8_I16_dual_indexes(self):
+        """get_bases_mask_10x_atac: run with I8,I16 dual indexes
+        """
+        # Make a single index RunInfo.xml file
+        run_info_xml = os.path.join(self.wd,"RunInfo.xml")
+        with open(run_info_xml,'w') as fp:
+            fp.write(RunInfoXml.create("171020_NB500968_00002_AHGXXXX",
+                                       "y76,I8,I16,y76",4,12))
+        self.assertEqual(get_bases_mask_10x_atac(run_info_xml),
+                         "y76,I8,y16,y76")
+
+    def test_get_bases_mask_10x_atac_I16_I16_dual_indexes(self):
+        """get_bases_mask_10x_atac: run with I16,I16 dual indexes
+        """
+        # Make a single index RunInfo.xml file
+        run_info_xml = os.path.join(self.wd,"RunInfo.xml")
+        with open(run_info_xml,'w') as fp:
+            fp.write(RunInfoXml.create("171020_NB500968_00002_AHGXXXX",
+                                       "y76,I16,I16,y76",4,12))
+        self.assertEqual(get_bases_mask_10x_atac(run_info_xml),
+                         "y76,I8nnnnnnnn,y16,y76")
+
+    def test_get_bases_mask_10x_atac_too_short_index(self):
+        """get_bases_mask_10x_atac: run with too-short index
+        """
+        # Make a single index RunInfo.xml file
+        run_info_xml = os.path.join(self.wd,"RunInfo.xml")
+        with open(run_info_xml,'w') as fp:
+            fp.write(RunInfoXml.create("171020_NB500968_00002_AHGXXXX",
+                                       "y76,I6,I16,y76",4,12))
+        self.assertRaises(Exception,
+                          get_bases_mask_10x_atac,
+                          run_info_xml)
 
 class TestCellrangerInfo(unittest.TestCase):
     """

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -49,6 +49,24 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
 3,smpl3,smpl3,,,A006,SI-GA-C1,10xGenomics,
 4,smpl4,smpl4,,,A007,SI-GA-D1,10xGenomics,
 """
+        self.sample_sheet_with_atac_indices = """[Header]
+IEMFileVersion,4
+
+[Reads]
+76
+76
+
+[Settings]
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+1,smpl1,smpl1,,,A001,SI-NA-A1,10xGenomics,
+2,smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
+3,smpl3,smpl3,,,A006,SI-NA-C1,10xGenomics,
+4,smpl4,smpl4,,,A007,SI-NA-D1,10xGenomics,
+"""
         self.sample_sheet_standard_indices = """[Header]
 IEMFileVersion,4
 
@@ -104,6 +122,13 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
         """
         s = self._make_sample_sheet(
             self.sample_sheet_with_chromium_indices)
+        self.assertTrue(has_chromium_sc_indices(s))
+    def test_sample_sheet_all_sc_atac_indices(self):
+        """
+        has_chromium_indices: sample sheet with 10x scATAC-seq indices only
+        """
+        s = self._make_sample_sheet(
+            self.sample_sheet_with_atac_indices)
         self.assertTrue(has_chromium_sc_indices(s))
     def test_sample_sheet_no_chromium_indices(self):
         """

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -270,6 +270,32 @@ class TestMetricsSummary(unittest.TestCase):
         m = MetricsSummary(metrics_summary)
         self.assertEqual(m.estimated_number_of_cells,2272)
 
+class TestAtacSummary(unittest.TestCase):
+    """
+    Tests for the 'AtacSummary' class
+    """
+    def setUp(self):
+        # Create a temp working dir
+        self.wd = tempfile.mkdtemp(suffix='TestAtacSummary')
+
+    def tearDown(self):
+        # Remove the temporary test directory
+        if REMOVE_TEST_OUTPUTS:
+            shutil.rmtree(self.wd)
+
+    def test_atac_summary(self):
+        """AtacSummary: check detected/annotated numbers of cells are extracted
+        """
+        summary = """annotated_cells,bc_q30_bases_fract,cellranger-atac_version,cells_detected,frac_cut_fragments_in_peaks,frac_fragments_nfr,frac_fragments_nfr_or_nuc,frac_fragments_nuc,frac_fragments_overlapping_peaks,frac_fragments_overlapping_targets,frac_mapped_confidently,frac_waste_chimeric,frac_waste_duplicate,frac_waste_lowmapq,frac_waste_mitochondrial,frac_waste_no_barcode,frac_waste_non_cell_barcode,frac_waste_overall_nondup,frac_waste_total,frac_waste_unmapped,median_fragments_per_cell,median_per_cell_unique_fragments_at_30000_RRPC,median_per_cell_unique_fragments_at_50000_RRPC,num_fragments,r1_q30_bases_fract,r2_q30_bases_fract,si_q30_bases_fract,total_usable_fragments,tss_enrichment_score
+5682,0.925226023701,1.0.1,6748,0.512279447992,0.392368676637,0.851506103882,0.459137427245,0.556428090013,0.575082094792,0.534945791083,0.00123066129161,0.160515305655,0.0892973647982,0.00899493352094,0.352907229061,0.0135851297269,0.471714266123,0.632229571777,0.00569894772443,16119.5,5769.94794925,8809.29425158,366582587,0.947387774999,0.941378123188,0.962708567847,134818235,6.91438390781
+"""
+        summary_csv = os.path.join(self.wd,"summary.csv")
+        with open(summary_csv,'w') as fp:
+            fp.write(summary)
+        s = AtacSummary(summary_csv)
+        self.assertEqual(s.cells_detected,6748)
+        self.assertEqual(s.annotated_cells,5682)
+
 class TestRunCellrangerMkfastq(unittest.TestCase):
     """
     Tests for the 'run_cellranger_mkfastq' function

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -80,6 +80,7 @@ import auto_process_ngs.envmod as envmod
 from auto_process_ngs.auto_processor import AutoProcess
 from auto_process_ngs.samplesheet_utils import predict_outputs
 from auto_process_ngs.utils import paginate
+from auto_process_ngs.commands.make_fastqs_cmd import MAKE_FASTQS_PROTOCOLS
 from auto_process_ngs.commands.report_cmd import ReportingMode
 
 __version__ = auto_process_ngs.get_version()
@@ -217,8 +218,9 @@ def add_make_fastqs_command(cmdparser):
                                 dest='protocol',default='standard',
                                 help="specify Fastq generation protocol "
                                 "depending on the data being processed. "
-                                "Must be one of 'standard', 'icell8', "
-                                "'10x_chromium_sc' (default: 'standard')")
+                                "Must be one of %s (default: 'standard')"
+                                % ', '.join(["'%s'" % x
+                                             for x in MAKE_FASTQS_PROTOCOLS]))
     fastq_generation.add_option('--sample-sheet',action="store",
                                 dest="sample_sheet",default=None,
                                 help="use an alternative sample sheet to "

--- a/bin/reportqc.py
+++ b/bin/reportqc.py
@@ -269,12 +269,12 @@ def main():
             out_file = opts.filename
         if not os.path.isabs(out_file):
             out_file = os.path.join(p.dirn,out_file)
-        print "Writing QC report to %s" % out_file
         report_html= qc_reporter.report(qc_dir=qc_dir,
                                         qc_protocol=protocol,
                                         title=opts.title,
                                         filename=out_file,
                                         relative_links=True)
+        print "Wrote QC report to %s" % out_file
         # Generate ZIP archive
         if opts.zip:
             report_zip = zip_report(p,report_html,qc_dir,

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -73,7 +73,7 @@ cellranger_localcores = 1
 # Assign organism name to path to cellranger
 # scATAC-seq reference data to use for that
 # organism in single library analysis
-[10xgenomics_atac_references]
+[10xgenomics_atac_genome_references]
 #human = /data/cellranger/refdata-cellranger-atac-GRCh38-1.0.1
 #mouse = /data/cellranger/refdata-cellranger-atac-mm10-1.0.1
 

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -69,6 +69,14 @@ cellranger_localcores = 1
 #human = /data/cellranger/refdata-cellranger-GRCh38-1.2.0
 #mouse = /data/cellranger/refdata-cellranger-mm10-1.2.0
 
+# 10xGenomics scATAC-seq genome references
+# Assign organism name to path to cellranger
+# scATAC-seq reference data to use for that
+# organism in single library analysis
+[10xgenomics_atac_references]
+#human = /data/cellranger/refdata-cellranger-atac-GRCh38-1.0.1
+#mouse = /data/cellranger/refdata-cellranger-atac-mm10-1.0.1
+
 # Platform specific settings
 # Make sections [platform:NAME] and add parameters to
 # override the default bcl2fastq settings (i.e. number of

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -11,25 +11,27 @@ Software dependencies
 The following ``auto_process`` subcommands depend on additional
 third-party software packages which must be installed separately:
 
-=================== ================= ===================
-Pipeline stage      Software packages Notes
-=================== ================= ===================
-make_fastqs         `bcl2fastq 2.17`_ 2.17+ recommended
-make_fastqs         `cellranger`_     10xGenomics Chromium single-cell data only
+=================== ================== ===================
+Pipeline stage      Software packages  Notes
+=================== ================== ===================
+make_fastqs         `bcl2fastq 2.17`_  2.17+ recommended
+make_fastqs         `cellranger`_      10xGenomics Chromium single-cell RNA-seq data only
+make_fastqs         `cellranger-atac`_ 10xGenomics Chromium single-cell ATAC-seq data only
 run_qc              `fastqc`_
 run_qc              `fastq_screen`_
-run_qc              `bowtie`_         Required by fastq_screen
-run_qc              `STAR`_           Required for strandedness determination
+run_qc              `bowtie`_          Required by fastq_screen
+run_qc              `STAR`_            Required for strandedness determination
 run_qc              `multiqc`_
 process_icell8      `cutadapt`_
 process_icell8      `fastq_screen`_
-process_icell8      `bowtie2`_        Required by fastq_screen
+process_icell8      `bowtie2`_         Required by fastq_screen
 process_10xgenomics `cellranger`_
-=================== ================= ===================
+=================== ================== ===================
 
 .. _bcl2fastq 2.17: https://support.illumina.com/downloads/bcl2fastq-conversion-software-v217.html
 .. _bcl2fastq1.8.4: http://support.illumina.com/downloads/bcl2fastq_conversion_software_184.html
 .. _cellranger: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/what-is-cell-ranger
+.. _cellranger-atac: https://support.10xgenomics.com/single-cell-atac/software/pipelines/latest/what-is-cell-ranger-atac
 .. _fastqc:  http://www.bioinformatics.babraham.ac.uk/projects/fastqc/
 .. _fastq_screen: http://www.bioinformatics.babraham.ac.uk/projects/fastq_screen/
 .. _bowtie: http://bowtie-bio.sourceforge.net/index.shtml
@@ -114,14 +116,14 @@ options.
   
 .. _auto_process_reference_data_10xgenomics:
 
----------------------------------------------
-process_10xgenomics (single library analysis)
----------------------------------------------
+----------------------------------------------------------------
+process_10xgenomics (single library analysis for scRNA-seq data)
+----------------------------------------------------------------
 
-The single library analysis step of ``process_10xgenomics``
-wraps ``cellranger count`` and requires a compatible ``cellranger``
-transcriptome reference data set for the organism in question
-to be provided.
+The single library analysis step of ``process_10xgenomics`` for
+single cell RNA-seq wraps ``cellranger count`` and requires a
+compatible ``cellranger`` transcriptome reference data set for the
+organism in question to be provided.
 
 10xGenomics provide a number of reference data sets which can
 be downloaded via:
@@ -137,6 +139,35 @@ section of the ``settings.ini`` file, for example::
   [10xgenomics_transcriptomes]
   human = /data/cellranger/refdata-cellranger-GRCh38-1.2.0
   mouse = /data/cellranger/refdata-cellranger-mm10-1.2.0
+
+or else must be specified using the relevant command line
+option.
+
+.. _auto_process_reference_data_10xgenomics_atac:
+
+-----------------------------------------------------------------
+process_10xgenomics (single library analysis for scATAC-seq data)
+-----------------------------------------------------------------
+
+The single library analysis step of ``process_10xgenomics`` for
+single cell ATAC-seq data wraps ``cellranger-atac count`` and
+requires a compatible ``cellranger-atac`` ATAC genome reference
+data set for the organism in question to be provided.
+
+10xGenomics provide a number of reference data sets which can
+be downloaded via:
+
+* https://support.10xgenomics.com/single-cell-atac/software/pipelines/latest/installation
+
+(There are also instructions for constructing reference data
+for novel organisms that are not supported.)
+
+These can be defined in the ``10xgenomics_atac_genome_references``
+section of the ``settings.ini`` file, for example::
+
+  [10xgenomics_atac_genome_references]
+  human = /data/cellranger/refdata-cellranger-atac-GRCh38-1.0.1
+  mouse = /data/cellranger/refdata-cellranger-atac-mm10-1.0.1
 
 or else must be specified using the relevant command line
 option.

--- a/docs/source/single_cell/10xgenomics.rst
+++ b/docs/source/single_cell/10xgenomics.rst
@@ -6,13 +6,16 @@ Background
 
 The 10xGenomics Chromium SC 3'v2 system prepares single cell (SC) samples
 which are then sequenced as part of an Illumina sequencing run. 10xGenomics
-provide the ``cellranger`` software package to perform Fastq generation
-and subsequent analyses.
+provide the ``cellranger`` and ``cellranger-atac`` software packages to
+perform Fastq generation and subsequent analyses:
+
+* ``cellranger`` is used for single cell RNA-seq data
+* ``cellranger-atac`` is used for single cell ATAC-seq data
 
 The auto-process package currently provides a utility script called
 ``process_10xgenomics.py`` which wraps a subset of the ``cellranger``
-commands whilst also providing a degree of integration with the
-``auto_process`` pipeline.
+and ``cellranger-atac`` commands, whilst also providing a degree of
+integration with the ``auto_process`` pipeline.
 
 Processing protocol for 10xGenomics Chromium data
 -------------------------------------------------
@@ -20,7 +23,8 @@ Processing protocol for 10xGenomics Chromium data
 The recommended steps are:
 
 1. Generate the Fastqs as described in
-   :ref:`make_fastqs-10x_chromium_sc-protocol`
+   :ref:`make_fastqs-10x_chromium_sc-protocol` or
+   :ref:`make_fastqs-10x_chromium_sc_atac-protocol`
 2. Set up analysis directories and run initial QC as per the standard
    protocol
 3. Perform initial single library analysis by running the
@@ -32,11 +36,20 @@ The recommended steps are:
 Perform initial single-library analysis
 ---------------------------------------
 
-Initial single-library analysis can be performed by using the
-``process_10xgenomics.py count`` wrapper to run ``cellranger count``
-on all the samples in the Chromium-based projects.
+Initial single-library analysis can be performed by using
+``process_10xgenomics.py count`` (for scRNA-seq data) or
+``process_10xgenomics.py count-atac`` (for scATAC-seq data) commands.
+These are wrappers which run ``cellranger count`` or
+``cellranger-atac count`` on all the samples in the Chromium-based
+projects.
 
-The general invocation is:
+.. _10xgenomics-count-options:
+
+Single-library analysis for scRNA-seq data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The general invocation for running the single-library analysis on
+single cell RNA-seq data is:
 
 ::
 
@@ -45,12 +58,17 @@ The general invocation is:
 	   PROJECT1 [ PROJECT2 ... ]
 
 where ``PROJECT1`` etc represent the projects with Chromium
-datasets.
+RNA-seq datasets.
 
-.. note::
+The ``count`` command supports the following options::
 
-   See https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/count
-   for more details on the single-library analysis.
+    -u : specify the name of the output directory from 'mkfastq'
+    -t : specify the path to the directory with the appropriate
+         10xGenomics transcriptome data
+    -c : specify the assay configuration (aka chemistry)
+
+in addition to the options outlined in the section
+:ref:`10xgenomics-additional-options`.
 
 .. note::
 
@@ -60,19 +78,45 @@ datasets.
    instead the matching reference data will be used automatically
    for the single-library analysis.
 
-.. _10xgenomics-count-options:
+See https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/count
+for more details on the single-library analysis for scRNA-seq.
 
-Command line options for 'count'
-********************************
+.. _10xgenomics-count-atac-options:
 
-The ``count`` command supports the following options::
+Single-library analysis for sATAC-seq data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The general invocation for running the single-library analysis on
+single cell ATAC-seq data is:
+
+::
+
+       process_10xgenomics.py count-atac \
+           -r /path/to/refdata-cellranger-atac-mm10-1.0.1
+	   PROJECT1 [ PROJECT2 ... ]
+
+where ``PROJECT1`` etc represent the projects with Chromium
+ATAC-seq datasets.
+
+The ``count-atac`` command supports the following options::
 
     -u : specify the name of the output directory from 'mkfastq'
-    -t : specify the path to the directory with the appropriate
-         10xGenomics transcriptome data
-    -c : specify the assay configuration (aka chemistry)
+    -r : specify the path to the directory with the appropriate
+         10xGenomics ATAC genome reference data
 
-See also :ref:`10xgenomics-additional-options`.
+in addition to the options outlined in the section
+:ref:`10xgenomics-additional-options`.
+
+.. note::
+
+   If a project metadata defines an organism name which matches one
+   of the entries in the ``10xgenomics_atac_genome_references``
+   section of the configuration file then the ``-r`` option isn't
+   required; instead the matching reference data will be used
+   automatically for the single-library analysis.
+
+See https://support.10xgenomics.com/single-cell-atac/software/pipelines/latest/using/count
+for more details on the single-library analysis for scATAC-seq.
 
 .. _10xgenomics-additional-options:
 

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -18,14 +18,17 @@ The general invocation of the command is:
 The ``--protocol`` option should be chosen according to the type
 of data that is being processed:
 
-=================== =====================================
-Protocol option     Used for
-=================== =====================================
-``standard``        Standard Illumina sequencing data
-                    (default)
-``icell8``          ICELL8 single-cell data
-``10x_chromium_sc`` 10xGenomics Chromium single-cell data
-=================== =====================================
+======================== =====================================
+Protocol option          Used for
+======================== =====================================
+``standard``             Standard Illumina sequencing data
+                         (default)
+``icell8``               ICELL8 single-cell RNA-seq data
+``10x_chromium_sc``      10xGenomics Chromium single-cell
+                         RNA-seq data
+``10x_chromium_sc_atac`` 10xGenomics Chromium single-cell
+                         ATAC-seq data
+======================== =====================================
 
 By default ``make_fastqs`` performs the following steps:
 
@@ -109,11 +112,11 @@ in the section :ref:`make_fastqs-outputs`.
 
 .. _make_fastqs-icell8-protocol:
 
-Fastq generation for ICELL8 single-cell data (``--protocol=icell8``)
---------------------------------------------------------------------
+Fastq generation for ICELL8 single-cell RNA-seq data (``--protocol=icell8``)
+----------------------------------------------------------------------------
 
-Initial Fastqs can be generated from ICELL8 single-cell8 data using the
-``--protocol=icell8`` option:
+Initial Fastqs can be generated from ICELL8 single-cell8 RNA-seq data
+using the ``--protocol=icell8`` option:
 
 ::
 
@@ -142,11 +145,11 @@ the Fastqs.
 
 .. _make_fastqs-10x_chromium_sc-protocol:
 
-Fastq generation for 10xGenomics Chromium single-cell data (``--protocol=10x_chromium_sc``)
--------------------------------------------------------------------------------------------
+Fastq generation for 10xGenomics Chromium single-cell RNA-seq data (``--protocol=10x_chromium_sc``)
+---------------------------------------------------------------------------------------------------
 
 Fastq generation can be performed for 10xGenomics Chromium
-single-cell data by using the ``--protocol=10x_chromium_sc``
+single-cell RNA-seq data by using the ``--protocol=10x_chromium_sc``
 option:
 
 ::
@@ -163,6 +166,31 @@ This will generate the Fastqs in the specified output directory
 
    ``make_fastqs`` offers various options for controlling the
    behaviour of ``cellranger mkfastqs``, for example setting the
+   jobmode (see :ref:`10xgenomics-additional-options`).
+
+.. _make_fastqs-10x_chromium_sc_atac-protocol:
+
+Fastq generation for 10xGenomics Chromium single-cell ATAC-seq data (``--protocol=10x_chromium_sc_atac``)
+---------------------------------------------------------------------------------------------------------
+
+Fastq generation can be performed for 10xGenomics Chromium
+single-cell ATAC-seq data by using the ``--protocol=10x_chromium_sc_atac``
+option:
+
+::
+
+    auto_process.py make_fastqs --protocol=10x_chromium_sc_atac ...
+
+which fetches the data and runs ``cellranger-atac mkfastq``.
+
+This will generate the Fastqs in the specified output directory
+(e.g. ``bcl2fastq``) along with an HTML report derived from the
+``cellranger-atac`` JSON QC summary file, statistics for the Fastqs.
+
+.. note::
+
+   ``make_fastqs`` offers various options for controlling the
+   behaviour of ``cellranger-atac mkfastqs``, for example setting the
    jobmode (see :ref:`10xgenomics-additional-options`).
 
 .. _make_fastqs-mixed-protocols:

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -22,7 +22,8 @@ QC protocol    Used for
 ============== ========================
 ``standardPE`` Standard paired-end data i.e. R1/R2 Fastq pairs
 ``standardSE`` Standard single-end data i.e. R1 Fastqs only
-``singlecell`` Data from single-cell platforms (ICELL8, 10xGenomics)
+``singlecell`` Single cell RNA-seq data from ICELL8 and 10xGenomics platforms
+``10x_scATAC`` 10xGenomics single cell ATAC-seq
 ============== ========================
 
 The protocol is determined automatically for each project.


### PR DESCRIPTION
PR to address issue #313 and add support for handling single cell ATAC-seq data from the 10xGenomics Chromium platform.

The changes add a new `make_fastqs` protocol `10x_chromium_sc_atac` which handles the Fastq generation for these data, and a new QC protocol `10x_scATAC` for running the QC pipeline on them. It also adds a new command `count-atac` to the `process_10xgenomics.py` utility for performing the single-library analysis.

The PR includes substantial updates to the QC reporting code to enable dealing with the `R3` reads produced by the Fastq generation (and which are equivalent to the `R2` reads from standard paired end protocols). These updates attempt to generalise the reporting so it should be easier to handle new QC protocols in future.