### PR TITLE
'run_qc': enable chemistry to be specified on command line for 10xGenomics scRNA-seq

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -80,6 +80,7 @@ from ..envmod import load as envmod_load
 from ..samplesheet_utils import predict_outputs
 from ..settings import Settings
 from ..settings import locate_settings_file
+from ..tenx_genomics_utils import CELLRANGER_ASSAY_CONFIGS
 from ..utils import paginate
 
 # Module specific logger
@@ -633,6 +634,12 @@ def add_run_qc_command(cmdparser):
     p.add_argument('--fastq_dir',action='store',dest='fastq_dir',default=None,
                    help="explicitly specify subdirectory of DIR with "
                    "Fastq files to run the QC on.")
+    p.add_argument("--10x_chemistry",
+                   choices=sorted(CELLRANGER_ASSAY_CONFIGS.keys()),
+                   dest="cellranger_chemistry",default="auto",
+                   help="assay configuration for 10xGenomics scRNA-seq; if "
+                   "set to 'auto' (the default) then cellranger will attempt "
+                   "to determine this automatically")
     p.add_argument('--10x_transcriptome',action='append',
                    metavar='ORGANISM=REFERENCE',
                    dest='cellranger_transcriptomes',
@@ -1217,6 +1224,8 @@ def run_qc(args):
                        nthreads=args.nthreads,
                        fastq_dir=args.fastq_dir,
                        qc_dir=args.qc_dir,
+                       cellranger_chemistry=
+                       args.cellranger_chemistry,
                        cellranger_transcriptomes=
                        cellranger_transcriptomes,
                        cellranger_premrna_references=

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
            fastq_screen_subset=100000,nthreads=1,
            runner=None,fastq_dir=None,qc_dir=None,
+           cellranger_chemistry='auto',
            cellranger_transcriptomes=None,
            cellranger_premrna_references=None,
            report_html=None,run_multiqc=True,
@@ -66,6 +67,9 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
       qc_dir (str): specify a non-standard directory to write the
         QC outputs to; will be used for all projects that are
         processed (default: 'qc')
+      cellranger_chemistry (str): assay configuration for
+        10xGenomics scRNA-seq data (set to 'auto' to let cellranger
+        determine this automatically (default: 'auto')
       cellranger_transcriptomes (dict): mapping of organism names
         to cellranger transcriptome reference data
       cellranger_premrna_references (dict): mapping of organism
@@ -163,6 +167,7 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
                        cellranger_premrna_references=\
                        cellranger_premrna_references,
                        cellranger_atac_references=cellranger_atac_references,
+                       cellranger_chemistry=cellranger_chemistry,
                        cellranger_jobmode=cellranger_jobmode,
                        cellranger_maxjobs=max_jobs,
                        cellranger_mempercore=cellranger_mempercore,

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -97,6 +97,7 @@ class QCPipeline(Pipeline):
         self.add_param('nthreads',type=int,value=1)
         self.add_param('fastq_subset',type=int)
         self.add_param('fastq_strand_indexes',type=dict)
+        self.add_param('cellranger_chemistry',type=str)
         self.add_param('cellranger_transcriptomes',type=dict)
         self.add_param('cellranger_premrna_references',type=dict)
         self.add_param('cellranger_atac_references',type=dict)
@@ -332,6 +333,7 @@ class QCPipeline(Pipeline):
                 project.dirn,
                 qc_dir=qc_dir,
                 working_dir=self.params.WORKING_DIR,
+                chemistry=self.params.cellranger_chemistry,
                 cellranger_jobmode=self.params.cellranger_jobmode,
                 cellranger_maxjobs=self.params.cellranger_maxjobs,
                 cellranger_mempercore=self.params.cellranger_mempercore,
@@ -371,7 +373,8 @@ class QCPipeline(Pipeline):
                       log_dir=log_dir)
 
     def run(self,nthreads=None,fastq_strand_indexes=None,
-            fastq_subset=None,cellranger_transcriptomes=None,
+            fastq_subset=None,cellranger_chemistry='auto',
+            cellranger_transcriptomes=None,
             cellranger_premrna_references=None,
             cellranger_atac_references=None,cellranger_jobmode='local',
             cellranger_maxjobs=None,cellranger_mempercore=None,
@@ -389,6 +392,10 @@ class QCPipeline(Pipeline):
             IDs to directories with STAR index
           fastq_subset (int): explicitly specify
             the subset size for subsetting running Fastqs
+          cellranger_chemistry (str): explicitly specify
+            the assay configuration (set to 'auto' to let
+            cellranger determine this automatically; ignored
+            if not scRNA-seq)
           cellranger_transcriptomes (mapping): mapping of
             organism names to reference transcriptome data
             for cellranger

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -478,6 +478,7 @@ class QCPipeline(Pipeline):
                                   'nthreads': nthreads,
                                   'fastq_subset': fastq_subset,
                                   'fastq_strand_indexes': fastq_strand_indexes,
+                                  'cellranger_chemistry': cellranger_chemistry,
                                   'cellranger_transcriptomes':
                                   cellranger_transcriptomes,
                                   'cellranger_premrna_references':

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -69,6 +69,7 @@ CELLRANGER_ASSAY_CONFIGS = {
     'fiveprime': 'Single Cell 5\'',
     'SC3Pv1': 'Single Cell 3\' v1',
     'SC3Pv2': 'Single Cell 3\' v2',
+    'SC3Pv3': 'Single Cell 3\' v3',
     'SC5P-PE': 'Single Cell 5\' paired-end (both R1 and R2 are used for alignment)',
     'SC5P-R2': 'Single Cell 5\' R2-only (where only R2 is used for alignment)',
 }

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -27,6 +27,7 @@ import auto_process_ngs
 import auto_process_ngs.settings
 import auto_process_ngs.envmod as envmod
 from auto_process_ngs.qc.pipeline import QCPipeline
+from auto_process_ngs.tenx_genomics_utils import CELLRANGER_ASSAY_CONFIGS
 
 # QC protocols
 from auto_process_ngs.qc.constants import PROTOCOLS
@@ -135,6 +136,12 @@ if __name__ == "__main__":
                    help="explicitly specify QC output directory. "
                    "NB if a relative path is supplied then it's assumed "
                    "to be a subdirectory of DIR (default: <DIR>/qc)")
+    p.add_argument("--10x_chemistry",
+                   choices=sorted(CELLRANGER_ASSAY_CONFIGS.keys()),
+                   dest="cellranger_chemistry",default="auto",
+                   help="assay configuration for 10xGenomics scRNA-seq; "
+                   "if set to 'auto' (the default) then cellranger will "
+                   "attempt to determine this automatically")
     p.add_argument('--10x_transcriptome',action='append',
                    metavar='ORGANISM=REFERENCE',
                    dest='cellranger_transcriptomes',
@@ -257,6 +264,8 @@ if __name__ == "__main__":
                        fastq_subset=args.fastq_screen_subset,
                        fastq_strand_indexes=
                        __settings.fastq_strand_indexes,
+                       cellranger_chemistry=\
+                       args.cellranger_chemistry,
                        cellranger_transcriptomes=cellranger_transcriptomes,
                        cellranger_premrna_references=\
                        cellranger_premrna_references,


### PR DESCRIPTION
PR which implements a new `--10x_chemistry` option on the `run_qc` command and `run_qc.py` utility, which enables the user to specify the chemistry for running `cellranger count` for 10xGenomics scRNA-seq data.