### PR TITLE
Fix setting cell count for 10xGenomics single nuclei ATAC-seq data

### DIFF
--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -444,7 +444,8 @@ def set_cell_count_for_project(project_dir,qc_dir=None):
                 logger.critical("Failed to add cell count for sample "
                                 "'%s': %s" % (sample.name,ex))
                 return 1
-    elif project.info.library_type == 'scATAC-seq':
+    elif project.info.library_type in ('scATAC-seq',
+                                       'snATAC-seq'):
         # Single cell ATAC-seq
         for sample in project.samples:
             try:
@@ -459,6 +460,10 @@ def set_cell_count_for_project(project_dir,qc_dir=None):
                 logger.critical("Failed to add cell count for sample "
                                 "'%s': %s" % (sample.name,ex))
                 return 1
+    else:
+        raise Exception("%s: don't know how to set cell count for "
+                        "library type '%s'" % (project.name,
+                                               project.info.library_type))
     # Store in the project metadata
     project.info['number_of_cells'] = number_of_cells
     project.info.save()

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -608,3 +608,34 @@ class TestSetCellCountForProject(unittest.TestCase):
         self.assertEqual(AnalysisProject("PJB1",
                                          project_dir).info.number_of_cells,
                          5682)
+    def test_set_cell_count_for_single_nuclei_atac_project(self):
+        """
+        set_cell_count_for_project: test for snATAC-seq
+        """
+        # Set up mock project
+        project_dir = self._make_mock_analysis_project(
+            "10xGenomics Single Cell ATAC",
+            "snATAC-seq")
+        # Add metrics_summary.csv
+        counts_dir = os.path.join(project_dir,
+                                  "qc",
+                                  "cellranger_count",
+                                  "PJB1",
+                                  "outs")
+        mkdirs(counts_dir)
+        summary_file = os.path.join(counts_dir,
+                                            "summary.csv")
+        with open(summary_file,'w') as fp:
+            fp.write(ATAC_SUMMARY)
+        # Check initial cell count
+        print("Checking number of cells")
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         None)
+        # Update the cell counts
+        print("Updating number of cells")
+        set_cell_count_for_project(project_dir)
+        # Check updated cell count
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         5682)


### PR DESCRIPTION
PR to fix a bug in the setting of cell counts in the project metadata for 10xGenomics single nuclei (sn)ATAC-seq data. Previously the cell count was not set for this library type.

Also the PR implements a trap in the `set_cell_count_for_project` function (in `tenx_genomics_utils`) when it's invoked with a project which has an unimplemented library type, which should help with keeping the functionality updated for any future library types.