### PR TITLE
Fix setting the cell count for 10xGenomics snRNA-seq data

### DIFF
--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -423,8 +423,9 @@ def set_cell_count_for_project(project_dir,qc_dir=None):
         qc_dir = project.qc_dir
     qc_dir = os.path.abspath(qc_dir)
     number_of_cells = 0
-    if project.info.library_type == 'scRNA-seq':
-        # Single cell RNA-seq
+    if project.info.library_type in ('scRNA-seq',
+                                     'snRNA-seq'):
+        # Single cell/single nuclei RNA-seq
         for sample in project.samples:
             try:
                 metrics_summary_csv = os.path.join(


### PR DESCRIPTION
PR which attempts to fix a bug in the QC pipeline, when setting the cell count for 10xGenomics snRNA-seq data.

The fix is actually in the `set_cell_count_for_project` function in the `tenx_genomics_utils` module, where `snRNA-seq` needed to be added as a recognised library type for which cell counts can be obtained.