### PR TITLE
run_qc.py: new option to force jobs to be executed on current host

### DIFF
--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -304,8 +304,10 @@ if __name__ == "__main__":
         cellranger_jobmode = "local"
         cellranger_mempercore = None
         cellranger_jobinterval = None
-        cellranger_localcores = max_cores
+        cellranger_localcores = min(max_cores,16)
         cellranger_localmem = max_mem
+        print("-- Cellranger localcores: %s" % cellranger_localcores)
+        print("-- Cellranger localmem  : %s" % cellranger_localmem)
         # Set up local runners
         default_runner = SimpleJobRunner()
         runners = {

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -283,11 +283,12 @@ if __name__ == "__main__":
         if args.max_mem:
             max_mem = args.max_mem
         else:
-            # NB might need to implement a check on
-            # available memory when running jobs?
+            # Maximum memory is scaled by the proportion
+            # of the total cores being used
             # Needs to be converted from bytes to Gbs
             max_mem = math.floor(
-                float(psutil.virtual_memory().total)/(1024.0**3))
+                float(psutil.virtual_memory().total)/(1024.0**3)
+                *float(max_cores)/float(psutil.cpu_count()))
         print("-- Maximum memory: %s Gbs" % max_mem)
         # Set number of threads for QC jobs
         if args.nthreads:

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -109,9 +109,6 @@ if __name__ == "__main__":
                    "for fastq_screen (i.e. --subset option); (default "
                    "%d, set to 0 to use all reads)" %
                    __settings.qc.fastq_screen_subset)
-    p.add_argument('--multiqc',action='store_true',dest='run_multiqc',
-                   default=False,
-                   help="also generate MultiQC report")
     p.add_argument('-t','--threads',action='store',dest="nthreads",
                    type=int,default=default_nthreads,
                    help="number of threads to use for QC script "
@@ -131,33 +128,6 @@ if __name__ == "__main__":
                    "concurrent QC jobs to run (default %d, change "
                    "in settings file)"
                    % __settings.general.max_concurrent_jobs)
-    p.add_argument('--qc_dir',metavar='QC_DIR',
-                   action='store',dest='qc_dir',default=None,
-                   help="explicitly specify QC output directory. "
-                   "NB if a relative path is supplied then it's assumed "
-                   "to be a subdirectory of DIR (default: <DIR>/qc)")
-    p.add_argument("--10x_chemistry",
-                   choices=sorted(CELLRANGER_ASSAY_CONFIGS.keys()),
-                   dest="cellranger_chemistry",default="auto",
-                   help="assay configuration for 10xGenomics scRNA-seq; "
-                   "if set to 'auto' (the default) then cellranger will "
-                   "attempt to determine this automatically")
-    p.add_argument('--10x_transcriptome',action='append',
-                   metavar='ORGANISM=REFERENCE',
-                   dest='cellranger_transcriptomes',
-                   help="specify cellranger transcriptome reference datasets "
-                   "to associate with organisms (overrides references defined "
-                   "in config file)")
-    p.add_argument('--10x_premrna_reference',action='append',
-                   metavar='ORGANISM=REFERENCE',
-                   dest='cellranger_premrna_references',
-                   help="specify cellranger pre-mRNA reference datasets "
-                   "to associate with organisms (overrides references defined "
-                   "in config file)")
-    p.add_argument('-f','--filename',metavar='NAME',action='store',
-                   dest='filename',default=None,
-                   help="file name for output QC report (default: "
-                   "<DIR>/<QC_DIR>_report.html)")
     p.add_argument('--fastq_dir',metavar='SUBDIR',
                    action='store',dest='fastq_dir',default=None,
                    help="explicitly specify subdirectory of DIR with "
@@ -177,6 +147,44 @@ if __name__ == "__main__":
                    help="run the QC on the local system (overrides "
                    "any runners defined in the configuration or on "
                    "the command line")
