### PR TITLE
Implement 'transfer_data.py' utility to replace functionality of 'auto_process-extras'

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -265,6 +265,13 @@ class AnalysisDir(object):
                 logger.debug("- %s: unknown" % dirn)
 
     @property
+    def analysis_dir(self):
+        """Return the path to the analysis directory
+
+        """
+        return self._analysis_dir
+
+    @property
     def n_projects(self):
         """Return number of projects found
 

--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -193,6 +193,7 @@ def main():
                      (project.name,fastq_dir,ex))
         return 1
     print("Transferring data from '%s'" % project.name)
+    print("Fastqs in %s" % project.fastq_dir)
 
     # Summarise samples and Fastqs
     samples = set()
@@ -230,8 +231,11 @@ def main():
         qc_zips = list()
         # Check QC directories and look for zipped reports
         for qc_dir in project.qc_dirs:
-            fq_dir = project.qc_info(qc_dir).fastq_dir
-            if fq_dir == project.fastq_dir:
+            # Get the associated Fastq set
+            # NB only compare the basename of the Fastq dir
+            # in case full paths weren't updated
+            fq_set = os.path.basename(project.qc_info(qc_dir).fastq_dir)
+            if fq_set == os.path.basename(project.fastq_dir):
                 qc_zip = os.path.join(project.dirn,
                                       "%s_report.%s.%s.zip" %
                                       (qc_dir,project.name,

--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -345,4 +345,9 @@ def main():
                  os.path.join(target_dir,os.path.basename(qc_zip)))
 
     print("Files now at %s" % target_dir)
+    if args.weburl:
+        url = args.weburl
+        if subdir is not None:
+            url = os.path.join(url,subdir)
+        print("URL: %s" % url)
     print("Done")

--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -17,6 +17,7 @@ from random import shuffle
 from datetime import date
 from bcftbx.JobRunner import fetch_runner
 from bcftbx.utils import find_program
+from bcftbx.utils import format_file_size
 from ..analysis import AnalysisDir
 from ..applications import Command
 from ..simple_scheduler import SchedulerJob
@@ -192,6 +193,18 @@ def main():
                      (project.name,fastq_dir,ex))
         return 1
     print("Transferring data from '%s'" % project.name)
+
+    # Summarise samples and Fastqs
+    samples = set()
+    nfastqs = 0
+    fsize = 0
+    for sample in project.samples:
+        samples.add(sample.name)
+        for fq in sample.fastq:
+            fsize += os.lstat(fq).st_size
+            nfastqs += 1
+    print("%d Fastqs from %d samples totalling %s" %
+          (nfastqs,len(samples),format_file_size(fsize)))
 
     # Check target dir
     if not exists(target_dir):

--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -368,7 +368,7 @@ def main():
     try:
         copy_job.wait(poll_interval=settings.general.poll_interval)
     except KeyboardInterrupt as ex:
-        logger.errore("Keyboard interrupt, terminating file copy")
+        logger.error("Keyboard interrupt, terminating file copy")
         copy_job.terminate()
         return 1
     exit_code = copy_job.exit_code

--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -168,7 +168,7 @@ def main():
         if downloader is None:
             logging.error("Unable to locate download_fastqs.py")
             return 1
-        print("Downloader %s" % downloader)
+        print("... found %s" % downloader)
     else:
         downloader = None
 
@@ -214,7 +214,7 @@ def main():
         if subdir is None:
             print("Failed to locate empty subdirectory")
             return
-        print("Using random empty subdirectory '%s'" % subdir)
+        print("... found '%s'" % subdir)
         # Update target dir
         target_dir = os.path.join(target_dir,subdir)
     elif args.subdir == "run_id":
@@ -249,6 +249,7 @@ def main():
     # Construct the README
     if readme_template:
         # Check that template file exists
+        print("Locating README template")
         template = None
         for filen in (readme_template,
                       os.path.join(get_templates_dir(),
@@ -262,8 +263,7 @@ def main():
             return 1
         else:
             readme_template = template
-        print("Using '%s' as template for README file" %
-              readme_template)
+        print("... found %s" % readme_template)
         # Read in template
         with open(readme_template,'rt') as fp:
             readme = fp.read()

--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -16,7 +16,6 @@ import tempfile
 from random import shuffle
 from datetime import date
 from bcftbx.JobRunner import fetch_runner
-from bcftbx.JobRunner import SimpleJobRunner
 from bcftbx.utils import find_program
 from ..analysis import AnalysisDir
 from ..applications import Command
@@ -54,6 +53,12 @@ def get_templates_dir():
 def main():
     """
     """
+    # Load configuration
+    settings = Settings()
+
+    # Collect defaults
+    default_runner = settings.runners.rsync
+
     # Command line
     p = argparse.ArgumentParser(
         description="Transfer copies of Fastq data from an analysis "
@@ -87,7 +92,8 @@ def main():
     p.add_argument('--runner',action='store',
                    help="specify the job runner to use for executing "
                    "the checksumming and Fastq copy operations "
-                   "(defaults to local job runner)")
+                   "(defaults to job runner defined for copying in "
+                   "config file [%s])" % default_runner)
     p.add_argument('dest',action='store',metavar="DEST",
                    help="destination to copy Fastqs to; can be an "
                    "arbitrary location of the form [[USER@]HOST:]DIR'")
@@ -106,9 +112,6 @@ def main():
 
     target_dir = args.dest
     readme_template = args.readme_template
-
-    # Load configuration
-    settings = Settings()
 
     # Load analysis directory and projects
     analysis_dir = AnalysisDir(args.analysis_dir)
@@ -244,7 +247,7 @@ def main():
     if args.runner:
         runner = fetch_runner(args.runner)
     else:
-        runner = settings.general.default_runner
+        runner = default_runner
 
     # Construct the README
     if readme_template:

--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python
+#
+#     cli/transfer_data.py: utility for copying data for sharing
+#     Copyright (C) University of Manchester 2019 Peter Briggs
+#
+#########################################################################
+#
+# transfer_data.py
+#
+#########################################################################
+
+import os
+import re
+import argparse
+import tempfile
+from random import shuffle
+from datetime import date
+from bcftbx.JobRunner import fetch_runner
+from bcftbx.JobRunner import SimpleJobRunner
+from bcftbx.utils import find_program
+from ..analysis import AnalysisDir
+from ..applications import Command
+from ..simple_scheduler import SchedulerJob
+from ..fileops import exists
+from ..fileops import mkdir
+from ..fileops import copy
+from ..settings import Settings
+from .. import get_version
+
+# Logging
+import logging
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+
+# Main function
+
+def main():
+    """
+    """
+    # Command line
+    p = argparse.ArgumentParser(
+        description="Transfer copies of Fastq data from an analysis "
+        "project to an arbitrary destination for sharing with other "
+        "people",
+        version="%(prog)s "+get_version())
+    p.add_argument('--subdir',action='store',
+                   choices=('random_bin','run_id'),
+                   default=None,
+                   help="subdirectory naming scheme: 'random_bin' "
+                   "locates a random pre-existing empty subdirectory "
+                   "under the target directory; 'run_id' creates a "
+                   "new subdirectory "
+                   "'PLATFORM_DATESTAMP.RUN_ID-PROJECT'. If this "
+                   "option is not set then no subdirectory will be "
+                   "used")
+    p.add_argument('--readme',action='store',
+                   metavar='README_TEMPLATE',dest='readme_template',
+                   help="template file to generate README file from")
+    p.add_argument('--weburl',action='store',
+                   help="base URL for webserver (sets the value of "
+                   "the WEBURL variable in the template README)")
+    p.add_argument('--include_downloader',action='store_true',
+                   help="copy the 'download_fastqs.py' utility to the "
+                   "final location")
+    p.add_argument('--runner',action='store',
+                   help="specify the job runner to use for executing "
+                   "the checksumming and Fastq copy operations "
+                   "(defaults to local job runner)")
+    p.add_argument('dest',action='store',metavar="DEST",
+                   help="destination to copy Fastqs to; can be an "
+                   "arbitrary location of the form [[USER@]HOST:]DIR'")
+    p.add_argument('analysis_dir',action='store',
+                   metavar="ANALYSIS_DIR",
+                   help="analysis directory holding the project to "
+                   "copy Fastqs from")
+    p.add_argument('project',action='store',nargs='?',
+                   metavar="PROJECT[:FASTQ_SET]",
+                   help="project directory to copy Fastqs from; "
+                   "specifying an optional FASTQ_SET copies them "
+                   "from the named Fastq subdirectory")
+
+    # Process command line
+    args = p.parse_args()
+
+    target_dir = args.dest
+    readme_template = args.readme_template
+
+    # Load configuration
+    settings = Settings()
+
+    # Load analysis directory and projects
+    analysis_dir = AnalysisDir(args.analysis_dir)
+    projects = analysis_dir.projects
+
+    # If no project supplied then list projects
+    if args.project is None:
+        if len(projects) == 0:
+            print("No projects found")
+        else:
+            for project in projects:
+                print("%s" % project.name)
+                if len(project.fastq_dirs) > 1:
+                    # List the fastq sets if there are more than one
+                    # and flag the primary set with an asterisk
+                    for d in project.fastq_dirs:
+                        is_primary = (d == project.info.primary_fastq_dir)
+                        print("- %s%s" % (d,
+                                          (" *" if is_primary else "")))
+        if analysis_dir.undetermined:
+            print("_undetermined")
+        return
+
+    # Sort out project and Fastq dir
+    try:
+        project_name,fastq_dir = args.project.split(':')
+    except ValueError:
+        project_name = args.project
+        fastq_dir = None
+    project = None
+    for p in projects:
+        if project_name == p.name:
+            project = p
+            break
+    if project is None:
+        logger.error("'%s': project not found" % project_name)
+        return 1
+    try:
+        project.use_fastq_dir(fastq_dir)
+    except Exception as ex:
+        logger.error("'%s': failed to load Fastq set '%s': %s" %
+                     (project.name,fastq_dir,ex))
+        return 1
+    print("Transferring data from '%s'" % project.name)
+
+    # Check target dir
+    if not exists(target_dir):
+        print("'%s': target directory not found" % target_dir)
+        return
+    else:
+        print("Target directory %s" % target_dir)
+
+    # Locate downloader
+    if args.include_downloader:
+        print("Locating downloader for inclusion")
+        downloader = find_program("download_fastqs.py")
+        if downloader is None:
+            logging.error("Unable to locate download_fastqs.py")
+            return 1
+        print("Downloader %s" % downloader)
+    else:
+        downloader = None
+
+    # Determine subdirectory
+    if args.subdir == "random_bin":
+        # Find a random empty directory under the
+        # target directory
+        print("Locating random empty bin")
+        subdirs = [d for d in os.listdir(target_dir)
+                   if os.path.isdir(os.path.join(target_dir,d))]
+        if not subdirs:
+            print("Failed to locate subdirectories")
+            return
+        shuffle(subdirs)
+        subdir = None
+        for d in subdirs:
+            if not os.listdir(os.path.join(target_dir,d)):
+                # Empty bin
+                subdir = d
+                break
+        if subdir is None:
+            print("Failed to locate empty subdirectory")
+            return
+        print("Using random empty subdirectory '%s'" % subdir)
+        # Update target dir
+        target_dir = os.path.join(target_dir,subdir)
+    elif args.subdir == "run_id":
+        # Construct subdirectory name based on the
+        # run ID
+        subdir = "{platform}_{datestamp}.{run_number}-{project}".format(
+            platform=analysis_dir.metadata.platform.upper(),
+            datestamp=analysis_dir.metadata.instrument_datestamp,
+            run_number=analysis_dir.metadata.run_number,
+            project=project.name)
+        # Check it doesn't already exist
+        if exists(os.path.join(target_dir,subdir)):
+            logger.error("'%s': subdirectory already exists" % subdir)
+            return
+        print("Using subdirectory '%s'" % subdir)
+        # Update target dir
+        target_dir = os.path.join(target_dir,subdir)
+    else:
+        # No subdir
+        subdir = None
+
+    # Make target directory
+    if not exists(target_dir):
+        mkdir(target_dir)
+
+    # Get runner for copy job
+    if args.runner:
+        runner = fetch_runner(args.runner)
+    else:
+        runner = settings.general.default_runner
+
+    # Construct the README
+    if readme_template:
+        # Check that template file exists
+        if not os.path.exists(readme_template):
+            logger.error("'%s': template file not found" %
+                         readme_template)
+            return 1
+        print("Using '%s' as template for README file" %
+              readme_template)
+        # Read in template
+        with open(readme_template,'rt') as fp:
+            readme = fp.read()
+        # Substitute template variables
+        template_vars = {
+            'PLATFORM': analysis_dir.metadata.platform.upper(),
+            'RUN_NUMBER': analysis_dir.metadata.run_number,
+            'DATESTAMP': analysis_dir.metadata.instrument_datestamp,
+            'PROJECT': project_name,
+            'WEBURL': args.weburl,
+            'BIN': subdir,
+            'DIR': target_dir,
+            'TODAY': date.today().strftime("%d/%m/%Y"),
+        }
+        for var in template_vars:
+            value = template_vars[var]
+            if value is None:
+                value = '?'
+            else:
+                value = str(value)
+            readme = re.sub(r"%{var}%".format(var=var),
+                            value,
+                            readme)
+        # Write out a temporary README file
+        tmpdir = tempfile.mkdtemp()
+        readme_file = os.path.join(tmpdir,"README")
+        with open(readme_file,'wt') as fp:
+            fp.write(readme)
+    else:
+        # No README
+        readme_file = None
+
+    # Build command to run manage_fastqs.py
+    copy_cmd = Command("manage_fastqs.py",
+                       analysis_dir.analysis_dir,
+                       project_name)
+    if fastq_dir is not None:
+        copy_cmd.add_args(fastq_dir)
+    copy_cmd.add_args("copy",target_dir)
+    print("Running %s" % copy_cmd)
+    copy_job = SchedulerJob(runner,
+                            copy_cmd.command_line,
+                            name="copy.%s%s" % (project_name,
+                                                (fastq_dir
+                                                 if fastq_dir is not None
+                                                 else '')),
+                            working_dir=os.getcwd())
+    copy_job.start()
+    try:
+        copy_job.wait(poll_interval=settings.general.poll_interval)
+    except KeyboardInterrupt as ex:
+        logger.errore("Keyboard interrupt, terminating file copy")
+        copy_job.terminate()
+        return 1
+    exit_code = copy_job.exit_code
+    if exit_code != 0:
+        logger.error("File copy exited with an error")
+        return exit_code
+
+    # Copy README
+    if readme_file is not None:
+        print("Copying README file")
+        copy(readme_file,os.path.join(target_dir,"README"))
+
+    # Copy download_fastqs.py
+    if downloader:
+        print("Copying downloader")
+        copy(downloader,
+             os.path.join(target_dir,os.path.basename(downloader)))
+
+    print("Files now at %s" % target_dir)
+    print("Done")

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -250,12 +250,19 @@ class Settings(object):
                 self['reporting_templates'][template] = fields
         except NoSectionError:
             logging.debug("No reporting templates defined")
+        # Destinations for data transfer
+        self.add_section('destination')
+        for section in filter(lambda x: x.startswith('destination:'),
+                              config.sections()):
+            dest = section.split(':')[1]
+            self.destination[dest] = self.get_destination_config(
+                section,config)
 
     def get_bcl2fastq_config(self,section,config):
         """
         Retrieve bcl2fastq configuration options from .ini file
 
