### PR TITLE
tenx_genomics_utils: fix 'has_chromium_sc_indices' function for samplesheet with no indices

### DIFF
--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -252,8 +252,11 @@ def has_chromium_sc_indices(sample_sheet):
     index_pattern = re.compile(r"SI-(GA|NA)-[A-H](1[0-2]|[1-9])$")
     s = SampleSheet(sample_sheet)
     for line in s:
-        if index_pattern.match(line['index']):
-            return True
+        try:
+            if index_pattern.match(line['index']):
+                return True
+        except KeyError:
+            pass
     return False
 
 def get_bases_mask_10x_atac(runinfo_xml):

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -124,6 +124,24 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
 3,smpl3,smpl3,,,A006,SI-GA-C1,10xGenomics,
 4,smpl4,smpl4,,,A007,SI-GA-D1,10xGenomics,
 """
+        self.sample_sheet_no_indices = """[Header]
+IEMFileVersion,4
+
+[Reads]
+76
+76
+
+[Settings]
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,Sample_Project,Description
+1,smpl1,smpl1,,GGTTTACT,standard,
+2,smpl2,smpl2,,GTAATCTT,standard,
+3,smpl3,smpl3,,SI-GA-C1,10xGenomics,
+4,smpl4,smpl4,,SI-GA-D1,10xGenomics,
+"""
         # Make temporary working dir
         self.wd = tempfile.mkdtemp(suffix="TestHasChromiumSCIndices")
     def tearDown(self):
@@ -164,6 +182,13 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
         """
         s = self._make_sample_sheet(
             self.sample_sheet_standard_indices)
+        self.assertFalse(has_chromium_sc_indices(s))
+    def test_sample_sheet_no_indices(self):
+        """
+        has_chromium_indices: sample sheet with no indices
+        """
+        s = self._make_sample_sheet(
+            self.sample_sheet_no_indices)
         self.assertFalse(has_chromium_sc_indices(s))
     def test_sample_sheet_some_chromium_sc_3_v2_indices(self):
         """


### PR DESCRIPTION
PR which fixes a bug in the `has_chromium_sc_indices` function in the `tenx_genomics_utils` module, when the supplied samplesheet doesn't have an `index` column defined.