### PR TITLE
'run_qc': enable extra 'cellranger count' references to be specified

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -633,6 +633,18 @@ def add_run_qc_command(cmdparser):
     p.add_argument('--fastq_dir',action='store',dest='fastq_dir',default=None,
                    help="explicitly specify subdirectory of DIR with "
                    "Fastq files to run the QC on.")
+    p.add_argument('--10x_transcriptome',action='append',
+                   metavar='ORGANISM=REFERENCE',
+                   dest='cellranger_transcriptomes',
+                   help="specify cellranger transcriptome reference datasets "
+                   "to associate with organisms (overrides references defined "
+                   "in config file)")
+    p.add_argument('--10x_premrna_reference',action='append',
+                   metavar='ORGANISM=REFERENCE',
+                   dest='cellranger_premrna_references',
+                   help="specify cellranger pre-mRNA reference datasets "
+                   "to associate with organisms (overrides references defined "
+                   "in config file)")
     p.add_argument('--report',action='store',dest='html_file',default=None,
                    help="file name for output HTML QC report (default: "
                    "<QC_DIR>_report.html)")
@@ -1180,6 +1192,18 @@ def run_qc(args):
     if not analysis_dir:
         analysis_dir = os.getcwd()
     d = AutoProcess(analysis_dir)
+    # Handle 10x transcriptomes
+    cellranger_transcriptomes = dict()
+    if args.cellranger_transcriptomes:
+        for transcriptome in args.cellranger_transcriptomes:
+            organism,reference =  transcriptome.split('=')
+            cellranger_transcriptomes[organism] = reference
+    # Handle 10x pre-mRNA references
+    cellranger_premrna_references = dict()
+    if args.cellranger_premrna_references:
+        for premrna_reference in args.cellranger_premrna_references:
+            organism,reference =  premrna_reference.split('=')
+            cellranger_premrna_references[organism] = reference
     # Handle job runner specification
     if args.runner is not None:
         runner = fetch_runner(args.runner)
@@ -1193,6 +1217,10 @@ def run_qc(args):
                        nthreads=args.nthreads,
                        fastq_dir=args.fastq_dir,
                        qc_dir=args.qc_dir,
+                       cellranger_transcriptomes=
+                       cellranger_transcriptomes,
+                       cellranger_premrna_references=
+                       cellranger_premrna_references,
                        report_html=args.html_file,
                        runner=runner)
     sys.exit(retcode)

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -135,6 +135,18 @@ if __name__ == "__main__":
                    help="explicitly specify QC output directory. "
                    "NB if a relative path is supplied then it's assumed "
                    "to be a subdirectory of DIR (default: <DIR>/qc)")