-        Given the name of a section (e.g. 'blc2fastq',
+        Given the name of a section (e.g. 'bcl2fastq',
         'platform:miseq'), fetch the bcl2fastq settings and return
         in an AttributeDictionary object.
 
@@ -296,6 +303,43 @@ class Settings(object):
                 section,
                 'create_empty_fastqs',
                 None)
+        return values
+
+    def get_destination_config(self,section,config):
+        """
+        Retrieve 'destination' configuration options from .ini file
+
+        Given the name of a section (e.g. 'destination:webserver'),
+        fetch the associated data transfer settings and return
+        in an AttributeDictionary object.
+
+        The options that can be extracted are:
+
+        - directory (compulsory, str)
+        - subdir (optional, str, default 'None')
+        - readme_template (optional, str, default 'None')
+        - url (optional, str, default 'None')
+        - include_downloader (optional, boolean, default 'False')
+        - include_qc_report (optional, boolean, default 'False')
+
+        Arguments:
+          section (str): name of the section to retrieve the
+            settings from
+          config (Config): Config object with settings loaded
+
+        Returns:
+          AttributeDictionary: dictionary of option:value pairs.
+
+        """
+        values = AttributeDictionary()
+        values['directory'] = config.get(section,'directory',None)
+        values['subdir'] = config.get(section,'subdir',None)
+        values['readme_template'] = config.get(section,'readme_template',None)
+        values['url'] = config.get(section,'url',None)
+        values['include_downloader'] = config.getboolean(
+            section,'include_downloader',False)
+        values['include_qc_report'] = config.getboolean(
+            section,'include_qc_report',False)
         return values
 
     def set(self,param,value):

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -116,6 +116,7 @@ class TestAnalysisDir(unittest.TestCase):
             top_dir=self.dirn)
         mockdir.create()
         analysis_dir = AnalysisDir(mockdir.dirn)
