### PR TITLE
samplesheet_utils: fixes to unit tests for Python 3 compatibility

### DIFF
--- a/auto_process_ngs/test/test_samplesheet_utils.py
+++ b/auto_process_ngs/test/test_samplesheet_utils.py
@@ -7,7 +7,7 @@ import unittest
 import tempfile
 import shutil
 import codecs
-import cStringIO
+from io import StringIO
 from bcftbx.IlluminaData import SampleSheet
 from auto_process_ngs.samplesheet_utils import SampleSheetLinter
 from auto_process_ngs.samplesheet_utils import has_invalid_characters
@@ -42,7 +42,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
 2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 """
-        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=StringIO(
             self.sample_sheet_no_close_project_names))
         self.assertEqual(linter.close_project_names(),{})
     def test_sample_sheet_with_close_project_names(self):
@@ -53,7 +53,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
 2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 """
-        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=StringIO(
             self.sample_sheet_close_project_names))
         self.assertEqual(linter.close_project_names(),
                          { 'Andrew_Bloggs': ['Andrew_Blogs'],
@@ -69,7 +69,7 @@ Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,ind
 2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
 2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 """
-        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=StringIO(
             self.sample_sheet_no_samples_in_multiple_projects))
         self.assertEqual(linter.samples_in_multiple_projects(),{})
     def test_sample_sheet_with_samples_in_multiple_projects(self):
@@ -81,7 +81,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
 2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 """
-        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=StringIO(
             self.sample_sheet_samples_in_multiple_projects))
         self.assertEqual(linter.samples_in_multiple_projects(),
                          { 'AB1': ['Andrew_Bloggs1','Andrew_Bloggs2'] })
@@ -96,7 +96,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
 2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 """
-        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=StringIO(
             self.sample_sheet_without_multiple_barcodes))
         self.assertEqual(linter.samples_with_multiple_barcodes(),{})
     def test_sample_sheet_with_multiple_barcodes(self):
@@ -108,7 +108,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
 2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 """
-        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=StringIO(
             self.sample_sheet_with_multiple_barcodes))
         self.assertEqual(linter.samples_with_multiple_barcodes(),
                          { 'AB1': ['CGATGTAT-TCTTTCCC','CTGTAGTA-TCTTTCCC'] })
@@ -122,7 +122,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
 2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 """
-        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=StringIO(
             self.sample_sheet_without_invalid_lines))
         self.assertFalse(linter.has_invalid_lines())
     def test_sample_sheet_with_invalid_lines_missing_lane(self):
@@ -135,7 +135,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 ,,,,,,,,,Filipe_Greer,
 ,,,,,,,,,Filipe_Greer,
 """
-        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=StringIO(
             self.sample_sheet_with_invalid_lines))
         self.assertTrue(linter.has_invalid_lines())
     def test_sample_sheet_with_invalid_lines_no_lane(self):
@@ -148,7 +148,7 @@ FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 ,,,,,,,,Filipe_Greer,
 ,,,,,,,,Filipe_Greer,
 """
-        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=StringIO(
             self.sample_sheet_with_invalid_lines_no_lane))
         self.assertTrue(linter.has_invalid_lines())
 
@@ -161,7 +161,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
 2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 """
-        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=StringIO(
             self.sample_sheet_with_valid_barcodes))
         self.assertEqual(linter.has_invalid_barcodes(),list())
     def test_sample_sheet_with_no_barcodes(self):
@@ -169,7 +169,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
 1,AB1,AB1,,,,,,,Andrew_Bloggs,
 """
-        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=StringIO(
             self.sample_sheet_with_no_barcodes))
         self.assertEqual(linter.has_invalid_barcodes(),list())
     def test_sample_sheet_with_10xgenomics_barcodes(self):
@@ -184,7 +184,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
 7,AB7,AB7,,,N701,SI-P03-C9,Philip_Crook,
 8,AB8,AB8,,,N701,SI-P03-C9,Philip_Crook,
 """
-        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=StringIO(
             self.sample_sheet_with_10xgenomics_barcodes))
         self.assertEqual(linter.has_invalid_barcodes(),list())
     def test_sample_sheet_with_invalid_barcodes(self):
