### PR TITLE
Update octal numbers for Python 3 compatibility

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -634,7 +634,7 @@ class AnalysisProject(object):
             qc_dir = os.path.join(self.dirn,qc_dir)
         if not os.path.exists(qc_dir):
             print("Creating QC dir: %s" % qc_dir)
-            bcf_utils.mkdir(qc_dir,mode=o0775)
+            bcf_utils.mkdir(qc_dir,mode=0o775)
         else:
             print("QC dir already exists: %s" % qc_dir)
         # Set up metadata
@@ -725,10 +725,10 @@ class AnalysisProject(object):
             logger.warning("Directory %s already exists" % self.dirn)
         else:
             logger.debug("Making analysis directory %s" % self.dirn)
-            bcf_utils.mkdir(self.dirn,mode=o0775)
+            bcf_utils.mkdir(self.dirn,mode=0o775)
         # Make a 'ScriptCode' directory
         scriptcode_dir = os.path.join(self.dirn,"ScriptCode")
-        bcf_utils.mkdir(scriptcode_dir,mode=o0775)
+        bcf_utils.mkdir(scriptcode_dir,mode=0o775)
         # Put a file in ScriptCode to make sure it's
         # not pruned on subsequent rsync operations
         fp = open(os.path.join(self.dirn,'ScriptCode','README.txt'),'w')
@@ -738,7 +738,7 @@ class AnalysisProject(object):
         if fastq_dir is None:
             fastq_dir = "fastqs"
         fastq_dir = os.path.join(self.dirn,fastq_dir)
-        bcf_utils.mkdir(fastq_dir,mode=o0775)
+        bcf_utils.mkdir(fastq_dir,mode=0o775)
         # Check for & create links to fastq files
         if fastqs is None:
             # Make a list of fastqs to import from the supplied

--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -634,7 +634,7 @@ class AnalysisProject(object):
             qc_dir = os.path.join(self.dirn,qc_dir)
         if not os.path.exists(qc_dir):
             print("Creating QC dir: %s" % qc_dir)
-            bcf_utils.mkdir(qc_dir,mode=0775)
+            bcf_utils.mkdir(qc_dir,mode=o0775)
         else:
             print("QC dir already exists: %s" % qc_dir)
         # Set up metadata
@@ -725,10 +725,10 @@ class AnalysisProject(object):
             logger.warning("Directory %s already exists" % self.dirn)
         else:
             logger.debug("Making analysis directory %s" % self.dirn)
-            bcf_utils.mkdir(self.dirn,mode=0775)
+            bcf_utils.mkdir(self.dirn,mode=o0775)
         # Make a 'ScriptCode' directory
         scriptcode_dir = os.path.join(self.dirn,"ScriptCode")
-        bcf_utils.mkdir(scriptcode_dir,mode=0775)
+        bcf_utils.mkdir(scriptcode_dir,mode=o0775)
         # Put a file in ScriptCode to make sure it's
         # not pruned on subsequent rsync operations
         fp = open(os.path.join(self.dirn,'ScriptCode','README.txt'),'w')
@@ -738,7 +738,7 @@ class AnalysisProject(object):
         if fastq_dir is None:
             fastq_dir = "fastqs"
         fastq_dir = os.path.join(self.dirn,fastq_dir)
-        bcf_utils.mkdir(fastq_dir,mode=0775)
+        bcf_utils.mkdir(fastq_dir,mode=o0775)
         # Check for & create links to fastq files
         if fastqs is None:
             # Make a list of fastqs to import from the supplied

--- a/auto_process_ngs/commands/setup_cmd.py
+++ b/auto_process_ngs/commands/setup_cmd.py
@@ -184,7 +184,7 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
                   original_sample_sheet)
             shutil.copyfile(tmp_sample_sheet,original_sample_sheet)
             # Set the permissions for the original SampleSheet
-            os.chmod(original_sample_sheet,o0664)
+            os.chmod(original_sample_sheet,0o664)
             # Process acquired sample sheet
             custom_sample_sheet = os.path.join(ap.analysis_dir,
                                                'custom_SampleSheet.csv')

