### PR TITLE
Add option to 'setup' command to enable import of extra files

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -106,7 +106,13 @@ def add_setup_command(cmdparser):
                    default=None,
                    help="Copy sample sheet file from name and location "
                    "SAMPLE_SHEET (default is to look for SampleSheet.csv "
-                   "inside DIR)")
+                   "inside DIR). SAMPLE_SHEET can be a local or remote "
+                   "file, or a URL")
+    p.add_argument('-f','--file',action='append',dest='extra_files',
+                   metavar="FILE",default=None,
+                   help="Additional file(s) to copy into new analysis "
+                   "directory (e.g. ICELL8 well list). FILE can be a "
+                   "local or remote file, or a URL")
     p.add_argument('--fastq-dir',action='store',dest='unaligned_dir',
                    default=None,
                    help="Import fastq.gz files from FASTQ_DIR (which should "
@@ -993,6 +999,7 @@ def setup(args):
         d.setup(args.run_dir,
                 analysis_dir=args.analysis_dir,
                 sample_sheet=args.sample_sheet,
+                extra_files=args.extra_files,
                 unaligned_dir=args.unaligned_dir)
 
 def params(args):

--- a/docs/source/using/setup.rst
+++ b/docs/source/using/setup.rst
@@ -142,6 +142,32 @@ For example:
    current session, to suppress multiple password prompts
    each time the remote system is accessed.
 
+.. _setup_specifying_additional_files:
+
+***************************
+Specifying additional files
+***************************
+
+For some types of data (e.g. ICELL8 runs) additional files
+may be required for processing or downstream analysis (e.g.
+well list files).
+
+In these cases the ``-f``/``--file`` option of the ``setup``
+command can be used to specify one or more additional files
+which will be copied into the analysis directory.
+
+For example:
+
+::
+
+   auto_process.py setup \
+      --file /mnt/data/icell8/Well_List_01234.txt \
+      /mnt/data/seqruns/180817_M00123_0001_000000000-BV1X2
+
+Files can be either be local or on a remote system, or can be
+specified as URLs. Multiple ``--file`` options can be specified
+to import more than one file.
+
 .. _setup_import_fastqs:
 
 ************************************


### PR DESCRIPTION
PR which implements new `-f`/`--file` option on the `setup` command to enable arbitrary additional files (e.g. well list files for ICELL8 runs) to be imported into the analysis directory on creation.