### PR TITLE
Enable 'manage_fastqs.py' to make hard links for file copies

### DIFF
--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -93,6 +93,8 @@ def main():
     p.add_argument('--include_qc_report',action='store_true',
                    help="copy the zipped QC reports to the final "
                    "location")
+    p.add_argument('--link',action='store_true',
+                   help="hard link files instead of copying")
     p.add_argument('--runner',action='store',
                    help="specify the job runner to use for executing "
                    "the checksumming and Fastq copy operations "
@@ -149,6 +151,7 @@ def main():
         include_qc_report = True
     if args.weburl:
         weburl = args.weburl
+    hard_link = args.link
 
     # Load analysis directory and projects
     analysis_dir = AnalysisDir(args.analysis_dir)
@@ -350,9 +353,11 @@ def main():
         readme_file = None
 
     # Build command to run manage_fastqs.py
-    copy_cmd = Command("manage_fastqs.py",
-                       analysis_dir.analysis_dir,
-                       project_name)
+    copy_cmd = Command("manage_fastqs.py")
+    if hard_link:
+        copy_cmd.add_args("--link")
+    copy_cmd.add_args(analysis_dir.analysis_dir,
+                      project_name)
     if fastq_dir is not None:
         copy_cmd.add_args(fastq_dir)
     copy_cmd.add_args("copy",target_dir)

--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -131,6 +131,7 @@ def main():
         subdir = dest.subdir
         include_downloader = dest.include_downloader
         include_qc_report = dest.include_qc_report
+        hard_links = dest.hard_links
         weburl = dest.url
     else:
         target_dir = args.dest
@@ -138,6 +139,7 @@ def main():
         subdir = None
         include_downloader = False
         include_qc_report = False
+        hard_links = False
         weburl = None
 
     # Update defaults with command line values
@@ -151,7 +153,8 @@ def main():
         include_qc_report = True
     if args.weburl:
         weburl = args.weburl
-    hard_link = args.link
+    if args.link:
+        hard_links = args.link
 
     # Load analysis directory and projects
     analysis_dir = AnalysisDir(args.analysis_dir)
@@ -354,7 +357,7 @@ def main():
 
     # Build command to run manage_fastqs.py
     copy_cmd = Command("manage_fastqs.py")
-    if hard_link:
+    if hard_links:
         copy_cmd.add_args("--link")
     copy_cmd.add_args(analysis_dir.analysis_dir,
                       project_name)

--- a/auto_process_ngs/fileops.py
+++ b/auto_process_ngs/fileops.py
@@ -231,7 +231,7 @@ def mkdir(newdir,recursive=False):
             "Exception making directory %s: %s" %
             (newdir,ex))
 
-def copy(src,dest):
+def copy(src,dest,link=False):
     """
     Copy a file
 
@@ -242,8 +242,11 @@ def copy(src,dest):
       dest (str): destination (file or directory)
         on a local or remote system, identified by
         a specifier of the form '[[USER@]HOST:]DEST'
+      link (bool): hard link files instead of
+        copying (ignored for remote copies)
+
     """
-    copy_cmd = copy_command(src,dest)
+    copy_cmd = copy_command(src,dest,link=link)
     try:
         return _run_command(copy_cmd)
     except Exception as ex:
@@ -449,7 +452,7 @@ def disk_usage(path):
 # Command generation functions
 #########################################################################
 
-def copy_command(src,dest):
+def copy_command(src,dest,link=False):
     """
     Generate command to copy a file
 
@@ -461,6 +464,8 @@ def copy_command(src,dest):
       dest (str): destination (file or directory)
         on a local or remote system, identified by
         a specifier of the form '[[USER@]HOST:]DEST'
+      link (bool): hard link files instead of
+        copying (ignored for remote copies)
 
     Returns:
       Command: Command instance that can be used to
@@ -469,9 +474,11 @@ def copy_command(src,dest):
     dest = Location(dest)
     if not dest.is_remote:
         # Local-to-local copy
-        copy_cmd = applications.Command('cp',
-                                        src,
-                                        dest.path)
+        copy_cmd = applications.Command('cp')
+        if link:
+            copy_cmd.add_args('-l')
+        copy_cmd.add_args(src,
+                          dest.path)
     if dest.is_remote:
         # Local-to-remote copy
         copy_cmd = applications.general.scp(

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -321,6 +321,7 @@ class Settings(object):
         - url (optional, str, default 'None')
         - include_downloader (optional, boolean, default 'False')
         - include_qc_report (optional, boolean, default 'False')
+        - hard_links (optional, boolean, default 'False')
 
         Arguments:
           section (str): name of the section to retrieve the
@@ -340,6 +341,7 @@ class Settings(object):
             section,'include_downloader',False)
         values['include_qc_report'] = config.getboolean(
             section,'include_qc_report',False)
+        values['hard_links'] = config.getboolean(section,'hard_links',False)
         return values
 
     def set(self,param,value):

--- a/auto_process_ngs/test/test_settings.py
+++ b/auto_process_ngs/test/test_settings.py
@@ -130,6 +130,7 @@ readme_template = README.webserver.template
 url = https://our.data.com/data
 include_downloader = true
 include_qc_report = true
+hard_links = true
 
 [destination:local]
 directory = /mnt/shared
@@ -150,6 +151,7 @@ subdir = run_id
                          True)
         self.assertEqual(s.destination['webserver']['include_qc_report'],
                          True)
+        self.assertEqual(s.destination['webserver']['hard_links'],True)
         self.assertTrue('local' in s.destination)
         self.assertEqual(s.destination['local']['directory'],'/mnt/shared')
         self.assertEqual(s.destination['local']['subdir'],'run_id')
@@ -157,3 +159,4 @@ subdir = run_id
         self.assertEqual(s.destination['local']['url'],None)
         self.assertEqual(s.destination['local']['include_downloader'],False)
         self.assertEqual(s.destination['local']['include_qc_report'],False)
+        self.assertEqual(s.destination['local']['hard_links'],False)

--- a/bin/manage_fastqs.py
+++ b/bin/manage_fastqs.py
@@ -130,13 +130,12 @@ def copy_to_dest(f,dirn,chksum=None,link=False):
     if not exists(dirn):
         raise Exception("'%s': destination not found" % dirn)
     # Copy the file
-    copy(f,dirn)
+    copy(f,dirn,link=link)
     if chksum is not None:
         user,host,dest = utils.split_user_host_dir(dirn)
         remote = (host is not None)
         if not remote:
             # Check local copy
-            copy(f,dirn)
             if chksum is not None:
                 if md5sum.md5sum(f) != chksum:
                     raise Exception("MD5 checksum failed for "

--- a/bin/manage_fastqs.py
+++ b/bin/manage_fastqs.py
@@ -106,7 +106,7 @@ def write_checksums(project,pattern=None,filen=None,relative=True):
     if filen:
         fp.close()
 
-def copy_to_dest(f,dirn,chksum=None):
+def copy_to_dest(f,dirn,chksum=None,link=False):
     """Copy a file to a local or remote destination
 
     Raises an exception if the copy operation fails.