--- a/auto_process_ngs/commands/setup_cmd.py
+++ b/auto_process_ngs/commands/setup_cmd.py
@@ -184,7 +184,7 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
                   original_sample_sheet)
             shutil.copyfile(tmp_sample_sheet,original_sample_sheet)
             # Set the permissions for the original SampleSheet
-            os.chmod(original_sample_sheet,0664)
+            os.chmod(original_sample_sheet,o0664)
             # Process acquired sample sheet
             custom_sample_sheet = os.path.join(ap.analysis_dir,
                                                'custom_SampleSheet.csv')

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -928,7 +928,7 @@ sys.exit(MockBcl2fastq2Exe(exit_code=%s,
                     if assert_bases_mask is not None
                     else None),
                    version))
-            os.chmod(path,o0775)
+            os.chmod(path,0o775)
         with open(path,'r') as fp:
             print("bcl2fastq:")
             print("%s" % fp.read())
@@ -1160,7 +1160,7 @@ sys.exit(MockCellrangerExe(path=sys.argv[0],
                     if assert_bases_mask is not None
                     else None),
                    reads))
-            os.chmod(path,o0775)
+            os.chmod(path,0o775)
         with open(path,'r') as fp:
             print("cellranger:")
             print("%s" % fp.read())
@@ -1513,7 +1513,7 @@ sys.exit(MockIlluminaQcSh(version=%s,
                    fastq_screen,
                    fastqc,
                    exit_code))
-            os.chmod(path,o0775)
+            os.chmod(path,0o775)
         with open(path,'r') as fp:
             print("illumina_qc.sh:")
             print("%s" % fp.read())
@@ -1646,7 +1646,7 @@ from auto_process_ngs.mock import MockMultiQC
 sys.exit(MockMultiQC(no_outputs=%s,
                      exit_code=%s).main(sys.argv[1:]))
             """ % (no_outputs,exit_code))
-            os.chmod(path,o0775)
+            os.chmod(path,0o775)
         with open(path,'r') as fp:
             print("multiqc:")
             print("%s" % fp.read())
@@ -1756,7 +1756,7 @@ from auto_process_ngs.mock import MockFastqStrandPy
 sys.exit(MockFastqStrandPy(no_outputs=%s,
                      exit_code=%s).main(sys.argv[1:]))
             """ % (no_outputs,exit_code))
-            os.chmod(path,o0775)
+            os.chmod(path,0o775)
         with open(path,'r') as fp:
             print("fastq_strand.py:")
             print("%s" % fp.read())

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -928,7 +928,7 @@ sys.exit(MockBcl2fastq2Exe(exit_code=%s,
                     if assert_bases_mask is not None
                     else None),
                    version))
-            os.chmod(path,0775)
+            os.chmod(path,o0775)
         with open(path,'r') as fp:
             print("bcl2fastq:")
             print("%s" % fp.read())
@@ -1160,7 +1160,7 @@ sys.exit(MockCellrangerExe(path=sys.argv[0],
                     if assert_bases_mask is not None
                     else None),
                    reads))
-            os.chmod(path,0775)
+            os.chmod(path,o0775)
         with open(path,'r') as fp:
             print("cellranger:")
             print("%s" % fp.read())
@@ -1513,7 +1513,7 @@ sys.exit(MockIlluminaQcSh(version=%s,
                    fastq_screen,
                    fastqc,
                    exit_code))
-            os.chmod(path,0775)
+            os.chmod(path,o0775)
         with open(path,'r') as fp:
             print("illumina_qc.sh:")
             print("%s" % fp.read())
@@ -1646,7 +1646,7 @@ from auto_process_ngs.mock import MockMultiQC
 sys.exit(MockMultiQC(no_outputs=%s,
                      exit_code=%s).main(sys.argv[1:]))
             """ % (no_outputs,exit_code))
-            os.chmod(path,0775)
+            os.chmod(path,o0775)
         with open(path,'r') as fp:
             print("multiqc:")
             print("%s" % fp.read())
@@ -1756,7 +1756,7 @@ from auto_process_ngs.mock import MockFastqStrandPy
 sys.exit(MockFastqStrandPy(no_outputs=%s,
                      exit_code=%s).main(sys.argv[1:]))
             """ % (no_outputs,exit_code))
