### PR TITLE
Enable modules-based environments to be assigned to tasks in pipelines

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2207,7 +2207,8 @@ class PipelineCommand(object):
         """
         return sanitize_name(self._name)
 
-    def make_wrapper_script(self,scripts_dir=None,shell="/bin/bash"):
+    def make_wrapper_script(self,scripts_dir=None,shell="/bin/bash",
+                            modules=None):
         """
         Generate a uniquely-named wrapper script to run the command
 
@@ -2215,6 +2216,7 @@ class PipelineCommand(object):
           scripts_dir (str): path of directory to write
             the wrapper scripts to
           shell (str): shell to use (defaults to '/bin/bash')
+          modules (str): list of environment modules to load
 
         Returns:
           String: name of the wrapper script.
@@ -2228,6 +2230,10 @@ class PipelineCommand(object):
                     "echo \"#### HOSTNAME $HOSTNAME\"",
                     "echo \"#### USER $USER\"",
                     "echo \"#### START $(date)\""]
+        if modules:
+            shell += " --login"
+            for module in modules:
+                prologue.append("module load %s" % module)
         epilogue = ["exit_code=$?",
                     "echo \"#### END $(date)\"",
                     "echo \"#### EXIT_CODE $exit_code\"",

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -618,6 +618,65 @@ setting up tasks, for example:
 The values will be set when the pipeline's ``run`` method is
 invoked.
 
+Defining execution environment for a task: runners and envmodules
+-----------------------------------------------------------------
+
+It is possible to define the execution environment on a per-task
+basis within a pipeline, by defining job runners and environment
+modules.
+
+Runners and environments can be declared in a parameterised
+fashion when a pipline is created, using the ``add_runner`` and
+``add_envmodules`` methods respectively of the ``Pipeline`` class.
+
+For example:
+
+::
+
+    ppl = Pipeline()
+    ppl.add_runner('4_cpus')
+    ppl.add_envmodules('myenv')
+
+This defines a ``runner`` called ``4_cpus`` and an environment
+called ``myenv``.
+
+The runners and environments are accessed via the ``runners``
+and ``envmodules`` properties of the ``Pipeline`` instance, and
+can be associated with tasks within the pipeline when they
+are added via the ``add_task`` method, using the ``runner`` and
+``envmodules`` keywords respectively).
+
+For example:
+
+::
+
+    ppl.add_task(my_task,runner=ppl.runners['4_cpus'],...)
+
+and
+
+::
+
+    ppl.add_task(my_task,envmodules=ppl.envmodules['myenv'],...)
+
+Actual runners and environments can be assigned when the pipeline
+is executed, via the ``runners`` and ``envmodules`` options of
+the ``run`` method of the ``Pipeline`` instance - these are
+mappings of the names defined previously to ``JobRunner`` instances,
+and to lists of environment modules.
+
+For example:
+
+::
+
+    ppl.run(runners={ '4_cpus': GEJobRunner('-pe smp.pe 4'), },
+            envmodules={ 'myenv': 'apps/trimmomatic/0.38', },...)
+
+If a runner is not explicitly set for a task then the pipeline's
+default runner is used for that task; this defaults to a
+``SimpleJobRunner`` instance but can be set explicitly via the
+``default_runner`` argument of the ``Pipeline`` instance's ``run``
+method.
+
 Defining outputs from a pipeline
 --------------------------------
 
@@ -967,7 +1026,7 @@ class Pipeline(object):
         self._removed = []
         self._params = AttributeDictionary()
         self._runners = dict()
-        self._modules = dict()
+        self._envmodules = dict()
         self._scheduler = None
         self._log_file = None
         self._exit_on_failure = PipelineFailure.IMMEDIATE
@@ -1009,7 +1068,7 @@ class Pipeline(object):
         return dict(**self._runners)
 
     @property
-    def modules(self):
+    def envmodules(self):
         """
         Access the modules environments defined for the pipeline
 
@@ -1018,9 +1077,9 @@ class Pipeline(object):
         module lists; so to get the list of modules associated
         with an environment name do e.g.
 
-        >>> modules = ppl.modules['my_env'].value
+        >>> modules = ppl.envmodules['my_env'].value
         """
