### PR TITLE
run_qc.py: fix broken --multiqc option

### DIFF
--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -197,7 +197,8 @@ if __name__ == "__main__":
                       qc_dir=args.qc_dir,
                       fastq_dir=args.fastq_dir,
                       organism=args.organism,
-                      qc_protocol=args.qc_protocol)
+                      qc_protocol=args.qc_protocol,
+                      multiqc=args.run_multiqc)
     status = runqc.run(nthreads=args.nthreads,
                        fastq_subset=args.fastq_screen_subset,
                        fastq_strand_indexes=


### PR DESCRIPTION
PR to fix the broke `--multiqc` option in the `run_qc.py` utility - previously it was silently ignored when specified and did nothing.