### PR TITLE
Fix broken 'barcode_splitter.py' utility

### DIFF
--- a/bin/barcode_splitter.py
+++ b/bin/barcode_splitter.py
@@ -29,6 +29,7 @@ For each barcode there will be an output file called BARCODE.fastq
 import argparse
 import logging
 import sys
+import os
 from auto_process_ngs import get_version
 from auto_process_ngs.barcodes.splitter import BarcodeMatcher
 from auto_process_ngs.barcodes.splitter import get_fastqs_from_dir


### PR DESCRIPTION
PR to fix the broken `barcode_splitter.py` utility (adds missing import of the `os` module).