### PR TITLE
download_fastqs.py: updates for Python2/3 compatibility

### DIFF
--- a/bin/download_fastqs.py
+++ b/bin/download_fastqs.py
@@ -41,13 +41,18 @@ BLOCKSIZE = 1024*1024
 # Functions
 #######################################################################
 
+def print_(s,end='\n'):
+    # Implement a local version of 'print' function which
+    # mimics the 'end' argument from Python3
+    sys.stdout.write(u"%s%s" % (s,end))
+
 def download_file(url,dest):
     # See http://stackoverflow.com/a/22776/579925
     u = urlopen(url)
     f = io.open(dest,'wb')
     meta = u.info()
     file_size = int(meta.getheaders("Content-Length")[0])
-    print "Downloading: %s Bytes: %s" % (dest, file_size)
+    print_("Downloading: %s Bytes: %s " % (dest, file_size))
     file_size_dl = 0
     block_sz = 8192
     while True:
@@ -56,10 +61,12 @@ def download_file(url,dest):
             break
         file_size_dl += len(buffer)
         f.write(buffer)
-        status = r"%10d  [%3.2f%%]" % (file_size_dl, file_size_dl * 100. / file_size)
+        status = r"% 10d  [%3.2f%%]" % (file_size_dl,
+                                        file_size_dl*100.0/file_size)
         status = status + chr(8)*(len(status)+1)
-        print status,
+        print_(status,end='')
     f.close()
+    print_("")
 
 def check_md5sum(filen,md5):
     try:
@@ -93,7 +100,7 @@ if __name__ == "__main__":
         dest_dir = os.path.abspath(args.dir)
     else:
         dest_dir = os.getcwd()
-    print "Moving to %s" % dest_dir
+    print_("Moving to %s" % dest_dir)
     try:
         os.chdir(dest_dir)
     except Exception,ex:
@@ -102,9 +109,9 @@ if __name__ == "__main__":
         else:
             sys.stderr.write("ERROR %s\n" % ex)
         sys.exit(1)
-    print "Fetching index from %s" % args.url
+    print_("Fetching index from %s" % args.url)
     index_page = urlopen(args.url).read()
-    print "Locating chksum file",
+    print_("Locating chksum file",end='')
     for line in index_page.split('\n'):
         chksum_file = re.search('[A-Za-z0-9_]*\.chksums',line)
         if chksum_file:
@@ -112,10 +119,10 @@ if __name__ == "__main__":
     if not chksum_file:
         sys.stderr.write("ERROR failed to find a chksum file\n")
         sys.exit(1)
-    print chksum_file.group(0)
+    print_(chksum_file.group(0))
     chksum_file = chksum_file.group(0)
     # Download chksum file
-    print "Fetching %s" % chksum_file
+    print_("Fetching %s" % chksum_file)
     download_file(os.path.join(args.url,chksum_file),chksum_file)
     # Get file list and checksums
     chksums = dict()
@@ -128,20 +135,20 @@ if __name__ == "__main__":
     # Flag for checking MD5 sums
     checksum_errors = False
     # Download the files
-    print "Downloading %d files" % len(file_list)
+    print_("Downloading %d files" % len(file_list))
     for f in file_list:
         if os.path.exists(f):
-            print "%s: file exists, skipping download" % f
+            print_("%s: file exists, skipping download" % f)
         else:
             download_file(os.path.join(args.url,f),f)
         if check_md5sum(f,chksums[f]):
-            print "%s: checksum OK" % f
+            print_("%s: checksum OK" % f)
         else:
-            print "%s: checksum FAILED" % f
+            print_("%s: checksum FAILED" % f)
             checksum_errors = True
     if checksum_errors:
         sys.stderr.write("ERROR one or more checksums failed, see above\n")
         sys.exit(1)
     else:
-        print "All checksums verified ok"
+        print_("All checksums verified ok")
 

--- a/bin/download_fastqs.py
+++ b/bin/download_fastqs.py
@@ -18,7 +18,7 @@ Utility to download Fastq files from web server.
 # Imports
 #######################################################################
 
-import optparse
+import argparse
 import tempfile
 from urllib2 import urlopen
 import re
@@ -77,30 +77,32 @@ def check_md5sum(filen,md5):
 #######################################################################
 
 if __name__ == "__main__":
