### PR TITLE
Update QC reports to include ICELL8 stats and processing reports

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -695,8 +695,8 @@ def add_publish_qc_command(cmdparser):
                    "even if verification has failed")
     p.add_argument('--legacy',action='store_true',
                    dest='legacy_mode',default=False,
-                   help="legacy mode: include links to MultiQC reports in "
-                   "the top-level index page")
+                   help="legacy mode: include links to MultiQC, cellranger "
+                   "count and ICELL8 reports in the top-level index page")
     add_debug_option(p)
     p.add_argument('analysis_dir',metavar="ANALYSIS_DIR",nargs="?",
                    help="auto_process analysis directory (optional: defaults "

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -507,10 +507,12 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                 fastq_dir = project.qc_info(qc_dir).fastq_dir
                 if fastq_dir.startswith("%s%s" % (project.dirn,os.sep)):
                     fastq_dir = os.path.relpath(fastq_dir,project.dirn)
-                if fastq_dir != project.info.primary_fastq_dir:
-                    fastq_set = fastq_dir
-                else:
+                if fastq_dir == "fastqs":
                     fastq_set = None
+                elif fastq_dir.startswith("fastqs."):
+                    fastq_set = fastq_dir[7:]
+                else:
+                    fastq_set = fastq_dir
                 # QC report
                 try:
                     qc_zip = qc_artefacts.qc_zip

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -93,6 +93,7 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
     explicit links for each project for the following (where
     appropriate):
 
+    - ICELL8 processing reports
     - cellranger count outputs
     - MultiQC report
 
@@ -313,14 +314,14 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                     qc_artefacts['multiqc_report'] = multiqc_report
                 else:
                     print("...%s: no MultiQC report" % qc_dir)
-        # ICell8 pipeline report
-        icell8_zip = os.path.join(project.dirn,
-                                  "icell8_processing.%s.%s.zip" %
-                                  (project.name,
-                                   os.path.basename(ap.analysis_dir)))
-        if os.path.exists(icell8_zip):
-            print("...%s: found ICell8 pipeline report" % project.name)
-            project_qc[project.name]['icell8_zip'] = icell8_zip
+                # ICELL8 pipeline report
+                icell8_zip = os.path.join(project.dirn,
+                                          "icell8_processing.%s.%s.zip" %
+                                          (project.name,
+                                           os.path.basename(ap.analysis_dir)))
+                if os.path.exists(icell8_zip):
+                    print("...%s: found ICELL8 pipeline report" % project.name)
+                    project_qc[project.name]['icell8_zip'] = icell8_zip
         # Cellranger count report
         if legacy:
             cellranger_zip = os.path.join(project.dirn,

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -83,10 +83,10 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
 
     - QC report for standard QC
 
-    Also if a project comprises ICell8 or 10xGenomics Chromium
+    Also if a project comprises ICELL8 or 10xGenomics Chromium
     data:
 
-    - ICell8 processing report, or
+    - ICELL8 processing reports, or
     - 'cellranger count' reports for each sample
 
     In 'legacy' mode, the top-level report will also contain
@@ -574,11 +574,11 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                 except AttributeError:
                     # No MultiQC report
                     pass
-            # ICell8 pipeline report
+            # ICELL8 pipeline report
             try:
                 icell8_zip = project_qc[project.name].icell8_zip
                 try:
-                    # Copy and unzip ICell8 report
+                    # Copy and unzip ICELL8 report
                     copy_job = sched.submit(
                         fileops.copy_command(icell8_zip,dirn),
                         name="copy.icell8_report.%s" % project.name)
@@ -600,7 +600,7 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                             os.path.basename(icell8_zip)))
                     # Append info to the index page
                     report_html.add(
-                        Link("[Icell8 processing]",
+                        Link("[ICELL8 processing]",
                              "icell8_processing.%s.%s/"
                              "icell8_processing.html" %
                              (project.name,
@@ -610,9 +610,9 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                             Link("[ZIP]",
                                  os.path.basename(icell8_processing_zip)))
                 except Exception as ex:
-                    print("Failed to copy ICell8 report: %s" % ex)
+                    print("Failed to copy ICELL8 report: %s" % ex)
             except AttributeError:
-                # No ICell8 report
+                # No ICELL8 report
                 pass
             # Cellranger count reports
             try:

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -702,6 +702,18 @@ class QCReport(Document):
                     os.path.join(self.qc_dir,f)).version)
             if versions:
                 software['fastq_strand'] = sorted(list(versions))
+        # Look for ICELL8 outputs
+        print("Checking for ICELL8 reports in %s/stats" %
+              self.project.dirn)
+        icell8_stats_xlsx = os.path.join(self.project.dirn,
+                                         "stats",
+                                         "icell8_stats.xlsx")
+        if os.path.exists(icell8_stats_xlsx):
+            outputs.add("icell8_stats")
+        icell8_report_html = os.path.join(self.project.dirn,
+                                          "icell8_processing.html")
+        if os.path.exists(icell8_report_html):
+            outputs.add("icell8_report")
         # Look for cellranger_count outputs
         cellranger_count_dir = os.path.join(self.qc_dir,
                                              "cellranger_count")
@@ -766,6 +778,10 @@ class QCReport(Document):
                           'qc_protocol',]
         if 'multiqc' in self.outputs:
             metadata_items.append('multiqc')
