### PR TITLE
Update 'pipeliner' to work under Python 3

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -944,7 +944,7 @@ class FileCollector(Iterator):
             self._files = collect_files(self._dirn,self._pattern)
             self._idx = -1
         return len(self._files)
-    def next(self):
+    def __next__(self):
         if self._files is None:
             self._files = collect_files(self._dirn,self._pattern)
         if self._idx is None:
@@ -957,6 +957,11 @@ class FileCollector(Iterator):
             self._files = None
             self._idx = None
             raise StopIteration
+    def next(self):
+        """
+        Implemented for Python2 compatibility
+        """
+        return self.__next__()
 
 # Capture stdout and stderr from a function call
 # Based on code from http://stackoverflow.com/a/16571630/579925

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -786,6 +786,7 @@ import cloudpickle
 import atexit
 from collections import Iterator
 from io import StringIO
+from functools import reduce
 from bcftbx.utils import mkdir
 from bcftbx.utils import AttributeDictionary
 from bcftbx.JobRunner import SimpleJobRunner

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -785,7 +785,12 @@ import string
 import cloudpickle
 import atexit
 from collections import Iterator
-from io import StringIO
+try:
+    # Python2
+    from cStringIO import StringIO
+except ImportError:
+    # Python3
+    from io import StringIO
 from functools import reduce
 from bcftbx.utils import mkdir
 from bcftbx.utils import AttributeDictionary

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -785,7 +785,7 @@ import string
 import cloudpickle
 import atexit
 from collections import Iterator
-from cStringIO import StringIO
+from io import StringIO
 from bcftbx.utils import mkdir
 from bcftbx.utils import AttributeDictionary
 from bcftbx.JobRunner import SimpleJobRunner

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -1392,7 +1392,7 @@ class Pipeline(object):
             # Populate the current rank with tasks which don't
             # have any requirements
             current_rank = []
-            for task_id in required.keys():
+            for task_id in list(required.keys()):
                 if not required[task_id]:
                     # Task no longer has requirements so add
                     # to the current rank
@@ -1402,7 +1402,7 @@ class Pipeline(object):
                     del(required[task_id])
             # Update the requirement lists for remaining tasks
             # to remove those add to the current rank
-            for task_id in required.keys():
+            for task_id in list(required.keys()):
                 new_reqs = []
                 for req in required[task_id]:
                     if req not in current_rank:

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -1358,7 +1358,7 @@ class Pipeline(object):
         """
         Return a list of task ids
         """
-        return self._tasks.keys()
+        return list(self._tasks.keys())
 
     def get_task(self,task_id):
         """

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -932,8 +932,10 @@ prepend-path PATH %s
         self.assertEqual(len(ppl1.task_list()),7)
         # Check requirements on first task of pipeline 2
         # have been updated
-        self.assertEqual(sorted(ppl1.get_task(task5.id())[1]),
-                         sorted([task2,task4,]))
+        self.assertEqual(
+            sorted(ppl1.get_task(task5.id())[1],key=lambda t: t.id()),
+            sorted([task2,task4,],key=lambda t: t.id())
+        )
         # Check params from both pipelines are defined
         self.assertTrue('param1' in ppl1.params)
         self.assertTrue('param2' in ppl1.params)

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -10,6 +10,7 @@ import os
 import io
 import getpass
 import platform
+from builtins import range
 import auto_process_ngs.envmod as envmod
 from auto_process_ngs.simple_scheduler import SimpleScheduler
 from auto_process_ngs.applications import Command
@@ -1371,7 +1372,7 @@ class TestPipelineTask(unittest.TestCase):
             def init(self,s,n=1):
                 pass
             def setup(self):
-                for i in xrange(self.args.n):
+                for i in range(self.args.n):
                     self.add_cmd(
                         PipelineCommandWrapper(
                             "Echo text","echo",self.args.s))
@@ -1402,7 +1403,7 @@ class TestPipelineTask(unittest.TestCase):
         print(task.stdout)
         stdout = task.stdout.split("\n")
         self.assertEqual(len(stdout),22) # 22 = 21 + trailing newline
-        for i in xrange(3):
+        for i in range(3):
             self.assertEqual(stdout[0+i*7],"#### COMMAND Echo text")
             self.assertEqual(stdout[1+i*7],"#### HOSTNAME %s" % self._hostname())
             self.assertEqual(stdout[2+i*7],"#### USER %s" % self._user())


### PR DESCRIPTION
PR which updates the `pipeliner` module to work with both Python 2 and Python 3:

* Fix implementation of  `FileCollector` class for Python 3
* Explicitly import `reduce` function (no longer built-in for Python 3)
* Replace `cStringIO.StringIO` with `io.StringIO`
* Fix iteration over dictionary keys in `Pipeliner` class
* Update tests to use Python 2/3 compatible `range` function (instead of `xrange`)