-        return dict(**self._modules)
+        return dict(**self._envmodules)
 
     @property
     def output(self):
@@ -1152,32 +1211,32 @@ class Pipeline(object):
             name=name,
             default=lambda: self.runners['default'].value)
 
-    def add_modules_env(self,name):
+    def add_envmodules(self,name):
         """
         Define a new environment defined by modules
 
         Creates a new ``PipelineParam`` instance associated
-        with the supplied mrunner name.
+        with the supplied environment name.
 
         Runner instances can be accessed and set via the
-        ``modules`` property of the pipeline, for example:
+        ``envmodules`` property of the pipeline, for example:
 
         To access:
 
-        >>> env_modules = ppl.modules['my_runner'].value
+        >>> env_modules = ppl.envmodules['my_env'].value
 
         To set:
 
-        >>> ppl.modules['my_env'].set("")
+        >>> ppl.envmodules['my_env'].set("")
 
         Arguments:
           name (str): name for the new runner
         """
-        if name in self._modules:
+        if name in self._envmodules:
             raise KeyError("Modules environment '%s' already defined"
                            % name)
         self.report("Defining new modules environment '%s'" % name)
-        self._modules[name] = PipelineParam(
+        self._envmodules[name] = PipelineParam(
             name=name,
             value=list())
 
@@ -1362,7 +1421,7 @@ class Pipeline(object):
 
     def run(self,working_dir=None,log_dir=None,scripts_dir=None,
             log_file=None,sched=None,default_runner=None,max_jobs=1,
-            poll_interval=5,params=None,runners=None,modules=None,
+            poll_interval=5,params=None,runners=None,envmodules=None,
             batch_size=None,verbose=False,
             exit_on_failure=PipelineFailure.IMMEDIATE,
             finalize_outputs=True):
@@ -1395,9 +1454,9 @@ class Pipeline(object):
             associates parameter names with values
           runners (mapping): a dictionary or mapping which
             associates runner names with job runners
-          modules (mapping): a dictionary or mapping which
-            associates module environments with lists of
-            module names
+          envmodules (mapping): a dictionary or mapping which
+            associates envmodule names with list of
+            environment module names
           batch_size (int): if set then run commands in
             each task in batches, with each batch running
             this many commands at a time (default is to run
@@ -1428,10 +1487,10 @@ class Pipeline(object):
                 self.runners[r].set(runners[r])
         if default_runner:
             self.runners['default'].set(default_runner)
-        # Deal with module environments
-        if modules:
-            for m in modules:
-                self.modules[m].value.append(modules[m])
+        # Deal with environment modules
+        if envmodules:
+            for m in envmodules:
+                self.envmodules[m].value.append(envmodules[m])
         # Deal with scheduler
         if sched is None:
             # Create and start a scheduler
@@ -1499,18 +1558,18 @@ class Pipeline(object):
                                          ' '*(width-len(r)),
                                          self.runners[r].value))
         # Report modules environments
-        if self.modules:
+        if self.envmodules:
             self.report("Modules environments:")
-            width = max([len(m) for m in self.modules])
-            for m in sorted(self.modules):
-                self.report("-- %s%s: %s" % (m,
-                                             ' '*(width-len(m)),
-                                             ('<not set>'
-                                              if self.modules[m].value is None
-                                              else
-                                              ','.join(
-                                                  [str(x) for x in
-                                                   self.modules[m].value]))))
+            width = max([len(m) for m in self.envmodules])
+            for m in sorted(self.envmodules):
+                self.report("-- %s%s: %s" %
+                            (m,
+                             ' '*(width-len(m)),
+                             ('<not set>'
+                              if self.envmodules[m].value is None
+                              else
+                              ','.join(
+                                  [str(x) for x in self.envmodules[m].value]))))
         # Sort the tasks and set up the pipeline
         self.report("Scheduling tasks...")
         for i,rank in enumerate(self.rank_tasks()):
