### PR TITLE
Fixes to the 'analysis' module for Python3 compatibility

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -47,6 +47,7 @@ from .metadata import ProjectMetadataFile
 from .metadata import AnalysisProjectQCDirInfo
 from .fastq_utils import BaseFastqAttrs
 from .fastq_utils import IlluminaFastqAttrs
+from functools import reduce
 
 # Module specific logger
 logger = logging.getLogger(__name__)

--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -310,8 +310,9 @@ class AnalysisDir(object):
             projects.append(self.undetermined)
         # Filter on pattern
         if pattern is not None:
-            projects = filter(lambda p: fnmatch.fnmatch(p.name,pattern),
-                              projects)
+            projects = list(filter(lambda p:
+                                   fnmatch.fnmatch(p.name,pattern),
+                                   projects))
         return projects
         
 class AnalysisProject(object):
@@ -815,8 +816,9 @@ class AnalysisProject(object):
                         reduced_fastqs.append(fq)
                         break
             # Remove index reads
-            reduced_fastqs = filter(lambda fq: not fq.is_index_read,
-                                    reduced_fastqs)
+            reduced_fastqs = list(filter(lambda fq:
+                                         not fq.is_index_read,
+                                         reduced_fastqs))
             if len(reduced_fastqs) > 1:
                 multiple_fastqs = True
             samples[sample_name] = reduced_fastqs

--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     analysis: classes & funcs for handling analysis dirs and projects
-#     Copyright (C) University of Manchester 2018-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2020 Peter Briggs
 #
 ########################################################################
 #


### PR DESCRIPTION
PR which makes some fixes to the `analysis` module for Python3 compatibility:

* Import `reduce` from `functools`
* Wrap results from the `filter` function in `list`