### PR TITLE
docwriter: minor update to unit test for 'Para' class

### DIFF
--- a/auto_process_ngs/test/test_docwriter.py
+++ b/auto_process_ngs/test/test_docwriter.py
@@ -614,6 +614,9 @@ class TestPara(unittest.TestCase):
         self.assertEqual(p.html(),"<p>some text that was added</p>")
         p = Para("some text","that was added")
         self.assertEqual(p.html(),"<p>some text that was added</p>")
+        p = Para()
+        p.add("some text","that was added")
+        self.assertEqual(p.html(),"<p>some text that was added</p>")
 
     def test_para_with_mixture_of_types(self):
         img = Img("picture.png")


### PR DESCRIPTION
PR which extends the unit test for the `Para` class in `docwriter`, to check that multiple items are correctly handled by the `add` method.