### PR TITLE
Remove unused 'izip_longest' import in 'analysis' module

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -47,7 +47,6 @@ from .metadata import ProjectMetadataFile
 from .metadata import AnalysisProjectQCDirInfo
 from .fastq_utils import BaseFastqAttrs
 from .fastq_utils import IlluminaFastqAttrs
-from itertools import izip_longest
 
 # Module specific logger
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
PR which removes the import of the unused `izip_longest` function import in the 'analysis' module.