### PR TITLE
QC pipeline: add support for 10xGenomics single nuclei (sn)RNA-seq 

### DIFF
--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -133,12 +133,15 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
     cellranger_localcores = cellranger_settings.cellranger_localcores
     cellranger_localmem = cellranger_settings.cellranger_localmem
     cellranger_transcriptomes = ap.settings['10xgenomics_transcriptomes']
+    cellranger_premrna_references = ap.settings['10xgenomics_premrna_references']
     cellranger_atac_references = ap.settings['10xgenomics_atac_genome_references']
     # Run the QC
     status = runqc.run(nthreads=nthreads,
                        fastq_strand_indexes=
                        ap.settings.fastq_strand_indexes,
                        cellranger_transcriptomes=cellranger_transcriptomes,
+                       cellranger_premrna_references=\
+                       cellranger_premrna_references,
                        cellranger_atac_references=cellranger_atac_references,
                        cellranger_jobmode=cellranger_jobmode,
                        cellranger_maxjobs=max_jobs,

--- a/auto_process_ngs/qc/constants.py
+++ b/auto_process_ngs/qc/constants.py
@@ -19,6 +19,7 @@ PROTOCOLS = ('standardPE',
              'standardSE',
              'singlecell',
              '10x_scRNAseq',
+             '10x_snRNAseq',
              '10x_scATAC',
              'ICELL8_scATAC',)
 

--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -211,8 +211,9 @@ def check_illumina_qc_outputs(project,qc_dir,qc_protocol=None):
             if not os.path.exists(output):
                 fastqs.add(fastq)
         # Fastq_screen
-        if qc_protocol == 'singlecell' or \
-           qc_protocol == '10x_scRNAseq':
+        if qc_protocol in ('singlecell',
+                           '10x_scRNAseq',
+                           '10x_snRNAseq',):
             if project.fastq_attrs(fastq).read_number == 1:
                 # No screens for R1 for single cell
                 continue
@@ -273,8 +274,9 @@ def check_fastq_strand_outputs(project,qc_dir,fastq_strand_conf,
         if qc_protocol == '10x_scATAC':
             # Strand stats output based on R1/R3 pair
             fq_pair = (fq_group[0],fq_group[2])
-        elif qc_protocol == 'singlecell' or \
-             qc_protocol == '10x_scRNAseq':
+        elif qc_protocol in ('singlecell',
+                             '10x_scRNAseq',
+                             '10x_snRNAseq',):
             # Strand stats output based on R2
             fq_pair = (fq_group[1],)
         else:
@@ -389,9 +391,10 @@ def expected_outputs(project,qc_dir,fastq_strand_conf=None,
                        for f in fastqc_output(fastq)]:
             outputs.add(output)
         # Fastq_screen
-        if (qc_protocol == 'singlecell' or
-            qc_protocol == '10x_scRNAseq') and \
-            project.fastq_attrs(fastq).read_number == 1:
+        if (qc_protocol in ('singlecell',
+                            '10x_scRNAseq',
+                            '10x_snRNAseq',)) \
+            and project.fastq_attrs(fastq).read_number == 1:
             # No screens for R1 for single cell
             continue
         for screen in FASTQ_SCREENS:
@@ -404,8 +407,9 @@ def expected_outputs(project,qc_dir,fastq_strand_conf=None,
                                     project.fastq_attrs),
                 fastq_attrs=project.fastq_attrs):
             # Strand stats output
-            if qc_protocol == 'singlecell' or \
-               qc_protocol == '10x_scRNAseq':
+            if qc_protocol in ('singlecell',
+                               '10x_scRNAseq',
+                               '10x_snRNAseq',):
                 # Strand stats output based on R2
                 output = os.path.join(qc_dir,
                                       fastq_strand_output(fq_group[1]))
@@ -415,7 +419,8 @@ def expected_outputs(project,qc_dir,fastq_strand_conf=None,
                                       fastq_strand_output(fq_group[0]))
             outputs.add(output)
     # Cellranger count output
-    if qc_protocol == '10x_scRNAseq':
+    if qc_protocol in ('10x_scRNAseq',
+                       '10x_snRNAseq',):
         for output in cellranger_count_output(project):
             outputs.add(os.path.join(qc_dir,output))
     elif qc_protocol == '10x_scATAC':

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -50,12 +50,16 @@ def determine_qc_protocol(project):
         # Default
         protocol = "singlecell"
         single_cell_platform = project.info.single_cell_platform
+        library_type = project.info.library_type
         if single_cell_platform in ('10xGenomics Chromium 3\'v2',
-                                    '10xGenomics Chromium 3\'v3',) \
-            and project.info.library_type == "scRNA-seq":
-            # 10xGenomics scATAC-seq
-            protocol = "10x_scRNAseq"
-        elif project.info.library_type == "scATAC-seq":
+                                    '10xGenomics Chromium 3\'v3',):
+            if library_type == "scRNA-seq":
+                # 10xGenomics scATAC-seq
+                protocol = "10x_scRNAseq"
+            elif library_type == "snRNA-seq":
+                # 10xGenomics snRNA-seq
+                protocol = "10x_snRNAseq"
+        elif library_type == "scATAC-seq":
             if single_cell_platform == "10xGenomics Single Cell ATAC":
                 # 10xGenomics scATAC-seq
                 protocol = "10x_scATAC"

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -198,6 +198,13 @@ class Settings(object):
                 self['10xgenomics_transcriptomes'][genome] = transcriptome
         except NoSectionError:
             logging.debug("No 10xgenomics transcriptomes defined")
