### PR TITLE
simple_scheduler: fixes to unit tests for Python 3 compatibility

### DIFF
--- a/auto_process_ngs/test/test_simple_scheduler.py
+++ b/auto_process_ngs/test/test_simple_scheduler.py
@@ -926,7 +926,8 @@ class TestSchedulerReporter(unittest.TestCase):
         """SchedulerReporter returns correct output for scheduler status
         """
         fp = StringIO()
-        reporter = SchedulerReporter(fp=fp,scheduler_status="%(n_running)s jobs")
+        reporter = SchedulerReporter(fp=fp,
+                                     scheduler_status=u"%(n_running)s jobs")
         sched = SimpleScheduler(poll_interval=0.01)
         reporter.scheduler_status(sched)
         self.assertEqual('0 jobs\n',fp.getvalue())
@@ -937,7 +938,7 @@ class TestSchedulerReporter(unittest.TestCase):
         fp = StringIO()
         reporter = SchedulerReporter(
             fp=fp,
-            job_scheduled="Job scheduled: #%(job_number)d: \"%(job_name)s\""
+            job_scheduled=u"Job scheduled: #%(job_number)d: \"%(job_name)s\""
         )
         job = SchedulerJob(MockJobRunner(),['sleep','50'],
                            job_number=2,name='test',wait_for=[])
@@ -950,7 +951,7 @@ class TestSchedulerReporter(unittest.TestCase):
         fp = StringIO()
         reporter = SchedulerReporter(
             fp=fp,
-            job_start="Job started: #%(job_number)d (%(job_id)s): \"%(job_name)s\""
+            job_start=u"Job started: #%(job_number)d (%(job_id)s): \"%(job_name)s\""
         )
         job = SchedulerJob(MockJobRunner(),['sleep','50'],
                            job_number=2,name='test',wait_for=[])
@@ -964,7 +965,7 @@ class TestSchedulerReporter(unittest.TestCase):
         fp = StringIO()
         reporter = SchedulerReporter(
             fp=fp,
-            job_end="Job completed: #%(job_number)d (%(job_id)s): \"%(job_name)s\""
+            job_end=u"Job completed: #%(job_number)d (%(job_id)s): \"%(job_name)s\""
         )
         job = SchedulerJob(MockJobRunner(),['sleep','50'],
                            job_number=2,name='test',wait_for=[])
@@ -979,7 +980,7 @@ class TestSchedulerReporter(unittest.TestCase):
         fp = StringIO()
         reporter = SchedulerReporter(
             fp=fp,
-            group_added="Group has been added: #%(group_id)d: \"%(group_name)s\""
+            group_added=u"Group has been added: #%(group_id)d: \"%(group_name)s\""
         )
         group = SchedulerGroup('test',1,SimpleScheduler(poll_interval=0.01))
         reporter.group_added(group)
@@ -991,7 +992,7 @@ class TestSchedulerReporter(unittest.TestCase):
         fp = StringIO()
         reporter = SchedulerReporter(
             fp=fp,
-            group_end="Group completed: #%(group_id)d: \"%(group_name)s\""
+            group_end=u"Group completed: #%(group_id)d: \"%(group_name)s\""
         )
         group = SchedulerGroup('test',1,SimpleScheduler(poll_interval=0.01))
         job = group.add(['sleep','50'],name='sleep',wait_for=[])

--- a/auto_process_ngs/test/test_simple_scheduler.py
+++ b/auto_process_ngs/test/test_simple_scheduler.py
@@ -9,6 +9,7 @@ import logging
 import tempfile
 import shutil
 from io import StringIO
+from builtins import range
 from bcftbx.JobRunner import BaseJobRunner
 from bcftbx.JobRunner import SimpleJobRunner
 from auto_process_ngs.simple_scheduler import *
@@ -892,7 +893,7 @@ class TestSchedulerJob(unittest.TestCase):
         self.assertTrue(job.is_running)
         self.assertFalse(job.completed)
         max_tries = 3
