### PR TITLE
archive command: don't copy leftover QC pipeline temporary directories

### DIFF
--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -206,7 +206,8 @@ def archive(ap,archive_dir=None,platform=None,year=None,
         excludes = ['--exclude=primary_data',
                     '--exclude=save.*',
                     '--exclude=*.bak',
-                    '--exclude=tmp.*']
+                    '--exclude=tmp.*',
+                    '--exclude=__qc.*.tmp',]
         if not include_bcl2fastq:
             # Determine whether bcl2fastq dir should be included implicitly
             # because there are links from the analysis directories

--- a/auto_process_ngs/test/commands/test_archive_cmd.py
+++ b/auto_process_ngs/test/commands/test_archive_cmd.py
@@ -1109,6 +1109,8 @@ poll_interval = 0.5
         exclude_files = ("custom_SampleSheet.csv.bak",)
         for d in exclude_dirs:
             os.makedirs(os.path.join(mockdir.dirn,d))
+            with open(os.path.join(mockdir.dirn,d,"placeholder"),'wt')  as fp:
+                fp.write("")
         for f in exclude_files:
             with open(os.path.join(mockdir.dirn,f),'wt') as fp:
                 fp.write("")

--- a/auto_process_ngs/test/commands/test_archive_cmd.py
+++ b/auto_process_ngs/test/commands/test_archive_cmd.py
@@ -1090,3 +1090,72 @@ poll_interval = 0.5
                                  "fastqs",
                                  fq)
             self.assertTrue(os.path.exists(fastq))
+
+    def test_archive_excludes_unwanted_content(self):
+        """archive: excludes unwanted content
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901" },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add unwanted content
+        exclude_dirs = ("primary_data",
+                        "save.bcl2fastqL1234",
+                        "save.bcl2fastqL5678",
+                        "tmp.illumina_qc.XYZ")
+        exclude_files = ("custom_SampleSheet.csv.bak",)
+        for d in exclude_dirs:
+            os.makedirs(os.path.join(mockdir.dirn,d))
+        for f in exclude_files:
+            with open(os.path.join(mockdir.dirn,f),'wt') as fp:
+                fp.write("")
+        # Make a mock archive directory
+        archive_dir = os.path.join(self.dirn,"archive")
+        final_dir = os.path.join(archive_dir,
+                                 "2017",
+                                 "miseq")
+        os.makedirs(final_dir)
+        self.assertTrue(os.path.isdir(final_dir))
+        self.assertEqual(len(os.listdir(final_dir)),0)
+        # Make autoprocess instance and set required metadata
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=self.settings)
+        ap.set_metadata("source","testing")
+        ap.set_metadata("run_number","87")
+        # Do archiving to staging
+        status = archive(ap,
+                         archive_dir=archive_dir,
+                         year='2017',platform='miseq',
+                         read_only_fastqs=True,
+                         final=False)
+        self.assertEqual(status,0)
+        # Check staging dir
+        staging_dir = os.path.join(
+            final_dir,
+            "__170901_M00879_0087_000000000-AGEW9_analysis.pending")
+        self.assertTrue(os.path.exists(staging_dir))
+        # Check unwanted content not copied across
+        for d in exclude_dirs:
+            self.assertFalse(os.path.exists(os.path.join(staging_dir,d)))
+        for f in exclude_files:
+            self.assertFalse(os.path.exists(os.path.join(staging_dir,f)))
+        # Do second archive operation to final
+        status = archive(ap,
+                         archive_dir=archive_dir,
+                         year='2017',platform='miseq',
+                         read_only_fastqs=True,
+                         final=True)
+        self.assertEqual(status,0)
+        # Check final dir
+        final_archive_dir = os.path.join(
+            final_dir,
+            "170901_M00879_0087_000000000-AGEW9_analysis")
+        self.assertTrue(os.path.exists(final_archive_dir))
+        # Check unwanted content not copied across
+        for d in exclude_dirs:
+            self.assertFalse(os.path.exists(os.path.join(final_archive_dir,d)))
+        for f in exclude_files:
+            self.assertFalse(os.path.exists(os.path.join(final_archive_dir,f)))

--- a/auto_process_ngs/test/commands/test_archive_cmd.py
+++ b/auto_process_ngs/test/commands/test_archive_cmd.py
@@ -1105,7 +1105,8 @@ poll_interval = 0.5
         exclude_dirs = ("primary_data",
                         "save.bcl2fastqL1234",
                         "save.bcl2fastqL5678",
-                        "tmp.illumina_qc.XYZ")
+                        "tmp.illumina_qc.XYZ",
+                        "__qc.XYZ123.tmp",)
         exclude_files = ("custom_SampleSheet.csv.bak",)
         for d in exclude_dirs:
             os.makedirs(os.path.join(mockdir.dirn,d))


### PR DESCRIPTION
PR to address issue #333 and fix the `archive` command to exclude leftover temporary directories from failed QC pipeline runs from the archive.