### PR TITLE
'archive' command: fix bug for read-only Fastqs copied to final archive destination

### DIFF
--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -262,7 +262,7 @@ def archive(ap,archive_dir=None,platform=None,year=None,
             rsync_fastqs = applications.general.rsync(
                 "%s/" % ap.analysis_dir,
                 os.path.join(archive_dir,staging),
-                prune_empty_dirs=True,
+                prune_empty_dirs=False,
                 mirror=True,
                 dry_run=dry_run,
                 chmod='ugo-w',


### PR DESCRIPTION
PR which attempts to fix bug #428, by turning off the `prune_empty_dirs` option for the Fastq `rsync` operation when copying them to the final archive destination using `archive --final`.