@@ -121,6 +121,8 @@ def copy_to_dest(f,dirn,chksum=None):
         "[user@]host:dir"
       chksum: (optional) MD5 sum of the original file
         to match against the copy
+      link: (optional) if True then hard link files
+        instead of copying
     
     """
     if not exists(f):
@@ -185,6 +187,9 @@ if __name__ == "__main__":
                    default=None,
                    help="explicitly specify subdirectory of DIR with "
                    "Fastq files to run the QC on.")
+    p.add_argument('--link',action='store_true',dest='link',
+                   default=False,
+                   help="hard link files instead of copying")
     options,args = p.parse_known_args()
     # Get analysis dir
     try:
@@ -305,7 +310,8 @@ if __name__ == "__main__":
         for sample_name,fastq,fq in get_fastqs(project,pattern=options.pattern):
             i += 1
             print("(% 2d/% 2d) %s" % (i,nfastqs,fq))
-            copy_to_dest(fq,dest,chksums[os.path.basename(fq)])
+            copy_to_dest(fq,dest,chksums[os.path.basename(fq)],
+                         link=options.link)
     elif cmd == 'md5':
         # Generate MD5 checksums
         md5file = "%s.chksums" % project.name

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -160,6 +160,8 @@ exclude_zip_files = False
 #   'download_fastqs.py' utility with the copied data
 # - include_qc_report: whether to include a copy of the
 #   zipped QC reports with the copied data
+# - hard_links: whether to hard link files instead of copying
+#   them (only for local copies on same filesystem)
 #[destination:webserver]
 #directory = /mnt/hosted/web
 #subdir = random_bin
@@ -167,3 +169,4 @@ exclude_zip_files = False
 #url = http://awesome.com/data
 #include_downloader = true
 #include_qc_report = true
+#hard_links = false

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -282,6 +282,9 @@ Parameter              Function
 ``url``                Base URL to access copied data at
 ``include_downloader`` Whether to include ``download_fastqs.py``
 ``include_qc_report``  Whether to include zipped QC reports
+``hard_links``         Whether to hard link to Fastqs rather making
+                       copies (for local directories on the same file
+                       system as the original Fastqs)
 ====================== ==============================================
 
 For example:
@@ -293,6 +296,7 @@ For example:
     subdir = random_bin
     readme_template = README.webserver
     url = http://ourdata.com/shared
+    hard_links = true
 
 See :ref:`transfer_data` for more information on what these settings do.
 

--- a/docs/source/using/managing_data.rst
+++ b/docs/source/using/managing_data.rst
@@ -165,11 +165,22 @@ By default only Fastqs are copied by ``transfer_data.py``, however it
 is possible to include additional files:
 
  * A standalone downloader script (see :ref:`download_fastqs`)
-   (specify the ``--include_downloader`` or set the
+   (specify the ``--include_downloader`` option or set the
    ``include_downloader`` parameter in the configuration);
  * The zipped QC reports for the project (specify the
-   ``--include_qc_report`` or set the ``include_qc_report``
+   ``--include_qc_report`` option or set the ``include_qc_report``
    parameter)
+
+Hard linking Fastqs
+-------------------
+
+When sharing Fastqs via a local directory which is on the same file
+system as the original files, it is possible to make hard links to
+the Fastqs rather than making copies by specifying the ``--link``
+option (or setting the ``hard_links`` parameter).
+
+Linking Fastqs is quicker than copying and saves space as hard links
+reference the same copy of the file's data on the file system.
 
 .. _download_fastqs:
 


### PR DESCRIPTION
PR to address issue #143 by updating `manage_fastqs.py` and `transfer_data.py` to allow hard linking of Fastqs instead of copying.

Hard linking can be specified by using the `--link` command line option (available on both utilities); for `transfer_data.py` hard links can also be specified for `destination`s configured in the settings file (by setting the `hard_links` parameter).

Note that hard links can only be made for destinations which are on the same file system as the original Fastqs, so the option is ignore for remote destinations.

The PR also fixes a bug in `manage_fastqs.py` where copying appeared to be done twice.