-    p = optparse.OptionParser(usage="%prog [OPTIONS] URL [DIR]",
-                              description="Download checksum file and fastqs from "
-                              "URL into current directory (or directory DIR, if "
-                              "specified), and verify the downloaded files against "
-                              "the checksum file.")
-    options,args = p.parse_args()
-    if not len(args):
-        p.error("Supply a URL to download Fastqs from, and an option target d")
-    elif len(args) > 2:
-        p.error("Too many arguments, use -h for usage information")
-    url = args[0]
-    if len(args) == 2:
-        dest_dir = os.path.abspath(args[1])
-        print "Moving to %s" % dest_dir
-        try:
-            os.chdir(dest_dir)
-        except Exception,ex:
-            if not os.path.isdir(dest_dir):
-                sys.stderr.write("ERROR directory doesn't exist?\n")
-            else:
-                sys.stderr.write("ERROR %s\n" % ex)
-            sys.exit(1)
-    print "Fetching index from %s" % url
-    index_page = urlopen(url).read()
+    p = argparse.ArgumentParser(
+        description="Download checksum file and fastqs from "
+        "URL into current directory (or directory DIR, if "
+        "specified), and verify the downloaded files against "
+        "the checksum file.")
+    p.add_argument('url',metavar="URL",
+                   help="URL with checksum file and fastqs")
+    p.add_argument('dir',metavar="DIR",
+                   nargs='?',help="directory to put downloaded "
+                   "fastqs into (defaults to current directory)")
+    args = p.parse_args()
+    if args.dir:
+        dest_dir = os.path.abspath(args.dir)
+    else:
+        dest_dir = os.getcwd()
+    print "Moving to %s" % dest_dir
+    try:
+        os.chdir(dest_dir)
+    except Exception,ex:
+        if not os.path.isdir(dest_dir):
+            sys.stderr.write("ERROR directory doesn't exist?\n")
+        else:
+            sys.stderr.write("ERROR %s\n" % ex)
+        sys.exit(1)
+    print "Fetching index from %s" % args.url
+    index_page = urlopen(args.url).read()
     print "Locating chksum file",
     for line in index_page.split('\n'):
         chksum_file = re.search('[A-Za-z0-9_]*\.chksums',line)
@@ -113,7 +115,7 @@ if __name__ == "__main__":
     chksum_file = chksum_file.group(0)
     # Download chksum file
     print "Fetching %s" % chksum_file
-    download_file(os.path.join(url,chksum_file),chksum_file)
+    download_file(os.path.join(args.url,chksum_file),chksum_file)
     # Get file list and checksums
     chksums = dict()
     with open(chksum_file,'r') as fp:
@@ -130,7 +132,7 @@ if __name__ == "__main__":
         if os.path.exists(f):
             print "%s: file exists, skipping download" % f
         else:
-            download_file(os.path.join(url,f),f)
+            download_file(os.path.join(args.url,f),f)
         if check_md5sum(f,chksums[f]):
             print "%s: checksum OK" % f
         else:

--- a/bin/download_fastqs.py
+++ b/bin/download_fastqs.py
@@ -24,6 +24,7 @@ from urllib2 import urlopen
 import re
 import sys
 import os
+import io
 try:
     import hashlib
 except ImportError:
@@ -43,7 +44,7 @@ BLOCKSIZE = 1024*1024
 def download_file(url,dest):
     # See http://stackoverflow.com/a/22776/579925
     u = urlopen(url)
-    f = open(dest,'wb')
+    f = io.open(dest,'wb')
     meta = u.info()
     file_size = int(meta.getheaders("Content-Length")[0])
     print "Downloading: %s Bytes: %s" % (dest, file_size)
@@ -65,7 +66,7 @@ def check_md5sum(filen,md5):
         c = hashlib.md5()
     except NameError:
         c = md5.new()
-    f = open(filen,'rb')
+    f = io.open(filen,'rb')
     for block in iter(lambda: f.read(BLOCKSIZE),''):
         c.update(block)
     c = c.digest()
@@ -118,7 +119,7 @@ if __name__ == "__main__":
     download_file(os.path.join(args.url,chksum_file),chksum_file)
     # Get file list and checksums
     chksums = dict()
-    with open(chksum_file,'r') as fp:
+    with io.open(chksum_file,'rt') as fp:
         for line in fp:
             chksum,filen = line.strip('\n').split()
             chksums[filen] = chksum


### PR DESCRIPTION
PR which updates the `download_fastqs.py` utility so that it will work under both Python2 and Python3. This includes fixes to move to the `argparse` module for command line parsing (issue #105).

(NB the utility is intended to work standalone so it can't rely on external libraries (e.g. `future`) to ensure compatibility, hence some of the fixes are suboptimal.)