+        # 10xgenomics snRNA-seq pre-mRNA references
+        self.add_section('10xgenomics_premrna_references')
+        try:
+            for genome,reference in config.items('10xgenomics_premrna_references'):
+                self['10xgenomics_premrna_references'][genome] = reference
+        except NoSectionError:
+            logging.debug("No 10xgenomics snRNA-seq pre-mRNA references defined")
         # 10xgenomics scATAC-seq genome references
         self.add_section('10xgenomics_atac_genome_references')
         try:

--- a/auto_process_ngs/test/commands/test_run_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_run_qc_cmd.py
@@ -412,6 +412,96 @@ mouse = /data/cellranger/transcriptomes/mm10
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
 
+    def test_run_qc_10x_snRNAseq(self):
+        """run_qc: 10x snRNA-seq with strandedness and single library analysis
+        """
+        # Make mock illumina_qc.sh and multiqc
+        MockIlluminaQcSh.create(os.path.join(self.bin,
+                                             "illumina_qc.sh"))
+        MockFastqStrandPy.create(os.path.join(self.bin,
+                                              "fastq_strand.py"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"))
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901" },
+            project_metadata={ "AB": { "Organism": "human",
+                                       "Single cell platform":
+                                       "10xGenomics Chromium 3'v3",
+                                       "Library type": "snRNA-seq", },
+                               "CDE": { "Organism": "mouse",
+                                        "Single cell platform":
+                                        "10xGenomics Chromium 3'v3",
+                                        "Library type": "snRNA-seq", } },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Settings file with fastq_strand indexes and
+        # polling interval
+        settings_ini = os.path.join(self.dirn,"settings.ini")
+        with open(settings_ini,'w') as s:
+            s.write("""[general]
+poll_interval = 1.0
+
+[fastq_strand_indexes]
+human = /data/genomeIndexes/hg38/STAR
+mouse = /data/genomeIndexes/mm10/STAR
+
+[10xgenomics_premrna_references]
+human = /data/cellranger/transcriptomes/hg38_pre_mrna
+mouse = /data/cellranger/transcriptomes/mm10_pre_mrna
+""")
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=Settings(settings_ini))
+        # Run the QC
+        status = run_qc(ap,
+                        run_multiqc=True,
+                        max_jobs=1)
+        self.assertEqual(status,0)
+        # Check the fastq_strand_conf files were created
+        for p in ("AB","CDE"):
+            self.assertTrue(os.path.exists(
+                os.path.join(mockdir.dirn,p,"qc","fastq_strand.conf")))
+        # Check fastq_strand outputs are present
+        for p in ("AB","CDE"):
+            fastq_strand_outputs = filter(lambda f:
+                                          f.endswith("fastq_strand.txt"),
+                                          os.listdir(os.path.join(
+                                              mockdir.dirn,p,"qc")))
+            self.assertTrue(len(fastq_strand_outputs) > 0)
+        # Check cellranger count outputs are present
+        for p in ("AB","CDE"):
+            self.assertTrue(os.path.exists(os.path.join(mockdir.dirn,
+                                                        p,
+                                                        "qc",
+                                                        "cellranger_count")))
+        # Check output and reports
+        for p in ("AB","CDE","undetermined"):
+            for f in ("qc",
+                      "qc_report.html",
+                      "qc_report.%s.%s_analysis.zip" % (
+                          p,
+                          '170901_M00879_0087_000000000-AGEW9'),
+                      "multiqc_report.html"):
+                self.assertTrue(os.path.exists(os.path.join(mockdir.dirn,
+                                                            p,f)),
+                                "Missing %s in project '%s'" % (f,p))
+            # Check zip file has MultiQC report
+            zip_file = os.path.join(mockdir.dirn,p,
+                                    "qc_report.%s.%s_analysis.zip" % (
+                                        p,
+                                        '170901_M00879_0087_000000000-AGEW9'))
+            with zipfile.ZipFile(zip_file) as z:
+                multiqc = os.path.join(
+                    "qc_report.%s.%s_analysis" % (
+                        p,'170901_M00879_0087_000000000-AGEW9'),
+                    "multiqc_report.html")
+                self.assertTrue(multiqc in z.namelist())
+
     def test_run_qc_10x_scATACseq(self):
         """run_qc: 10x scATAC-seq with strandedness and single library analysis
         """

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -577,6 +577,44 @@ class TestCheckCellrangerCountOutputs(unittest.TestCase):
         # Check the outputs
         self.assertEqual(check_cellranger_count_outputs(project),[])
 
+    def test_check_cellranger_count_outputs_10x_snRNAseq_missing(self):
+        """
+        check_cellranger_count_outputs: cellranger count output missing (10x_snRNAseq)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           "10xGenomics Chromium 3'v3", })
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",os.path.join(self.wd,"PJB"))
+        UpdateAnalysisProject(project).add_qc_outputs(
+            protocol="10x_snRNAseq",
+            include_fastq_strand=False,
+            include_multiqc=False)
+        # Check the outputs
+        self.assertEqual(check_cellranger_count_outputs(project),["PJB1",])
+
+    def test_check_cellranger_count_outputs_10x_snRNAseq_present(self):
+        """
+        check_cellranger_count_outputs: cellranger count output present (10x_snRNAseq)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           "10xGenomics Chromium 3'v3" })
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",os.path.join(self.wd,"PJB"))
+        UpdateAnalysisProject(project).add_qc_outputs(
+            protocol="10x_snRNAseq",
+            include_fastq_strand=False,
+            include_multiqc=False)
+        UpdateAnalysisProject(project).add_cellranger_count_outputs()
+        # Check the outputs
+
 class TestCheckCellrangerAtacCountOutputs(unittest.TestCase):
     """
     Tests for the 'check_cellranger_atac_count_outputs' function

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -583,8 +583,8 @@ class TestQCPipeline(unittest.TestCase):
         self.assertTrue(os.path.exists(log_dir),
                         "Log dir '%s' not found" % log_dir)
 
-    def test_qcpipeline_with_cellranger_count(self):
-        """QCPipeline: single cell QC run with 'cellranger count'
+    def test_qcpipeline_with_cellranger_count_scRNA_seq(self):
+        """QCPipeline: single cell RNA-seq QC run with 'cellranger count'
         """
         # Make mock illumina_qc.sh and multiqc
         MockIlluminaQcSh.create(os.path.join(self.bin,
@@ -640,8 +640,65 @@ class TestQCPipeline(unittest.TestCase):
                                                         "PJB",f)),
                             "Missing %s" % f)
 
