### PR TITLE
make_fastqs command: reinstate missing CLI options

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -396,6 +396,12 @@ def add_make_fastqs_command(cmdparser):
                               "demultiplexing step (turn off using "
                               "--create-empty-fastqs)%s"
                               % default_no_create_empty_fastqs)
+    # Fastqs for index reads
+    bcl_to_fastq.add_argument('--create-fastq-for-index-reads',
+                              action='store_true',
+                              dest='create_fastq_for_index_reads',
+                              default=False,
+                              help="also create FASTQs for index reads")
     # Number of processors
     default_nprocessors = []
     for platform in __settings.platform:
@@ -413,6 +419,24 @@ def add_make_fastqs_command(cmdparser):
     add_nprocessors_option(bcl_to_fastq,None,
                            default_display=default_nprocessors)
     add_runner_option(bcl_to_fastq)
+    # ICELL8 options
+    icell8 = p.add_argument_group('ICELL8 options (ICELL8 data only)')
+    icell8.add_argument("--well-list",
+                        dest="icell8_well_list",
+                        default=None,
+                        help="specify ICELL8 well list file")
+    icell8.add_argument('--swap-i1-and-i2',
+                        action='store_true',
+                        dest="icell8_swap_i1_and_i2",
+                        help="swap supplied I1 and I2 Fastqs when matching "
+                        "ATAC barcodes against well list")
+    icell8.add_argument('--reverse-complement',type='choice',
+                        choices=['i1','i2','both'],
+                        dest="icell8_reverse_complement",
+                        default=None,
+                        help="can be 'i1','i2', or 'both'; reverse complement "
+                        "the specified indices from the well list when "
+                        "matching ATAC barcodes against well list")
     # Cellranger (10xgenomics Chromium SC 3') options
     cellranger = p.add_argument_group('Cellranger options (10xGenomics '
                                       'Chromium SC 3\' and ATAC data only)')
@@ -1094,10 +1118,14 @@ def make_fastqs(args):
         sample_sheet=args.sample_sheet,
         bases_mask=args.bases_mask,
         lanes=lanes,
+        icell8_well_list=args.icell8_well_list,
+        icell8_swap_i1_and_i2=args.icell8_swap_i1_and_i2,
+        icell8_reverse_complement=args.icell8_reverse_complement,
         platform=args.platform,
         no_lane_splitting=no_lane_splitting,
         minimum_trimmed_read_length=args.minimum_trimmed_read_length,
         mask_short_adapter_reads=args.mask_short_adapter_reads,
+        create_fastq_for_index_reads=args.create_fastq_for_index_reads,
         stats_file=args.stats_file,
         per_lane_stats_file=args.per_lane_stats_file,
         barcode_analysis_dir=args.barcode_analysis_dir,

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -430,7 +430,7 @@ def add_make_fastqs_command(cmdparser):
                         dest="icell8_swap_i1_and_i2",
                         help="swap supplied I1 and I2 Fastqs when matching "
                         "ATAC barcodes against well list")
-    icell8.add_argument('--reverse-complement',type='choice',
+    icell8.add_argument('--reverse-complement',
                         choices=['i1','i2','both'],
                         dest="icell8_reverse_complement",
                         default=None,


### PR DESCRIPTION
PR to reinstate missing command line options for the `make_fastqs` command:

*  `--create-fastq-for-index-reads`
* `--well-list`
* `--reverse-complement`
* `--swap-i1-and-i2`

which were introduced for handling ICELL8 scATAC-seq data (PR #337) but which seem to have dropped when moving from `bin/auto_process.py` and `cli/auto_process.py`.