### PR TITLE
Minor fixes to the Fastq statistics code

### DIFF
--- a/auto_process_ngs/stats.py
+++ b/auto_process_ngs/stats.py
@@ -209,7 +209,7 @@ class FastqStatistics(object):
                 self._stats.append(data=data)
             else:
                 # Overwrite existing entry
-                logging.warning("Overwriting exisiting entry for "
+                logging.warning("Overwriting existing entry for "
                                 "%s/%s/%s" % (fastq.project,
                                               fastq.sample,
                                               fastq.name))

--- a/bin/fastq_statistics.py
+++ b/bin/fastq_statistics.py
@@ -36,7 +36,6 @@ import bcftbx.IlluminaData as IlluminaData
 import bcftbx.TabFile as TabFile
 import bcftbx.utils as bcf_utils
 from auto_process_ngs.stats import FastqStatistics
-from auto_process_ngs.stats import FastqStats
 
 from auto_process_ngs import get_version
 __version__ = get_version()


### PR DESCRIPTION
PR which implements small fixes to the code for Fastq statistics:

* `stats`: fix a cosmetic typo in the warning message from `FastqStatistics` when overwriting files, and
* `fastq_statistics.py`: remove import of the unused `FastqStats` class.