### PR TITLE
qc/plots: remove the unused import from 'matplotlib'

### DIFF
--- a/auto_process_ngs/qc/plots.py
+++ b/auto_process_ngs/qc/plots.py
@@ -6,7 +6,6 @@ import shutil
 import tempfile
 import logging
 from math import ceil
-from matplotlib import pyplot as plt
 from PIL import Image
 from bcftbx.htmlpagewriter import PNGBase64Encoder
 from .fastqc import FastqcData


### PR DESCRIPTION
PR which removes the import of the unused `pyplot` from `matplotlib` in the `qc/plots` module.