### PR TITLE
Fix job runner acquisition in auto_process commands

### DIFF
--- a/auto_process_ngs/commands/analyse_barcodes_cmd.py
+++ b/auto_process_ngs/commands/analyse_barcodes_cmd.py
@@ -136,9 +136,7 @@ def analyse_barcodes(ap,unaligned_dir=None,lanes=None,
     # Log dir
     ap.set_log_dir(ap.get_log_subdir('analyse_barcodes'))
     # Set up runner
-    if runner is not None:
-        runner = fetch_runner(runner)
-    else:
+    if runner is None:
         runner = ap.settings.general.default_runner
     runner.set_log_dir(ap.log_dir)
     # Schedule the jobs needed to do counting

--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -17,7 +17,6 @@ import auto_process_ngs.applications as applications
 import auto_process_ngs.fileops as fileops
 import auto_process_ngs.simple_scheduler as simple_scheduler
 import auto_process_ngs.tenx_genomics_utils as tenx_genomics_utils
-from bcftbx.JobRunner import fetch_runner
 from bcftbx.utils import format_file_size
 
 # Module specific logger
@@ -232,9 +231,7 @@ def archive(ap,archive_dir=None,platform=None,year=None,
             log_dir += '_dry_run'
         ap.set_log_dir(ap.get_log_subdir(log_dir))
         # Set up runner
-        if runner is not None:
-            runner = fetch_runner(runner)
-        else:
+        if runner is None:
             runner = ap.settings.runners.rsync
         runner.set_log_dir(ap.log_dir)
         # Setup a scheduler for multiple rsync jobs

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -512,9 +512,7 @@ def get_primary_data(ap,runner=None):
     data_dir = ap.params.data_dir
     ap.params["primary_data_dir"] = ap.add_directory('primary_data')
     # Set up runner
-    if runner is not None:
-        runner = fetch_runner(runner)
-    else:
+    if runner is None:
         runner = ap.settings.runners.rsync
     runner.set_log_dir(ap.log_dir)
     # Run rsync command
@@ -706,9 +704,7 @@ def bcl_to_fastq(ap,unaligned_dir,sample_sheet,primary_data_dir,
     print "Min trimmed read len  : %s" % minimum_trimmed_read_length
     print "Mask short adptr reads: %s" % mask_short_adapter_reads
     # Set up runner
-    if runner is not None:
-        runner = fetch_runner(runner)
-    else:
+    if runner is None:
         runner = ap.settings.runners.bcl2fastq
     runner.set_log_dir(ap.log_dir)
     # Run bcl2fastq
@@ -1003,9 +999,7 @@ def fastq_statistics(ap,stats_file=None,per_lane_stats_file=None,
             report_processing_qc(ap,processing_qc_html)
             return
     # Set up runner
-    if runner is not None:
-        runner = fetch_runner(runner)
-    else:
+    if runner is None:
         runner = ap.settings.runners.stats
     runner.set_log_dir(ap.log_dir)
     # Number of cores

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -16,7 +16,6 @@ from ..qc.pipeline import QCPipeline
 from ..qc.fastq_strand import build_fastq_strand_conf
 from ..qc.utils import determine_qc_protocol
 from ..utils import get_organism_list
-from bcftbx.JobRunner import fetch_runner
 
 # Module specific logger
 logger = logging.getLogger(__name__)
@@ -57,8 +56,8 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
         (default: 100000)
       nthreads (int): specify number of threads to run the QC jobs
         with (default: 1)
-      runner (str): specify a non-default job runner to use for
-        the QC jobs
+      runner (JobRunner): specify a non-default job runner to use
+        for the QC jobs
       fastq_dir (str): specify the subdirectory to take the
         Fastq files from; will be used for all projects that are
         processed (default: 'fastqs')
@@ -94,9 +93,7 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
         return 1
     # Set up runners
     default_runner = ap.settings.general.default_runner
-    if runner is not None:
-        qc_runner = fetch_runner(runner)
-    else:
+    if runner is None:
         qc_runner = ap.settings.runners.qc
     # Get scheduler parameters
     if max_jobs is None:

--- a/bin/auto_process.py
+++ b/bin/auto_process.py
@@ -74,6 +74,7 @@ from bcftbx.cmdparse import add_no_save_option
 from bcftbx.cmdparse import add_dry_run_option
 from bcftbx.cmdparse import add_nprocessors_option
 from bcftbx.cmdparse import add_runner_option
+from bcftbx.JobRunner import fetch_runner
 import auto_process_ngs
 import auto_process_ngs.settings
 import auto_process_ngs.envmod as envmod
@@ -987,13 +988,18 @@ if __name__ == "__main__":
             # Deal with --skip-... for fastq generation
             skip_fastq_generation = (options.skip_fastq_generation or
                                      options.skip_bcl2fastq)
+            # Handle job runner specification
+            if options.runner is not None:
+                runner = fetch_runner(options.runner)
+            else:
+                runner = None
             # Do the make_fastqs step
             try:
                 d.make_fastqs(
                     protocol=options.protocol,
                     skip_rsync=options.skip_rsync,
                     nprocessors=options.nprocessors,
-                    runner=options.runner,
+                    runner=runner,
                     remove_primary_data=options.remove_primary_data,
                     ignore_missing_bcl=options.ignore_missing_bcl,
                     ignore_missing_stats=options.ignore_missing_stats,
@@ -1027,25 +1033,38 @@ if __name__ == "__main__":
                                output_dir=options.output_dir,
                                dry_run=options.dry_run)
         elif cmd == 'update_fastq_stats':
+            # Handle job runner specification
+            if options.runner is not None:
+                runner = fetch_runner(options.runner)
+            else:
+                runner = None
+            # Do the updated
             d.update_fastq_stats(
                 unaligned_dir=options.unaligned_dir,
                 stats_file=options.stats_file,
                 per_lane_stats_file=options.per_lane_stats_file,
                 add_data=options.add_data,
                 nprocessors=options.nprocessors,
-                runner=options.runner)
+                runner=runner)
         elif cmd == 'analyse_barcodes':
+            # Deal with --lanes
             if options.lanes is not None:
                 lanes = bcf_utils.parse_lanes(options.lanes)
             else:
                 lanes = None
+            # Handle job runner specification
+            if options.runner is not None:
+                runner = fetch_runner(options.runner)
+            else:
+                runner = None
+            # Do barcode analysis
             d.analyse_barcodes(unaligned_dir=options.unaligned_dir,
                                lanes=lanes,
                                mismatches=options.mismatches,
                                cutoff=options.cutoff,
                                sample_sheet=options.sample_sheet,
                                barcode_analysis_dir=options.barcode_analysis_dir,
-                               runner=options.runner,
+                               runner=runner,
                                force=options.force)
         elif cmd == 'setup_analysis_dirs':
             d.setup_analysis_dirs(unaligned_dir=options.unaligned_dir,
@@ -1055,7 +1074,12 @@ if __name__ == "__main__":
                                   short_fastq_names=options.short_fastq_names,
                                   link_to_fastqs=options.link_to_fastqs)
         elif cmd == 'run_qc':
-            # Do the make_fastqs step
+            # Handle job runner specification
+            if options.runner is not None:
+                runner = fetch_runner(options.runner)
+            else:
+                runner = None
+            # Do the run_qc step
             retcode = d.run_qc(projects=options.project_pattern,
                                max_jobs=options.max_jobs,
                                ungzip_fastqs=options.ungzip_fastqs,
@@ -1064,7 +1088,7 @@ if __name__ == "__main__":
                                fastq_dir=options.fastq_dir,
                                qc_dir=options.qc_dir,
                                report_html=options.html_file,
-                               runner=options.runner)
+                               runner=runner)
             sys.exit(retcode)
         elif cmd == 'samplesheet':
             # Sample sheet operations


### PR DESCRIPTION
PR which addresses bugs/issues with how job runners are handled in some of the `auto_process` commands (specifically the `make_fastqs`, `archive`, `update_fastq_stats` and `run_qc` commands).

The issues essentially arose out of an ambiguity over how job runner definitions should be passed to the functions implementing these commands. The PR resolves this by requiring that runners should always be passed as `JobRunner` instances, and delegating the task of generating these instances from textual definitions (supplied for example via the `--runner` option available to the above commands) to `auto_process.py` (which implements the command line interface).