### PR TITLE
'run_qc': explicitly supply the default job runner when running the QC pipeline

### DIFF
--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -159,5 +159,6 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
                            'verify_runner': default_runner,
                            'report_runner': default_runner,
                        },
+                       default_runner=default_runner,
                        envmodules=envmodules)
     return status

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -245,6 +245,7 @@ if __name__ == "__main__":
                            'verify_runner': verify_runner,
                            'report_runner': report_runner,
                        },
+                       default_runner=default_runner,
                        envmodules=envmodules)
     if status:
         logger.critical("QC failed (see warnings above)")


### PR DESCRIPTION
PR which fixes a minor bug in the `run_qc` command and `run_qc.py` utility, by explicitly passing the value for the default runner.