### PR TITLE
QC pipeline: enable environment modules to be targeted to specific tasks

### DIFF
--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -95,6 +95,16 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
     default_runner = ap.settings.general.default_runner
     if runner is None:
         qc_runner = ap.settings.runners.qc
+    # Get environment modules
+    envmodules = dict()
+    for name in ('illumina_qc',
+                 'fastq_strand',
+                 'cellranger',
+                 'report_qc',):
+        try:
+            envmodules[name] = ap.settings.modulefiles[name]
+        except KeyError:
+            envmodules[name] = None
     # Get scheduler parameters
     if max_jobs is None:
         max_jobs = ap.settings.general.max_concurrent_jobs
@@ -143,5 +153,6 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
                            'qc_runner': qc_runner,
                            'verify_runner': default_runner,
                            'report_runner': default_runner,
-                       })
+                       },
+                       envmodules=envmodules)
     return status

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1070,10 +1070,6 @@ class RunCellrangerCount(PipelineTask):
             cellranger_exe = "cellranger-atac"
         else:
             cellranger_exe = "cellranger"
-        # Check that the cellranger software is available
-        if not find_program(cellranger_exe):
-            self.fail(message="Can't locate %s" % cellranger_exe)
-            return
         # Run cellranger for each sample
         for sample in self.args.samples:
             work_dir = os.path.join(self._working_dir,

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -119,6 +119,10 @@ class Settings(object):
         self.modulefiles['process_icell8'] = config.get('modulefiles','process_icell8')
         self.modulefiles['process_10xgenomics'] = config.get('modulefiles',
                                                              'process_10xgenomics')
+        self.modulefiles['illumina_qc'] = config.get('modulefiles','illumina_qc')
+        self.modulefiles['fastq_strand'] = config.get('modulefiles','fastq_strand')
+        self.modulefiles['cellranger'] = config.get('modulefiles','cellranger')
+        self.modulefiles['report_qc'] = config.get('modulefiles','report_qc')
         # bcl2fastq
         self.add_section('bcl2fastq')
         self.bcl2fastq = self.get_bcl2fastq_config('bcl2fastq',config)

--- a/auto_process_ngs/test/test_settings.py
+++ b/auto_process_ngs/test/test_settings.py
@@ -35,8 +35,16 @@ class TestSettings(unittest.TestCase):
         self.assertTrue(isinstance(s.general.default_runner,SimpleJobRunner))
         self.assertEqual(s.general.max_concurrent_jobs,12)
         self.assertEqual(s.general.poll_interval,5.0)
+        # Modulefiles
         self.assertEqual(s.modulefiles.make_fastqs,None)
         self.assertEqual(s.modulefiles.run_qc,None)
+        self.assertEqual(s.modulefiles.publish_qc,None)
+        self.assertEqual(s.modulefiles.process_icell8,None)
+        self.assertEqual(s.modulefiles.process_10xgenomics,None)
+        self.assertEqual(s.modulefiles.illumina_qc,None)
+        self.assertEqual(s.modulefiles.fastq_strand,None)
+        self.assertEqual(s.modulefiles.cellranger,None)
+        self.assertEqual(s.modulefiles.report_qc,None)
         # Bcl2fastq
         self.assertEqual(s.bcl2fastq.nprocessors,1)
         self.assertEqual(s.bcl2fastq.default_version,'>=1.8.4')
@@ -77,6 +85,7 @@ nprocessors = 8
         self.assertTrue(isinstance(s.general.default_runner,SimpleJobRunner))
         self.assertEqual(s.general.max_concurrent_jobs,12)
         self.assertEqual(s.general.poll_interval,5.0)
+        # Modulefiles
         self.assertEqual(s.modulefiles.make_fastqs,None)
         self.assertEqual(s.modulefiles.run_qc,None)
         # Fastq_stats

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -14,6 +14,10 @@ run_qc = None
 publish_qc = None
 process_icell8 = None
 process_10xgenomics = None
+illumina_qc = None
+fastq_strand = None
+cellranger = None
+report_qc = None
 
 # bcl2fastq settings
 [bcl2fastq]

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -147,7 +147,7 @@ with 8 cores might look like:
 ::
 
    [runners]
-    bcl2fastq = GEJobRunner(-pe smp.pe 8)
+   bcl2fastq = GEJobRunner(-pe smp.pe 8)
 
 .. note::
 
@@ -168,7 +168,7 @@ Using environment modules
 -------------------------
 
 `Environment modules <http://modules.sourceforge.net/>`_ provide a way to
-dynamic modify the user's environment. They can be especially useful to
+dynamically modify the user's environment. They can be especially useful to
 provide access to multiple versions of the same software package, and to
 manage conflicts between packages.
 
@@ -178,10 +178,32 @@ files to be loaded before a specific step, for example::
     [modulefiles]
     make_fastqs = apps/bcl2fastq/1.8.4
 
+These can be defined for the following stages:
+
+ * ``make_fastqs``
+ * ``run_qc``
+ * ``publish_qc``
+ * ``process_icell8``
+ * ``process_10xgenomics``
+
+(see :ref:`software_dependencies` for details of what software is required
+for each of these stages.)
+
 .. note::
 
-   These can be overridden for the ``make_fastqs`` and ``run_qc`` using
-   the ``--modulefiles`` option.
+   These can be overridden for the ``make_fastqs`` and ``run_qc`` stages
+   using the ``--modulefiles`` option.
+
+For the ``run_qc`` stage, additional module files can be specified for
+individual tasks within the QC pipeline:
+
+ * ``illumina_qc``
+ * ``fastq_strand``
+ * ``cellranger``
+ * ``report_qc``
+
+If any of these are defined then they will be loaded for the relevant
+tasks in the QC pipeline.
 
 .. _required_bcl2fastq_versions:
 

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -70,6 +70,21 @@ there for sharing using the :doc:`publish_qc command <publish_qc>`.
 
 .. _multiqc: http://multiqc.info/
 
+---------------------------
+Configuring the QC pipeline
+---------------------------
+
+See :ref:`software_dependencies` for details of the additional
+software required to run the QC pipeline. Environment modules can be
+used to set up the runtime environment for the pipeline (see
+:ref:`environment_modules`) and suitable job runners should be
+defined if running the pipeline on a compute cluster (see
+:ref:`running_on_compute_cluster`).
+
+Some of the pipeline stages also require appropriate reference
+data to be set up before they can run; see the :ref:`reference_data`
+configuration documentation for more details.
+
 -------------------------
 Running the QC standalone
 -------------------------


### PR DESCRIPTION
PR which allows environment modules to be specified for certain tasks in the QC pipeline, specifically:

* `illumina_qc` (basic QC)
* `fastq_strand` (strandedness)
* `cellranger` (single library analyses for 10xGenomics data)
* `report_qc` (QC reporting)

These should be specified in the `settings.ini` file under the `modulefiles` section.

The global `run_qc` modulefiles setting is still available and can be used instead of or in addition to the task-specific specifications above.