### PR TITLE
qc/pipeline: respect the 'poll_interval' supplied to pipeline 'run' method

### DIFF
--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -461,6 +461,7 @@ class QCPipeline(Pipeline):
                                   'cellranger_localcores': cellranger_localcores,
                                   'cellranger_localmem': cellranger_localmem
                               },
+                              poll_interval=poll_interval,
                               max_jobs=max_jobs,
                               runners=runners,
                               default_runner=default_runner,


### PR DESCRIPTION
PR which fixes a bug in the `run` method of the `QCPipeline` class in `qc/pipeline.py`, where the `poll_interval` argument supplied to the method was being ignored. This change ensures that the supplied value of the interval is respected.