### PR TITLE
update_fastq_stats: add --force option to force regeneration of statistics

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -944,6 +944,9 @@ def add_update_fastq_stats_command(cmdparser):
     p.add_argument('-a','--add',action="store_true",dest="add_data",
                    help="add new data from UNALIGNED_DIR to existing "
                    "statistics")
+    p.add_argument('--force',action="store_true",dest="force",
+                   help="force statistics to be regenerated even if "
+                   "existing statistics files are newer than fastqs ")
     add_nprocessors_option(p,__settings.fastq_stats.nprocessors)
     add_runner_option(p)
     add_debug_option(p)
@@ -1367,6 +1370,7 @@ def update_fastq_stats(args):
         stats_file=args.stats_file,
         per_lane_stats_file=args.per_lane_stats_file,
         add_data=args.add_data,
+        force=args.force,
         nprocessors=args.nprocessors,
         runner=runner)
 

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -1392,7 +1392,7 @@ def verify_fastq_generation(ap,unaligned_dir=None,lanes=None,
 
 def fastq_statistics(ap,stats_file=None,per_lane_stats_file=None,
                      unaligned_dir=None,sample_sheet=None,add_data=False,
-                     nprocessors=None,runner=None):
+                     forces=False,nprocessors=None,runner=None):
     """Generate statistics for Fastq files
 
     Generates statistics for all Fastq files found in the
@@ -1415,6 +1415,10 @@ def fastq_statistics(ap,stats_file=None,per_lane_stats_file=None,
       add_data (bool): if True then add stats to the existing
         stats files (default is to overwrite existing stats
         files)
+      force (bool): if True then force update of the stats
+        files even if they are newer than the Fastq files
+        (by default stats are only updated if they are older
+        than the Fastqs)
       nprocessors (int): number of cores to use when running
         'fastq_statistics.py'
       runner (JobRunner): (optional) specify a non-default job
@@ -1465,12 +1469,13 @@ def fastq_statistics(ap,stats_file=None,per_lane_stats_file=None,
         if regenerate_stats:
             logger.warning("Fastqs are newer than stats files")
         else:
-            # Don't rerun the stats, just regenerate the report
             logger.warning("Stats files are newer than Fastqs")
-            processing_qc_html = os.path.join(ap.analysis_dir,
-                                              "processing_qc.html")
-            report_processing_qc(ap,processing_qc_html)
-            return
+            if not force:
+                # Don't rerun the stats, just regenerate the report
+                processing_qc_html = os.path.join(ap.analysis_dir,
+                                                  "processing_qc.html")
+                report_processing_qc(ap,processing_qc_html)
+                return
     # Set up runner
     if runner is None:
         runner = ap.settings.runners.stats

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -1392,7 +1392,7 @@ def verify_fastq_generation(ap,unaligned_dir=None,lanes=None,
 
 def fastq_statistics(ap,stats_file=None,per_lane_stats_file=None,
                      unaligned_dir=None,sample_sheet=None,add_data=False,
-                     forces=False,nprocessors=None,runner=None):
+                     force=False,nprocessors=None,runner=None):
     """Generate statistics for Fastq files
 
     Generates statistics for all Fastq files found in the

--- a/auto_process_ngs/commands/update_fastq_stats_cmd.py
+++ b/auto_process_ngs/commands/update_fastq_stats_cmd.py
@@ -20,8 +20,8 @@ logger = logging.getLogger(__name__)
 #######################################################################
 
 def update_fastq_stats(ap,stats_file=None,per_lane_stats_file=None,
-                       unaligned_dir=None,add_data=False,nprocessors=None,
-                       runner=None):
+                       unaligned_dir=None,add_data=False,force=False,
+                       nprocessors=None,runner=None):
     """Update statistics for Fastq files
 
     Updates the statistics for all Fastq files found in the
@@ -42,6 +42,10 @@ def update_fastq_stats(ap,stats_file=None,per_lane_stats_file=None,
       add_data (bool): if True then add stats to the existing
         stats files (default is to overwrite existing stats
         files)
+      force (bool): if True then force update of the stats
+        files even if they are newer than the Fastq files
+        (by default stats are only updated if they are older
+        than the Fastqs)
       nprocessors (int): number of cores to use when running
         'fastq_statistics.py'
       runner (JobRunner): (optional) specify a non-default job
@@ -53,5 +57,6 @@ def update_fastq_stats(ap,stats_file=None,per_lane_stats_file=None,
                      stats_file=stats_file,
                      per_lane_stats_file=per_lane_stats_file,
                      add_data=add_data,
+                     force=force,
                      nprocessors=nprocessors,
                      runner=runner)


### PR DESCRIPTION
PR to address issue #388 and add a `--force` option to the `update_fastq_stats` command, which forces regeneration of Fastq statistics even when the Fastq files are older than the existing stats files.