### PR TITLE
Fix statistics for 10xGenomics scATAC-seq data

### DIFF
--- a/auto_process_ngs/qc/processing.py
+++ b/auto_process_ngs/qc/processing.py
@@ -262,7 +262,7 @@ def report_processing_qc(analysis_dir,html_file):
                                 [line[l] for l in subset_lanes])
                 if not nreads or min(nreads) == 0:
                     s.add(Para(WarningIcon(),"One or more Fastqs with zero "
-                               "read counts in one or lanes",
+                               "read counts in one or more lanes",
                                css_classes=('warning',)))
                     has_warnings = True
                     break

--- a/auto_process_ngs/test/test_stats.py
+++ b/auto_process_ngs/test/test_stats.py
@@ -1111,6 +1111,206 @@ Lane 3	19	15	4	78.95	21.05
 Lane 4	11	8	3	72.73	27.27
 """)
 
+class TestFastqStatistics10xscATAC(unittest.TestCase):
+    def setUp(self):
+        # Create a temp working dir
+        self.dirn = tempfile.mkdtemp(suffix='TestFastqStats')
+        # Expected data
+        self.expected = [
+            ['AB','AB1','AB1_S1_I1_001.fastq.gz',5,{'L1':3,'L2':2,}],
+            ['AB','AB1','AB1_S1_R1_001.fastq.gz',5,{'L1':3,'L2':2}],
+            ['AB','AB1','AB1_S1_R2_001.fastq.gz',5,{'L1':3,'L2':2}],
+            ['AB','AB1','AB1_S1_R3_001.fastq.gz',5,{'L1':3,'L2':2}],
+            ['AB','AB2','AB2_S2_I1_001.fastq.gz',8,{'L1':5,'L2':3}],
+            ['AB','AB2','AB2_S2_R1_001.fastq.gz',8,{'L1':5,'L2':3}],
+            ['AB','AB2','AB2_S2_R2_001.fastq.gz',8,{'L1':5,'L2':3}],
+            ['AB','AB2','AB2_S2_R3_001.fastq.gz',8,{'L1':5,'L2':3}],
+            ['CDE','CDE3','CDE3_S3_I1_001.fastq.gz',9,{'L3':7,'L4':2}],
+            ['CDE','CDE3','CDE3_S3_R1_001.fastq.gz',9,{'L3':7,'L4':2}],
+            ['CDE','CDE3','CDE3_S3_R2_001.fastq.gz',9,{'L3':7,'L4':2}],
+            ['CDE','CDE3','CDE3_S3_R3_001.fastq.gz',9,{'L3':7,'L4':2}],
+            ['CDE','CDE4','CDE4_S4_I1_001.fastq.gz',14,{'L3':8,'L4':6}],
+            ['CDE','CDE4','CDE4_S4_R1_001.fastq.gz',14,{'L3':8,'L4':6}],
+            ['CDE','CDE4','CDE4_S4_R2_001.fastq.gz',14,{'L3':8,'L4':6}],
+            ['CDE','CDE4','CDE4_S4_R3_001.fastq.gz',14,{'L3':8,'L4':6}],
+            ['Undetermined_indices','undetermined',
+             'Undetermined_S0_I1_001.fastq.gz',10,
+             {'L1':2,'L2':1,'L3':4,'L4':3}],
+            ['Undetermined_indices','undetermined',
+             'Undetermined_S0_R1_001.fastq.gz',10,
+             {'L1':2,'L2':1,'L3':4,'L4':3}],
+            ['Undetermined_indices','undetermined',
+             'Undetermined_S0_R2_001.fastq.gz',10,
+             {'L1':2,'L2':1,'L3':4,'L4':3}],
+            ['Undetermined_indices','undetermined',
+             'Undetermined_S0_R3_001.fastq.gz',10,
+             {'L1':2,'L2':1,'L3':4,'L4':3}],
+        ]
+    def tearDown(self):
+        # Remove the temporary test directory
+        shutil.rmtree(self.dirn)
+        pass
+    def _setup_10x_sc_atac(self):
+        # Create mock bcl2fastq2 dir structure with no lane splitting
+        # and with I1 and R3 reads
+        mock_data = AugmentedMockIlluminaData(
+            '151125_S00879_0001_000000000-ABCDE1_analysis',
+            'bcl2fastq2',
+            unaligned_dir='bcl2fastq',
+            paired_end=True,
+            no_lane_splitting=True,
+            top_dir=self.dirn)
+        fastq_reads = ('R1','R2','R3','I1')
+        mock_data.add_fastq_batch('AB','AB1','AB1_S1',lanes=[1,2],
+                                  reads=fastq_reads)
+        mock_data.add_fastq_batch('AB','AB2','AB2_S2',lanes=[1,2],
+                                  reads=fastq_reads)
+        mock_data.add_fastq_batch('CDE','CDE3','CDE3_S3',lanes=[3,4],
+                                  reads=fastq_reads)
+        mock_data.add_fastq_batch('CDE','CDE4','CDE4_S4',lanes=[3,4],
+                                  reads=fastq_reads)
+        mock_data.add_undetermined(lanes=(1,2,3,4),reads=fastq_reads)
+        # Create on disk
+        mock_data.create()
+        # Populate the FASTQs with 'fake' reads
+        reads = {
+            "AB": {
+                "AB1": { 1:3, 2:2 },
+                "AB2": { 1:5, 2:3 },
+            },
+            "CDE": {
+                "CDE3": { 3:7, 4:2 },
+                "CDE4": { 3:8, 4:6 },
+            },
+            "Undetermined_indices": {
+                "Undetermined": { 1: 2, 2: 1, 3: 4, 4: 3 },
+            },
+        }
+        s_indices = {
+            "AB1": "S1",
+            "AB2": "S2",
+            "CDE3": "S3",
+            "CDE4": "S4"
+        }
+        for project in reads:
+            for sample in reads[project]:
+                for lane in reads[project][sample]:
+                    for read_id in fastq_reads:
+                        try:
+                            s_index = s_indices[sample]
+                        except KeyError:
+                            s_index = "S0"
+                        nreads = reads[project][sample][lane]
+                        if project != "Undetermined_indices":
+                            project_name = project
+                        else:
+                            project_name = ""
+                        fastq = os.path.join(
+                            project_name,
+                            "%s_%s_%s_001.fastq.gz" %
+                            (sample,s_index,read_id))
+                        mock_data.populate_fastq(fastq,nreads,lane=lane,
+                                                 append=True)
+        # Store the location of the mock data
+        self.illumina_data = mock_data.dirn
+    def test_fastqstatistics_10x_sc_atac(self):
+        self._setup_10x_sc_atac()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        self.assertEqual(fqstatistics.lane_names,
+                         ['L1','L2','L3','L4'])
+        self.assertEqual(fqstatistics.raw.header(),
+                         ['Project',
+                          'Sample',
+                          'Fastq',
+                          'Size',
+                          'Nreads',
+                          'Paired_end',
+                          'Read_number',
+                          'L1','L2','L3','L4'])
+        # Check "raw" stored data
+        self.assertEqual(len(fqstatistics.raw),20)
+        for line,expctd in zip(fqstatistics.raw,self.expected):
+            self.assertEqual(line['Project'],expctd[0])
+            self.assertEqual(line['Sample'],expctd[1])
+            self.assertEqual(line['Fastq'],expctd[2])
+            self.assertEqual(line['Nreads'],expctd[3])
+            for lane in ('L1','L2','L3','L4'):
+                if lane in expctd[4]:
+                    self.assertEqual(line[lane],expctd[4][lane])
+                else:
+                    self.assertEqual(line[lane],'')
+            self.assertEqual(line['Read_number'],
+                             IlluminaFastq(expctd[2]).read_number)
+            self.assertEqual(line['Paired_end'],'Y')
+    def test_report_basic_stats_10x_sc_atac(self):
+        fp = cStringIO.StringIO()
+        self._setup_10x_sc_atac()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        fqstatistics.report_basic_stats(fp=fp)
+        stats = fp.getvalue().strip('\n').split('\n')
+        self.assertEqual(len(stats),21)
+        self.assertEqual(stats[0],"#Project	Sample	Fastq	Size	Nreads	Paired_end")
+        for line,expctd in zip(stats[1:],self.expected):
+            line = line.split('\t')
+            self.assertEqual(line[0],expctd[0]) # Project
+            self.assertEqual(line[1],expctd[1]) # Sample
+            self.assertEqual(line[2],expctd[2]) # Fastq
+            self.assertEqual(int(line[4]),expctd[3]) # Nreads
+            self.assertEqual(line[5],'Y') # Paired_end
+    def test_report_per_lane_sample_stats_10x_sc_atac(self):
+        fp = cStringIO.StringIO()
+        self._setup_10x_sc_atac()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        fqstatistics.report_per_lane_sample_stats(fp=fp)
+        self.assertEqual(fp.getvalue(),"""
+Lane 1
+Total reads = 10
+- AB/AB1	3	30.0%
+- AB/AB2	5	50.0%
+- Undetermined_indices/undetermined	2	20.0%
+
+Lane 2
+Total reads = 6
+- AB/AB1	2	33.3%
+- AB/AB2	3	50.0%
+- Undetermined_indices/undetermined	1	16.7%
+
+Lane 3
+Total reads = 19
+- CDE/CDE3	7	36.8%
+- CDE/CDE4	8	42.1%
+- Undetermined_indices/undetermined	4	21.1%
+
+Lane 4
+Total reads = 11
+- CDE/CDE3	2	18.2%
+- CDE/CDE4	6	54.5%
+- Undetermined_indices/undetermined	3	27.3%
+""")
+    def test_report_per_lane_summary_stats_10x_sc_atac(self):
+        fp = cStringIO.StringIO()
+        self._setup_10x_sc_atac()
+        fqstatistics = FastqStatistics(
+            IlluminaData(
+                self.illumina_data,
+                unaligned_dir="bcl2fastq"))
+        fqstatistics.report_per_lane_summary_stats(fp=fp)
+        self.assertEqual(fp.getvalue(),"""#Lane	Total reads	Assigned reads	Unassigned reads	%assigned	%unassigned
+Lane 1	10	8	2	80.0	20.0
+Lane 2	6	5	1	83.33	16.67
+Lane 3	19	15	4	78.95	21.05
+Lane 4	11	8	3	72.73	27.27
+""")
+
 class TestFastqStatisticsBcl2fastq2NoUndetermined(unittest.TestCase):
     def setUp(self):
         # Create a temp working dir


### PR DESCRIPTION
PR which fixes a bug in the statistics generation for e.g. 10xGenomics scATAC-seq data (and more generally for any dataset with more reads than just R1 or an R1/R2 pair - the 10x ATAC has R1/R2/R3). 

The bug was that in these cases the `statistics_full.info` file was producing empty lines for the non-R1/R2 Fastq files, and the processing QC was reporting zero reads in one or more lanes for those files.

The PR also fixes a typo in the warning message for zero reads in one or more lanes.