### PR TITLE
Fix a collection of minor bug fixes (make_fastqs, publish_qc, icell8/utils, metadata)

### DIFF
--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -170,7 +170,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
     if protocol not in MAKE_FASTQS_PROTOCOLS:
         raise Exception("Unknown protocol: '%s' (must be one of "
                         "%s)" % (protocol,
-                                 ','.join([MAKE_FASTQS_PROTOCOLS])))
+                                 ','.join(MAKE_FASTQS_PROTOCOLS)))
     # Unaligned dir
     if unaligned_dir is not None:
         ap.params['unaligned_dir'] = unaligned_dir

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -361,7 +361,6 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
     if projects:
         # Make log directory and set up scheduler
         # to farm out the intensive operations to
-        ap.set_log_dir(ap.get_log_subdir('publish_qc'))
         runner = ap.settings.general.default_runner
         runner.set_log_dir(ap.log_dir)
         sched = SimpleScheduler(

--- a/auto_process_ngs/icell8/utils.py
+++ b/auto_process_ngs/icell8/utils.py
@@ -120,7 +120,7 @@ def get_batch_size(fastqs,min_batches=1,
 
     # Assert that all reads are covered with none left over
     # with no remainder
-    assert(batch_size*nbatches >= nreads,"Batches won't cover all reads")
+    assert(batch_size*nbatches >= nreads),"Batches won't cover all reads"
     return (batch_size,nbatches)
 
 def batch_fastqs(fastqs,batch_size,basename="batched",

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -125,7 +125,7 @@ class MetadataDict(bcf_utils.AttributeDictionary):
                 if key in self.__attributes:
                     self.__key_order.append(key)
                 else:
-                    raise KeyError,"Key '%s' not defined in attributes"
+                    raise KeyError("Key '%s' not defined in attributes")
             # Append keys not explicitly listed in the order
             extra_keys = []
             for key in self.__attributes:

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -1086,3 +1086,30 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
+
+    def test_make_fastqs_unknown_protocol(self):
+        """make_fastqs: fails with unknown protocol
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_SN7001250_00002_AHGXXXX",
+            "hiseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        # Create mock bcl2fastq and cellranger executables
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,"bcl2fastq"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Do the test
+        ap = AutoProcess(settings=self.settings)
+        ap.setup(os.path.join(self.wd,
+                              "171020_SN7001250_00002_AHGXXXX"))
+        self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
+        self.assertRaises(Exception,
+                          make_fastqs,
+                          ap,
+                          protocol="undefined_protocol")


### PR DESCRIPTION
PR which groups together a collection of minor bug fixes:

* Fix error when unknown protocol is specified for `make_fastqs` command
* Fix bad `assert` statement in `icell8/utils` module
* Remove multiple log directory creation in `publish_qc` command
* Fix syntax raising an exception in the `metadata` module