### PR TITLE
archive: ensure redundant Fastqs are removed from final archive

### DIFF
--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python
 #
 #     archive_cmd.py: implement auto process archive command
@@ -264,6 +263,7 @@ def archive(ap,archive_dir=None,platform=None,year=None,
                 "%s/" % ap.analysis_dir,
                 os.path.join(archive_dir,staging),
                 prune_empty_dirs=True,
+                mirror=True,
                 dry_run=dry_run,
                 chmod='ugo-w',
                 extra_options=extra_options)


### PR DESCRIPTION
PR to address the bug in issue #413, which manifests specifically when:

* A run is archived to 'staging', then
* Reprocessing takes place which results in different Fastqs being created for a project
* The run is subsequently archived to the final location with read-only Fastqs and without an intermediate archive operation to the staging area

The PR adds a test which replicates this specific set of circumstances. The bug shouldn't manifest if one or more of these conditions isn't met.