+        if 'icell8_stats' in self.outputs:
+            metadata_items.append('icell8_stats')
+        if 'icell8_report' in self.outputs:
+            metadata_items.append('icell8_report')
         metadata_titles = {
             'run_id': 'Run ID',
             'run': 'Run name',
@@ -777,6 +793,8 @@ class QCReport(Document):
             'organism': 'Organism',
             'qc_protocol': 'QC protocol',
             'multiqc': 'MultiQC report',
+            'icell8_stats': 'ICELL8 statistics',
+            'icell8_report': 'ICELL8 processing report',
         }
         for item in metadata_items:
             # Acquire the value
@@ -804,6 +822,12 @@ class QCReport(Document):
                     multiqc_report = "multi%s_report.html" \
                                      % os.path.basename(self.qc_dir)
                     value = Link(multiqc_report)
+                elif item == 'icell8_stats':
+                    value = Link("icell8_stats.xlsx",
+                                 os.path.join("stats",
+                                              "icell8_stats.xlsx"))
+                elif item == 'icell8_report':
+                    value = Link("icell8_processing.html")
                 else:
                     raise Exception("Unrecognised item to report: '%s'"
                                     % item)

--- a/auto_process_ngs/test/commands/test_publish_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_publish_qc_cmd.py
@@ -478,7 +478,7 @@ poll_interval = 0.5
                              project.name)
 
     def test_publish_qc_with_icell8_outputs(self):