-            os.chmod(path,0775)
+            os.chmod(path,o0775)
         with open(path,'r') as fp:
             print("fastq_strand.py:")
             print("%s" % fp.read())

--- a/auto_process_ngs/test/commands/test_archive_cmd.py
+++ b/auto_process_ngs/test/commands/test_archive_cmd.py
@@ -48,12 +48,12 @@ poll_interval = 0.5
             # Explicitly remove read only files/
             # dirs
             if os.path.isfile(name):
-                os.chmod(os.path.dirname(name),0755)
-                os.chmod(name,0655)
+                os.chmod(os.path.dirname(name),o0755)
+                os.chmod(name,o0655)
                 os.remove(name)
             elif os.path.isdir(name):
-                os.chmod(os.path.dirname(name),0755)
-                os.chmod(name,0755)
+                os.chmod(os.path.dirname(name),o0755)
+                os.chmod(name,o0755)
                 os.rmdir(name)
         if REMOVE_TEST_OUTPUTS:
             shutil.rmtree(self.dirn,onerror=del_rw)

--- a/auto_process_ngs/test/commands/test_archive_cmd.py
+++ b/auto_process_ngs/test/commands/test_archive_cmd.py
@@ -48,12 +48,12 @@ poll_interval = 0.5
             # Explicitly remove read only files/
             # dirs
             if os.path.isfile(name):
-                os.chmod(os.path.dirname(name),o0755)
-                os.chmod(name,o0655)
+                os.chmod(os.path.dirname(name),0o755)
+                os.chmod(name,0o655)
                 os.remove(name)
             elif os.path.isdir(name):
-                os.chmod(os.path.dirname(name),o0755)
-                os.chmod(name,o0755)
+                os.chmod(os.path.dirname(name),0o755)
+                os.chmod(name,0o755)
                 os.rmdir(name)
         if REMOVE_TEST_OUTPUTS:
             shutil.rmtree(self.dirn,onerror=del_rw)

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -39,8 +39,8 @@ class TestReportInfo(unittest.TestCase):
         def del_rw(action,name,excinfo):
             # Explicitly remove read only files/
             # dirs
-            os.chmod(os.path.dirname(name),0755)
-            os.chmod(name,0655)
+            os.chmod(os.path.dirname(name),o0755)
+            os.chmod(name,o0655)
             os.remove(name)
         shutil.rmtree(self.dirn,onerror=del_rw)
 
@@ -260,8 +260,8 @@ class TestReportConcise(unittest.TestCase):
         def del_rw(action,name,excinfo):
             # Explicitly remove read only files/
             # dirs
-            os.chmod(os.path.dirname(name),0755)
-            os.chmod(name,0655)
+            os.chmod(os.path.dirname(name),o0755)
+            os.chmod(name,o0655)
             os.remove(name)
         shutil.rmtree(self.dirn,onerror=del_rw)
 
@@ -360,8 +360,8 @@ class TestReportSummary(unittest.TestCase):
         def del_rw(action,name,excinfo):
             # Explicitly remove read only files/
             # dirs
-            os.chmod(os.path.dirname(name),0755)
-            os.chmod(name,0655)
+            os.chmod(os.path.dirname(name),o0755)
+            os.chmod(name,o0655)
             os.remove(name)
         shutil.rmtree(self.dirn,onerror=del_rw)
 
@@ -526,8 +526,8 @@ class TestReportProjects(unittest.TestCase):
         def del_rw(action,name,excinfo):
             # Explicitly remove read only files/
             # dirs
-            os.chmod(os.path.dirname(name),0755)
-            os.chmod(name,0655)
+            os.chmod(os.path.dirname(name),o0755)
+            os.chmod(name,o0655)
             os.remove(name)
         shutil.rmtree(self.dirn,onerror=del_rw)
 