+        self.assertEqual(analysis_dir.analysis_dir,mockdir.dirn)
         self.assertEqual(analysis_dir.run_name,mockdir.run_name)
         self.assertEqual(analysis_dir.n_sequencing_data,1)
         self.assertEqual(analysis_dir.n_projects,2)
@@ -130,6 +131,7 @@ class TestAnalysisDir(unittest.TestCase):
             top_dir=self.dirn)
         mockdir.create()
         analysis_dir = AnalysisDir(mockdir.dirn)
+        self.assertEqual(analysis_dir.analysis_dir,mockdir.dirn)
         self.assertEqual(analysis_dir.run_name,mockdir.run_name)
         self.assertEqual(analysis_dir.n_sequencing_data,1)
         self.assertEqual(analysis_dir.n_projects,2)
@@ -156,6 +158,7 @@ class TestAnalysisDir(unittest.TestCase):
                 fp.write("")
         # Load and check the analysis dir
         analysis_dir = AnalysisDir(mockdir.dirn)
+        self.assertEqual(analysis_dir.analysis_dir,mockdir.dirn)
         self.assertEqual(analysis_dir.run_name,mockdir.run_name)
         self.assertEqual(analysis_dir.n_sequencing_data,1)
         self.assertEqual(analysis_dir.n_projects,2)

