### PR TITLE
Fixes to 'utils' modules for Python3 compatibility

### DIFF
--- a/auto_process_ngs/test/test_utils.py
+++ b/auto_process_ngs/test/test_utils.py
@@ -207,9 +207,9 @@ class TestBufferedOutputFiles(unittest.TestCase):
         out.write('test1','Some test text')
         out.write('test2','Some more\ntest text')
         out.close()
-        self.assertEqual(open(out.file_name('test1'),'r').read(),
+        self.assertEqual(open(out.file_name('test1'),'rt').read(),
                          "Some test text\n")
-        self.assertEqual(open(out.file_name('test2'),'r').read(),
+        self.assertEqual(open(out.file_name('test2'),'rt').read(),
                          "Some more\ntest text\n")
     def test_bufferedoutputfiles_with_gzip(self):
         out = BufferedOutputFiles()
@@ -222,9 +222,9 @@ class TestBufferedOutputFiles(unittest.TestCase):
         out.write('test1','Some test text')
         out.write('test2','Some more\ntest text')
         out.close()
-        self.assertEqual(gzip.open(out.file_name('test1'),'r').read(),
+        self.assertEqual(gzip.open(out.file_name('test1'),'rt').read(),
                          "Some test text\n")
-        self.assertEqual(gzip.open(out.file_name('test2'),'r').read(),
+        self.assertEqual(gzip.open(out.file_name('test2'),'rt').read(),
                          "Some more\ntest text\n")
     def test_bufferedoutputfiles_with_basedir(self):
         out = BufferedOutputFiles(self.wd)
@@ -236,9 +236,9 @@ class TestBufferedOutputFiles(unittest.TestCase):
             out.file_name('test2'),os.path.join(self.wd,'test2.txt'))
     def test_bufferedoutputfiles_append(self):
         out = BufferedOutputFiles()
-        with open(os.path.join(self.wd,'test1.txt'),'w') as fp:
+        with open(os.path.join(self.wd,'test1.txt'),'wt') as fp:
             fp.write("test1 already exists\n")
-        with open(os.path.join(self.wd,'test2.txt'),'w') as fp:
+        with open(os.path.join(self.wd,'test2.txt'),'wt') as fp:
             fp.write("test2 already exists\n")
         out.open('test1',os.path.join(self.wd,'test1.txt'),append=True)
         out.open('test2',os.path.join(self.wd,'test2.txt'))
@@ -249,9 +249,9 @@ class TestBufferedOutputFiles(unittest.TestCase):
         out.write('test1','Some test text')
         out.write('test2','Some more\ntest text')
         out.close()
-        self.assertEqual(open(out.file_name('test1'),'r').read(),
+        self.assertEqual(open(out.file_name('test1'),'rt').read(),
                          "test1 already exists\nSome test text\n")
-        self.assertEqual(open(out.file_name('test2'),'r').read(),
+        self.assertEqual(open(out.file_name('test2'),'rt').read(),
                          "Some more\ntest text\n")
     def test_bufferedoutputfiles_reopen(self):
         out = BufferedOutputFiles(base_dir=self.wd)
@@ -264,9 +264,9 @@ class TestBufferedOutputFiles(unittest.TestCase):
         out.write('test1','Some test text')
         out.write('test2','Some more\ntest text')
         out.close()
-        self.assertEqual(open(out.file_name('test1'),'r').read(),
+        self.assertEqual(open(out.file_name('test1'),'rt').read(),
                          "Some test text\n")
-        self.assertEqual(open(out.file_name('test2'),'r').read(),
+        self.assertEqual(open(out.file_name('test2'),'rt').read(),
                          "Some more\ntest text\n")
         # Reopen files
         out.open('test1',append=True)
@@ -278,9 +278,9 @@ class TestBufferedOutputFiles(unittest.TestCase):
         out.write('test1','Some extra test text')
         out.write('test2','Some different\ntest text')
         out.close()
-        self.assertEqual(open(out.file_name('test1'),'r').read(),
+        self.assertEqual(open(out.file_name('test1'),'rt').read(),
                          "Some test text\nSome extra test text\n")
-        self.assertEqual(open(out.file_name('test2'),'r').read(),
+        self.assertEqual(open(out.file_name('test2'),'rt').read(),
                          "Some different\ntest text\n")
     def test_bufferedoutputfiles_exceed_maximum_open_files(self):
         # Only allow 2 open files at once internally
@@ -309,19 +309,19 @@ class TestBufferedOutputFiles(unittest.TestCase):
         # Close everything
         out.close()
         # Check the contents for each file
-        self.assertEqual(open(out.file_name('test1'),'r').read(),
+        self.assertEqual(open(out.file_name('test1'),'rt').read(),
                          "test text\n"
                          "and a bit more\n"
                          "plus some final\ntext\n")
-        self.assertEqual(open(out.file_name('test2'),'r').read(),
+        self.assertEqual(open(out.file_name('test2'),'rt').read(),
                          "different\ntest text\n"
                          "more but different\n"
                          "and a last bit\n")
-        self.assertEqual(open(out.file_name('test3'),'r').read(),
+        self.assertEqual(open(out.file_name('test3'),'rt').read(),
                          "more test text\n"
                          "different again\n"
                          "plus a coda\n")
-        self.assertEqual(open(out.file_name('test4'),'r').read(),
+        self.assertEqual(open(out.file_name('test4'),'rt').read(),
                          "yet more\ntest text\n"
                          "and even more different\ntest text\n"
                          "et\nFIN\n")

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -129,18 +129,14 @@ class OutputFiles(object):
         will be reopened).
 
         If 'append' is True then append to an existing
-        file rather than overwriting (i.e. use mode 'a'
-        instead of 'w').
-
-        If 'append' is True then append to an existing
-        file rather than overwriting (i.e. use mode 'a'
-        instead of 'w').
+        file rather than overwriting (i.e. use mode 'at'
+        instead of 'wt').
 
         """
         if append:
-            mode = 'a'
+            mode = 'at'
         else:
-            mode = 'w'
+            mode = 'wt'
         if filen is None:
             filen = self.file_name(name)
         elif self._base_dir is not None:

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -818,9 +818,9 @@ def write_script_file(script_file,contents,append=False,shell=None):
 
     """
     if append:
-        mode = 'a'
+        mode = 'at'
     else:
-        mode = 'w'
+        mode = 'wt'
     with open(script_file,mode=mode) as fp:
         if (not append) and (shell is not None):
             fp.write("#!%s\n" % shell)
@@ -857,7 +857,7 @@ def edit_file(filen,editor="vi",append=None):
     # Make a temporary copy for editing
     f,tmpfile = tempfile.mkstemp()
     os.fdopen(f).close()
-    with open(tmpfile,'w') as fp:
+    with open(tmpfile,'wt') as fp:
         if os.path.exists(filen):
             fp.write(open(filen,'r').read())
         else:
@@ -872,7 +872,7 @@ def edit_file(filen,editor="vi",append=None):
     edit_cmd.run_subprocess()
     # Finished
     if md5sum(tmpfile) != checksum:
-        with open(filen,'w') as fp:
+        with open(filen,'wt') as fp:
             fp.write(open(tmpfile,'r').read())
             os.remove(tmpfile)
     else:

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -236,14 +236,14 @@ class BufferedOutputFiles(OutputFiles):
         a gzip-compressed file.
 
         If 'append' is True then append to an existing
-        file rather than overwriting (i.e. use mode 'a'
-        instead of 'w').
+        file rather than overwriting (i.e. use mode 'at'
+        instead of 'wt').
 
         """
         if append:
-            mode = 'a'
+            mode = 'at'
         else:
-            mode = 'w'
+            mode = 'wt'
         if filen is None:
             filen = self.file_name(name)
         elif self._base_dir is not None:

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -264,7 +264,7 @@ class BufferedOutputFiles(OutputFiles):
             if len(self._fp) == self._max_open_files:
                 # Arbitrarily close file attached to first
                 # handle in the list of keys
-                name0 = self._fp.keys()[0]
+                name0 = list(self._fp.keys())[0]
                 self.close(name0)
                 # Reset the mode to 'append', so the contents
                 # aren't clobbered if the file is reopened

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -694,10 +694,11 @@ def find_executables(names,info_func,reqs=None,paths=None):
             logger.debug("Pre filter: %s" % available_exes)
             logger.debug("Versions  : %s" % [info_func(x)[2]
                                               for x in available_exes])
-            available_exes = filter(lambda x: op(
-                parse_version(info_func(x)[2]),
-                parse_version(req_version)),
-                                    available_exes)
+            available_exes = list(
+                filter(lambda x: op(
+                    parse_version(info_func(x)[2]),
+                    parse_version(req_version)),
+                       available_exes))
             logger.debug("Post filter: %s" % available_exes)
         # Sort into version order, highest to lowest
         available_exes.sort(

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     utils: utility classes & funcs for auto_process_ngs module
-#     Copyright (C) University of Manchester 2013-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2020 Peter Briggs
 #
 ########################################################################
 #

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -178,7 +178,7 @@ class OutputFiles(object):
             self._fp[name].close()
             del(self._fp[name])
         else:
-            names = self._fp.keys()
+            names = list(self._fp.keys())
             for name in names:
                 self.close(name)
 


### PR DESCRIPTION
PR which adds various fixes to the `utils` module for Python3 compatibility:

* `OutputFiles`: fix file modes and wrap dictionary keys in `list`
* `BufferedOutputFiles`: fix file modes and wrap dictionary keys in `list`
* `find_executables`: wrap output from `filter` function in `list`
* Various updates to file opening to use `text` mode