+    def test_qcpipeline_with_cellranger_count_snRNA_seq(self):
+        """QCPipeline: single nuclei RNA-seq QC run with 'cellranger count'
+        """
+        # Make mock illumina_qc.sh and multiqc
+        MockIlluminaQcSh.create(os.path.join(self.bin,
+                                             "illumina_qc.sh"))
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v2',
+                                           'Library type': 'snRNA-seq' })
+        p.create(top_dir=self.wd)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject("PJB",
+                                          os.path.join(self.wd,"PJB")),
+                          multiqc=True)
+        status = runqc.run(fastq_strand_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           cellranger_premrna_references=
+                           { 'human': '/data/hg38/cellranger' },
+                           poll_interval=0.5,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        # Check output and reports
+        self.assertEqual(status,0)
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/PJB1/_cmdline",
+                  "qc/cellranger_count/PJB1/outs/web_summary.html",
+                  "qc/cellranger_count/PJB1/outs/metrics_summary.csv",
+                  "qc/cellranger_count/PJB2/_cmdline",
+                  "qc/cellranger_count/PJB2/outs/web_summary.html",
+                  "qc/cellranger_count/PJB2/outs/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/PJB1/_cmdline",
+                  "cellranger_count/PJB1/outs/web_summary.html",
+                  "cellranger_count/PJB1/outs/metrics_summary.csv",
+                  "cellranger_count/PJB2/_cmdline",
+                  "cellranger_count/PJB2/outs/web_summary.html",
+                  "cellranger_count/PJB2/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
     def test_qcpipeline_with_cellranger_atac_count(self):
-        """QCPipeline: single cell QC run with 'cellranger-atac count'
+        """QCPipeline: single cell ATAC QC run with 'cellranger-atac count'
         """
         # Make mock illumina_qc.sh and multiqc
         MockIlluminaQcSh.create(os.path.join(self.bin,

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -140,6 +140,24 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
         self.assertEqual(determine_qc_protocol(project),
                          "10x_scRNAseq")
 
+    def test_determine_qc_protocol_10xchromium3v3_sn_rna_seq(self):
+        """determine_qc_protocol: single-nuclei RNA-seq (10xGenomics Chromium 3'v3)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={'Single cell platform':
+                                          "10xGenomics Chromium 3'v3",
+                                          'Library type':
+                                          "snRNA-seq"})
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        self.assertEqual(determine_qc_protocol(project),
+                         "10x_snRNAseq")
+
     def test_determine_qc_protocol_10xchromium3v2_atac_seq(self):
         """determine_qc_protocol: single-cell ATAC-seq (10xGenomics Single Cell ATAC)
         """

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -209,6 +209,7 @@ if __name__ == "__main__":
     cellranger_localcores = cellranger_settings.cellranger_localcores
     cellranger_localmem = cellranger_settings.cellranger_localmem
     cellranger_transcriptomes = __settings['10xgenomics_transcriptomes']