+    # Reporting options
+    reporting = p.add_argument_group('Output and reporting')
+    reporting.add_argument('--qc_dir',metavar='QC_DIR',
+                           action='store',dest='qc_dir',default=None,
+                           help="explicitly specify QC output directory. "
+                           "NB if a relative path is supplied then it's "
+                           "assumed to be a subdirectory of DIR (default: "
+                           "<DIR>/qc)")
+    reporting.add_argument('-f','--filename',metavar='NAME',action='store',
+                           dest='filename',default=None,
+                           help="file name for output QC report (default: "
+                           "<DIR>/<QC_DIR>_report.html)")
+    reporting.add_argument('--multiqc',action='store_true',
+                           dest='run_multiqc', default=False,
+                           help="also generate MultiQC report")
+    # Cellranger options
+    cellranger = p.add_argument_group('Cellranger/10xGenomics options')
+    cellranger.add_argument('--10x_transcriptome',action='append',
+                            metavar='ORGANISM=REFERENCE',
+                            dest='cellranger_transcriptomes',
+                            help="specify cellranger transcriptome "
+                            "reference datasets to associate with "
+                            "organisms (overrides references defined "
+                            "in config file)")
+    cellranger.add_argument('--10x_premrna_reference',action='append',
+                            metavar='ORGANISM=REFERENCE',
+                            dest='cellranger_premrna_references',
+                            help="specify cellranger pre-mRNA reference "
+                            "datasets to associate with organisms "
+                            "(overrides references defined in config "
+                            "file)")
+    cellranger.add_argument("--10x_chemistry",
+                            choices=sorted(CELLRANGER_ASSAY_CONFIGS.keys()),
+                            dest="cellranger_chemistry",default="auto",
+                            help="assay configuration for 10xGenomics "
+                            "scRNA-seq; if set to 'auto' (the default) then "
+                            "cellranger will attempt to determine this "
+                            "automatically")
     # Advanced options
     advanced = p.add_argument_group('Advanced/debugging options')
     advanced.add_argument('--verbose',action="store_true",

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -97,12 +97,6 @@ if __name__ == "__main__":
                    "be determined automatically based on directory "
                    "contents." %
                    ", ".join(["'%s'" % x for x in PROTOCOLS]))