@@ -673,8 +673,8 @@ class TestReport(unittest.TestCase):
         def del_rw(action,name,excinfo):
             # Explicitly remove read only files/
             # dirs
-            os.chmod(os.path.dirname(name),0755)
-            os.chmod(name,0655)
+            os.chmod(os.path.dirname(name),o0755)
+            os.chmod(name,o0655)
             os.remove(name)
         shutil.rmtree(self.dirn,onerror=del_rw)
 
@@ -736,8 +736,8 @@ class TestFetchValueFunction(unittest.TestCase):
         def del_rw(action,name,excinfo):
             # Explicitly remove read only files/
             # dirs
-            os.chmod(os.path.dirname(name),0755)
-            os.chmod(name,0655)
+            os.chmod(os.path.dirname(name),o0755)
+            os.chmod(name,o0655)
             os.remove(name)
         shutil.rmtree(self.dirn,onerror=del_rw)
 

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -39,8 +39,8 @@ class TestReportInfo(unittest.TestCase):
         def del_rw(action,name,excinfo):
             # Explicitly remove read only files/
             # dirs
-            os.chmod(os.path.dirname(name),o0755)
-            os.chmod(name,o0655)
+            os.chmod(os.path.dirname(name),0o755)
+            os.chmod(name,0o655)
             os.remove(name)
         shutil.rmtree(self.dirn,onerror=del_rw)
 
@@ -260,8 +260,8 @@ class TestReportConcise(unittest.TestCase):
         def del_rw(action,name,excinfo):
             # Explicitly remove read only files/
             # dirs
-            os.chmod(os.path.dirname(name),o0755)
-            os.chmod(name,o0655)
+            os.chmod(os.path.dirname(name),0o755)
+            os.chmod(name,0o655)
             os.remove(name)
         shutil.rmtree(self.dirn,onerror=del_rw)
 
@@ -360,8 +360,8 @@ class TestReportSummary(unittest.TestCase):
         def del_rw(action,name,excinfo):
             # Explicitly remove read only files/
             # dirs
-            os.chmod(os.path.dirname(name),o0755)
-            os.chmod(name,o0655)
+            os.chmod(os.path.dirname(name),0o755)
+            os.chmod(name,0o655)
             os.remove(name)
         shutil.rmtree(self.dirn,onerror=del_rw)
 
@@ -526,8 +526,8 @@ class TestReportProjects(unittest.TestCase):
         def del_rw(action,name,excinfo):
             # Explicitly remove read only files/
             # dirs
-            os.chmod(os.path.dirname(name),o0755)
-            os.chmod(name,o0655)
+            os.chmod(os.path.dirname(name),0o755)
+            os.chmod(name,0o655)
             os.remove(name)
         shutil.rmtree(self.dirn,onerror=del_rw)
 
@@ -673,8 +673,8 @@ class TestReport(unittest.TestCase):
         def del_rw(action,name,excinfo):
             # Explicitly remove read only files/
             # dirs
-            os.chmod(os.path.dirname(name),o0755)
-            os.chmod(name,o0655)
+            os.chmod(os.path.dirname(name),0o755)
+            os.chmod(name,0o655)
             os.remove(name)
         shutil.rmtree(self.dirn,onerror=del_rw)
 
@@ -736,8 +736,8 @@ class TestFetchValueFunction(unittest.TestCase):
         def del_rw(action,name,excinfo):
             # Explicitly remove read only files/
             # dirs
-            os.chmod(os.path.dirname(name),o0755)
-            os.chmod(name,o0655)
+            os.chmod(os.path.dirname(name),0o755)
+            os.chmod(name,0o655)
             os.remove(name)
         shutil.rmtree(self.dirn,onerror=del_rw)
 

--- a/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
@@ -31,8 +31,8 @@ class TestSetupAnalysisDirs(unittest.TestCase):
         def del_rw(action,name,excinfo):
             # Explicitly remove read only files/
             # dirs
