### PR TITLE
Enable outputs to be defined for Pipeline instances

### DIFF
--- a/auto_process_ngs/barcodes/pipeline.py
+++ b/auto_process_ngs/barcodes/pipeline.py
@@ -75,9 +75,6 @@ class AnalyseBarcodes(Pipeline):
         self.add_param('cutoff',type=float)
         self.add_param('force',type=bool,value=False)
 
-        # Output
-        self._output = AttributeDictionary()
-
         # Load data from bcl2fastq output
         if not os.path.exists(unaligned_dir):
             raise OSError("'%s': not found" % unaligned_dir)
@@ -152,23 +149,6 @@ class AnalyseBarcodes(Pipeline):
         self.add_output('report_file',report_barcodes.output.report_file)
         self.add_output('xls_file',report_barcodes.output.xls_file)
         self.add_output('html_file',report_barcodes.output.html_file)
-
-    def add_output(self,name,value):
-        """
-        Add an output to the pipeline
-
-        Arguments:
-          name (str): name for the output
-          value (object): associated object
-        """
-        self._output[name] = value
-
-    @property
-    def output(self):
-        """
-        Return the output object
-        """
-        return self._output
 
     def run(self,barcode_analysis_dir,title=None,lanes=None,
             mismatches=None,bases_mask=None,cutoff=None,sample_sheet=None,
@@ -254,18 +234,12 @@ class AnalyseBarcodes(Pipeline):
                               },
                               max_jobs=max_jobs,
                               default_runner=runner,
+                              finalize_outputs=False,
                               verbose=verbose)
 
         # Clean up working dir
         if status == 0 and clean_up_on_completion:
             shutil.rmtree(working_dir)
-
-        # Update the outputs
-        for name in self._output:
-            try:
-                self._output[name] = self._output[name].value
-            except AttributeError:
-                pass
 
         # Return pipeline status
         return status


### PR DESCRIPTION
PR which updates the `Pipeline` class from `pipeliner` to allow outputs to be defined (in a similar way as they are for tasks).

For example:

    ppl = Pipeline()
    ppl.add_output('result',result)
    ...
    ppl.run()
    result = ppl.output.result

This functionality was originally implemented in the `AnalyseBarcodes` class in `barcode/pipeline.py`; this PR moves it into the core 'Pipeline' class in `pipeliner`. It also adds an option to turn off the "finalization" of the output values (i.e. automatic conversion of outputs from `PipelineParam` instances to their actual values).