### PR TITLE
make_fastqs: implement protocol for miRNA-seq data

### DIFF
--- a/auto_process_ngs/bcl2fastq_utils.py
+++ b/auto_process_ngs/bcl2fastq_utils.py
@@ -227,7 +227,8 @@ def bcl_to_fastq_info(path=None):
     return (bcl2fastq_path,package_name,package_version)
 
 def make_custom_sample_sheet(input_sample_sheet,output_sample_sheet=None,
-                             lanes=None,fmt=None):
+                             lanes=None,adapter=None,adapter_read2=None,
+                             fmt=None):
     """
     Creates a corrected copy of a sample sheet file
 
@@ -246,6 +247,10 @@ def make_custom_sample_sheet(input_sample_sheet,output_sample_sheet=None,
         output sample sheet; if `None` then all lanes will be kept
         (the default), otherwise lanes will be dropped if they don't
         appear in the supplied list
+      adapter (str): (optional) if set then write to the `Adapter`
+        setting
+      adapter_read2 (str): (optional) if set then write to the
+        `AdapterRead2` setting
       fmt (str): (optional) format for the output sample sheet,
         either 'CASAVA' or 'IEM'; if this is `None` then the format
         of the original file will be used
@@ -289,6 +294,23 @@ def make_custom_sample_sheet(input_sample_sheet,output_sample_sheet=None,
                 i += 1
             else:
                 del(sample_sheet[i])
+    # Update adapter sequences
+    if adapter is not None:
+        if adapter:
+            sample_sheet.settings['Adapter'] = str(adapter)
+        else:
+            try:
+                del(sample_sheet.settings['Adapter'])
+            except KeyError:
+                pass
+    if adapter_read2 is not None:
+        if adapter_read2:
+            sample_sheet.settings['AdapterRead2'] = str(adapter_read2)
+        else:
+            try:
+                del(sample_sheet.settings['AdapterRead2'])
+            except KeyError:
+                pass
     # Write out new sample sheet
     if output_sample_sheet is not None:
         sample_sheet.write(output_sample_sheet,fmt=fmt)

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 #######################################################################
 
 MAKE_FASTQS_PROTOCOLS = ('standard',
-                         'mirna_seq',
+                         'mirna',
                          'icell8',
                          'icell8_atac',
                          '10x_chromium_sc',
@@ -434,7 +434,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
                     runner=runner)
             except Exception as ex:
                 raise Exception("Bcl2fastq stage failed: '%s'" % ex)
-        elif protocol == 'mirna_seq':
+        elif protocol == 'mirna':
             # miRNA-seq protocol
             # Set minimum trimmed read length and turn off masking
             minimum_trimmed_read_length = 10

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -52,6 +52,7 @@ logger = logging.getLogger(__name__)
 #######################################################################
 
 MAKE_FASTQS_PROTOCOLS = ('standard',
+                         'mirna_seq',
                          'icell8',
                          'icell8_atac',
                          '10x_chromium_sc',
@@ -415,6 +416,30 @@ def make_fastqs(ap,protocol='standard',platform=None,
         # Do fastq generation according to protocol
         if protocol == 'standard':
             # Standard protocol
+            try:
+                exit_code = bcl_to_fastq(
+                    ap,
+                    unaligned_dir=ap.params.unaligned_dir,
+                    sample_sheet=sample_sheet,
+                    primary_data_dir=primary_data_dir,
+                    require_bcl2fastq=require_bcl2fastq_version,
+                    bases_mask=bases_mask,
+                    ignore_missing_bcl=ignore_missing_bcl,
+                    ignore_missing_stats=ignore_missing_stats,
+                    no_lane_splitting=no_lane_splitting,
+                    minimum_trimmed_read_length=minimum_trimmed_read_length,
+                    mask_short_adapter_reads=mask_short_adapter_reads,
+                    create_fastq_for_index_reads=create_fastq_for_index_reads,
+                    nprocessors=nprocessors,
+                    runner=runner)
+            except Exception as ex:
+                raise Exception("Bcl2fastq stage failed: '%s'" % ex)
+        elif protocol == 'mirna_seq':
+            # miRNA-seq protocol
+            # Set minimum trimmed read length and turn off masking
+            minimum_trimmed_read_length = 10
+            mask_short_adapter_reads = 0
+            # Run bcl2fastq
             try:
                 exit_code = bcl_to_fastq(
                     ap,

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -72,6 +72,9 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 bases_mask=None,no_lane_splitting=None,
                 minimum_trimmed_read_length=None,
                 mask_short_adapter_reads=None,
+                trim_adapters=True,
+                adapter_sequence=None,
+                adapter_sequence_read2=None,
                 create_fastq_for_index_reads=False,
                 generate_stats=True,stats_file=None,
                 per_lane_stats_file=None,
@@ -149,6 +152,16 @@ def make_fastqs(ap,protocol='standard',platform=None,
         length of ACGT bases that must be present in a read after
         adapter trimming for it not to be masked completely
         with Ns.
+      trim_adapters (boolean): if True (the default) then pass
+        adapter sequence(s) to bcl2fastq to perform adapter trimming;
+        otherwise remove adapter sequences
+      adapter_sequence (str): if not None then specifies adapter
+        sequence to use instead of any sequences already set in the
+        samplesheet (nb will be ignored if 'trim_adapters' is False)
+      adapter_sequence_read2 (str): if not None then specifies adapter
+        sequence to use for read2 instead of any sequences already set
+        in the samplesheet (nb will be ignored if 'trim_adapters' is
+        False)
       create_fastq_for_index_reads (boolean): if True then also create
         Fastq files for index reads (default, don't create index read
         Fastqs)
@@ -233,6 +246,31 @@ def make_fastqs(ap,protocol='standard',platform=None,
             if l not in samplesheet_lanes:
                 raise Exception("Requested lane '%d' not present "
                                 "in samplesheet" % l)
+    # Adapter trimming
+    if trim_adapters:
+        # Sort out adapter sequences
+        s = IlluminaData.SampleSheet(ap.params.sample_sheet)
+        if adapter_sequence is None:
+            # Use adapter sequence from sample sheet
+            try:
+                adapter_sequence = s.settings['Adapter']
+            except KeyError:
+                adapter_sequence = ""
+        if adapter_sequence_read2 is None:
+            # Use read2 adapter from sample sheet
+            try:
+                adapter_sequence_read2 = s.settings['AdapterRead2']
+            except KeyError:
+                adapter_sequence_read2 = ""
+    else:
+        # No adapter trimming
+        adapter_sequence = ""
+        adapter_sequence_read2 = ""
+    print("Adapter sequence      : %s" % (adapter_sequence
+                                          if adapter_sequence
+                                          else "<none>"))
+    if adapter_sequence_read2:
+        print("Adapter sequence read2: %s" % adapter_sequence_read2)
     # Make a temporary sample sheet
     if lanes:
         lanes_id = ".L%s" % ''.join([str(l) for l in lanes])
@@ -244,7 +282,9 @@ def make_fastqs(ap,protocol='standard',platform=None,
                                  time.strftime("%Y%m%d%H%M%S")))
     make_custom_sample_sheet(ap.params.sample_sheet,
                              sample_sheet,
-                             lanes=lanes)
+                             lanes=lanes,
+                             adapter=adapter_sequence,
+                             adapter_read2=adapter_sequence_read2)
     # Check the temporary sample sheet
     print("Checking temporary sample sheet")
     invalid_barcodes = SampleSheetLinter(

--- a/auto_process_ngs/test/test_bcl2fastq.py
+++ b/auto_process_ngs/test/test_bcl2fastq.py
@@ -697,6 +697,120 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertTrue(os.path.exists(sample_sheet_out))
         self.assertEqual(open(sample_sheet_out,'r').read(),
                          expected)
+    def test_make_custom_sample_sheet_adapter(self):
+        """
+        make_custom_sample_sheet: update adapter sequence
+        """
+        sample_sheet_in = os.path.join(self.wd,
+                                       "SampleSheet.csv")
+        with open(sample_sheet_in,'w') as fp:
+            fp.write(self.iem_content)
+        sample_sheet_out = os.path.join(self.wd,
+                                       "custom_SampleSheet.csv")
+        make_custom_sample_sheet(sample_sheet_in,
+                                 output_sample_sheet=sample_sheet_out,
+                                 adapter="TACACATCTCTGTCTCTTA")
+        expected = """[Header]
+IEMFileVersion,4
+
+[Reads]
+101
+101
+
+[Settings]
+ReverseComplement,0
+Adapter,TACACATCTCTGTCTCTTA
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+1,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+2,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+2,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+3,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+3,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+4,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+4,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+"""
+        self.assertTrue(os.path.exists(sample_sheet_out))
+        self.assertEqual(open(sample_sheet_out,'r').read(),
+                         expected)
+    def test_make_custom_sample_sheet_adapter_read2(self):
+        """
+        make_custom_sample_sheet: update adapter sequence (read2)
+        """
+        sample_sheet_in = os.path.join(self.wd,
+                                       "SampleSheet.csv")
+        with open(sample_sheet_in,'w') as fp:
+            fp.write(self.iem_content)
+        sample_sheet_out = os.path.join(self.wd,
+                                       "custom_SampleSheet.csv")
+        make_custom_sample_sheet(sample_sheet_in,
+                                 output_sample_sheet=sample_sheet_out,
+                                 adapter_read2="TACACATCTCTGTCTCTTA")
+        expected = """[Header]
+IEMFileVersion,4
+
+[Reads]
+101
+101
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+AdapterRead2,TACACATCTCTGTCTCTTA
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+1,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+2,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+2,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+3,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+3,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+4,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+4,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+"""
+        self.assertTrue(os.path.exists(sample_sheet_out))
+        self.assertEqual(open(sample_sheet_out,'r').read(),
+                         expected)
+    def test_make_custom_sample_sheet_no_adapters(self):
+        """
+        make_custom_sample_sheet: remove adapter sequences
+        """
+        sample_sheet_in = os.path.join(self.wd,
+                                       "SampleSheet.csv")
+        with open(sample_sheet_in,'w') as fp:
+            fp.write(self.iem_content)
+        sample_sheet_out = os.path.join(self.wd,
+                                       "custom_SampleSheet.csv")
+        make_custom_sample_sheet(sample_sheet_in,
+                                 output_sample_sheet=sample_sheet_out,
+                                 adapter="",adapter_read2="")
+        expected = """[Header]
+IEMFileVersion,4
+
+[Reads]
+101
+101
+
+[Settings]
+ReverseComplement,0
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+1,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+2,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+2,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+3,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+3,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+4,PJB1-1579,PJB1-1579,,,N701,CGATGTAT,N501,TCTTTCCC,PeterBriggs,
+4,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
+"""
+        self.assertTrue(os.path.exists(sample_sheet_out))
+        self.assertEqual(open(sample_sheet_out,'r').read(),
+                         expected)
 
 class TestBasesMaskIsValid(unittest.TestCase):
     """Tests for the bases_mask_is_valid function

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -23,6 +23,7 @@ Protocol option          Used for
 ======================== =====================================
 ``standard``             Standard Illumina sequencing data
                          (default)
