### PR TITLE
run_qc: use the '10x_scATAC' protocol for single nuclei ATAC-seq data

### DIFF
--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -59,7 +59,8 @@ def determine_qc_protocol(project):
             elif library_type == "snRNA-seq":
                 # 10xGenomics snRNA-seq
                 protocol = "10x_snRNAseq"
-        elif library_type == "scATAC-seq":
+        elif library_type in ("scATAC-seq",
+                              "snATAC-seq",):
             if single_cell_platform == "10xGenomics Single Cell ATAC":
                 # 10xGenomics scATAC-seq
                 protocol = "10x_scATAC"

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -176,6 +176,24 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
         self.assertEqual(determine_qc_protocol(project),
                          "10x_scATAC")
 
+    def test_determine_qc_protocol_10xchromium3v2_single_nuclei_atac_seq(self):
+        """determine_qc_protocol: single-nuclei ATAC-seq (10xGenomics Single Cell ATAC)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={'Single cell platform':
+                                          "10xGenomics Single Cell ATAC",
+                                          'Library type':
+                                          "snATAC-seq"})
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        self.assertEqual(determine_qc_protocol(project),
+                         "10x_scATAC")
+
     def test_determine_qc_protocol_icell8_atac_seq(self):
         """determine_qc_protocol: single-cell ATAC-seq (ICELL8)
         """

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -17,16 +17,17 @@ can be used to run the QC pipeline on an arbitrary subdirectory.
 The QC pipeline protocol used for each project will differ slightly
 depending on the nature of the data within that project:
 
-================ ========================
-QC protocol      Used for
-================ ========================
-``standardPE``   Standard paired-end data i.e. R1/R2 Fastq pairs
-``standardSE``   Standard single-end data i.e. R1 Fastqs only
-``10x_scATAC``   10xGenomics single cell ATAC-seq
-``10x_scRNAseq`` 10xGenomics single cell RNA-seq
-``10x_snRNAseq`` 10xGenomics single nuclei RNA-seq
-``singlecell``   ICELL8 single cell RNA-seq
-================ ========================
+================  ========================
+QC protocol       Used for
+================  ========================
+``standardPE``    Standard paired-end data i.e. R1/R2 Fastq pairs
+``standardSE``    Standard single-end data i.e. R1 Fastqs only
+``10x_scATAC``    10xGenomics single cell & single nuclei ATAC-seq
+``10x_scRNAseq``  10xGenomics single cell RNA-seq
+``10x_snRNAseq``  10xGenomics single nuclei RNA-seq
+``singlecell``    ICELL8 single cell RNA-seq
+``ICELL8_scATAC`` ICELL8 single cell ATAC-seq
+================= ========================
 
 The protocol is determined automatically for each project.
 


### PR DESCRIPTION
PR which explicitly sets the QC protocol used by the `run_qc` command to be `10x_scATAC` for 10xGenomics  single nuclei ATAC-seq data.

From our local expert:

> For single nuclei ATAC-seq you can just use the ATAC-seq reference genome. In 10X there is no single cell ATAC-seq, its always single nuclei ATAC-seq and the reference genome they gave for ATAC-seq is single nuclei ATAC-seq