### PR TITLE
Fix adding sample names from projects in QCReport

### DIFF
--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -683,7 +683,7 @@ class QCReport(Document):
         # Samples
         samples = set([self.fastq_attrs(fq).sample_name
                        for fq in self.fastqs] +
-                      self.project.samples)
+                      [s.name for s in self.project.samples])
         self.samples = sorted(list(samples),
                               key=lambda s: split_sample_name(s))
         # QC outputs


### PR DESCRIPTION
PR to fix a minor bug introduced with the changes to the `qc/reporting.py` module in PR #324, where trying to add sample names from the project information resulted in double-counting and empty sections in the output HTML.