### PR TITLE
qc/reporting: remove import of unused 'cmp_sample_names' function

### DIFF
--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -15,7 +15,6 @@ import time
 import ast
 from collections import defaultdict
 from bcftbx.IlluminaData import IlluminaFastq
-from bcftbx.IlluminaData import cmp_sample_names
 from bcftbx.TabFile import TabFile
 from bcftbx.qc.report import strip_ngs_extensions
 from bcftbx.utils import AttributeDictionary


### PR DESCRIPTION
PR which removes the import of the unused `cmp_sample_names` function (which will be removed from `bcftbx` as part of the Python3 compatibility updates in the next release).