### PR TITLE
Drop per-Fastq 'program info' tables in QC reports by default

### DIFF
--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -492,8 +492,7 @@ class QCReport(Document):
         # Attributes to report for each sample
         if report_attrs is None:
             report_attrs = ['fastqc',
-                            'fastq_screen',
-                            'program_versions']
+                            'fastq_screen',]
             if 'strandedness' in self.outputs:
                 report_attrs.append('strandedness')
         self.report_attrs = report_attrs


### PR DESCRIPTION
PR to address issue #316, and remove the tables of program versions that are reported by default for each Fastq file.