-    p.add_argument('--samples',metavar='PATTERN',
-                   action='store',dest='sample_pattern',default=None,
-                   help="simple wildcard-based pattern specifying a "
-                   "subset of samples to run the QC on. If specified "
-                   "then only FASTQs with sample names matching "
-                   "PATTERN will be examined.")
     p.add_argument('--organism',metavar='ORGANISM',
                    action='store',dest='organism',default=None,
                    help="explicitly specify organism (e.g. 'human', "

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -51,6 +51,7 @@ at the `University of Manchester <https://www.manchester.ac.uk/>`_.
 
    Reporting analyses <using/report>
    Managing and sharing data <using/managing_data>
+   Running QC stand-alone <using/run_qc_standalone>
 
 .. _single-cell-docs:
 

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -70,6 +70,12 @@ generated for each project; these are described in
 specified in the configuration then the reports can be copied
 there for sharing using the :doc:`publish_qc command <publish_qc>`.
 
+.. note::
+
+   The QC pipeline can be run outside of the ``auto_process``
+   pipeline by using the ``run_qc.py`` utility; see the
+   section on :doc:`running the QC standalone <run_qc_standalone>`.
+
 .. _multiqc: http://multiqc.info/
 
 ---------------------------
@@ -88,29 +94,3 @@ particularly if running the pipeline on a compute cluster (see
 Some of the pipeline stages also require appropriate reference
 data to be set up before they can run; see the :ref:`reference_data`
 configuration documentation for more details.
-
--------------------------
-Running the QC standalone
--------------------------
-
-The utility ``run_qc.py`` allows the QC pipeline to be run on an
-arbitrary set of Fastqs outside of the ``auto_process`` pipeline.
-
-The general invocation is:
-
-::
-
-   run_qc.py DIR [ DIR ... ]
-
-where ``DIR`` is a directory with the Fastq files to run the QC
-on (or which has a ``fastqs`` subdirectory with the Fastqs; use
-the ``--fastq_dir`` option to specify a different subdirectory).
-
-Some of the most commonly used options are:
-
-* ``--protocol``: specify the QC protocol
-* ``--organism``: specify the organism(s)
-* ``--multiqc``: turns on generation of MultiQC reports
-
-See the documentation in the :ref:`utilities_run_qc` section
-for the full range of options.

--- a/docs/source/using/run_qc_standalone.rst
+++ b/docs/source/using/run_qc_standalone.rst
@@ -1,0 +1,64 @@
+Running the QC standalone with ``run_qc.py``
+============================================
+
+The utility ``run_qc.py`` allows the QC pipeline to be run on an
+arbitrary set of Fastqs outside of the ``auto_process`` pipeline.
+
+The general invocation is:
+
+::
+
+   run_qc.py DIR [ DIR ... ]
+
+where ``DIR`` is a directory with the Fastq files to run the QC
+on (or which has a ``fastqs`` subdirectory with the Fastqs; use
+the ``--fastq_dir`` option to specify a different subdirectory).
+
+Some of the most commonly used options are:
+
+* ``--protocol``: specify the QC protocol
+* ``--organism``: specify the organism(s)
+* ``--multiqc``: turns on generation of MultiQC reports
+
+(See the documentation in the :ref:`utilities_run_qc` section
+for the full range of options.)
+
+Running on different platforms: ``--local``
+-------------------------------------------
+
+By default the QC pipeline will run using the settings from the
+``auto_process`` configuration file; however it is recommended
+to use the ``--local`` option if running the QC on a local
+workstation, or within a job submitted to a compute cluster
+(for example, if running inside another script).
+
+For example: submitting a QC run as a single job on a Grid
+Engine compute cluster might look like:
+
+::
+
+   qsub -b y -V -pe smp.pe 16 'run_qc.py --local /data/Fastqs'
+
+In this mode the pipeline overrides the central configuration
+and attempts to adjust parameters for running the QC to suit
+the local setup.
+
+It should make reasonable guesses for the number of available
+CPUs and memory. However the following options can be used with
+``--local`` to override the guesses:
+
+* ``--maxcores``: sets the maximum number of CPUs available;
+  the QC will not exceed this number when running jobs. If
+  this isn't set explicitly then the pipeline will attempt to
+  determine the number of CPUs automatically;
+* ``--maxmem``: sets the maximum amount of memory available
+  (in Gbs); currently this is only used if ``cellranger`` is
+  being run. If this isn't set explicitly then the pipeline will
+  attempt to determine the available memory automatically.
+
+For example: submitting a QC run as a single job on a Grid
+Engine compute cluster might look like:
+
+::
+
+   qsub -b y -V -pe smp.pe 16 'run_qc.py --local --maxcores=16 --maxmem=64 /data/Fastqs'


### PR DESCRIPTION
PR which adds a run option `--local` to the `run_qc.py` utility to force jobs to be executed on the current host, ignoring any runners configured elsewhere.

The use-case for this is to make it simpler to append the `run_qc.py` invocation to a script which has been submitted to Grid Engine and is already running on a compute node.

Some potential issues:

- ~Might need an additional `--no-modulefiles` option to prevent loading of environment modules specified in configuration~ PR #416 enabled per-task environment modules to be configured for the pipeline, and environment module loading for autoprocess commands is generally broken under Python 3 (see issue #505). So this option is probably not needed at the moment.

Update:

In the `--local` mode, the pipeline attempts to adjust the job running options to match the local environment. It tries to obtain information on the compute environment as follows:

- First check for the `NSLOTS` environment variable: if present then this indicates that we're on a Grid Engine node, and this also tells us the maximum number of CPUs available, otherwise the number of CPUs is obtained from `psutil.cpu_count()`. This can be overridden by the `--maxcores` option;
- Then: the maximum available memory is derived from `psutil.virtual_memory().total`, scaled by the proportion of the total cores that are being used. This can be overridden by the `--maxmem` option.

Runners are then created for different pipeline tasks with appropriate resources, within these CPU and memory limits.