### PR TITLE
'barcodes' modules: updates for Python 3 compatibility

### DIFF
--- a/auto_process_ngs/barcodes/analysis.py
+++ b/auto_process_ngs/barcodes/analysis.py
@@ -184,7 +184,7 @@ class BarcodeCounter(object):
             ascending order.
 
         """
-        lanes = self._seqs.keys()
+        lanes = list(self._seqs.keys())
         if lanes == [None]:
             return []
         else:
@@ -761,7 +761,7 @@ class SampleSheetBarcodes(object):
             # Special case: sample sheet doesn't define any lanes
             lane = None
         if lane in self._lanes:
-            barcodes = self._sample_lookup[lane].keys()
+            barcodes = list(self._sample_lookup[lane].keys())
         elif lane is None:
             barcodes = []
             for l in self._lanes:
@@ -788,7 +788,7 @@ class SampleSheetBarcodes(object):
             # Special case:sample sheet doesn't define any lanes
             lane = None
         if lane in self._lanes:
-            samples = self._barcode_lookup[lane].keys()
+            samples = list(self._barcode_lookup[lane].keys())
         elif lane is None:
             samples = []
             for l in self._lanes:

--- a/auto_process_ngs/barcodes/analysis.py
+++ b/auto_process_ngs/barcodes/analysis.py
@@ -1150,9 +1150,9 @@ def report_barcodes(counts,lane=None,sample_sheet=None,cutoff=None,
     overrepresented = []
     if sample_sheet is not None:
         sample_sheet = SampleSheetBarcodes(sample_sheet)
-        found_samples = filter(lambda s: s is not None,
-                               [analysis.counts[bc].sample
-                                for bc in analysis.barcodes])
+        found_samples = list(filter(lambda s: s is not None,
+                                    [analysis.counts[bc].sample
+                                     for bc in analysis.barcodes]))
         # Get the underrepresented sample names
         for sample in sample_sheet.samples(lane):
             if sample not in found_samples:

--- a/auto_process_ngs/barcodes/analysis.py
+++ b/auto_process_ngs/barcodes/analysis.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     barcodes/analysis.py: classes and functions for analysing barcodes
-#     Copyright (C) University of Manchester 2016-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2016-2020 Peter Briggs
 #
 ########################################################################
 #

--- a/auto_process_ngs/barcodes/splitter.py
+++ b/auto_process_ngs/barcodes/splitter.py
@@ -21,7 +21,12 @@ index sequences) from the read headers:
 
 """
 
-import itertools
+try:
+    # Python 2
+    from itertools import izip as zip
+except ImportError:
+    # Python 3
+    pass
 import logging
 import bcftbx.IlluminaData as IlluminaData
 import bcftbx.FASTQFile as FASTQFile
@@ -58,7 +63,7 @@ class HammingMetrics(object):
         """
         if len(s1) != len(s2):
             raise ValueError("Undefined for sequences of unequal length")
-        return sum(ch1 != ch2 for ch1, ch2 in itertools.izip(s1, s2))
+        return sum(ch1 != ch2 for ch1, ch2 in zip(s1, s2))
 
     @classmethod
     def hamming_distance_truncate(self,s1,s2):
@@ -70,7 +75,7 @@ class HammingMetrics(object):
             l = min(len(s1),len(s2))
             s1 = s1[:l]
             s2 = s2[:l]
-        return sum(ch1 != ch2 for ch1, ch2 in itertools.izip(s1, s2))
+        return sum(ch1 != ch2 for ch1, ch2 in zip(s1, s2))
 
     @classmethod
     def hamming_distance_with_N(self,s1,s2):
@@ -82,7 +87,7 @@ class HammingMetrics(object):
         if len(s1) != len(s2):
             raise ValueError("Undefined for sequences of unequal length")
         return sum((ch1 != ch2 or ch1 == 'N' or ch2 == 'N') \
-                   for ch1, ch2 in itertools.izip(s1, s2))
+                   for ch1, ch2 in zip(s1, s2))
 
 class HammingLookup(object):
     """
@@ -311,8 +316,8 @@ def split_paired_end(matcher,fastq_pairs,base_name=None,output_dir=None):
     nread = 0
     for fq_r1,fq_r2 in fastq_pairs:
         print("Processing reads from fastq pair %s %s" % (fq_r1,fq_r2))
-        for read1,read2 in itertools.izip(FASTQFile.FastqIterator(fq_r1),
-                                          FASTQFile.FastqIterator(fq_r2)):
+        for read1,read2 in zip(FASTQFile.FastqIterator(fq_r1),
+                               FASTQFile.FastqIterator(fq_r2)):
             nread += 1
             seq = read1.seqid.index_sequence
             if not seq:

--- a/auto_process_ngs/barcodes/splitter.py
+++ b/auto_process_ngs/barcodes/splitter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     barcodes/splitter.py: classes & functions to sort reads by barcode
-#     Copyright (C) University of Manchester 2019 Peter Briggs
+#     Copyright (C) University of Manchester 2019-2020 Peter Briggs
 #
 #########################################################################
 #

--- a/auto_process_ngs/test/barcodes/test_analysis.py
+++ b/auto_process_ngs/test/barcodes/test_analysis.py
@@ -6,6 +6,7 @@ import os
 import unittest
 import tempfile
 import shutil
+from builtins import range
 from auto_process_ngs.barcodes.analysis import BarcodeCounter
 from auto_process_ngs.barcodes.analysis import BarcodeGroup
 from auto_process_ngs.barcodes.analysis import SampleSheetBarcodes
@@ -72,7 +73,7 @@ class TestBarcodeCounter(unittest.TestCase):
                        ((3,"CCAGCAATATCGCGAG"),2),
                        ((3,"CCGCGTAAGCAATAGA"),1)):
             lane,seq = r
-            for i in xrange(incr):
+            for i in range(incr):
                 bc.count_barcode(seq,lane=lane)
         # Check contents
         self.assertEqual(bc.barcodes(),["AGGCAGAATCTTACGC",

--- a/auto_process_ngs/test/barcodes/test_analysis.py
+++ b/auto_process_ngs/test/barcodes/test_analysis.py
@@ -118,7 +118,7 @@ class TestBarcodeCounter(unittest.TestCase):
         bc.count_barcode("TATGCGCGGTG",lane=1,incr=532)
         bc.count_barcode("ACCTACCGGTA",lane=1,incr=315)
         bc.count_barcode("CCCTTATGCGA",lane=1,incr=22)
-	bc.count_barcode("ACCTAGCGGTA",lane=2,incr=477)
+        bc.count_barcode("ACCTAGCGGTA",lane=2,incr=477)
         bc.count_barcode("ACCTCTATGCT",lane=2,incr=368)
         self.assertEqual(bc.barcodes(),["TATGCGCGGTA",
                                         "TATGCGCGGTG",


### PR DESCRIPTION
PR which fixes issues with the `barcodes` submodules (i.e. `analysis` and `splitter`) and associated unit tests, to enable compatibility with Python 3.