@@ -1985,7 +2044,7 @@ class PipelineTask(object):
         """
         return self._output
 
-    def run(self,sched=None,runner=None,modules=None,working_dir=None,
+    def run(self,sched=None,runner=None,envmodules=None,working_dir=None,
             log_dir=None,scripts_dir=None,log_file=None,wait_for=(),
             async=True,poll_interval=5,batch_size=None,verbose=False):
         """
@@ -1999,7 +2058,7 @@ class PipelineTask(object):
           sched (SimpleScheduler): scheduler to submit jobs to
           runner (JobRunner): job runner to use when running
             jobs via the scheduler
-          modules (list): list of environment modules to load when
+          envmodules (list): list of environment modules to load when
             running jobs in the task
           working_dir (str): path to the working directory to use
             (defaults to the current working directory)
@@ -2044,9 +2103,9 @@ class PipelineTask(object):
                     self.report("%s" % command.cmd())
                 script_file = command.make_wrapper_script(
                     scripts_dir=scripts_dir,
-                    modules=modules)
+                    envmodules=envmodules)
                 cmd = Command('/bin/bash')
-                if modules:
+                if envmodules:
                     cmd.add_args('-l')
                 cmd.add_args(script_file)
                 if verbose:
@@ -2073,9 +2132,9 @@ class PipelineTask(object):
                     self.report("%s" % batch_cmd.cmd())
                 script_file = batch_cmd.make_wrapper_script(
                     scripts_dir=scripts_dir,
-                    modules=modules)
+                    envmodules=envmodules)
                 cmd = Command('/bin/bash')
-                if modules:
+                if envmodules:
                     cmd.add_args('-l')
                 cmd.add_args(script_file)
                 if verbose:
@@ -2283,7 +2342,7 @@ class PipelineCommand(object):
         return sanitize_name(self._name)
 
     def make_wrapper_script(self,scripts_dir=None,shell="/bin/bash",
-                            modules=None):
+                            envmodules=None):
         """
         Generate a uniquely-named wrapper script to run the command
 
@@ -2291,7 +2350,7 @@ class PipelineCommand(object):
           scripts_dir (str): path of directory to write
             the wrapper scripts to
           shell (str): shell to use (defaults to '/bin/bash')
-          modules (str): list of environment modules to load
+          envmodules (str): list of environment modules to load
 
         Returns:
           String: name of the wrapper script.
@@ -2305,9 +2364,9 @@ class PipelineCommand(object):
                     "echo \"#### HOSTNAME $HOSTNAME\"",
                     "echo \"#### USER $USER\"",
                     "echo \"#### START $(date)\""]
-        if modules:
+        if envmodules:
             shell += " --login"
-            for module in modules:
+            for module in envmodules:
                 prologue.append("module load %s" % module)
         epilogue = ["exit_code=$?",
                     "echo \"#### END $(date)\"",

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -606,9 +606,9 @@ class TestPipeline(unittest.TestCase):
 
     @unittest.skipIf(not envmod.__ENVMODULES__,
                      "Environment modules not available")
-    def test_pipeline_with_modules_environment(self):
+    def test_pipeline_with_envmodules(self):
         """
