### PR TITLE
Update import of itertools 'izip' for Python 3 compatibility

### DIFF
--- a/auto_process_ngs/barcodes/analysis.py
+++ b/auto_process_ngs/barcodes/analysis.py
@@ -29,7 +29,11 @@ FASTQ read headers:
 #######################################################################
 
 import sys
-from itertools import izip
+try:
+    # Python2
+    from itertools import izip as zip
+except ImportError:
+    pass
 from bcftbx.IlluminaData import SampleSheet
 from bcftbx.IlluminaData import samplesheet_index_sequence
 from bcftbx.IlluminaData import normalise_barcode
@@ -636,12 +640,12 @@ class BarcodeGroup(object):
         """
         if len(seq) != len(self._barcode):
             return False
-        for index,ref in izip(seq.replace('-','+').split('+'),
+        for index,ref in zip(seq.replace('-','+').split('+'),
                               self._barcode.split('+')):
             if len(index) != len(ref):
                 return False
             m = 0
-            for c1,c2 in izip(index,ref):
+            for c1,c2 in zip(index,ref):
                 if c1 == 'N' or c2 == 'N' or c1 != c2:
                     m += 1
                     if m > mismatches:

--- a/auto_process_ngs/icell8/atac.py
+++ b/auto_process_ngs/icell8/atac.py
@@ -26,7 +26,11 @@ import sys
 import os
 import glob
 import time
-from itertools import izip
+try:
+    # Python 2
+    from itertools import izip as zip
+except ImportError:
+    pass
 from collections import defaultdict
 from bcftbx.FASTQFile import SequenceIdentifier
 from bcftbx.ngsutils import getreads
@@ -307,10 +311,10 @@ def assign_reads(args):
     if mode == 'samples':
         # Assigning reads to samples
         with open(undetermined_barcodes_file,"w") as fp:
-            for r1,r2,i1,i2 in izip(getreads(fastq_r1),
-                                    getreads(fastq_r2),
-                                    getreads(fastq_i1),
-                                    getreads(fastq_i2)):
+            for r1,r2,i1,i2 in zip(getreads(fastq_r1),
+                                   getreads(fastq_r2),
+                                   getreads(fastq_i1),
+                                   getreads(fastq_i2)):
                 # Get barcodes to match against adjusted
                 # versions from well list
                 fastq_barcode = "%s+%s" % (i1[1],i2[1])
@@ -344,10 +348,10 @@ def assign_reads(args):
     elif mode == 'barcodes':
         # Assigning reads to barcodes
         with open(undetermined_barcodes_file,"w") as fp:
-            for r1,r2,i1,i2 in izip(getreads(fastq_r1),
-                                    getreads(fastq_r2),
-                                    getreads(fastq_i1),
-                                    getreads(fastq_i2)):
+            for r1,r2,i1,i2 in zip(getreads(fastq_r1),
+                                   getreads(fastq_r2),
+                                   getreads(fastq_i1),
+                                   getreads(fastq_i2)):
                 # Get barcodes to match against adjusted
                 # versions from well list
                 fastq_barcode = "%s+%s" % (i1[1],i2[1])

--- a/auto_process_ngs/icell8/utils.py
+++ b/auto_process_ngs/icell8/utils.py
@@ -34,7 +34,6 @@ Functions:
 import os
 import time
 import logging
-from itertools import izip
 from collections import Iterator
 from multiprocessing import Pool
 from bcftbx.FASTQFile import FastqIterator

--- a/bin/demultiplex_icell8_atac.py
+++ b/bin/demultiplex_icell8_atac.py
@@ -22,7 +22,11 @@ import tempfile
 import shutil
 import json
 from argparse import ArgumentParser
-from itertools import izip
+try:
+    # Python 2
+    from itertools import izip as zip
+except ImportError:
+    pass
 from multiprocessing import Pool
 from bcftbx.simple_xls import XLSWorkBook
 from auto_process_ngs import get_version
@@ -186,10 +190,10 @@ if __name__ == "__main__":
     # Build barcode list
     report("Assigning reads to barcodes and samples")
     inputs = list()
-    for fastq_r1,fastq_r2,fastq_i1,fastq_i2 in izip(fastqs[0],
-                                                    fastqs[1],
-                                                    fastqs[2],
-                                                    fastqs[3]):
+    for fastq_r1,fastq_r2,fastq_i1,fastq_i2 in zip(fastqs[0],
+                                                   fastqs[1],
+                                                   fastqs[2],
+                                                   fastqs[3]):
         inputs.append((fastq_r1,fastq_r2,
                        fastq_i1,fastq_i2,
                        well_list_file,

--- a/bin/icell8_contamination_filter.py
+++ b/bin/icell8_contamination_filter.py
@@ -27,7 +27,11 @@ import tempfile
 import logging
 import argparse
 import shutil
-from itertools import izip
+try:
+    # Python 2
+    from itertools import izip as zip
+except ImportError:
+    pass
 from bcftbx.utils import mkdir
 from bcftbx.FASTQFile import FastqIterator
 from bcftbx.utils import strip_ext
@@ -244,9 +248,9 @@ if __name__ == "__main__":
     output_fqs.open('fqr2',fqr2_out)
 
     # Filter the iCell8 read pairs against the tagged reads
-    for pair,pref,contam in izip(ICell8FastqIterator(fqr1,fqr2),
-                                 FastqIterator(mammalian_tagged_fq),
-                                 FastqIterator(contaminants_tagged_fq)):
+    for pair,pref,contam in zip(ICell8FastqIterator(fqr1,fqr2),
+                                FastqIterator(mammalian_tagged_fq),
+                                FastqIterator(contaminants_tagged_fq)):
         # Get the tags
         pref_tag = extract_fastq_screen_tag(pref)
         contam_tag = extract_fastq_screen_tag(contam)


### PR DESCRIPTION
PR which updates how the `izip` function is imported from `itertools`, for compatibility with both Python 2 and 3. (In Python 2 the `itertools.izip` function is imported as `zip`; in Python 3 the `itertools.izip` function no longer exists, the built-in `zip` function provides the same functionality.)