-            os.chmod(os.path.dirname(name),o0755)
-            os.chmod(name,o0655)
+            os.chmod(os.path.dirname(name),0o755)
+            os.chmod(name,0o655)
             os.remove(name)
         shutil.rmtree(self.dirn,onerror=del_rw)
 

--- a/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
@@ -31,8 +31,8 @@ class TestSetupAnalysisDirs(unittest.TestCase):
         def del_rw(action,name,excinfo):
             # Explicitly remove read only files/
             # dirs
-            os.chmod(os.path.dirname(name),0755)
-            os.chmod(name,0655)
+            os.chmod(os.path.dirname(name),o0755)
+            os.chmod(name,o0655)
             os.remove(name)
         shutil.rmtree(self.dirn,onerror=del_rw)
 

--- a/auto_process_ngs/test/test_bcl2fastq.py
+++ b/auto_process_ngs/test/test_bcl2fastq.py
@@ -93,7 +93,7 @@ class MockBcl2fastq(object):
         print("Content = %s" % content)
         with open(os.path.join(self.dirn,*args),'w') as fp:
             fp.write(content)
-        os.chmod(os.path.join(self.dirn,*args),0775)
+        os.chmod(os.path.join(self.dirn,*args),o0775)
         self._exes.append(os.path.join(self.dirn,*args))
 
     def set_path(self,prepend=True):

--- a/auto_process_ngs/test/test_bcl2fastq.py
+++ b/auto_process_ngs/test/test_bcl2fastq.py
@@ -93,7 +93,7 @@ class MockBcl2fastq(object):
         print("Content = %s" % content)
         with open(os.path.join(self.dirn,*args),'w') as fp:
             fp.write(content)
-        os.chmod(os.path.join(self.dirn,*args),o0775)
+        os.chmod(os.path.join(self.dirn,*args),0o775)
         self._exes.append(os.path.join(self.dirn,*args))
 
     def set_path(self,prepend=True):

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -619,7 +619,7 @@ class TestPipeline(unittest.TestCase):
 echo $1
 exit 0
 """)
-        os.chmod(os.path.join(bin_dir,"fastqc"),0775)
+        os.chmod(os.path.join(bin_dir,"fastqc"),o0775)
         # Set up mock environment module
         modules_dir = os.path.join(self.working_dir,"modulefiles")
         os.mkdir(modules_dir)

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -619,7 +619,7 @@ class TestPipeline(unittest.TestCase):
 echo $1
 exit 0
 """)
-        os.chmod(os.path.join(bin_dir,"fastqc"),o0775)
+        os.chmod(os.path.join(bin_dir,"fastqc"),0o775)
         # Set up mock environment module
         modules_dir = os.path.join(self.working_dir,"modulefiles")
         os.mkdir(modules_dir)

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -265,14 +265,14 @@ class TestCellrangerInfo(unittest.TestCase):
         cellranger_201 = os.path.join(self.wd,"cellranger")
         with open(cellranger_201,'w') as fp:
             fp.write("#!/bin/bash\ncat <<EOF\ncellranger $1  (2.0.1)\nCopyright (c) 2017 10x Genomics, Inc.  All rights reserved.\n-------------------------------------------------------------------------------\n\nUsage:\n    cellranger mkfastq\n\n    cellranger count\n    cellranger aggr\n    cellranger reanalyze\n    cellranger mkloupe\n    cellranger mat2csv\n\n    cellranger mkgtf\n    cellranger mkref\n\n    cellranger vdj\n\n    cellranger mkvdjref\n\n    cellranger testrun\n    cellranger upload\n    cellranger sitecheckEOF")
-        os.chmod(cellranger_201,o0775)
+        os.chmod(cellranger_201,0o775)
         return cellranger_201
     def _make_mock_cellranger_atac_101(self):
         # Make a fake cellranger-atac 1.0.1 executable
         cellranger_atac_101 = os.path.join(self.wd,"cellranger-atac")
         with open(cellranger_atac_101,'w') as fp:
             fp.write("#!/bin/bash\ncat <<EOF\ncellranger-atac  (1.0.1)\nCopyright (c) 2018 10x Genomics, Inc.  All rights reserved.\n-------------------------------------------------------------------------------\n\nUsage:\n    cellranger-atac mkfastq\n\n    cellranger-atac count\n\n    cellranger-atac testrun\n    cellranger-atac upload\n    cellranger-atac sitecheckEOF")
