### PR TITLE
transfer_data.py: hard link QC reports

### DIFF
--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -400,7 +400,8 @@ def main():
         for qc_zip in qc_zips:
             print("Copying '%s'" % os.path.basename(qc_zip))
             copy(qc_zip,
-                 os.path.join(target_dir,os.path.basename(qc_zip)))
+                 os.path.join(target_dir,os.path.basename(qc_zip)),
+                 link=hard_links)
 
     print("Files now at %s" % target_dir)
     if weburl:


### PR DESCRIPTION
PR which updates the `transfer_data.py` utility to also hard link to the QC reports when `--link` and `--include_qc_report` options are specified.