+``mirna_seq``            miRNA-seq data
 ``icell8``               ICELL8 single-cell RNA-seq data
 ``icell8_atac``          ICELL8 single-cell ATAC-seq data
 ``10x_chromium_sc``      10xGenomics Chromium single-cell
@@ -50,10 +51,12 @@ more detail on the different usage modes can be found in the
 subsequent sections:
 
 * :ref:`make_fastqs-standard-protocol`
+* :ref:`make_fastqs-mirna_seq-protocol`
 * :ref:`make_fastqs-icell8-protocol`
 * :ref:`make_fastqs-icell8-atac-protocol`
 * :ref:`make_fastqs-10x_chromium_sc-protocol`
 * :ref:`make_fastqs-10x_chromium_sc_atac-protocol`
+* :ref:`make_fastqs-adapter-trimming-and-masking`
 * :ref:`make_fastqs-mixed-protocols`
 
 Information on other commonly used options can be found
@@ -120,6 +123,30 @@ in the section :ref:`make_fastqs-outputs`; it is recommended to check
 the :doc:`processing QC <../output/processing_qc>` and
 :doc:`barcode analysis <../output/barcode_analysis>` reports which
 will highlight issues with the demultiplexing.
+
+.. _make_fastqs-mirna_seq-protocol:
+
+miRNA-seq Fastq generation (``--protocol=mirna_seq``)
+-----------------------------------------------------
+
+Initial Fastqs can be generated from miRNA-seq data using the
+``--protocol=mirna_seq`` option:
+
+::
+
+    auto_process.py make_fastqs --protocol=mirna_seq ...
+
+This adjusts the adapter trimming and masking options as follows:
+
+ * Sets the minimum trimmed read length to 10 bases
+ * Turn off short read masking by setting the threshold length
+   to zero
+
+Subsequently the Fastq generation is the same as the standard
+protocol described in :ref:`make_fastqs-standard-protocol`.
+
+More details about adapter trimming and short read masking can be
+found in the section :ref:`make_fastqs-adapter-trimming-and-masking`.
 
 .. _make_fastqs-icell8-protocol:
 
