### PR TITLE
reportqc.py: update to use argparse for command line parsing

### DIFF
--- a/bin/reportqc.py
+++ b/bin/reportqc.py
@@ -10,7 +10,7 @@
 
 import sys
 import os
-import optparse
+import argparse
 import logging
 from bcftbx.utils import find_program
 from auto_process_ngs.analysis import AnalysisProject
@@ -93,69 +93,65 @@ def zip_report(project,report_html,qc_dir=None,qc_protocol=None):
 
 def main():
     # Deal with command line
-    p = optparse.OptionParser(usage="%prog DIR [DIR...]",
-                              version="%prog "+__version__,
-                              description="Generate QC report for each directory "
-                              "DIR")
-    p.add_option('--protocol',
-                 action='store',dest='qc_protocol',default=None,
-                 help="explicitly specify QC protocol (must be one of "
-                 "%s). Default is to determine the protocol "
-                 "automatically (recommended)" %
-                 str(','.join(["'%s'" % pr for pr in PROTOCOLS])))
-    p.add_option('--qc_dir',action='store',dest='qc_dir',default='qc',
-                 help="explicitly specify QC output directory (nb if "
-                 "supplied then the same QC_DIR will be used for each "
-                 "DIR. Non-absolute paths are assumed to be relative to "
-                 "DIR). Default: 'qc'")
-    p.add_option('--fastq_dir',
-                 action='store',dest='fastq_dir',default=None,
-                 help="explicitly specify subdirectory of DIRs with "
-                 "Fastq files to run the QC on")
-    reporting = optparse.OptionGroup(p,'Reporting options')
-    reporting.add_option('-t','--title',action='store',dest='title',
-                         default=None,
-                         help="title for output QC reports")
-    reporting.add_option('-f','--filename',
-                         action='store',dest='filename',default=None,
-                         help="file name for output HTML QC report "
-                         "(default: <DIR>/<QC_DIR>_report.html)")
-    reporting.add_option('--zip',action='store_true',
-                         dest='zip',default=False,
-                         help="make ZIP archive for the QC report")
-    reporting.add_option('--multiqc',action='store_true',
-                         dest='multiqc',default=False,
-                         help="generate MultiQC report")
-    reporting.add_option('--force',action='store_true',
-                         dest='force',default=False,
-                         help="force generation of reports even if "
-                         "verification fails")
-    p.add_option_group(reporting)
-    verification = optparse.OptionGroup(p,'Verification options')
-    verification.add_option('--verify',action='store_true',dest='verify',
-                            help="verify the QC products only (don't "
-                            "write the report); returns exit code 0 "
-                            "if QC is verified, 1 if not")
-    p.add_option_group(verification)
-    deprecated = optparse.OptionGroup(p,'Deprecated options')
-    deprecated.add_option('-l','--list-unverified',action='store_true',
-                          dest='list_unverified',default=False,
-                          help="deprecated: does nothing (Fastqs with "
-                          "missing QC outputs can no longer be listed)")
-    deprecated.add_option('--strand_stats',action='store_true',
-                          dest='fastq_strand',default=False,
-                          help="deprecated: does nothing (strand stats "
-                          "are automatically included if present)")
-    p.add_option_group(deprecated)
-    opts,args = p.parse_args()
-    if len(args) < 1:
-        p.error("Need to supply at least one directory")
+    p = argparse.ArgumentParser(version="%(prog)s "+__version__,
+                                description="Generate QC report for each "
+                                "directory DIR")
+    p.add_argument('--protocol',
+                   action='store',dest='qc_protocol',default=None,
+                   help="explicitly specify QC protocol (must be one of "
+                   "%s). Default is to determine the protocol "
+                   "automatically (recommended)" %
+                   str(','.join(["'%s'" % pr for pr in PROTOCOLS])))
+    p.add_argument('--qc_dir',action='store',dest='qc_dir',default='qc',
+                   help="explicitly specify QC output directory (nb if "
+                   "supplied then the same QC_DIR will be used for each "
+                   "DIR. Non-absolute paths are assumed to be relative to "
+                   "DIR). Default: 'qc'")
+    p.add_argument('--fastq_dir',
+                   action='store',dest='fastq_dir',default=None,
+                   help="explicitly specify subdirectory of DIRs with "
+                   "Fastq files to run the QC on")
+    reporting = p.add_argument_group('Reporting options')
+    reporting.add_argument('-t','--title',action='store',dest='title',
+                           default=None,
+                           help="title for output QC reports")
+    reporting.add_argument('-f','--filename',
+                           action='store',dest='filename',default=None,
+                           help="file name for output HTML QC report "
+                           "(default: <DIR>/<QC_DIR>_report.html)")
+    reporting.add_argument('--zip',action='store_true',
+                           dest='zip',default=False,
+                           help="make ZIP archive for the QC report")
+    reporting.add_argument('--multiqc',action='store_true',
+                           dest='multiqc',default=False,
+                           help="generate MultiQC report")
+    reporting.add_argument('--force',action='store_true',
+                           dest='force',default=False,
+                           help="force generation of reports even if "
+                           "verification fails")
+    verification = p.add_argument_group('Verification options')
+    verification.add_argument('--verify',action='store_true',dest='verify',
+                              help="verify the QC products only (don't "
+                              "write the report); returns exit code 0 "
+                              "if QC is verified, 1 if not")
+    deprecated = p.add_argument_group('Deprecated options')
+    deprecated.add_argument('-l','--list-unverified',action='store_true',
+                            dest='list_unverified',default=False,
+                            help="deprecated: does nothing (Fastqs with "
+                            "missing QC outputs can no longer be listed)")
+    deprecated.add_argument('--strand_stats',action='store_true',
+                            dest='fastq_strand',default=False,
+                            help="deprecated: does nothing (strand stats "
+                            "are automatically included if present)")
+    p.add_argument('dirs',metavar="DIR",nargs='+',
+                   help="directory to report QC for")
+    args = p.parse_args()
 
     # Report name and version
     print "%s version %s" % (os.path.basename(sys.argv[0]),__version__)
 
     # Check for MultiQC if required
