### PR TITLE
Update import of 'urlopen' for Python 2/3 compatibility

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -22,7 +22,6 @@ import uuid
 import time
 import ast
 import gzip
-import urllib2
 import bcftbx.IlluminaData as IlluminaData
 import bcftbx.TabFile as TabFile
 import bcftbx.utils as bcf_utils

--- a/auto_process_ngs/commands/setup_cmd.py
+++ b/auto_process_ngs/commands/setup_cmd.py
@@ -8,8 +8,14 @@
 import os
 import uuid
 import shutil
-import urllib2
 import logging
+try:
+    from urllib.request import urlopen
+    from urllib.error import URLError
+except ImportError:
+    # Failed to get Python3 urlopen, fallback to Python2
+    from urllib2 import urlopen
+    from urllib2 import URLError
 from ..bcl2fastq_utils import get_sequencer_platform
 from ..bcl2fastq_utils import make_custom_sample_sheet
 from ..applications import general as general_applications
@@ -145,10 +151,10 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
                     # Try fetching samplesheet from URL
                     print("Trying '%s'" % target.url)
                     try:
-                        urlfp = urllib2.urlopen(target.url)
+                        urlfp = urlopen(target.url)
                         with open(tmp_sample_sheet,'w') as fp:
                             fp.write(urlfp.read())
-                    except urllib2.URLError as ex:
+                    except URLError as ex:
                         # Failed to download from URL
                         raise Exception("Error fetching sample sheet data "
                                         "from '%s': %s" % (target.url,ex))
@@ -232,12 +238,12 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
             if extra_file.is_url:
                 # Try fetching file from URL
                 try:
-                    urlfp = urllib2.urlopen(extra_file.url)
+                    urlfp = urlopen(extra_file.url)
                     with open(os.path.join(ap.analysis_dir,
                                            os.path.basename(extra_file.path)),
                               'w') as fp:
                         fp.write(urlfp.read())
-                except urllib2.URLError as ex:
+                except URLError as ex:
                     # Failed to download from URL
                     raise Exception("Error fetching '%s': %s" %
                                     (extra_file.url,ex))


### PR DESCRIPTION
PR which updates the import of the `urlopen` function (and associated `URLError` exception class) so that the code should be compatible with both Python 2 and 3.