+    cellranger_premrna_references = ap.settings['10xgenomics_premrna_references']
     cellranger_atac_references = __settings['10xgenomics_atac_genome_references']
 
     # Set up and run the QC pipeline
@@ -225,6 +226,8 @@ if __name__ == "__main__":
                        fastq_strand_indexes=
                        __settings.fastq_strand_indexes,
                        cellranger_transcriptomes=cellranger_transcriptomes,
+                       cellranger_premrna_references=\
+                       cellranger_premrna_references,
                        cellranger_atac_references=cellranger_atac_references,
                        cellranger_jobmode=cellranger_jobmode,
                        cellranger_maxjobs=args.max_jobs,

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -73,6 +73,14 @@ cellranger_localcores = 1
 #human = /data/cellranger/refdata-cellranger-GRCh38-1.2.0
 #mouse = /data/cellranger/refdata-cellranger-mm10-1.2.0
 
+# 10xGenomics snRNA-seq pre-mRNA references
+# Assign organism name to path to cellranger
+# snRNA-seq reference data to use for that
+# organism in single library analysis
+[10xgenomics_premrna_references]
+#human = /data/cellranger/refdata-cellranger-GRCh38-1.0.1-pre_mrna
+#mouse = /data/cellranger/refdata-cellranger-mm10-1.0.1-pre_mrna
+
 # 10xGenomics scATAC-seq genome references
 # Assign organism name to path to cellranger
 # scATAC-seq reference data to use for that

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -143,6 +143,32 @@ section of the ``settings.ini`` file, for example::
 or else must be specified using the relevant command line
 option.
 
