### PR TITLE
'assign_barcodes.py': update to argparse for command line parsing

### DIFF
--- a/bin/assign_barcodes.py
+++ b/bin/assign_barcodes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     assign_barcodes.py: assign barcodes to read headers in fastqs
-#     Copyright (C) University of Manchester 2016 Peter Briggs
+#     Copyright (C) University of Manchester 2016,2019 Peter Briggs
 #
 """
 assign_barcodes.py
@@ -11,20 +11,21 @@ format files and assign these to the index sequence in the read
 headers.
 
 """
-import optparse
+import argparse
 from auto_process_ngs.fastq_utils import assign_barcodes_single_end
 
 if __name__ == '__main__':
-    p = optparse.OptionParser(usage="%prog [OPTIONS] INPUT.fq OUTPUT.fq",
-                              description="Extract arbitrary sequence "
-                              "fragments from reads in INPUT.fq FASTQ "
-                              "file and assign these as the index "
-                              "(barcode) sequences in the read headers "
-                              "in OUTPUT.fq.")
-    p.add_option('-n',action='store',dest='n',type='int',default=5,
-                 help="remove first N bases from each read and assign "
-                 "these as barcode index sequence (default: 5)")
-    opts,args = p.parse_args()
-    if len(args) != 2:
-        p.error('Need to specify input and output files')
-    assign_barcodes_single_end(args[0],args[1],opts.n)
+    p = argparse.ArgumentParser(
+        description="Extract arbitrary sequence fragments from reads "
+        "in INPUT.fq FASTQ file and assign these as the index (barcode) "
+        "sequences in the read headers in OUTPUT.fq.")
+    p.add_argument('-n',
+                   action='store',dest='n',type=int,default=5,
+                   help="remove first N bases from each read and assign "
+                   "these as barcode index sequence (default: 5)")
+    p.add_argument('fq_in',metavar="INPUT.fq",
+                   help="Input FASTQ file")
+    p.add_argument('fq_out',metavar="OUTPUT.fq",
+                   help="Output FASTQ file")
+    args = p.parse_args()
+    assign_barcodes_single_end(args.fq_in,args.fq_out,args.n)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -322,6 +322,7 @@ are available:
 
 """)
 for utility in ("analyse_barcodes.py",
+                "assign_barcodes.py",
                 "audit_projects.py",
                 "download_fastqs.py",
                 "demultiplex_icell8_atac.py",


### PR DESCRIPTION
PR which updates the `assign_barcodes.py` utility to use `argparse` for command line parsing (cf issue #105).