### PR TITLE
Fixes to the 'applications' module for Python3 compatibility

### DIFF
--- a/auto_process_ngs/applications.py
+++ b/auto_process_ngs/applications.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     applications.py: utilities for running command line applications
-#     Copyright (C) University of Manchester 2013-17,2019 Peter Briggs
+#     Copyright (C) University of Manchester 2013-17,2019-2020 Peter Briggs
 #
 ########################################################################
 #

--- a/auto_process_ngs/applications.py
+++ b/auto_process_ngs/applications.py
@@ -180,14 +180,14 @@ class Command(object):
             fpout = None
         else:
             logging.debug("Writing stdout to %s" % log)
-            fpout = open(log,'w')
+            fpout = open(log,'wt')
         if err is None:
             if log is not None:
                 fperr = subprocess.STDOUT
             else:
                 fperr = None
         else:
-            fperr = open(err,'w')
+            fperr = open(err,'wt')
             logging.debug("Writing stderr to %s" % err)
         # Execute command and wait for finish
         try:
@@ -228,7 +228,7 @@ class Command(object):
         else:
             stderr = None
         # Create a temporary file-like object to capture output
-        ftmp = tempfile.TemporaryFile()
+        ftmp = tempfile.TemporaryFile(mode='w+t')
         status = subprocess.call(self.command_line,stdout=ftmp,
                                  cwd=working_dir,stderr=stderr)
         # Read the output
@@ -286,7 +286,7 @@ class Command(object):
         if fp is not None:
             fp.write(script)
         if filen is not None:
-            with open(filen,'w') as fp:
+            with open(filen,'wt') as fp:
                 fp.write(script)
         return script
 

--- a/auto_process_ngs/test/test_applications.py
+++ b/auto_process_ngs/test/test_applications.py
@@ -3,7 +3,11 @@
 #######################################################################
 from auto_process_ngs.applications import *
 import unittest
-import cStringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    # cStringIO not available in Python3
+    from io import StringIO
 
 class TestCommand(unittest.TestCase):
 
@@ -79,7 +83,7 @@ class TestCommand(unittest.TestCase):
                 epilogue="echo \"# $(date)\""),
             "#!/bin/bash\necho \"# $(hostname)\"\n"
             "echo hello\necho \"# $(date)\"")
-        fp = cStringIO.StringIO()
+        fp = StringIO()
         cmd.make_wrapper_script(fp=fp)
         self.assertEqual(fp.getvalue(),"echo hello")
 


### PR DESCRIPTION
PR which implements fixes to the `applications` module for compatibility with Python3:

* Fix import of `StringIO` for Python3 in unit tests
* Add `t` (i.e. text mode) to file opening calls in the `Command` class