### PR TITLE
tenx_genomics_utils: fix bug in 'has_chromium_sc_indices' for e.g. 'SI-GA-A10'

### DIFF
--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -249,7 +249,7 @@ def has_chromium_sc_indices(sample_sheet):
       Boolean: True if the sample sheet contains at least
         one Chromium SC index, False if not.
     """
-    index_pattern = re.compile(r"SI-(GA|NA)-[A-H](1[1-2]|[1-9])$")
+    index_pattern = re.compile(r"SI-(GA|NA)-[A-H](1[0-2]|[1-9])$")
     s = SampleSheet(sample_sheet)
     for line in s:
         if index_pattern.match(line['index']):

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -55,6 +55,21 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
 3,smpl3,smpl3,,,A006,SI-GA-C1,10xGenomics,
 4,smpl4,smpl4,,,A007,SI-GA-D1,10xGenomics,
 """
+        self.sample_sheet_with_chromium_indices_A10 = """[Header]
+IEMFileVersion,4
+
+[Reads]
+76
+76
+
+[Settings]
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+1,smpl1,smpl1,,,A001,SI-GA-A10,10xGenomics,
+"""
         self.sample_sheet_with_atac_indices = """[Header]
 IEMFileVersion,4
 
@@ -128,6 +143,13 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
         """
         s = self._make_sample_sheet(
             self.sample_sheet_with_chromium_indices)
+        self.assertTrue(has_chromium_sc_indices(s))
+    def test_sample_sheet_with_star10_chromium_sc_3_v2_index(self):
+        """
+        has_chromium_indices: sample sheet with '*10' Chromium SC 3'v2 index
+        """
+        s = self._make_sample_sheet(
+            self.sample_sheet_with_chromium_indices_A10)
         self.assertTrue(has_chromium_sc_indices(s))
     def test_sample_sheet_all_sc_atac_indices(self):
         """


### PR DESCRIPTION
PR which fixes a bug in the `has_chromium_sc_indices` (in the `tenx_genomics_utils` module) when an index ends with `10` (e.g. `SI-GA-A10`). Previously these were not being recognised as Chromium indices.