-        """publish_qc: project with ICell8 QC outputs
+        """publish_qc: project with ICELL8 QC outputs
         """
         # Make an auto-process directory
         mockdir = MockAnalysisDirFactory.bcl2fastq2(
@@ -497,7 +497,7 @@ poll_interval = 0.5
         for project in projects:
             UpdateAnalysisProject(project).add_qc_outputs(
                 protocol="singlecell")
-        # Add ICell8 report for one project
+        # Add ICELL8 report for one project
         icell8_project = projects[0]
         UpdateAnalysisProject(icell8_project).add_icell8_outputs()
         # Make a mock publication area
@@ -890,7 +890,7 @@ poll_interval = 0.5
         projects = ap.get_analysis_projects()
         for project in projects:
             UpdateAnalysisProject(project).add_qc_outputs()
-        # Add ICell8 report for one project
+        # Add ICELL8 report for one project
         icell8_project = projects[0]
         UpdateAnalysisProject(icell8_project).add_icell8_outputs()
         # Add cellranger count output for one project
@@ -955,7 +955,7 @@ poll_interval = 0.5
         projects = ap.get_analysis_projects()
         for project in projects:
             UpdateAnalysisProject(project).add_qc_outputs()
-        # Add ICell8 report for one project
+        # Add ICELL8 report for one project
         icell8_project = projects[0]
         UpdateAnalysisProject(icell8_project).add_icell8_outputs()
         # Add cellranger count output for one project
@@ -981,7 +981,7 @@ poll_interval = 0.5
             outputs.append(os.path.join(project_qc,"qc_report.html"))
             outputs.append(os.path.join(project_qc,"qc"))
             zip_files.append("%s.zip" % project_qc)
-        # ICell8 outputs
+        # ICELL8 outputs
         icell8_dir = "icell8_processing.%s.%s" % (icell8_project.name,
                                                   os.path.basename(
                                                       ap.analysis_dir))

--- a/auto_process_ngs/test/commands/test_publish_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_publish_qc_cmd.py
@@ -517,7 +517,70 @@ poll_interval = 0.5
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
             outputs.append(os.path.join(project_qc,"qc"))
-        # ICell8 outputs
+        # Do checks
+        for item in outputs:
+            f = os.path.join(publication_dir,
+                             "160621_K00879_0087_000000000-AGEW9_analysis",
+                             item)
+            self.assertTrue(os.path.exists(f),"Missing %s" % f)
+        # ICELL8 outputs shouldn't be present
+        icell8_dir = "icell8_processing.%s.%s" % (icell8_project.name,
+                                                  os.path.basename(
+                                                      ap.analysis_dir))
+        outputs = []
+        outputs.append(icell8_dir)
+        outputs.append("%s.zip" % icell8_dir)
+        outputs.append(os.path.join(icell8_dir,"icell8_processing_data"))
+        outputs.append(os.path.join(icell8_dir,"icell8_processing.html"))
+        outputs.append(os.path.join(icell8_dir,"stats"))
+        # Do checks
+        for item in outputs:
+            f = os.path.join(publication_dir,
+                             "160621_K00879_0087_000000000-AGEW9_analysis",
+                             item)
+            self.assertFalse(os.path.exists(f),"Found %s" % f)
+
+    def test_publish_qc_with_icell8_outputs_legacy_mode(self):
+        """publish_qc: project with ICELL8 QC outputs (legacy mode)
+        """
+        # Make an auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '160621_K00879_0087_000000000-AGEW9',
+            'hiseq',
+            metadata={ "run_number": 87,
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
+            top_dir=self.dirn)
+        mockdir.create()
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
+        # Add processing report and QC outputs
+        UpdateAnalysisDir(ap).add_processing_report()
+        projects = ap.get_analysis_projects()
+        for project in projects:
+            UpdateAnalysisProject(project).add_qc_outputs(
+                protocol="singlecell")
+        # Add ICELL8 report for one project
+        icell8_project = projects[0]
+        UpdateAnalysisProject(icell8_project).add_icell8_outputs()
+        # Make a mock publication area
+        publication_dir = os.path.join(self.dirn,'QC')
+        os.mkdir(publication_dir)
+        # Publish
+        publish_qc(ap,location=publication_dir,legacy=True)
+        # Check outputs
+        outputs = ["index.html",
+                   "processing_qc.html"]
+        for project in ap.get_analysis_projects():
+            # Standard QC outputs
+            project_qc = "qc_report.%s.%s" % (project.name,
+                                              os.path.basename(
+                                                  ap.analysis_dir))
+            outputs.append(project_qc)
+            outputs.append("%s.zip" % project_qc)
+            outputs.append(os.path.join(project_qc,"qc_report.html"))
+            outputs.append(os.path.join(project_qc,"qc"))
+        # ICELL8 outputs
         icell8_dir = "icell8_processing.%s.%s" % (icell8_project.name,
                                                   os.path.basename(
                                                       ap.analysis_dir))
@@ -852,16 +915,7 @@ poll_interval = 0.5
             outputs.append(os.path.join(project_qc,"qc_report.html"))
             outputs.append(os.path.join(project_qc,"qc"))
             zip_files.append("%s.zip" % project_qc)
-        # ICell8 outputs
-        icell8_dir = "icell8_processing.%s.%s" % (icell8_project.name,
-                                                  os.path.basename(
-                                                      ap.analysis_dir))
-        outputs.append(icell8_dir)
-        outputs.append(os.path.join(icell8_dir,"icell8_processing_data"))
-        outputs.append(os.path.join(icell8_dir,"icell8_processing.html"))
-        outputs.append(os.path.join(icell8_dir,"stats"))
-        zip_files.append("%s.zip" % icell8_dir)
-        # NB cellranger count outputs shouldn't be present
+        # NB ICELL8 and cellranger count outputs shouldn't be present
         # Do checks
         for item in outputs:
             f = os.path.join(publication_dir,

--- a/bin/reportqc.py
+++ b/bin/reportqc.py
@@ -93,6 +93,14 @@ def zip_report(project,report_html,qc_dir=None,qc_protocol=None):
                            os.path.basename(qc_dir))
     if os.path.exists(multiqc):
         zip_file.add(multiqc)
+    # ICELL8 reports
+    icell8_reports = (os.path.join("stats","icell8_stats.xlsx"),
+                      "icell8_processing.html",
+                      "icell8_processing_data",)
+    for f in icell8_reports:
+        f = os.path.join(project.dirn,f)
+        if os.path.exists(f):
+            zip_file.add(f)
     # Finished
     return report_zip
 


### PR DESCRIPTION
PR to address issue #440 and include the ICELL8 statistics and processing reports in the QC report for each project where these are present.

The PR also removes these reports from the top-level index produced by `publish_qc`, unless running in 'legacy' mode.