@@ -199,7 +199,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 4,KL1,KL1,,,N702,TGACC&^&,N502,TCTTTCCC,Karl_Landseer,
 4,KL2,KL2,,,N702,TGACCAAT,N502,TC%$TCCC,Karl_Landseer,
 """
-        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=StringIO(
             self.sample_sheet_with_invalid_barcodes))
         self.assertTrue(linter.has_invalid_barcodes())
 
@@ -212,7 +212,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
 2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 """
-        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=StringIO(
             self.sample_sheet_with_non_printing_ascii_characters))
         self.assertTrue(linter.has_invalid_characters())
     def test_sample_sheet_with_valid_characters(self):
@@ -223,7 +223,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 2,CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
 2,FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 """
-        linter = SampleSheetLinter(fp=cStringIO.StringIO(
+        linter = SampleSheetLinter(fp=StringIO(
             self.sample_sheet_with_valid_characters))
         self.assertFalse(linter.has_invalid_characters())
 

--- a/auto_process_ngs/test/test_samplesheet_utils.py
+++ b/auto_process_ngs/test/test_samplesheet_utils.py
@@ -238,7 +238,7 @@ class TestHasInvalidCharactersFunction(unittest.TestCase):
         """
         non_printing_ascii_file = os.path.join(self.wd,
                                                "test.nonprintingascii")
-        with open(non_printing_ascii_file,'wb') as fp:
+        with open(non_printing_ascii_file,'wt') as fp:
             fp.write(u"""This file contains:
 a non-printing ASCII ctrl-S character here\x13
 """)
@@ -268,7 +268,7 @@ a non-ASCII character here\x80
         """has_invalid_characters: works for valid file
         """
         valid_file = os.path.join(self.wd,"test.valid")
-        with open(valid_file,'wb') as fp:
+        with open(valid_file,'wt') as fp:
             fp.write(u"""This file contains valid characters:
 - ABCDEFGHIJKLMNOPQRSTUVWXYZ
 - abcdefghijklmnopqrstuvwxyz

--- a/auto_process_ngs/test/test_samplesheet_utils.py
+++ b/auto_process_ngs/test/test_samplesheet_utils.py
@@ -35,7 +35,7 @@ Adapter,CTGTCTCTTATACACATCT
 
 class TestCloseProjectNames(unittest.TestCase):
     def test_sample_sheet_without_close_project_names(self):
-        self.sample_sheet_no_close_project_names = """[Data]
+        self.sample_sheet_no_close_project_names = u"""[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
 1,AB1,AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
 1,AB2,AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
@@ -46,7 +46,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
             self.sample_sheet_no_close_project_names))
         self.assertEqual(linter.close_project_names(),{})
     def test_sample_sheet_with_close_project_names(self):
-        self.sample_sheet_close_project_names = """[Data]
+        self.sample_sheet_close_project_names = u"""[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
 1,AB1,AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Blogs,
 1,AB2,AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
@@ -61,7 +61,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 
 class TestSamplesInMultipleProjects(unittest.TestCase):
     def test_sample_sheet_without_samples_in_multiple_projects(self):
-        self.sample_sheet_no_samples_in_multiple_projects = """[Data]
+        self.sample_sheet_no_samples_in_multiple_projects = u"""[Data]
 Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
 1,AB1,AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
 1,AB2,AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
@@ -73,7 +73,7 @@ Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,ind
             self.sample_sheet_no_samples_in_multiple_projects))
         self.assertEqual(linter.samples_in_multiple_projects(),{})
     def test_sample_sheet_with_samples_in_multiple_projects(self):
-        self.sample_sheet_samples_in_multiple_projects = """[Data]
+        self.sample_sheet_samples_in_multiple_projects = u"""[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
 1,AB1,AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs1,
 1,AB2,AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs1,
@@ -88,7 +88,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 
 class TestSamplesWithMultipleBarcodes(unittest.TestCase):
     def test_sample_sheet_without_multiple_barcodes(self):
-        self.sample_sheet_without_multiple_barcodes = """[Data]
+        self.sample_sheet_without_multiple_barcodes = u"""[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
 1,AB1,AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
 1,AB2,AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
@@ -100,7 +100,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
             self.sample_sheet_without_multiple_barcodes))
         self.assertEqual(linter.samples_with_multiple_barcodes(),{})
     def test_sample_sheet_with_multiple_barcodes(self):
-        self.sample_sheet_with_multiple_barcodes = """[Data]
+        self.sample_sheet_with_multiple_barcodes = u"""[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
 1,AB1,AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
 1,AB2,AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
@@ -115,7 +115,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 
 class TestLinterHasInvalidLines(unittest.TestCase):
     def test_sample_sheet_without_invalid_lines(self):
-        self.sample_sheet_without_invalid_lines = """[Data]
+        self.sample_sheet_without_invalid_lines = u"""[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
 1,AB1,AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
 1,AB2,AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
@@ -126,7 +126,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
             self.sample_sheet_without_invalid_lines))
         self.assertFalse(linter.has_invalid_lines())
     def test_sample_sheet_with_invalid_lines_missing_lane(self):
-        self.sample_sheet_with_invalid_lines = """[Data]
+        self.sample_sheet_with_invalid_lines = u"""[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
 1,AB1,AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
 1,AB2,AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
@@ -139,7 +139,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
             self.sample_sheet_with_invalid_lines))
         self.assertTrue(linter.has_invalid_lines())
     def test_sample_sheet_with_invalid_lines_no_lane(self):
-        self.sample_sheet_with_invalid_lines_no_lane = """[Data]
+        self.sample_sheet_with_invalid_lines_no_lane = u"""[Data]
 Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
 AB1,AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
 AB2,AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
@@ -154,7 +154,7 @@ FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
 
 class TestLinterHasInvalidBarcodes(unittest.TestCase):
     def test_sample_sheet_with_valid_barcodes(self):
-        self.sample_sheet_with_valid_barcodes = """[Data]
+        self.sample_sheet_with_valid_barcodes = u"""[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
 1,AB1,AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
 1,AB2,AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
@@ -165,7 +165,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
             self.sample_sheet_with_valid_barcodes))
         self.assertEqual(linter.has_invalid_barcodes(),list())
     def test_sample_sheet_with_no_barcodes(self):
-        self.sample_sheet_with_no_barcodes = """[Data]
+        self.sample_sheet_with_no_barcodes = u"""[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
 1,AB1,AB1,,,,,,,Andrew_Bloggs,
 """
@@ -173,7 +173,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
             self.sample_sheet_with_no_barcodes))
         self.assertEqual(linter.has_invalid_barcodes(),list())
     def test_sample_sheet_with_10xgenomics_barcodes(self):