--- a/auto_process_ngs/test/test_settings.py
+++ b/auto_process_ngs/test/test_settings.py
@@ -116,3 +116,44 @@ SN7001251 = hiseq
         self.assertTrue('SN7001251' in s.sequencers)
         self.assertEqual(s.sequencers['SN7001251'],'hiseq')
         self.assertEqual(s.sequencers.SN7001251,'hiseq')
+
+    def test_destination_definitions(self):
+        """Settings: handle 'destination:...' sections
+        """
+        # Settings file
+        settings_file = os.path.join(self.dirn,"settings.ini")
+        with open(settings_file,'w') as s:
+            s.write("""[destination:webserver]
+directory = /mnt/www/data
+subdir = random_bin
+readme_template = README.webserver.template
+url = https://our.data.com/data
+include_downloader = true
+include_qc_report = true
+
+[destination:local]
+directory = /mnt/shared
+subdir = run_id
+""")
+        # Load settings
+        s = Settings(settings_file)
+        # Check destination settings
+        self.assertTrue('webserver' in s.destination)
+        self.assertEqual(s.destination['webserver']['directory'],
+                         '/mnt/www/data')
+        self.assertEqual(s.destination['webserver']['subdir'],'random_bin')
+        self.assertEqual(s.destination['webserver']['readme_template'],
+                         'README.webserver.template')
+        self.assertEqual(s.destination['webserver']['url'],
+                         'https://our.data.com/data')
+        self.assertEqual(s.destination['webserver']['include_downloader'],
+                         True)
+        self.assertEqual(s.destination['webserver']['include_qc_report'],
+                         True)
+        self.assertTrue('local' in s.destination)
+        self.assertEqual(s.destination['local']['directory'],'/mnt/shared')
+        self.assertEqual(s.destination['local']['subdir'],'run_id')
+        self.assertEqual(s.destination['local']['readme_template'],None)
+        self.assertEqual(s.destination['local']['url'],None)
+        self.assertEqual(s.destination['local']['include_downloader'],False)
+        self.assertEqual(s.destination['local']['include_qc_report'],False)

