### PR TITLE
Fix 'make_fastqs' when input sample sheet has lanes out of order

### DIFF
--- a/auto_process_ngs/bcl2fastq_utils.py
+++ b/auto_process_ngs/bcl2fastq_utils.py
@@ -266,6 +266,9 @@ def make_custom_sample_sheet(input_sample_sheet,output_sample_sheet=None,
     # Fix other problems
     sample_sheet.fix_illegal_names()
     sample_sheet.fix_duplicated_names()
+    # Put data into lane order (if lanes specified)
+    if sample_sheet.has_lanes:
+        sample_sheet.data.sort(lambda line: line['Lane'])
     # Select subset of lanes if requested
     if lanes is not None:
         logging.debug("Updating to include only specified lanes: %s" %


### PR DESCRIPTION
PR to fix a bug which occurs with newer `bcl2fastq` versions (2.20), when the input sample sheet file contains lanes which are out of order (so e.g. lane 3 appears after lane 5).

Older versions of `bcl2fastq` would reorder the sample sheet into lane order, and the `S`-indices of the output Fastqs reflected this reordering. The `make_fastqs` command therefore assumed this ordering when predicting the outputs.

In the newer versions of `bcl2fastq`, the sample sheet does not appear to be reordered, so for out-of-order lanes the `S`-indices of the output Fastqs no longer match those predictions.

This bug fix addresses the problem by updating `make_fastqs` so that sample sheets are now always reordered into lane order, which should mean the predicted outputs should match again.