-        Pipeline: define and run pipeline with 'modules' environment
+        Pipeline: define and run pipeline with environment modules
         """
         # Set up mock Fastqc
         bin_dir = os.path.join(self.working_dir,"apps","bin")
@@ -647,14 +647,14 @@ prepend-path PATH %s
                     self.output.files.append(f)
         # Build the pipeline
         ppl = Pipeline()
-        ppl.add_modules_env("fastqc")
+        ppl.add_envmodules("fastqc")
         task = RunFastqc("Run Fastqc",
                          "sample1.fastq","sample2.fastq")
         ppl.add_task(task,
-                     modules=ppl.modules["fastqc"])
+                     envmodules=ppl.envmodules["fastqc"])
         # Run the pipeline
         exit_status = ppl.run(working_dir=self.working_dir,
-                              modules={
+                              envmodules={
                                   'fastqc': modules,
                               },
                               poll_interval=0.1,
@@ -685,20 +685,36 @@ prepend-path PATH %s
                     self.output.files.append(f)
         # Build the pipeline
         ppl = Pipeline()
-        ppl.add_modules_env("fastqc")
+        ppl.add_envmodules("fastqc")
         task = RunFastqc("Run Fastqc",
                          "sample1.fastq","sample2.fastq")
         ppl.add_task(task,
-                     modules=ppl.modules["fastqc"])
+                     envmodules=ppl.envmodules["fastqc"])
         # Run the pipeline
         exit_status = ppl.run(working_dir=self.working_dir,
-                              modules={
+                              envmodules={
                                   'fastqc': modules,
                               },
                               poll_interval=0.1,
                               verbose=True)
         # Check the pipeline failed (non-zero exit)
         self.assertNotEqual(exit_status,0)
+
+    @unittest.skipIf(not envmod.__ENVMODULES__,
+                     "Environment modules not available")
+    def test_pipeline_add_envmodules_twice_raises_exception(self):
+        """
+        Pipeline: 'add_envmodules' raises exception when environment is added twice
+        """
+        # Make an empty pipeline
+        ppl = Pipeline()
+        # Add a environment definition
+        self.assertFalse('test_env' in ppl.envmodules)
+        ppl.add_envmodules('test_env')
+        self.assertTrue('test_env' in ppl.envmodules)
+        self.assertRaises(KeyError,
+                          ppl.add_envmodules,
+                          'test_env')
 
     def test_pipeline_define_outputs(self):
         """
@@ -1575,8 +1591,8 @@ class TestPipelineCommand(unittest.TestCase):
         # Check wrapper script file
         script_file = cmd.make_wrapper_script(
             scripts_dir=self.working_dir,
-            modules=('apps/fastq-screen/0.13.0',
-                     'apps/fastqc/0.11.8',))
+            envmodules=('apps/fastq-screen/0.13.0',
+                        'apps/fastqc/0.11.8',))
         self.assertTrue(os.path.isfile(script_file))
         self.assertEqual(os.path.dirname(script_file),
                          self.working_dir)

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -1456,6 +1456,46 @@ class TestPipelineCommand(unittest.TestCase):
                          "echo \"#### EXIT_CODE $exit_code\"\n"
                          "exit $exit_code")
 
+    def test_pipelinecommand_with_modules(self):
+        """
+        PipelineCommand: check command and wrapper script with modules
+        """
+        # Subclass PipelineCommand
+        class EchoCmd(PipelineCommand):
+            def init(self,txt):
+                self._txt = txt
+            def cmd(self):
+                return Command(
+                    "echo",
+                    self._txt)
+        # Make an instance
+        cmd = EchoCmd("hello there")
+        # Check name
+        self.assertEqual(cmd.name(),"echocmd")
+        # Check command
+        self.assertEqual(str(cmd.cmd()),"echo hello there")
+        # Check wrapper script file
+        script_file = cmd.make_wrapper_script(
+            scripts_dir=self.working_dir,
+            modules=('apps/fastq-screen/0.13.0',
+                     'apps/fastqc/0.11.8',))
+        self.assertTrue(os.path.isfile(script_file))
+        self.assertEqual(os.path.dirname(script_file),
+                         self.working_dir)
+        self.assertEqual(open(script_file,'r').read(),
+                         "#!/bin/bash --login\n"
+                         "echo \"#### COMMAND EchoCmd\"\n"
+                         "echo \"#### HOSTNAME $HOSTNAME\"\n"
+                         "echo \"#### USER $USER\"\n"
+                         "echo \"#### START $(date)\"\n"
+                         "module load apps/fastq-screen/0.13.0\n"
+                         "module load apps/fastqc/0.11.8\n"
+                         "echo 'hello there'\n"
+                         "exit_code=$?\n"
+                         "echo \"#### END $(date)\"\n"
+                         "echo \"#### EXIT_CODE $exit_code\"\n"
+                         "exit $exit_code")
+
 class TestPipelineCommandWrapper(unittest.TestCase):
 
     def test_piplinecommandwrapper(self):


### PR DESCRIPTION
PR which implements the definition of modules-based environments within pipelines based on the `Pipeline` class from the `pipeliner` module, which can then be assigned to one or more tasks within the pipeline (in a similar way to jobs runners).