### PR TITLE
pipeliner: rename 'async' parameter of PipelineTask.run() method

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2048,7 +2048,8 @@ class PipelineTask(object):
 
     def run(self,sched=None,runner=None,envmodules=None,working_dir=None,
             log_dir=None,scripts_dir=None,log_file=None,wait_for=(),
-            async=True,poll_interval=5,batch_size=None,verbose=False):
+            asynchronous=True,poll_interval=5,batch_size=None,
+            verbose=False):
         """
         Run the task
 
@@ -2072,11 +2073,11 @@ class PipelineTask(object):
             to (in addition to stdout)
           wait_for (list): deprecated: list of scheduler jobs to
             wait for before running jobs from this task
-          async (bool): if False then block until the task has
-            completed
+          asynchronous (bool): if False then block until the task
+            has completed
           poll_interval (float): interval between checks on task
-            completion (in seconds) for non-async tasks (defaults
-            to 5 seconds)
+            completion (in seconds) for non-asynchronous tasks
+            (defaults to 5 seconds)
           batch_size (int): if set then run commands in
             each task in batches, with each batch running
             this many commands at a time (default is to run
@@ -2180,7 +2181,7 @@ class PipelineTask(object):
             sched.callback("%s" % self._name,
                            callback_function,
                            wait_for=(callback_name,))
-            if not async:
+            if not asynchronous:
                 # Wait for job or group to complete before returning
                 while not self.completed:
                     time.sleep(poll_interval)

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -1040,7 +1040,7 @@ class TestPipelineTask(unittest.TestCase):
         # Run the task
         task.run(sched=self.sched,
                  working_dir=self.working_dir,
-                 async=False)
+                 asynchronous=False)
         # Check final state
         self.assertTrue(task.completed)
         self.assertEqual(task.exit_code,0)
@@ -1149,7 +1149,7 @@ class TestPipelineTask(unittest.TestCase):
         # Run the task
         task.run(sched=self.sched,
                  working_dir=self.working_dir,
-                 async=False)
+                 asynchronous=False)
         # Check final state
         self.assertTrue(task.completed)
         self.assertEqual(task.exit_code,0)
@@ -1179,7 +1179,7 @@ class TestPipelineTask(unittest.TestCase):
         # Run the task
         task.run(sched=self.sched,
                  working_dir=self.working_dir,
-                 async=False)
+                 asynchronous=False)
         # Check final state
         self.assertTrue(task.completed)
         self.assertEqual(task.exit_code,0)
@@ -1227,7 +1227,7 @@ class TestPipelineTask(unittest.TestCase):
         # Run the task
         task.run(sched=self.sched,
                  working_dir=self.working_dir,
-                 async=False)
+                 asynchronous=False)
         # Check final state
         self.assertTrue(task.completed)
         self.assertEqual(task.exit_code,0)
@@ -1290,7 +1290,7 @@ class TestPipelineTask(unittest.TestCase):
         task.run(sched=self.sched,
                  working_dir=self.working_dir,
                  batch_size=2,
-                 async=False)
+                 asynchronous=False)
         # Check final state
         self.assertTrue(task.completed)
         self.assertEqual(task.exit_code,0)
@@ -1339,7 +1339,7 @@ class TestPipelineTask(unittest.TestCase):
         # Run the task
         task.run(sched=self.sched,
                  working_dir=self.working_dir,
-                 async=False)
+                 asynchronous=False)
         # Check final state
         self.assertTrue(task.completed)
         self.assertNotEqual(task.exit_code,0)
@@ -1384,7 +1384,7 @@ class TestPipelineTask(unittest.TestCase):
         # Run the task
         task.run(sched=self.sched,
                  working_dir=self.working_dir,
-                 async=False)
+                 asynchronous=False)
         # Check final state
         self.assertTrue(task.completed)
         self.assertEqual(task.exit_code,0)
@@ -1432,7 +1432,7 @@ class TestPipelineTask(unittest.TestCase):
         task.run(sched=self.sched,
                  working_dir=self.working_dir,
                  poll_interval=0.5,
-                 async=False)
+                 asynchronous=False)
         # Check final state
         self.assertTrue(task.completed)
         self.assertEqual(task.exit_code,123)
@@ -1483,7 +1483,7 @@ class TestPipelineFunctionTask(unittest.TestCase):
         task.run(sched=self.sched,
                  working_dir=self.working_dir,
                  poll_interval=0.1,
-                 async=False)
+                 asynchronous=False)
         # Check final state
         self.assertTrue(task.completed)
         self.assertEqual(task.exit_code,0)
@@ -1515,7 +1515,7 @@ class TestPipelineFunctionTask(unittest.TestCase):
         task.run(sched=self.sched,
                  working_dir=self.working_dir,
                  poll_interval=0.1,
-                 async=False)
+                 asynchronous=False)
         # Check final state
         self.assertTrue(task.completed)
         self.assertNotEqual(task.exit_code,0)


### PR DESCRIPTION
PR which renames the `async` parameter of the `run` method of the `PipelineTask` class (in the `pipeliner` module) to `asynchronous` for Python 3 compatibility (`async` is reserved word in Python3).