### PR TITLE
pipeliner: use 'string.ascii_lowercase' for Python 2/3 compatibility

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -801,7 +801,7 @@ logger.addHandler(logging.NullHandler())
 # Pipeline infrastructure constants
 ######################################################################
 
-ALLOWED_CHARS = string.lowercase + string.digits + "._-"
+ALLOWED_CHARS = string.ascii_lowercase + string.digits + "._-"
 
 # Pipeline failure modes
 class PipelineFailure(object):


### PR DESCRIPTION
PR which updates the `pipeliner` module to use `string.ascii_lowercase` (which is available for both Python 2 and 3) instead of `string.lowercase` (which is not available in Python 3).