--- a/bin/transfer_data.py
+++ b/bin/transfer_data.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+#
+#     transfer_data.py: copy Fastq data for sharing
+#     Copyright (C) University of Manchester 2019 Peter Briggs
+#
+from auto_process_ngs.cli.transfer_data import main
+if __name__ == "__main__":
+     main()

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -140,3 +140,30 @@ exclude_zip_files = False
 # Assign fields to template names for reporting projects
 [reporting_templates]
 #bcf = datestamp,,user,run_id,#samples,#cells,organism,library_type,PI,analysis_dir
+
+# Destinations data can be copied to using 'transfer_data.py'
+# Define destinations with sections '[destination:NAME]' and
+# set parameters to define following settings:
+# - directory: destination directory to copy Fastqs to, defined
+#   as an arbitrary location of the form '[[USER@]HOST:]DIR'
+# - subdir: subdirectory naming scheme; if set then files are
+#   copied to a subdirectory of the destination directory
+#   according to this scheme:
+#   * 'random_bin': used a random pre-existing empty subdir
+#   * 'run_id': creates new subdir 'PLATFORM_DATESTAMP.RUN_ID-PROJECT'
+# - readme_template: template file to generate README file from
+#   (either full path or the name of a file in the 'templates'
+#   directory of the installation
+# - url: base URL for the copied data (sets value of WEBURL
+#   variable in the template README file)
+# - include_downloader: whether to include a copy of the
+#   'download_fastqs.py' utility with the copied data
+# - include_qc_report: whether to include a copy of the
+#   zipped QC reports with the copied data
+#[destination:webserver]
+#directory = /mnt/hosted/web
+#subdir = random_bin
+#readme_template = README.webserver.txt
+#url = http://awesome.com/data
+#include_downloader = true
+#include_qc_report = true

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -337,6 +337,7 @@ for utility in ("analyse_barcodes.py",
                 "process_icell8.py",
                 "run_qc.py",
                 "split_icell8_fastqs.py",
+                "transfer_data.py",
                 "update_project_metadata.py"):
     # Capture the output
     help_text_file = "%s.help" % utility

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -248,6 +248,54 @@ version will be used.
    This mechanism allows multiple ``bcl2fastq`` versions to be present
    in the environment simultaneously.
 
