### PR TITLE
pipeliner: fix calls to 'traceback.format_exc' function

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -1651,7 +1651,7 @@ class Pipeline(object):
                         task.fail(exit_code=1,
                                   message="Exception trying to run task "
                                   "'%s': %s\n%s" %
-                                  (task.id(),ex,traceback.format_exc(ex)))
+                                  (task.id(),ex,traceback.format_exc()))
                         failed.append(task)
                     self._running.append(task)
                     update = True
@@ -1974,7 +1974,7 @@ class PipelineTask(object):
         except Exception as ex:
             self.report("exception invoking '%s': %s" %
                         (f.__name__,ex))
-            self.report(traceback.format_exc(ex))
+            self.report(traceback.format_exc())
             self._exit_code += 1
         # Report stdout and stderr
         for line in output.stdout:


### PR DESCRIPTION
PR which fixes the calls to the `traceback.format_exc` (was sending an exception as an argument, but this is not valid - only a limit is allowed). This was a bug under both Python 2 and 3, but in Python it raised an explicit exception. 