### PR TITLE
Update QC pipeline to handle non-canonical analysis projects and Fastq names

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -585,7 +585,8 @@ class AnalysisProject(object):
             full_fastq_dir = os.path.join(self.dirn,fastq_dir)
         else:
             full_fastq_dir = fastq_dir
-        if full_fastq_dir not in [os.path.join(self.dirn,d)
+        full_fastq_dir = os.path.normpath(full_fastq_dir)
+        if full_fastq_dir not in [os.path.normpath(os.path.join(self.dirn,d))
                                   for d in self.fastq_dirs]:
             raise Exception("Fastq dir '%s' not found in "
                             "project '%s' (%s)" %

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -370,7 +370,8 @@ class MockAnalysisProject(object):
         os.mkdir(project_dir)
         # Create fastqs subdirectory
         fqs_dir = os.path.join(project_dir,self.fastq_dir)
-        os.mkdir(fqs_dir)
+        if not os.path.exists(fqs_dir):
+            os.mkdir(fqs_dir)
         # Add Fastq files
         for fq in self.fastq_names:
             fq = os.path.basename(fq)

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -649,11 +649,15 @@ class QCReport(Document):
             for screen in filter(lambda s:
                                  s.endswith("_screen.txt"),
                                  screens):
-                fq = self.fastq_attrs(os.path.splitext(screen)[0])
-                fastq_names.add(fq.canonical_name)
-                outputs.add("screens_%s%s" % (('i' if fq.is_index_read
-                                               else 'r'),
-                                              fq.read_number))
+                screen_base = os.path.splitext(screen)[0]
+                fq = self.fastq_attrs(screen)
+                s = os.path.basename(screen_base)[:-len("_screen")]
+                for name in FASTQ_SCREENS:
+                    if s.endswith("_%s" % name):
+                        outputs.add("screens_%s%s" % (('i' if fq.is_index_read
+                                                       else 'r'),
+                                                      fq.read_number))
+                        fastq_names.add(s[:-len("_%s" % name)])
                 versions.add(Fastqscreen(
                     os.path.join(self.qc_dir,screen)).version)
             if versions:
@@ -668,7 +672,7 @@ class QCReport(Document):
             for fastqc in fastqcs:
                 fastqc = os.path.splitext(fastqc)[0]
                 fq = self.fastq_attrs(fastqc)
-                fastq_names.add(fq.canonical_name)
+                fastq_names.add(os.path.basename(fastqc)[:-len("_fastqc")])
                 outputs.add("fastqc_%s%s" % (('i' if fq.is_index_read
                                               else 'r'),
                                              fq.read_number))
@@ -685,7 +689,8 @@ class QCReport(Document):
             versions = set()
             for f in fastq_strand:
                 fq = self.fastq_attrs(os.path.splitext(f)[0])
-                fastq_names.add(fq.canonical_name)
+                fastq_names.add(
+                    os.path.basename(fastq_strand)[:-len("_fastq_strand")])
                 versions.add(Fastqstrand(
                     os.path.join(self.qc_dir,f)).version)
             if versions:

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -690,7 +690,8 @@ class QCReport(Document):
             for f in fastq_strand:
                 fq = self.fastq_attrs(os.path.splitext(f)[0])
                 fastq_names.add(
-                    os.path.basename(fastq_strand)[:-len("_fastq_strand")])
+                    os.path.basename(
+                        os.path.splitext(f)[0])[:-len("_fastq_strand")])
                 versions.add(Fastqstrand(
                     os.path.join(self.qc_dir,f)).version)
             if versions:

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -717,6 +717,38 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertEqual(project.qc_dir,
                          os.path.join(project.dirn,'qc.new'))
 
+    def test_analysis_project_handle_no_fastq_dir(self):
+        """Check AnalysisProject with no top-level Fastqs dir
+        """
+        # Construct test project with no fastq subdirectory
+        self.make_mock_project_dir(
+            'PJB',
+            ('PJB1-A_ACAGTG_L001_R1_001.fastq.gz',
+             'PJB1-B_ACAGTG_L002_R1_001.fastq.gz',),
+            fastq_dir='.')
+        # Load and check AnalysisProject: default fastqs dir
+        dirn = os.path.join(self.dirn,'PJB')
+        project = AnalysisProject('PJB',dirn)
+        self.assertEqual(project.name,'PJB')
+        self.assertTrue(os.path.isdir(project.dirn))
+        self.assertFalse(project.multiple_fastqs)
+        self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.samples[0].name,'PJB1-A')
+        self.assertEqual(project.samples[1].name,'PJB1-B')
+        self.assertEqual(project.fastq_dir,project.dirn)
+        self.assertEqual(project.info.samples,'2 samples (PJB1-A, PJB1-B)')
+        self.assertEqual(project.fastq_dirs,['.'])
+        self.assertEqual(project.info.primary_fastq_dir,'.')
+        # Check we can switch fastq dir to '.'
+        project.use_fastq_dir('.')
+        self.assertEqual(project.fastq_dir,project.dirn)
+        # Check we can switch fastq dir to full path
+        project.use_fastq_dir(project.dirn)
+        self.assertEqual(project.fastq_dir,project.dirn)
+        # Check we can switch fastq dir to primary fastq dir
+        project.use_fastq_dir()
+        self.assertEqual(project.fastq_dir,project.dirn)
+
     def test_sample_summary_single_ended(self):
         """AnalysisProject: sample_summary works for SE data
         """


### PR DESCRIPTION
PR to fix the QC pipeline and reporting to handle two unusual cases:

* Non-canonical analysis projects where the Fastq files are in the top-level project directory (i.e. not in a `fastqs` or equivalent subdirectory)
* Non-canonical Fastq names (e.g. `PJB1_S1_R1_001_paired.fastq.gz`)