### PR TITLE
Formalise single cell platform names in 'projects.info' etc

### DIFF
--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -93,6 +93,17 @@ def setup_analysis_dirs(ap,
         else:
             logger.error("Missing project metadata")
             raise Exception("Missing project metadata")
+    # Validate the single cell data
+    for line in project_metadata:
+        sc_platform = line['SC_Platform']
+        if sc_platform not in ('.',
+                               '10xGenomics Chromium 3\'v2',
+                               '10xGenomics Chromium 3\'v3',
+                               '10xGenomics Single Cell ATAC',
+                               'ICELL8',):
+            logger.error("Unknown single cell platform for '%': '%'" %
+                         (line['Project'],sc_platform))
+            raise Exception("Unknown single cell platform")
     # Create the projects
     n_projects = 0
     for line in project_metadata:

--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -96,14 +96,15 @@ def setup_analysis_dirs(ap,
     # Validate the single cell data
     for line in project_metadata:
         sc_platform = line['SC_Platform']
-        if sc_platform not in ('.',
-                               '10xGenomics Chromium 3\'v2',
-                               '10xGenomics Chromium 3\'v3',
-                               '10xGenomics Single Cell ATAC',
-                               'ICELL8',):
-            logger.error("Unknown single cell platform for '%s': '%s'" %
-                         (line['Project'],sc_platform))
-            raise Exception("Unknown single cell platform")
+        if sc_platform:
+            if sc_platform not in ('.',
+                                   '10xGenomics Chromium 3\'v2',
+                                   '10xGenomics Chromium 3\'v3',
+                                   '10xGenomics Single Cell ATAC',
+                                   'ICELL8',):
+                logger.error("Unknown single cell platform for '%s': "
+                             "'%s'" % (line['Project'],sc_platform))
+                raise Exception("Unknown single cell platform")
     # Create the projects
     n_projects = 0
     for line in project_metadata:

--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -101,7 +101,7 @@ def setup_analysis_dirs(ap,
                                '10xGenomics Chromium 3\'v3',
                                '10xGenomics Single Cell ATAC',
                                'ICELL8',):
-            logger.error("Unknown single cell platform for '%': '%'" %
+            logger.error("Unknown single cell platform for '%s': '%s'" %
                          (line['Project'],sc_platform))
             raise Exception("Unknown single cell platform")
     # Create the projects

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -50,7 +50,7 @@ def determine_qc_protocol(project):
         # Default
         protocol = "singlecell"
         # 10xGenomics scATAC-seq
-        if project.info.single_cell_platform == "10xGenomics Chromium 3'v2" \
+        if project.info.single_cell_platform == "10xGenomics Single Cell ATAC" \
            and project.info.library_type == "scATAC-seq":
             protocol = "10x_scATAC"
     return protocol

--- a/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
@@ -153,3 +153,27 @@ CDE\tCDE3,CDE4\tClive David Edwards\tChIP-seq\t.\tMouse\tClaudia Divine Ecclesto
             for fq in projects[project]:
                 fastq = os.path.join(fastqs_dir,fq)
                 self.assertTrue(os.path.exists(fastq))
+
+    def test_setup_analysis_dirs_bad_single_cell_platform(self):
+        """
+        setup_analysis_dirs: raise exception for bad single cell platform
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901" },
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        # Add required metadata to 'projects.info'
+        projects_info = os.path.join(mockdir.dirn,"projects.info")
+        with open(projects_info,"w") as fp:
+            fp.write(
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+AB\tAB1,AB2\tAlan Brown\tRNA-seq\t.\tHuman\tAudrey Benson\t1% PhiX
+CDE\tCDE3,CDE4\tClive David Edwards\tscRNA-seq\t11xGenomics Chromium 5'v0\tMouse\tClaudia Divine Eccleston\t1% PhiX
+""")
+        # Attempt to set up the project dirs
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        self.assertRaises(Exception,
+                          setup_analysis_dirs,ap)

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -88,6 +88,22 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
         self.assertEqual(determine_qc_protocol(project),
                          "singlecell")
 
+    def test_determine_qc_protocol_10xchromium3v3(self):
+        """determine_qc_protocol: single-cell run (10xGenomics Chromium 3'v3)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={'Single cell platform':
+                                          "10xGenomics Chromium 3'v3"})
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        self.assertEqual(determine_qc_protocol(project),
+                         "singlecell")
+
     def test_determine_qc_protocol_10xchromium3v2_atac_seq(self):
         """determine_qc_protocol: single-cell ATAC-seq (10xGenomics Chromium 3'v2)
         """

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -105,7 +105,7 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
                          "singlecell")
 
     def test_determine_qc_protocol_10xchromium3v2_atac_seq(self):
-        """determine_qc_protocol: single-cell ATAC-seq (10xGenomics Chromium 3'v2)
+        """determine_qc_protocol: single-cell ATAC-seq (10xGenomics Single Cell ATAC)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -113,7 +113,7 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
                                        "PJB2_S2_R1_001.fastq.gz",
                                        "PJB2_S2_R2_001.fastq.gz"),
                                 metadata={'Single cell platform':
-                                          "10xGenomics Chromium 3'v2",
+                                          "10xGenomics Single Cell ATAC",
                                           'Library type':
                                           "scATAC-seq"})
         p.create(top_dir=self.wd)

--- a/docs/source/using/setup_analysis_dirs.rst
+++ b/docs/source/using/setup_analysis_dirs.rst
@@ -43,8 +43,12 @@ organism names. However the QC strandedness determination looks up
 available ``STAR`` indexes in the configuration based on the organism
 names, so these should be consistent.
 
-The single-cell platform should be one of either "ICELL8" or
-"10xGenomics Chromium 3'v2".
+If set then the single-cell platform must be one of:
+
+* ``ICELL8``
+* ``10xGenomics Chromium 3'v2``
+* ``10xGenomics Chromium 3'v3``
+* ``10xGenomics Single Cell ATAC``
 
 .. note::
 


### PR DESCRIPTION
PR which formalises the single cell platform names which can be specified in `projects.info` (including an update of the name used for 10xGenomics single cell ATAC-seq).

The PR also updates the `setup_analysis_dirs` command to check that the single cell platform is valid, and will refuse to create directories if it is unrecognised.

Also addresses issue #340 (check that `10xGenomics Chromium 3'v3` is a valid platform).