@@ -224,6 +251,45 @@ This will generate the Fastqs in the specified output directory
    ``make_fastqs`` offers various options for controlling the
    behaviour of ``cellranger-atac mkfastqs``, for example setting the
    jobmode (see :ref:`10xgenomics-additional-options`).
+
+.. _make_fastqs-adapter-trimming-and-masking:
+
+Configuring adapter trimming and masking
+----------------------------------------
+
+By default Fastq generation includes adapter trimming and masking of
+short reads via ``bcl2fastq``.
+
+Adapter sequences used for trimming are taken from those specified
+in the input sample sheet, but these can be overriden by using the
+``--adapter`` and ``--adapter-read2`` options to specify different
+sequences.
+
+Adapter trimming can be disabled by specifying the
+``--no-adapter-trimming`` option (or by setting both adapter
+sequences to empty strings).
+
+When adapter trimming is performed two additional operations are
+applied:
+
+ * **Minium read length** is enforced for reads which are shorter
+   than this length after trimming, by padding them with ``N``s
+   up to the minimum length
+ * **Masking of short reads** is performed for reads below a
+   masking threshold length, by masking *all* bases in the read
+   with ``N``s
+
+Minimum read length defaults to 35 bases but can set explicitly by
+using the ``--minimum-trimmed-read-length`` option; the masking
+threshold defaults to 22 bases but can be set using the
+``--mask-short-adapter-reads`` option. Set this to zero to turn
+off masking.
+
+.. warning::
+
+   Setting the minimum read length to zero when using adapter
+   trimming can result in read records with zero-length sequences,
+   which may cause problems in downstream analyses.
 
 .. _make_fastqs-mixed-protocols:
 

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -23,7 +23,7 @@ Protocol option          Used for
 ======================== =====================================
 ``standard``             Standard Illumina sequencing data
                          (default)