+.. _auto_process_reference_data_10xgenomics_snrna_seq:
+
+----------------------------------------------------------------
+process_10xgenomics (single library analysis for snRNA-seq data)
+----------------------------------------------------------------
+
+When dealing with single-nuclei RNA-seq (snRNA-seq) 10xGenomics
+data, it is recommended that ``cellranger count`` is run with a
+compatible ``cellranger`` "pre-mRNA" reference package (which
+includes both intronic and exonic information) instead of the
+standard transcriptome reference used for scRNA-seq.
+
+10xGenomics don't provide pre-mRNA references, but the
+documentation explains how to generate a custom reference
+package for these data:
+
+* https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/advanced/references#premrna
+
+These can be made available within ``auto-process`` by adding
+definitions into the ``10xgenomics_premrna_references``
+section of the ``settings.ini`` file, for example::
+
+  [10xgenomics_premrna_references]
+  human = /data/cellranger/refdata-cellranger-GRCh38-1.2.0_premrna
+  mouse = /data/cellranger/refdata-cellranger-mm10-1.2.0_premrna
+
 .. _auto_process_reference_data_10xgenomics_atac:
 
 -----------------------------------------------------------------

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -24,6 +24,7 @@ QC protocol      Used for
 ``standardSE``   Standard single-end data i.e. R1 Fastqs only
 ``10x_scATAC``   10xGenomics single cell ATAC-seq
 ``10x_scRNAseq`` 10xGenomics single cell RNA-seq
+``10x_snRNAseq`` 10xGenomics single nuclei RNA-seq
 ``singlecell``   ICELL8 single cell RNA-seq
 ================ ========================
 
@@ -40,8 +41,8 @@ each Fastq file in the project:
    or on R1 (for single-end data), to determine the strandedness
    of the sequence data
 
-For the single-cell RNA-seq data from ICELL8 and 10xGenomics Chromium
-platforms:
+For the single-cell and single-nuclei RNA-seq data from ICELL8 and
+10xGenomics Chromium platforms:
 
  * `fastqc`_ is run for each Fastq file
  * `fastq_screen`_ and `fastq_strand`_ are run on just the R2
@@ -51,7 +52,7 @@ platforms:
 .. _fastq_screen: http://www.bioinformatics.babraham.ac.uk/projects/fastq_screen/
 .. _fastq_strand: https://genomics-bcftbx.readthedocs.io/en/latest/reference/qc_pipeline.html#fastq-strand
 
-In addition for 10xGenomics scRNA-seq and scATAC data:
+In addition for 10xGenomics scRNA-seq, snRNA-seq and scATAC data:
 
  * Single library analysis is run using the ``count`` command of
    either `cellranger`_ or `cellranger_atac`_ (as appropriate)


### PR DESCRIPTION
PR to address issue #418 and implement new `10x_snRNAseq` QC protocol to deal with 10xGenomics single-nuclei RNA-seq data.

The new protocol mirrors the existing `10x_scRNAseq` protocol but uses different reference data for the `cellranger count` single library analysis ("pre-mRNA" reference rather than the standard transcriptome references; see https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/advanced/references#premrna), which can be defined in a new configuration section `10xgenomics_premrna_references`.