### PR TITLE
Fix 'run_reference_id' to handle non-numeric facility run number

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -1162,7 +1162,10 @@ def run_reference_id(run_name,platform=None,facility_run_number=None):
         run_number = int(run_number)
     # Facility run number
     if facility_run_number is not None:
-        facility_run_number = int(facility_run_number)
+        try:
+            facility_run_number = int(facility_run_number)
+        except ValueError:
+            facility_run_number = None
     else:
         facility_run_number = None
     # Construct the reference id

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -1081,6 +1081,14 @@ class TestRunReferenceIdFunction(unittest.TestCase):
                                           facility_run_number=90),
                          "MISEQ_rag_05_2017#90")
 
+    def test_run_reference_id_handle_non_numeric_run_number(self):
+        """run_reference_id: handle non-numeric facility run number
+        """
+        self.assertEqual(run_reference_id("RAG_10x_BCLFiles_Download",
+                                          platform=None,
+                                          facility_run_number="BCLFiles"),
+                         "RAG_10x_BCLFiles_Download")
+
 class TestSplitSampleNameFunction(unittest.TestCase):
     """
     Tests for the 'split_sample_name' function


### PR DESCRIPTION
PR which fixes issue #491 by updating the `run_reference_id` function from the `analysis` module to handle non-numeric facility run numbers.