-    if opts.multiqc:
+    if args.multiqc:
         if find_program("multiqc") is None:
             logging.critical("MultiQC report requested but 'multiqc' "
                              "not available")
@@ -163,16 +159,16 @@ def main():
 
     # Examine projects i.e. supplied directories
     retval = 0
-    for d in args:
+    for d in args.dirs:
         dir_path = os.path.abspath(d)
         project_name = os.path.basename(dir_path)
         p = AnalysisProject(project_name,dir_path)
         print "Project           : %s" % p.name
         print "Primary Fastqs dir: %s" % p.fastq_dir
-        if opts.qc_dir is None:
+        if args.qc_dir is None:
             qc_dir = p.qc_dir
         else:
-            qc_dir = opts.qc_dir
+            qc_dir = args.qc_dir
         if not os.path.isabs(qc_dir):
             qc_dir = os.path.join(p.dirn,qc_dir)
         qc_base = os.path.basename(qc_dir)
@@ -182,20 +178,20 @@ def main():
         print "...stored protocol: %s" % qc_info.protocol
         print "...stored Fastqdir: %s" % qc_info.fastq_dir
         # Set QC protocol
-        if opts.qc_protocol is None:
+        if args.qc_protocol is None:
             protocol = qc_info.protocol
             if protocol is None:
                 protocol = determine_qc_protocol(p)
         else:
-            protocol = opts.qc_protocol
+            protocol = args.qc_protocol
         print "QC protocol: %s" % protocol
         # Fastq subdirectory
-        if opts.fastq_dir is None:
+        if args.fastq_dir is None:
             fastq_dir = qc_info.fastq_dir
             if fastq_dir is None:
                 fastq_dir = p.fastq_dir
         else:
-            fastq_dir = opts.fastq_dir
+            fastq_dir = args.fastq_dir
             if qc_info.fastq_dir is not None:
                 if os.path.join(p.dirn,qc_info.fastq_dir) != fastq_dir:
                     logging.warning("Stored fastq dir mismatch "
@@ -219,22 +215,22 @@ def main():
                 verified = False
         if not verified:
             print "Verification: FAILED"
-            if not opts.force:
+            if not args.force:
                 retval = 1
                 continue
             else:
                 print "--force specified, ignoring previous errors"
         else:
             print "Verification: OK"
-            if opts.verify:
+            if args.verify:
                 continue
         # MultiQC report
-        if opts.multiqc:
+        if args.multiqc:
             multiqc_report = os.path.join(p.dirn,
                                           "multi%s_report.html" %
                                           qc_base)
             # Check if we need to rerun MultiQC
-            if os.path.exists(multiqc_report) and not opts.force:
+            if os.path.exists(multiqc_report) and not args.force:
                 run_multiqc = False
                 multiqc_mtime = os.path.getmtime(multiqc_report)
                 for f in os.listdir(qc_dir):
@@ -249,7 +245,7 @@ def main():
             if run_multiqc:
                 multiqc_cmd = Command(
                     'multiqc',
-                    '--title','%s' % opts.title,
+                    '--title','%s' % args.title,
                     '--filename','%s' % multiqc_report,
                     '--force',
                     qc_dir)
@@ -263,20 +259,20 @@ def main():
             else:
                 print "MultiQC: %s (already exists)" % multiqc_report
         # Report generation
-        if opts.filename is None:
+        if args.filename is None:
             out_file = '%s_report.html' % qc_base
         else:
-            out_file = opts.filename
+            out_file = args.filename
         if not os.path.isabs(out_file):
             out_file = os.path.join(p.dirn,out_file)
         report_html= qc_reporter.report(qc_dir=qc_dir,
                                         qc_protocol=protocol,
-                                        title=opts.title,
+                                        title=args.title,
                                         filename=out_file,
                                         relative_links=True)
         print "Wrote QC report to %s" % out_file
         # Generate ZIP archive
-        if opts.zip:
+        if args.zip:
             report_zip = zip_report(p,report_html,qc_dir,
                                     qc_protocol=protocol)
             print "ZIP archive: %s" % report_zip


### PR DESCRIPTION
PR working towards addressing issue #105 by updating `reportqc.py` to use `argparse` rather than `optparse`.