### PR TITLE
get_bases_mask_10x_atac: trap for incorrect number of reads

### DIFF
--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -284,6 +284,11 @@ def get_bases_mask_10x_atac(runinfo_xml):
       String: 10xGenomics scATAC-seq bases mask string
     """
     bases_mask = get_bases_mask(runinfo_xml).lower().split(',')
+    # Check there are four reads defined
+    if len(bases_mask) != 4:
+        raise Exception("Bases mask '%s' should have 4 reads "
+                        "defined (has %d)" % (bases_mask,
+                                              len(bases_mask)))
     # First read
     r1_mask = bases_mask[0]
     # Update first index to restrict to 8 bases

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -245,6 +245,18 @@ class TestGetBasesMask10xAtac(unittest.TestCase):
                           get_bases_mask_10x_atac,
                           run_info_xml)
 
+    def test_get_bases_mask_10x_atac_wrong_number_of_reads(self):
+        """get_bases_mask_10x_atac: run with wrong number of reads
+        """
+        # Make a single index RunInfo.xml file
+        run_info_xml = os.path.join(self.wd,"RunInfo.xml")
+        with open(run_info_xml,'w') as fp:
+            fp.write(RunInfoXml.create("171020_NB500968_00002_AHGXXXX",
+                                       "y76,I8,y76",4,12))
+        self.assertRaises(Exception,
+                          get_bases_mask_10x_atac,
+                          run_info_xml)
+
 class TestCellrangerInfo(unittest.TestCase):
     """
     Tests for the cellranger_info function


### PR DESCRIPTION
PR which adds a trap in the `get_bases_mask_10x_atac` function (in the `tenx_genomics_utils` module), if the supplied ATAC-seq bases mask doesn't have 4 'reads' defined. In these cases the data are probably not 10xGenomics ATAC-seq.