-        self.sample_sheet_with_10xgenomics_barcodes = """[Data]
+        self.sample_sheet_with_10xgenomics_barcodes = u"""[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
 1,AB1,AB1,,,N701,SI-GA-B3,Philip_Crook,
 2,AB2,AB2,,,N701,SI-GA-B3,Philip_Crook,
@@ -188,7 +188,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
             self.sample_sheet_with_10xgenomics_barcodes))
         self.assertEqual(linter.has_invalid_barcodes(),list())
     def test_sample_sheet_with_invalid_barcodes(self):
-        self.sample_sheet_with_invalid_barcodes = """[Data]
+        self.sample_sheet_with_invalid_barcodes = u"""[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
 1,AB1,AB1,,,N701,CGATGTNN,N501,TCTTTCCC,Andrew_Bloggs,
 1,AB2,AB2,,,N702,TGACCAAT,N502,TCTTNNNN,Andrew_Bloggs,
@@ -205,7 +205,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 
 class TestLinterHasInvalidCharacters(unittest.TestCase):
     def test_sample_sheet_with_non_printing_ascii_character(self):
-        self.sample_sheet_with_non_printing_ascii_characters = """[Data]
+        self.sample_sheet_with_non_printing_ascii_characters = u"""[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
 1,AB1,AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,\x13
 1,AB2,AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
@@ -216,7 +216,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
             self.sample_sheet_with_non_printing_ascii_characters))
         self.assertTrue(linter.has_invalid_characters())
     def test_sample_sheet_with_valid_characters(self):
-        self.sample_sheet_with_valid_characters = """[Data]
+        self.sample_sheet_with_valid_characters = u"""[Data]
 Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
 1,AB1,AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
 1,AB2,AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,


### PR DESCRIPTION
PR which fixes the unit tests for the `samplesheet_utils` module to work under Python 3.