### PR TITLE
Remove use of 'cmp' from sorting (use 'key' instead)

### DIFF
--- a/auto_process_ngs/barcodes/analysis.py
+++ b/auto_process_ngs/barcodes/analysis.py
@@ -205,12 +205,12 @@ class BarcodeCounter(object):
         """
         if lane is None:
             return sorted([s for s in self._seqs_all],
-                          cmp=lambda x,y: cmp(self.counts_all(y),
-                                              self.counts_all(x)))
+                          key=lambda x: self.counts_all(x),
+                          reverse=True)
         else:
             return sorted([s for s in self._seqs[lane]],
-                          cmp=lambda x,y: cmp(self.counts(y,lane),
-                                              self.counts(x,lane)))
+                          key=lambda x: self.counts(x,lane),
+                          reverse=True)
 
     def filter_barcodes(self,cutoff=None,lane=None):
         """
@@ -423,7 +423,8 @@ class BarcodeCounter(object):
                 # Discard group
                 pass
         # Sort groups into order of total counts
-        groups = sorted(groups,cmp=lambda x,y: cmp(y.counts,x.counts))
+        groups = sorted(groups,key=lambda x: x.counts,
+                        reverse=True)
         return groups
 
     def analyse(self,lane=None,sample_sheet=None,cutoff=None,

--- a/auto_process_ngs/fastq_utils.py
+++ b/auto_process_ngs/fastq_utils.py
@@ -539,7 +539,7 @@ def pair_fastqs(fastqs):
             logging.debug("Unpaired: %s" % fq)
             seq_ids[fq] = seq_id
     # Sort pairs into order
-    fq_pairs = sorted(fq_pairs,lambda x,y: cmp(x[0],y[0]))
+    fq_pairs = sorted(fq_pairs,key=lambda x: x[0])
     unpaired = sorted(seq_ids.keys() + bad_files)
     # Return paired and upaired fastqs
     return (fq_pairs,unpaired)
@@ -593,7 +593,7 @@ def pair_fastqs_by_name(fastqs,fastq_attrs=IlluminaFastqAttrs):
                 pass
         if fqr2 is not None:
             pairs.append((fqr2,))
-    pairs = sorted(pairs,cmp=lambda x,y: cmp(x[0],y[0]))
+    pairs = sorted(pairs,key=lambda x: x[0])
     return pairs
 
 def group_fastqs_by_name(fastqs,fastq_attrs=IlluminaFastqAttrs):
@@ -658,7 +658,7 @@ def group_fastqs_by_name(fastqs,fastq_attrs=IlluminaFastqAttrs):
                         unmatched_fastqs.append(fastq1)
                 fastq_sets[r] = unmatched_fastqs
             groups.append(group)
-    groups = sorted(groups,cmp=lambda x,y: cmp(x[0],y[0]))
+    groups = sorted(groups,key=lambda x: x[0])
     return groups
 
 def remove_index_fastqs(fastqs,fastq_attrs=IlluminaFastqAttrs):

--- a/auto_process_ngs/simple_scheduler.py
+++ b/auto_process_ngs/simple_scheduler.py
@@ -220,7 +220,7 @@ class SimpleScheduler(threading.Thread):
         for name in self.__jobs:
             if regex.match(name):
                 matches.append(self.__jobs[name])
-        matches.sort(lambda x,y: cmp(x.name,y.name))
+        matches = sorted(matches,key=lambda x: x.name)
         return matches
 
     def wait(self):


### PR DESCRIPTION
PR to address issue #327 and remove the use of the `cmp` keyword from sorting (switch to using `key` instead) for compatibility with Python 3.