### PR TITLE
Enable parameters to be set when creating 'MockAnalysisDir ' instances

### DIFF
--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -823,6 +823,7 @@ class MockAnalysisDirFactory(object):
                run_name,platform,
                paired_end=True,
                unaligned_dir='bcl2fastq',
+               params=None,
                metadata=None,
                top_dir=None):
         """


### PR DESCRIPTION
PR which updates the `MockAnalysisDir` and `MockAnalysisDirFactory` classes in the `mock` module to allow parameter values (i.e. values of settings written to the `auto_process.info` file of the mock directory) to be specified by the calling subprogram.