-        for i in xrange(max_tries+1):
+        for i in range(max_tries+1):
             restarted_job_id = job.restart(max_tries)
             if i < max_tries:
                 self.assertTrue(job.is_running)

--- a/auto_process_ngs/test/test_simple_scheduler.py
+++ b/auto_process_ngs/test/test_simple_scheduler.py
@@ -2,13 +2,13 @@
 # Tests for simple_scheduler.py module
 #######################################################################
 import unittest
-import cStringIO
 import os
 import sys
 import time
 import logging
 import tempfile
 import shutil
+from io import StringIO
 from bcftbx.JobRunner import BaseJobRunner
 from bcftbx.JobRunner import SimpleJobRunner
 from auto_process_ngs.simple_scheduler import *
@@ -915,7 +915,7 @@ class TestSchedulerReporter(unittest.TestCase):
     def test_empty_scheduler_reporter(self):
         """'Empty' SchedulerReporter returns no output for scheduler status
         """
-        fp = cStringIO.StringIO()
+        fp = StringIO()
         reporter = SchedulerReporter(fp=fp)
         sched = SimpleScheduler(poll_interval=0.01)
         reporter.scheduler_status(sched)
@@ -924,7 +924,7 @@ class TestSchedulerReporter(unittest.TestCase):
     def test_scheduler_reporter_scheduler_status(self):
         """SchedulerReporter returns correct output for scheduler status
         """
-        fp = cStringIO.StringIO()
+        fp = StringIO()
         reporter = SchedulerReporter(fp=fp,scheduler_status="%(n_running)s jobs")
         sched = SimpleScheduler(poll_interval=0.01)
         reporter.scheduler_status(sched)
@@ -933,7 +933,7 @@ class TestSchedulerReporter(unittest.TestCase):
     def test_scheduler_reporter_job_scheduled(self):
         """SchedulerReporter returns correct output when job is scheduled
         """
-        fp = cStringIO.StringIO()
+        fp = StringIO()
         reporter = SchedulerReporter(
             fp=fp,
             job_scheduled="Job scheduled: #%(job_number)d: \"%(job_name)s\""
@@ -946,7 +946,7 @@ class TestSchedulerReporter(unittest.TestCase):
     def test_scheduler_reporter_job_start(self):
         """SchedulerReporter returns correct output when job is started
         """
-        fp = cStringIO.StringIO()
+        fp = StringIO()
         reporter = SchedulerReporter(
             fp=fp,
             job_start="Job started: #%(job_number)d (%(job_id)s): \"%(job_name)s\""
@@ -960,7 +960,7 @@ class TestSchedulerReporter(unittest.TestCase):
     def test_scheduler_reporter_job_end(self):
         """SchedulerReporter returns correct output when job ends
         """
-        fp = cStringIO.StringIO()
+        fp = StringIO()
         reporter = SchedulerReporter(
             fp=fp,
             job_end="Job completed: #%(job_number)d (%(job_id)s): \"%(job_name)s\""
@@ -975,7 +975,7 @@ class TestSchedulerReporter(unittest.TestCase):
     def test_scheduler_reporter_group_added(self):
         """SchedulerReporter returns correct output when group is added
         """
-        fp = cStringIO.StringIO()
+        fp = StringIO()
         reporter = SchedulerReporter(
             fp=fp,
             group_added="Group has been added: #%(group_id)d: \"%(group_name)s\""
@@ -987,7 +987,7 @@ class TestSchedulerReporter(unittest.TestCase):
     def test_scheduler_reporter_group_end(self):
         """SchedulerReporter returns correct output when group finishes
         """
-        fp = cStringIO.StringIO()
+        fp = StringIO()
         reporter = SchedulerReporter(
             fp=fp,
             group_end="Group completed: #%(group_id)d: \"%(group_name)s\""


### PR DESCRIPTION
PR which fixes the unit tests for the `simple_scheduler` module for compatibility with Python 3.