### PR TITLE
publish_qc: fix broken --force argument

### DIFF
--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -255,6 +255,9 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                 log_dir=ap.log_dir)
             if verified:
                 print "...%s: verified QC" % qc_dir
+            else:
+                print "...%s: failed to verify QC" % qc_dir
+            if verified or force:
                 # Check for an existing report
                 qc_zip = os.path.join(
                     project.dirn,
@@ -278,9 +281,6 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                     qc_artefacts['qc_zip'] = qc_zip
                 else:
                     print "...%s: missing QC report" % qc_dir
-            else:
-                # Not verified
-                print "...%s: failed to verify QC" % qc_dir
             if legacy:
                 # MultiQC report
                 multiqc_report = os.path.join(project.dirn,


### PR DESCRIPTION
PR which fixes the `--force` option of the `publish_qc` command, which previously did nothing.

The fix that QC reports will be published for all projects (even those which failed QC verification).