+.. _data_transfer_destinations:
+
+--------------------------
+Data transfer destinations
+--------------------------
+
+The ``transfer_data.py`` utility can be used to copy Fastqs and other
+data produced by the ``auto_process.py`` pipeline to arbitrary
+destinations, typically for sharing with end users of the pipeline.
+
+The utility provides a number of command line options to specify a
+destination and the data that are transferred at runtime. However it
+is also to define one or more destinations in the configuration file,
+with appropriate presets for each destination.
+
+A destination can be defined by adding a new section to the config
+file of the form ``[destination:NAME]``, where ``NAME`` is the name
+that will be used to refer to the destination when it is specified in
+a run of ``transfer_data.py``.
+
+Within each section the following parameters can be set for the
+destination:
+
+====================== ==============================================
+Parameter              Function
+====================== ==============================================
+``directory``          **Compulsory** sets the destination directory
+                       to copy files to; can be an arbitrary location
+                       of the form ``[[USER@]HOST:]DIR``
+``subdir``             Subdirectory naming scheme
+``readme_template``    Template file to generate ``README`` from
+``url``                Base URL to access copied data at
+``include_downloader`` Whether to include ``download_fastqs.py``
+``include_qc_report``  Whether to include zipped QC reports
+====================== ==============================================
+
+For example:
+
+::
+
+    [destination:webserver]
+    directory = /mnt/hosted/web
+    subdir = random_bin
+    readme_template = README.webserver
+    url = http://ourdata.com/shared
+
+See :ref:`transfer_data` for more information on what these settings do.
+
 -------------------
 Bash tab completion
 -------------------

--- a/docs/source/using/managing_data.rst
+++ b/docs/source/using/managing_data.rst
@@ -6,6 +6,7 @@ the utilities for performing them are currently part of the same package so
 they are outlined here.
 
  * :ref:`manage_fastqs`
+ * :ref:`transfer_data`
  * :ref:`download_fastqs`
  * :ref:`update_project_metadata`
  * :ref:`audit_projects`
@@ -16,8 +17,8 @@ library, but suggestions on how to do this can be found in the section
 
 .. _manage_fastqs:
 
-``manage_fastqs.py``: copying data for transfer to end users
-************************************************************
+``manage_fastqs.py``: managing and copy Fastq files
+***************************************************
 
 The ``manage_fastqs.py`` utility can be used to explore and copy data from
 an analysis directory to another location on a per-project basis.
@@ -76,7 +77,99 @@ will be included.
 
 For example to only copy ``R1`` files::
 
