### PR TITLE
Barcode analysis bugfixes

### DIFF
--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -271,6 +271,12 @@ def make_fastqs(ap,protocol='standard',platform=None,
                             "'%s' has been specified; use an "
                             "appropriate '10x_...' protocol for these "
                             "indices" % protocol)
+    # Turn off barcode analysis where appropriate
+    if analyse_barcodes and protocol in ('icell8_atac',
+                                         '10x_chromium_sc',
+                                         '10x_chromium_sc_atac',):
+        print("Turning off barcode analysis for '%s'" % protocol)
+        analyse_barcodes = False
     # Check for pre-existing Fastq outputs
     if verify_fastq_generation(
             ap,
@@ -414,8 +420,6 @@ def make_fastqs(ap,protocol='standard',platform=None,
             except Exception as ex:
                 raise Exception("ICELL8 scATAC-seq Fastq generation failed: "
                                 "'%s'" % ex)
-            # Turn off barcode analysis
-            analyse_barcodes = False
         elif protocol == '10x_chromium_sc':
             # 10xGenomics Chromium SC
             exit_code = bcl_to_fastq_10x_chromium_sc(
@@ -433,8 +437,6 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 cellranger_localmem=cellranger_localmem,
                 log_dir=ap.log_dir
             )
-            # Turn off barcode analysis
-            analyse_barcodes = False
         elif protocol == '10x_chromium_sc_atac':
             # 10xGenomics Chromium scATAC-seq
             exit_code = bcl_to_fastq_10x_chromium_sc_atac(
@@ -452,8 +454,6 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 cellranger_localmem=cellranger_localmem,
                 log_dir=ap.log_dir
             )
-            # Turn off barcode analysis
-            analyse_barcodes = False
         else:
             # Unknown protocol
             raise Exception("Unknown protocol '%s'" % protocol)

--- a/bin/analyse_barcodes.py
+++ b/bin/analyse_barcodes.py
@@ -17,6 +17,7 @@ import argparse
 import sys
 import os
 import tempfile
+import logging
 from bcftbx.IlluminaData import IlluminaData
 from bcftbx.IlluminaData import IlluminaDataError
 from bcftbx.IlluminaData import SampleSheet


### PR DESCRIPTION
PR which fixes some bugs in the barcode analysis functionality:

* `analyse_barcodes.py` was missing import of the `logging` module
* In `make_fastqs`, if the Fastqs already exist and pass the verification stage then barcode analysis wasn't being turned off for those protocols (e.g. `10x_chromium_sc`) where it wasn't appropriate

These should be addressed by the changes in this PR.