### PR TITLE
'report' command: updates for 'projects' mode when writing output to file

### DIFF
--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -14,6 +14,7 @@ import os
 import ast
 import logging
 import tempfile
+import shutil
 import bcftbx.IlluminaData as IlluminaData
 import bcftbx.utils as bcf_utils
 from .. import analysis
@@ -59,15 +60,19 @@ def report(ap,mode=None,fields=None,out_file=None):
     if mode is None or mode == ReportingMode.INFO:
         f = report_info
         kws = {}
+        ext = 'txt'
     elif mode == ReportingMode.CONCISE:
         f = report_concise
         kws = {}
+        ext = 'txt'
     elif mode == ReportingMode.SUMMARY:
         f = report_summary
         kws = {}
+        ext = 'txt'
     elif mode == ReportingMode.PROJECTS:
         f = report_projects
         kws = { 'fields': fields }
+        ext = 'tsv'
     else:
         raise Exception("Unknown reporting mode")
     # Generate the report
@@ -84,11 +89,17 @@ def report(ap,mode=None,fields=None,out_file=None):
                                        else 's')))
     # Write report
     if out_file:
-        fp,temp_file = tempfile.mkstemp()
-        with os.fdopen(fp,'w') as fpp:
-            fpp.write("%s\n" % report)
+        temp_dir = tempfile.mkdtemp()
+        temp_file = os.path.join(temp_dir,
+                                 "%s_%s.%s.%s" %
+                                 (ap.metadata.platform,
+                                  ap.metadata.instrument_datestamp,
+                                  ap.metadata.run_number,
+                                  ext))
+        with open(temp_file,'wt') as fp:
+            fp.write("%s\n" % report)
         fileops.copy(temp_file,out_file)
-        os.remove(temp_file)
+        shutil.rmtree(temp_dir)
         print("Report written to %s" % out_file)
     elif report:
         print(report)

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -70,8 +70,19 @@ def report(ap,mode=None,fields=None,out_file=None):
         kws = { 'fields': fields }
     else:
         raise Exception("Unknown reporting mode")
-    # Generate and write the report
+    # Generate the report
     report = f(ap,**kws)
+    # Report number of projects (in 'projects' mode)
+    if mode == ReportingMode.PROJECTS:
+        if report:
+            nprojects = len(report.split('\n'))
+        else:
+            nprojects = 0
+        print("%s project%s found" % (('No' if not nprojects
+                                       else nprojects),
+                                      ('' if nprojects == 1
+                                       else 's')))
+    # Write report
     if out_file:
         fp,temp_file = tempfile.mkstemp()
         with os.fdopen(fp,'w') as fpp:
@@ -79,7 +90,7 @@ def report(ap,mode=None,fields=None,out_file=None):
         fileops.copy(temp_file,out_file)
         os.remove(temp_file)
         print("Report written to %s" % out_file)
-    else:
+    elif report:
         print(report)
 
 def report_info(ap):
@@ -452,13 +463,6 @@ def report_projects(ap,fields=None):
     analysis_dir = analysis.AnalysisDir(ap.analysis_dir)
     # Generate report, one line per project
     report = []
-    nprojects = len(analysis_dir.projects)
-    if nprojects == 0:
-        report.append("No projects found")
-    else:
-        report.append("%s project%s found" % (nprojects,
-                                              ('' if nprojects == 1
-                                               else 's')))
     for project in analysis_dir.projects:
         project_line = []
         for field in fields:

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -556,8 +556,7 @@ class TestReportProjects(unittest.TestCase):
         # Make autoprocess instance and set required metadata
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Generate projects report
-        expected = """2 projects found
-MISEQ_170901#87\t87\ttesting\t\tAlison Bell\tAudrey Bower\tRNA-seq\t\tHuman\tMISEQ\t2\t\tyes\tAB1-2
+        expected = """MISEQ_170901#87\t87\ttesting\t\tAlison Bell\tAudrey Bower\tRNA-seq\t\tHuman\tMISEQ\t2\t\tyes\tAB1-2
 MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\tChIP-seq\t\tMouse\tMISEQ\t2\t\tyes\tCDE3-4
 """
         for o,e in zip(report_projects(ap).split('\n'),
@@ -589,8 +588,7 @@ MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\t
         # Make autoprocess instance and set required metadata
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Generate projects report
-        expected = """2 projects found
-170901\tMISEQ_170901#87\t87\ttesting\t\tAB\tAlison Bell\tAudrey Bower\tRNA-seq\t\tHuman\tMISEQ\t2\t\tyes\tAB1-2\t%s
+        expected = """170901\tMISEQ_170901#87\t87\ttesting\t\tAB\tAlison Bell\tAudrey Bower\tRNA-seq\t\tHuman\tMISEQ\t2\t\tyes\tAB1-2\t%s
 170901\tMISEQ_170901#87\t87\ttesting\t\tCDE\tCharles David Edwards\tColin Delaney Eccleston\tChIP-seq\t\tMouse\tMISEQ\t2\t\tyes\tCDE3-4\t%s
 """ % (ap.params.analysis_dir,ap.params.analysis_dir)
         custom_fields = ['datestamp','run_id','run_number','source','null','project','user','PI','library_type','single_cell_platform','organism','platform','#samples','#cells','paired_end','samples','path']
@@ -625,8 +623,7 @@ MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\t
         # Make autoprocess instance and set required metadata
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Generate projects report
-        expected = """2 projects found
-MISEQ_170901#87\t87\ttesting\t\tAlison Bell\tAudrey Bower\tscRNA-seq\tICELL8\tHuman\tMISEQ\t2\t1311\tyes\tAB1-2
+        expected = """MISEQ_170901#87\t87\ttesting\t\tAlison Bell\tAudrey Bower\tscRNA-seq\tICELL8\tHuman\tMISEQ\t2\t1311\tyes\tAB1-2
 MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\tChIP-seq\t\tMouse\tMISEQ\t2\t\tyes\tCDE3-4
 """
         for o,e in zip(report_projects(ap).split('\n'),
@@ -648,8 +645,7 @@ MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\t
         # Make autoprocess instance and set required metadata
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Generate projects report
-        expected = """No projects found
-"""
+        expected = ""
         for o,e in zip(report_projects(ap).split('\n'),
                        expected.split('\n')):
             self.assertEqual(o,e)
@@ -706,8 +702,7 @@ class TestReport(unittest.TestCase):
         out_file = os.path.join(self.dirn,"projects.tsv")
         report(ap,mode=ReportingMode.PROJECTS,out_file=out_file)
         # Check the outputs
-        expected = """2 projects found
-MISEQ_170901#87\t87\ttesting\t\tAlison Bell\tAudrey Bower\tRNA-seq\t\tHuman\tMISEQ\t2\t\tyes\tAB1-2
+        expected = """MISEQ_170901#87\t87\ttesting\t\tAlison Bell\tAudrey Bower\tRNA-seq\t\tHuman\tMISEQ\t2\t\tyes\tAB1-2
 MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\tChIP-seq\t\tMouse\tMISEQ\t2\t\tyes\tCDE3-4
 """
         self.assertTrue(os.path.exists(out_file))


### PR DESCRIPTION
PR which updates the `report` command when writing output to a file (i.e. `--file` option):

* For 'projects' mode (i.e. `--projects`): report the number of projects to stdout only (i.e. don't write to the TSV file)
* In all modes, create a sensible output file name which will be used if `--file` specifies a directory rather than a target file.