### PR TITLE
make_fastqs: make symlinks to primary data if it's on the same file system

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -229,8 +229,14 @@ def add_make_fastqs_command(cmdparser):
                               "perform any other operations")
     primary_data.add_argument('--remove-primary-data',action='store_true',
                               dest='remove_primary_data',default=False,
-                              help="Delete the primary data at the end of "
+                              help="delete the primary data at the end of "
                               "processing (default is to keep data)")
+    primary_data.add_argument('--force-copy',action='store_true',
+                              dest='force_copy',default=False,
+                              help="force primary data to be copied (by "
+                              "default only data on a remote system will be "
+                              "copied; data on a local system will be "
+                              "symlinked)")
     # General Fastq generation options
     fastq_generation = p.add_argument_group('General Fastq generation')
     fastq_generation.add_argument('--protocol',choices=MAKE_FASTQS_PROTOCOLS,
@@ -1115,6 +1121,7 @@ def make_fastqs(args):
         skip_rsync=args.skip_rsync,
         nprocessors=args.nprocessors,
         runner=runner,
+        force_copy_of_primary_data=args.force_copy,
         remove_primary_data=args.remove_primary_data,
         ignore_missing_bcl=args.ignore_missing_bcl,
         ignore_missing_stats=args.ignore_missing_stats,

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -598,7 +598,7 @@ def get_primary_data(ap,force_copy=False,runner=None):
     # Check if source data are local or remote
     if not Location(data_dir).is_remote:
         # Local data
-        print("Data are on the local system")
+        print("Primary data are on the local system")
         if not force_copy:
             # Make a symlink
             print("Making a symlink to source data")

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -1121,6 +1121,35 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
                                     "171020_SN7001250_00002_AHGXXXX")
         self.assertTrue(os.path.islink(primary_data))
 
+    def test_make_fastqs_force_rsync_of_primary_data(self):
+        """make_fastqs: force rsync of primary data
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_SN7001250_00002_AHGXXXX",
+            "hiseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        # Create mock bcl2fastq and cellranger executables
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,"bcl2fastq"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Do the test
+        ap = AutoProcess(settings=self.settings)
+        ap.setup(os.path.join(self.wd,
+                              "171020_SN7001250_00002_AHGXXXX"))
+        self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
+        make_fastqs(ap,only_fetch_primary_data=True,
+                    force_copy_of_primary_data=True)
+        # Check primary data is not a link
+        primary_data = os.path.join(ap.params.primary_data_dir,
+                                    "171020_SN7001250_00002_AHGXXXX")
+        self.assertFalse(os.path.islink(primary_data))
+
     def test_make_fastqs_unknown_protocol(self):
         """make_fastqs: fails with unknown protocol
         """

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -1087,6 +1087,40 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
 
+    def test_make_fastqs_primary_data_is_link(self):
+        """make_fastqs: check primary data is a link by default
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_SN7001250_00002_AHGXXXX",
+            "hiseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        # Create mock bcl2fastq and cellranger executables
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,"bcl2fastq"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Do the test
+        ap = AutoProcess(settings=self.settings)
+        ap.setup(os.path.join(self.wd,
+                              "171020_SN7001250_00002_AHGXXXX"))
+        self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
+        make_fastqs(ap,only_fetch_primary_data=True)
+        # Check parameters
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(self.wd,
+                                      "171020_SN7001250_00002_AHGXXXX_analysis",
+                                      "primary_data"))
+        self.assertTrue(ap.params.acquired_primary_data)
+        # Check primary data is a link
+        primary_data = os.path.join(ap.params.primary_data_dir,
+                                    "171020_SN7001250_00002_AHGXXXX")
+        self.assertTrue(os.path.islink(primary_data))
+
     def test_make_fastqs_unknown_protocol(self):
         """make_fastqs: fails with unknown protocol
         """


### PR DESCRIPTION
PR to address issue #227 and have the `make_fastqs` command make a symlink to the primary data if it's on a local file system. Data are still copied if the source is a remote file system.