-        os.chmod(cellranger_atac_101,o0775)
+        os.chmod(cellranger_atac_101,0o775)
         return cellranger_atac_101
 
     def test_cellranger_201(self):

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -265,14 +265,14 @@ class TestCellrangerInfo(unittest.TestCase):
         cellranger_201 = os.path.join(self.wd,"cellranger")
         with open(cellranger_201,'w') as fp:
             fp.write("#!/bin/bash\ncat <<EOF\ncellranger $1  (2.0.1)\nCopyright (c) 2017 10x Genomics, Inc.  All rights reserved.\n-------------------------------------------------------------------------------\n\nUsage:\n    cellranger mkfastq\n\n    cellranger count\n    cellranger aggr\n    cellranger reanalyze\n    cellranger mkloupe\n    cellranger mat2csv\n\n    cellranger mkgtf\n    cellranger mkref\n\n    cellranger vdj\n\n    cellranger mkvdjref\n\n    cellranger testrun\n    cellranger upload\n    cellranger sitecheckEOF")
-        os.chmod(cellranger_201,0775)
+        os.chmod(cellranger_201,o0775)
         return cellranger_201
     def _make_mock_cellranger_atac_101(self):
         # Make a fake cellranger-atac 1.0.1 executable
         cellranger_atac_101 = os.path.join(self.wd,"cellranger-atac")
         with open(cellranger_atac_101,'w') as fp:
             fp.write("#!/bin/bash\ncat <<EOF\ncellranger-atac  (1.0.1)\nCopyright (c) 2018 10x Genomics, Inc.  All rights reserved.\n-------------------------------------------------------------------------------\n\nUsage:\n    cellranger-atac mkfastq\n\n    cellranger-atac count\n\n    cellranger-atac testrun\n    cellranger-atac upload\n    cellranger-atac sitecheckEOF")
-        os.chmod(cellranger_atac_101,0775)
+        os.chmod(cellranger_atac_101,o0775)
         return cellranger_atac_101
 
     def test_cellranger_201(self):

--- a/auto_process_ngs/test/test_utils.py
+++ b/auto_process_ngs/test/test_utils.py
@@ -582,7 +582,7 @@ class TestFindExecutables(unittest.TestCase):
                 "#!/bin/bash\necho %s %s" %
                 (name,
                  (version if version is not None else "")))
-        os.chmod(exe,0775)
+        os.chmod(exe,o0775)
         return exe
 
     def _info_func(self):

--- a/auto_process_ngs/test/test_utils.py
+++ b/auto_process_ngs/test/test_utils.py
@@ -582,7 +582,7 @@ class TestFindExecutables(unittest.TestCase):
                 "#!/bin/bash\necho %s %s" %
                 (name,
                  (version if version is not None else "")))
-        os.chmod(exe,o0775)
+        os.chmod(exe,0o775)
         return exe
 
     def _info_func(self):

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -828,7 +828,7 @@ def write_script_file(script_file,contents,append=False,shell=None):
         if (not append) and (shell is not None):
             fp.write("#!%s\n" % shell)
         fp.write("%s\n" % contents)
-    os.chmod(script_file,o0775)
+    os.chmod(script_file,0o775)
 
 def edit_file(filen,editor="vi",append=None):
     """

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -828,7 +828,7 @@ def write_script_file(script_file,contents,append=False,shell=None):
         if (not append) and (shell is not None):
             fp.write("#!%s\n" % shell)
         fp.write("%s\n" % contents)
-    os.chmod(script_file,0775)
+    os.chmod(script_file,o0775)
 
 def edit_file(filen,editor="vi",append=None):
     """


### PR DESCRIPTION
PR to update the syntax for specifying octals (including a leading `o` so that e.g. `0755` becomes `o0755`) for Python 3 compatibility.