### PR TITLE
QC pipeline: fix broken warning for protocol mismatch in SetupQCDirs task

### DIFF
--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -521,7 +521,7 @@ class SetupQCDirs(PipelineFunctionTask):
            stored_protocol != self.args.qc_protocol:
             logger.warning("QC protocol mismatch for %s: "
                            "'%s' stored, '%s' specified"
-                           % (self.project.name,
+                           % (self.args.project.name,
                               stored_protocol,
                               self.args.protocol))
             logger.warning("Stored protocol will be ignored")


### PR DESCRIPTION
PR which fixes a bug in the QC pipeline (specifically the `SetupQCDirs` task in `qc/pipeline.py`) which causes an error when reporting a mismatch in the stored versus the supplied QC protocols.