### PR TITLE
Fix bug acquiring cellranger pre-mRNA references in 'run_qc.py'

### DIFF
--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -211,7 +211,7 @@ if __name__ == "__main__":
     cellranger_localcores = cellranger_settings.cellranger_localcores
     cellranger_localmem = cellranger_settings.cellranger_localmem
     cellranger_transcriptomes = __settings['10xgenomics_transcriptomes']
-    cellranger_premrna_references = ap.settings['10xgenomics_premrna_references']
+    cellranger_premrna_references = __settings['10xgenomics_premrna_references']
     cellranger_atac_references = __settings['10xgenomics_atac_genome_references']
 
     # Set up and run the QC pipeline


### PR DESCRIPTION
PR to fix a bug with configuration acquisition when trying to run `run_qc.py`.