### PR TITLE
run_qc.py: fix bug with undefined 'max_jobs' parameter

### DIFF
--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -216,7 +216,7 @@ if __name__ == "__main__":
                        cellranger_transcriptomes=cellranger_transcriptomes,
                        cellranger_atac_references=cellranger_atac_references,
                        cellranger_jobmode=cellranger_jobmode,
-                       cellranger_maxjobs=max_jobs,
+                       cellranger_maxjobs=args.max_jobs,
                        cellranger_mempercore=cellranger_mempercore,
                        cellranger_jobinterval=cellranger_jobinterval,
                        cellranger_localcores=cellranger_localcores,


### PR DESCRIPTION
PR to fix a bug in the `run_qc.py` utility used for running the QC pipeline standalone:

    Traceback (most recent call last):
      File ".../auto-process-ngs/devel/bin/run_qc.py", line 219, in <module>
        cellranger_maxjobs=max_jobs,
    NameError: name 'max_jobs' is not defined