+    p.add_argument('--10x_transcriptome',action='append',
+                   metavar='ORGANISM=REFERENCE',
+                   dest='cellranger_transcriptomes',
+                   help="specify cellranger transcriptome reference datasets "
+                   "to associate with organisms (overrides references defined "
+                   "in config file)")
+    p.add_argument('--10x_premrna_reference',action='append',
+                   metavar='ORGANISM=REFERENCE',
+                   dest='cellranger_premrna_references',
+                   help="specify cellranger pre-mRNA reference datasets "
+                   "to associate with organisms (overrides references defined "
+                   "in config file)")
     p.add_argument('-f','--filename',metavar='NAME',action='store',
                    dest='filename',default=None,
                    help="file name for output QC report (default: "
@@ -210,8 +222,26 @@ if __name__ == "__main__":
     cellranger_jobinterval = cellranger_settings.cellranger_jobinterval
     cellranger_localcores = cellranger_settings.cellranger_localcores
     cellranger_localmem = cellranger_settings.cellranger_localmem
-    cellranger_transcriptomes = __settings['10xgenomics_transcriptomes']
-    cellranger_premrna_references = __settings['10xgenomics_premrna_references']
+    cellranger_transcriptomes = dict()
+    if __settings['10xgenomics_transcriptomes']:
+        for organism in __settings['10xgenomics_transcriptomes']:
+            if organism not in cellranger_transcriptomes:
+                cellranger_transcriptomes[organism] = \
+                    __settings['10xgenomics_transcriptomes'][organism]
+    if args.cellranger_transcriptomes:
+        for transcriptome in args.cellranger_transcriptomes:
+            organism,reference =  transcriptome.split('=')
+            cellranger_transcriptomes[organism] = reference
+    cellranger_premrna_references = dict()
+    if __settings['10xgenomics_premrna_references']:
+        for organism in __settings['10xgenomics_premrna_references']:
+            if organism not in cellranger_premrna_references:
+                cellranger_premrna_references[organism] = \
+                    __settings['10xgenomics_premrna_references'][organism]
+    if args.cellranger_premrna_references:
+        for premrna_reference in args.cellranger_premrna_references:
+            organism,reference =  premrna_reference.split('=')
+            cellranger_premrna_references[organism] = reference
     cellranger_atac_references = __settings['10xgenomics_atac_genome_references']
 
     # Set up and run the QC pipeline

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -21,11 +21,12 @@ run_qc              `fastqc`_
 run_qc              `fastq_screen`_
 run_qc              `bowtie`_          Required by fastq_screen
 run_qc              `STAR`_            Required for strandedness determination
+run_qc              `cellranger`_      10xGenomics Chromium single-cell RNA-seq data only
+run_qc              `cellranger-atac`_ 10xGenomics Chromium single-cell ATAC-seq data only
 run_qc              `multiqc`_
 process_icell8      `cutadapt`_
 process_icell8      `fastq_screen`_
 process_icell8      `bowtie2`_         Required by fastq_screen
-process_10xgenomics `cellranger`_
 =================== ================== ===================
 
 .. _bcl2fastq 2.17: https://support.illumina.com/downloads/bcl2fastq-conversion-software-v217.html
@@ -66,7 +67,6 @@ data:
 
 * :ref:`auto_process_reference_data_run_qc`
 * :ref:`auto_process_reference_data_icell8`
-* :ref:`auto_process_reference_data_10xgenomics`
   
 .. _auto_process_reference_data_run_qc:
 
@@ -90,6 +90,55 @@ defined in the ``fastq_strand_indexes`` section of the
   [fastq_strand_indexes]
   human = /data/genomeIndexes/hg38/STAR/
   mouse = /data/genomeIndexes/mm10/STAR/
+
+For 10xGenomics single cell data, the single library analysis
+requires appropriate compatible reference data for
+``cellranger[-atac] count``:
+
+* **scRNA-seq data**: transcriptome reference data set
+* **snRNA-seq data**: "pre-mRNA" reference data set (which
+  includes both intronic and exonic information)
+* **sc/snATAC-seq**: 
+
+The reference data sets can be assigned to different organisms
+in the ``10xgenomics_transcriptomes``,
+``10xgenomics_premrna_references`` and
+``10xgenomics_atac_genome_references``
+sections of the ``auto_process.ini`` file.
+
+For example:
+
+::
+
+   [10xgenomics_transcriptomes]
+   human = /data/cellranger/refdata-cellranger-GRCh38-1.2.0
+   mouse = /data/cellranger/refdata-cellranger-mm10-1.2.0
+   
+   [10xgenomics_premrna_references]
+   human = /data/cellranger/refdata-cellranger-GRCh38-1.2.0_premrna
+   mouse = /data/cellranger/refdata-cellranger-mm10-1.2.0_premrnaferences``
+
+   [10xgenomics_atac_genome_references]
+   human = /data/cellranger/refdata-cellranger-atac-GRCh38-1.0.1
+   mouse = /data/cellranger/refdata-cellranger-atac-mm10-1.0.1
+
+Alternatively reference data sets can be specified at run-time
+using the ``--10x_transcriptome`` and ``--10x_premrna_reference``
+command line options of ``run_qc`` and the ``run_qc.py`` utility.
+
+10xGenomics provide a number of reference data sets for scRNA-seq
+and ATAC-seq data, which can be downloaded via:
+
+* https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/installation
+* https://support.10xgenomics.com/single-cell-atac/software/pipelines/latest/installation
+
+There are also instructions for constructing reference data for
+novel organisms that are not supported by 10xGenomics.
+
+Pre-mRNA references are currently not available, but the documentation
+explains how to generate a custom reference package for these data:
+
+* https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/advanced/references#premrna
   
 .. _auto_process_reference_data_icell8:
 
@@ -113,87 +162,3 @@ These can be defined in the ``icell8`` section of the
 
 or else must be specified using the relevant command line
 options.
-  
-.. _auto_process_reference_data_10xgenomics:
-
-----------------------------------------------------------------
-process_10xgenomics (single library analysis for scRNA-seq data)
-----------------------------------------------------------------
-
-The single library analysis step of ``process_10xgenomics`` for
-single cell RNA-seq wraps ``cellranger count`` and requires a
-compatible ``cellranger`` transcriptome reference data set for the
-organism in question to be provided.
-
-10xGenomics provide a number of reference data sets which can
-be downloaded via:
-
-* https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/installation
-
-(There are also instructions for constructing reference data
-for novel organisms that are not supported.)
-
-These can be defined in the ``10xgenomics_transcriptomes``
-section of the ``auto_process.ini`` file, for example::
-
-  [10xgenomics_transcriptomes]
-  human = /data/cellranger/refdata-cellranger-GRCh38-1.2.0
-  mouse = /data/cellranger/refdata-cellranger-mm10-1.2.0
-
-or else must be specified using the relevant command line
-option.
-
-.. _auto_process_reference_data_10xgenomics_snrna_seq:
-
-----------------------------------------------------------------
-process_10xgenomics (single library analysis for snRNA-seq data)
-----------------------------------------------------------------
-
-When dealing with single-nuclei RNA-seq (snRNA-seq) 10xGenomics
-data, it is recommended that ``cellranger count`` is run with a
-compatible ``cellranger`` "pre-mRNA" reference package (which
-includes both intronic and exonic information) instead of the
-standard transcriptome reference used for scRNA-seq.
-
-10xGenomics don't provide pre-mRNA references, but the
-documentation explains how to generate a custom reference
-package for these data:
-
-* https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/advanced/references#premrna
-
-These can be made available within ``auto-process`` by adding
-definitions into the ``10xgenomics_premrna_references``
-section of the ``auto_process.ini`` file, for example::
-
-  [10xgenomics_premrna_references]
-  human = /data/cellranger/refdata-cellranger-GRCh38-1.2.0_premrna
-  mouse = /data/cellranger/refdata-cellranger-mm10-1.2.0_premrna
-
-.. _auto_process_reference_data_10xgenomics_atac:
-
------------------------------------------------------------------
-process_10xgenomics (single library analysis for scATAC-seq data)
------------------------------------------------------------------
-
-The single library analysis step of ``process_10xgenomics`` for
-single cell ATAC-seq data wraps ``cellranger-atac count`` and
-requires a compatible ``cellranger-atac`` ATAC genome reference
-data set for the organism in question to be provided.
-
-10xGenomics provide a number of reference data sets which can
-be downloaded via:
-
-* https://support.10xgenomics.com/single-cell-atac/software/pipelines/latest/installation
-
-(There are also instructions for constructing reference data
-for novel organisms that are not supported.)
-
-These can be defined in the ``10xgenomics_atac_genome_references``
-section of the ``auto_process.ini`` file, for example::
-
-  [10xgenomics_atac_genome_references]
-  human = /data/cellranger/refdata-cellranger-atac-GRCh38-1.0.1
-  mouse = /data/cellranger/refdata-cellranger-atac-mm10-1.0.1
-
-or else must be specified using the relevant command line
-option.


### PR DESCRIPTION
PR which adds new options to the `run_qc` command and `run_qc.py` utility to specify additional reference datasets for `cellranger count` on the command line.

The new options are `--10x_transcriptomes` and `--10x_premrna_references`. Datasets are specified using `ORGANISM=REFERENCE` (e.g. `human=/path/to/ref`). Multiple datasets can be supplied by specifying additional options. Datasets supplied on the command line will over-ride those in the configuration.