-``mirna_seq``            miRNA-seq data
+``mirna``                miRNA-seq data
 ``icell8``               ICELL8 single-cell RNA-seq data
 ``icell8_atac``          ICELL8 single-cell ATAC-seq data
 ``10x_chromium_sc``      10xGenomics Chromium single-cell
@@ -51,7 +51,7 @@ more detail on the different usage modes can be found in the
 subsequent sections:
 
 * :ref:`make_fastqs-standard-protocol`
-* :ref:`make_fastqs-mirna_seq-protocol`
+* :ref:`make_fastqs-mirna-protocol`
 * :ref:`make_fastqs-icell8-protocol`
 * :ref:`make_fastqs-icell8-atac-protocol`
 * :ref:`make_fastqs-10x_chromium_sc-protocol`
@@ -124,17 +124,17 @@ the :doc:`processing QC <../output/processing_qc>` and
 :doc:`barcode analysis <../output/barcode_analysis>` reports which
 will highlight issues with the demultiplexing.
 
-.. _make_fastqs-mirna_seq-protocol:
+.. _make_fastqs-mirna-protocol:
 
-miRNA-seq Fastq generation (``--protocol=mirna_seq``)
------------------------------------------------------
+miRNA-seq Fastq generation (``--protocol=mirna``)
+-------------------------------------------------
 
 Initial Fastqs can be generated from miRNA-seq data using the
-``--protocol=mirna_seq`` option:
+``--protocol=mirna`` option:
 
 ::
 
-    auto_process.py make_fastqs --protocol=mirna_seq ...
+    auto_process.py make_fastqs --protocol=mirna ...
 
 This adjusts the adapter trimming and masking options as follows:
 


### PR DESCRIPTION
PR to address issue #490 by implementing a new protocol for the `make_fastqs` command to handle miRNA-seq data (`--protocol=mirna`), which explicitly sets the minimum read length after adapter trimming to 10 and turning off short read masking.

Also includes changes to allow the adapter sequences to be specified via the command line, and adds an option to disable adapter trimming completely.