-    manage_fastqs.py RUN_DIR PROJECTNAME copy /path/to/local/dir --filter *_R1_*
+    manage_fastqs.py ANALYSIS_DIR PROJECTNAME copy /path/to/local/dir --filter *_R1_*
+
+.. _transfer_data:
+
+``transfer_data.py``: copying data for transfer to end users
+************************************************************
+
+The ``transfer_data.py`` utility can be used to copy data from analysis
+projects to different destinations, typically to transfer copies of
+data to end users.
+
+A destination is defined as a local or remote directory where files
+will be copied, for example in its most basic mode:
+
+::
+
+    transfer_data.py /mnt/data/shared ANALYSIS_DIR PROJECT
+
+will copy Fastq files from the ``PROJECT`` project in ``ANALYSIS_DIR``
+to the local directory ``/mnt/data/shared``.
+
+Destinations can also be defined in the configuration file (see
+:ref:`data_transfer_destinations`) and then referred to by their
+name when copying the Fastqs.
+
+For example:
+
+::
+
+    transfer_data.py webserver ANALYSIS_DIR PROJECT
+
+where ``webserver`` is a pre-defined destination.
+
+Schemes for dymanic subdirectory specification
+----------------------------------------------
+
+By default the data are copied directly to the specified directory.
+However it is possible to specify a scheme for dynamic subdirectory
+assignment, which can be useful for example if copying to a
+webserver.
+
+The scheme can be specified via either the ``--subdir`` command line
+option or the ``subdir`` parameter in the configuration file.
+
+The following schemes are available:
+
+==============  ==========================================
+Scheme name     Behaviour
+==============  ==========================================
+``random_bin``  Locates an empty pre-existing subdirectory
+                (aka 'bin') at random
+``run_id``      Creates a new subdirectory named
+                ``PLATFORM_DATESTAMP.RUN_NUMBER-PROJECT``
+                (must not already exist)
+==============  ==========================================
+
+Generating a README file from a template
+----------------------------------------
+
+It is possible to generate a ``README`` for the copied data by
+specifying a template file via either the ``--readme`` command line
+option or the ``readme_template`` parameter in the configuration
+file.
+
+The template should be a plain text file but it can also contain
+placeholders for 'template variables' which will be substituted with
+the appropriate values when the ``README`` file is generated:
+
+================  =================================
+Placeholder       Value
+================  =================================
+``%PLATFORM%``    Run platform (uppercase)
+``%RUN_NUMBER%``  Run number
+``%DATESTAMP%``   Run datestamp
+``%PROJECT%``     Name of project being copied
+``%WEBURL%``      Base URL for the webserver
+``%BIN%``         Name of the subdirectory, if any
+``%DIR%``         Directory data were copied to
+``%TODAY%``       Today's date
+================  =================================
+
+Including downloader and QC reports
+-----------------------------------
+
+By default only Fastqs are copied by ``transfer_data.py``, however it
+is possible to include additional files:
+
+ * A standalone downloader script (see :ref:`download_fastqs`)
+   (specify the ``--include_downloader`` or set the
+   ``include_downloader`` parameter in the configuration);
+ * The zipped QC reports for the project (specify the
+   ``--include_qc_report`` or set the ``include_qc_report``
+   parameter)
 
 .. _download_fastqs:
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name = "auto_process_ngs",
       scripts = scripts,
       # Configuration file for QC
       data_files = [('config',['config/settings.ini.sample']),
-                    ('templates',[]),
+                    ('templates',['templates/README.template.sample']),
                     ('etc/bash_completion.d',['scripts/auto_process-completion.bash']),],
       include_package_data=True,
       zip_safe = False)

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(name = "auto_process_ngs",
       scripts = scripts,
       # Configuration file for QC
       data_files = [('config',['config/settings.ini.sample']),
+                    ('templates',[]),
                     ('etc/bash_completion.d',['scripts/auto_process-completion.bash']),],
       include_package_data=True,
       zip_safe = False)

--- a/templates/README.template.sample
+++ b/templates/README.template.sample
@@ -1,0 +1,10 @@
+Example README template for transfer_data.py
+
+Platform  : %PLATFORM%
+Run_number: %RUN_NUMBER% 
+Datestamp : %DATESTAMP%
+Project   : %PROJECT%
+Base URL  : %WEBURL%
+Bin/subdir: %SUBDIR%
+
+Today is %TODAY%


### PR DESCRIPTION
PR which aims to address issue #168 by implementing a new utility `transfer_data.py`, to replace the functionality offered by `auto_process-extras`, and enabling destinations to be configured in the central `settings.ini` file.

The new utility also includes functionality to copy QC reports to the destination, to address issue #442.