### PR TITLE
Show samples with no reads in per-lane sample statistics

### DIFF
--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -923,8 +923,8 @@ def verify_fastq_generation(ap,unaligned_dir=None,lanes=None,
         include_sample_dir=include_sample_dir)
 
 def fastq_statistics(ap,stats_file=None,per_lane_stats_file=None,
-                     unaligned_dir=None,add_data=False,nprocessors=None,
-                     runner=None):
+                     unaligned_dir=None,sample_sheet=None,add_data=False,
+                     nprocessors=None,runner=None):
     """Generate statistics for Fastq files
 
     Generates statistics for all Fastq files found in the
@@ -942,6 +942,8 @@ def fastq_statistics(ap,stats_file=None,per_lane_stats_file=None,
         unless over-ridden by local settings)
       unaligned_dir (str): output directory for bcl-to-fastq
         conversion
+      sample_sheet (str): path to sample sheet file used in
+        bcl-to-fastq conversion
       add_data (bool): if True then add stats to the existing
         stats files (default is to overwrite existing stats
         files)
@@ -968,6 +970,9 @@ def fastq_statistics(ap,stats_file=None,per_lane_stats_file=None,
         unaligned_dir = ap.params.unaligned_dir
     if not os.path.exists(os.path.join(ap.params.analysis_dir,unaligned_dir)):
         logger.error("Unaligned dir '%s' not found" % unaligned_dir)
+    # Check for sample sheet
+    if sample_sheet is None:
+        sample_sheet = ap.params['sample_sheet']
     # Check if any Fastqs are newer than stats files
     newest_mtime = 0
     for f in (stats_file,per_lane_stats_file,):
@@ -1009,6 +1014,7 @@ def fastq_statistics(ap,stats_file=None,per_lane_stats_file=None,
     fastq_statistics_cmd = Command(
         'fastq_statistics.py',
         '--unaligned',unaligned_dir,
+        '--sample-sheet',sample_sheet,
         '--output',os.path.join(ap.params.analysis_dir,stats_file),
         '--per-lane-stats',os.path.join(ap.params.analysis_dir,
                                         per_lane_stats_file),

--- a/bin/fastq_statistics.py
+++ b/bin/fastq_statistics.py
@@ -64,6 +64,10 @@ if __name__ == '__main__':
                  default="Unaligned",
                  help="specify an alternative name for the 'Unaligned' "
                  "directory containing the fastq.gz files")
+    p.add_option("--sample-sheet",action="store",dest="sample_sheet",
+                 default="None",
+                 help="specify a sample sheet file to get additional "
+                 "information from")
     p.add_option('-o','--output',action="store",dest="stats_file",
                  default='statistics.info',
                  help="name of output file for per-file statistics (default "
@@ -105,6 +109,9 @@ if __name__ == '__main__':
     # Report settings etc
     print "Source directory      : %s" % args[0]
     print "Unaligned subdirectory: %s" % options.unaligned_dir
+    print "Samplesheet file      : %s" % (options.sample_sheet
+                                          if options.sample_sheet is not None
+                                          else '')
     print "Basic stats file      : %s" % options.stats_file
     print "Full stats file       : %s" % options.full_stats_file
     print "Update existing stats?: %s" % ('yes' if options.update else 'no')
@@ -147,7 +154,8 @@ if __name__ == '__main__':
     print "Full statistics written to %s" % options.full_stats_file
     stats.report_basic_stats(options.stats_file)
     print "Basic statistics written to %s" % options.stats_file
-    stats.report_per_lane_sample_stats(options.per_lane_sample_stats_file)
+    stats.report_per_lane_sample_stats(options.per_lane_sample_stats_file,
+                                       samplesheet=options.sample_sheet)
     print "Per-lane sample statistics written to %s" % \
         options.per_lane_sample_stats_file
     stats.report_per_lane_summary_stats(options.per_lane_stats_file)


### PR DESCRIPTION
PR to address the problem that the per-lane sample statistics generated by `fastq_statistics.py` doesn't display any information about samples with no reads, if the Fastqs were generated using the `--no-lane-splitting` option.

This is because in these cases there is no source of information about lanes for the sample (as the lane doesn't appear in the file name, and there are no reads to extract the lane from the header). To mitigate this, a sample sheet can be passed to `fastq_statistics.py` (via a new `--sample-sheet` option), and the information it contains can be used to identify any samples with no reads assigned.