### PR TITLE
Enable job runner for cellranger to be explicitly specified

### DIFF
--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -435,7 +435,8 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 cellranger_jobinterval=cellranger_jobinterval,
                 cellranger_localcores=cellranger_localcores,
                 cellranger_localmem=cellranger_localmem,
-                log_dir=ap.log_dir
+                log_dir=ap.log_dir,
+                runner=runner
             )
         elif protocol == '10x_chromium_sc_atac':
             # 10xGenomics Chromium scATAC-seq
@@ -452,7 +453,8 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 cellranger_jobinterval=cellranger_jobinterval,
                 cellranger_localcores=cellranger_localcores,
                 cellranger_localmem=cellranger_localmem,
-                log_dir=ap.log_dir
+                log_dir=ap.log_dir,
+                runner=runner
             )
         else:
             # Unknown protocol
@@ -681,8 +683,8 @@ def bcl_to_fastq(ap,unaligned_dir,sample_sheet,primary_data_dir,
         Fastq files for index reads (default, don't create index read
         Fastqs)
       nprocessors (int): number of processors to use
-      runner (JobRunner): (optional) specify a non-default job runner to
-        use for fastq generation
+      runner (JobRunner): (optional) specify a non-default job runner
+        to use for fastq generation
     """
     # Directories
     analysis_dir = ap.params.analysis_dir
@@ -917,7 +919,7 @@ def bcl_to_fastq_10x_chromium_sc(ap,output_dir,sample_sheet,
                                  cellranger_jobinterval=None,
                                  cellranger_localcores=None,
                                  cellranger_localmem=None,
-                                 log_dir=None):
+                                 log_dir=None,runner=None):
     """
     Generate FASTQ files for 10xGenomics single-cell Chromium run
 
@@ -950,6 +952,8 @@ def bcl_to_fastq_10x_chromium_sc(ap,output_dir,sample_sheet,
       cellranger_localmem (int): maximum memory cellranger can request
         in jobmode 'local' (default: None)
       log_dir (str): optional path to directory to write log files to
+      runner (JobRunner): (optional) specify a non-default job runner to
+        use for fastq generation
     """
     # Deal with bases mask
     if bases_mask == 'auto':
@@ -1006,6 +1010,10 @@ def bcl_to_fastq_10x_chromium_sc(ap,output_dir,sample_sheet,
     print("Cellranger localmem   : %s" % cellranger_localmem)
     print("Working directory     : %s" % working_dir)
     print("Log directory         : %s" % log_dir)
+    # Set up runner
+    if runner is None:
+        runner = ap.settings.runners.cellranger
+    runner.set_log_dir(ap.log_dir)
     # Run cellranger mkfastq
     try:
         return run_cellranger_mkfastq(
@@ -1023,7 +1031,8 @@ def bcl_to_fastq_10x_chromium_sc(ap,output_dir,sample_sheet,
             cellranger_localcores=cellranger_localcores,
             cellranger_localmem=cellranger_localmem,
             working_dir=working_dir,
-            log_dir=log_dir)
+            log_dir=log_dir,
+            runner=runner)
     except Exception as ex:
         raise Exception("'cellranger mkfastq' stage failed: "
                         "'%s'" % ex)
@@ -1037,7 +1046,7 @@ def bcl_to_fastq_10x_chromium_sc_atac(ap,output_dir,sample_sheet,
                                       cellranger_jobinterval=None,
                                       cellranger_localcores=None,
                                       cellranger_localmem=None,
-                                      log_dir=None):
+                                      log_dir=None,runner=None):
     """
     Generate FASTQ files for 10xGenomics single-cell ATAC-seq run
 
@@ -1070,6 +1079,8 @@ def bcl_to_fastq_10x_chromium_sc_atac(ap,output_dir,sample_sheet,
       cellranger_localmem (int): maximum memory cellranger can request
         in jobmode 'local' (default: None)
       log_dir (str): optional path to directory to write log files to
+      runner (JobRunner): (optional) specify a non-default job runner
+        to use for fastq generation
     """
     # Load run data
     illumina_run = IlluminaData.IlluminaRun(primary_data_dir,
@@ -1138,6 +1149,10 @@ def bcl_to_fastq_10x_chromium_sc_atac(ap,output_dir,sample_sheet,
     print("Cellranger localmem    : %s" % cellranger_localmem)
     print("Working directory      : %s" % working_dir)
     print("Log directory          : %s" % log_dir)
+    # Set up runner
+    if runner is None:
+        runner = ap.settings.runners.cellranger
+    runner.set_log_dir(ap.log_dir)
     # Run cellranger-atac mkfastq
     try:
         return run_cellranger_mkfastq(
@@ -1155,7 +1170,8 @@ def bcl_to_fastq_10x_chromium_sc_atac(ap,output_dir,sample_sheet,
             cellranger_localcores=cellranger_localcores,
             cellranger_localmem=cellranger_localmem,
             working_dir=working_dir,
-            log_dir=log_dir)
+            log_dir=log_dir,
+            runner=runner)
     except Exception as ex:
         raise Exception("'cellranger-atac mkfastq' failed: "
                         "'%s'" % ex)

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -95,6 +95,7 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
     default_runner = ap.settings.general.default_runner
     if runner is None:
         qc_runner = ap.settings.runners.qc
+        cellranger_runner = ap.settings.runners.cellranger
     # Get environment modules
     envmodules = dict()
     for name in ('illumina_qc',
@@ -153,6 +154,7 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
                        poll_interval=poll_interval,
                        max_jobs=max_jobs,
                        runners={
+                           'cellranger_runner': cellranger_runner,
                            'qc_runner': qc_runner,
                            'verify_runner': default_runner,
                            'report_runner': default_runner,

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -458,8 +458,6 @@ class QCPipeline(Pipeline):
         # Runners
         if runners is None:
             runners = dict()
-        if 'cellranger_runner' not in runners:
-            runners['cellranger_runner'] = SimpleJobRunner()
 
         # Execute the pipeline
         status = Pipeline.run(self,

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -224,7 +224,8 @@ class Settings(object):
                      'icell8',
                      'icell8_contaminant_filter',
                      'icell8_statistics',
-                     'icell8_report',):
+                     'icell8_report',
+                     'cellranger',):
             self.runners[name] = config.getrunner('runners',name,
                                                   default_runner)
         # Information for archiving analyses

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -538,6 +538,7 @@ def run_cellranger_mkfastq(sample_sheet,
                            cellranger_jobinterval=None,
                            cellranger_localcores=None,
                            cellranger_localmem=None,
+                           runner=None,
                            working_dir=None,
                            log_dir=None,
                            dry_run=False):
@@ -586,6 +587,9 @@ def run_cellranger_mkfastq(sample_sheet,
         (default: None)
       cellranger_localmem (int): maximum memory cellranger
         can request in jobmode 'local' (default: None)
+      runner (JobRunner): specify a non-default job runner
+        to use when running cellranger (default:
+        SimpleJobRunner)
       working_dir (str): path to a directory to use as
         as the working directory (default: current
         working directory)
@@ -600,6 +604,9 @@ def run_cellranger_mkfastq(sample_sheet,
     # Working directory
     if working_dir is None:
         working_dir = os.getcwd()
+    # Job runner
+    if runner is None:
+        runner = SimpleJobRunner(join_logs=True)
     # Check for existing cellranger outputs
     flow_cell_dir = os.path.join(working_dir,
                                  flow_cell_id(primary_data_dir))
@@ -654,7 +661,7 @@ def run_cellranger_mkfastq(sample_sheet,
             log_dir = os.path.abspath(log_dir)
         # Submit the job
         cellranger_mkfastq_job = SchedulerJob(
-            SimpleJobRunner(join_logs=True),
+            runner,
             cmd.command_line,
             name='cellranger_mkfastq',
             working_dir=working_dir,

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -182,8 +182,10 @@ if __name__ == "__main__":
     default_runner = __settings.general.default_runner
     if args.runner:
         qc_runner = fetch_runner(args.runner)
+        cellranger_runner = fetch_runner(args.runner)
     else:
         qc_runner = self._settings.runners.qc
+        cellranger_runner = self._settings.runners.cellranger
     verify_runner = default_runner
     report_runner = default_runner
 
@@ -238,6 +240,7 @@ if __name__ == "__main__":
                        max_jobs=args.max_jobs,
                        batch_size=args.batch_size,
                        runners={
+                           'cellranger_runner': cellranger_runner,
                            'qc_runner': qc_runner,
                            'verify_runner': verify_runner,
                            'report_runner': report_runner,

--- a/config/settings.ini.sample
+++ b/config/settings.ini.sample
@@ -107,6 +107,7 @@ bcl2fastq = SimpleJobRunner
 qc = SimpleJobRunner
 stats = SimpleJobRunner
 rsync = SimpleJobRunner
+cellranger = SimpleJobRunner
 icell8 = SimpleJobRunner
 icell8_contaminant_filter = SimpleJobRunner
 icell8_statistics = SimpleJobRunner


### PR DESCRIPTION
PR which enables the job runner to be used for executing `cellranger` jobs to be explicitly specified; previously it defaulted to `SimpleJobRunner` and assumed that `cellranger` would target a cluster (e.g. `--jobmode=sge`).

With this change it should be possible to specify a different runner, for example a `GEJobRunner` instance could be used to run `cellranger` with `--jobmode=local` instead.