### PR TITLE
setup.py: add 'future' to the list of modules required by installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ install_requires = ['pillow',
                     'pandas',
                     'cloudpickle',
                     'psutil',
+                    'future',
                     'genomics-bcftbx']
 # If we're on ReadTheDocs then we can reduce this
 # to a smaller set (to avoid build timeouts)


### PR DESCRIPTION
PR which fixes missing `future` module in `setup.py`, which is required for installation.