### PR TITLE
Fix '--version' option for  for command line utilities

### DIFF
--- a/auto_process_ngs/icell8/atac.py
+++ b/auto_process_ngs/icell8/atac.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 #
 #     icell8_atac.py: utility functions for handling ICELL8 ATAC-seq data
 #     Copyright (C) University of Manchester 2019 Peter Briggs

--- a/bin/analyse_barcodes.py
+++ b/bin/analyse_barcodes.py
@@ -84,7 +84,6 @@ if __name__ == '__main__':
                                 "\n\t%(prog)s FASTQ [FASTQ...]\n"
                                 "\t%(prog)s DIR\n"
                                 "\t%(prog)s -c COUNTS_FILE [COUNTS_FILE...]",
-                                version="%%(prog)s %s" % __version__,
                                 description="Collate and report counts and "
                                 "statistics for Fastq index sequences (aka "
                                 "barcodes). If multiple Fastq files are "
@@ -97,6 +96,8 @@ if __name__ == '__main__':
                                 "supplied then the input must be one or more "
                                 "file of barcode counts generated previously "
                                 "using the -o option.")
+    p.add_argument('-v','--version',action='version',
+                   version="%%(prog)s %s" % __version__)
     input_and_output = p.add_argument_group("Input and output options")
     input_and_output.add_argument(
         '-c','--counts',

--- a/bin/demultiplex_icell8_atac.py
+++ b/bin/demultiplex_icell8_atac.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2
 #
 #     demultiplex_icell8_atac.py: demultiplex reads from ICELL8 scATAC-seq
-#     Copyright (C) University of Manchester 2019 Peter Briggs
+#     Copyright (C) University of Manchester 2019-2020 Peter Briggs
 #
 """
 demultiplex_icell8_atac.py
@@ -58,8 +58,9 @@ if __name__ == "__main__":
     # Set up parser
     p = ArgumentParser(description="Assign reads from ICELL8 ATAC "
                        "R1/R2/I1/I2 Fastq set to barcodes and samples "
-                       "in a well list file",
-                       version="%(prog)s "+__version__)
+                       "in a well list file")
+    p.add_argument('-v','--version',action='version',
+                   version="%(prog)s "+__version__)
     p.add_argument("well_list",metavar="WELL_LIST",help="Well list file")
     p.add_argument("fastq_r1",metavar="FASTQ_R1",help="FASTQ R1")
     p.add_argument("fastq_r2",metavar="FASTQ_R2",help="FASTQ R2")

--- a/bin/demultiplex_icell8_atac.py
+++ b/bin/demultiplex_icell8_atac.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 #
 #     demultiplex_icell8_atac.py: demultiplex reads from ICELL8 scATAC-seq
 #     Copyright (C) University of Manchester 2019-2020 Peter Briggs

--- a/bin/fastq_statistics.py
+++ b/bin/fastq_statistics.py
@@ -54,10 +54,11 @@ logging.basicConfig(format='%(levelname)s %(name)s: %(message)s')
 if __name__ == '__main__':
 
     # Process command line
-    p = argparse.ArgumentParser(version="%(prog)s "+__version__,
-                                description="Generate statistics for FASTQ "
+    p = argparse.ArgumentParser(description="Generate statistics for FASTQ "
                                 "files in ILLUMINA_RUN_DIR (top-level "
                                 "directory of a processed Illumina run)")
+    p.add_argument("-v","--version",action="version",
+                   version="%(prog)s "+__version__)
     p.add_argument("--unaligned",action="store",dest="unaligned_dir",
                    default="Unaligned",
                    help="specify an alternative name for the 'Unaligned' "

--- a/bin/manage_fastqs.py
+++ b/bin/manage_fastqs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     manage_runs.py: utility for managing fastq files from auto_process
-#     Copyright (C) University of Manchester 2014,2019 Peter Briggs
+#     Copyright (C) University of Manchester 2014,2019-2020 Peter Briggs
 #
 #########################################################################
 #

--- a/bin/manage_fastqs.py
+++ b/bin/manage_fastqs.py
@@ -176,8 +176,9 @@ if __name__ == "__main__":
         "then list the fastqs; 'copy' command copies fastqs for the "
         "specified PROJECT to DEST on a local or remote server; 'md5' "
         "command generates checksums for the fastqs; 'zip' command "
-        "creates a zip file with the fastq files.",
-        version="%(prog)s "+get_version())
+        "creates a zip file with the fastq files.")
+    p.add_argument('-v','--version',action='version',
+                   version="%(prog)s "+get_version())
     p.add_argument('--filter',action='store',dest='pattern',
                    default=None,
                    help="filter file names for reporting and copying "


### PR DESCRIPTION
PR which updates how the `--version` is handled in various command line utilities:

* `analyse_barcodes.py`
* `demultiplex_icell8_atac.py`
* `fastq_statistics.py`
* `manage_fastqs.py`

The issue was that in Python 2 the version option is implicitly provided by `ArgumentParser`, while in some versions of Python 3 (e.g. 3.7) it needs to be added explicitly within the application (and attempting to specify it when instantiating `ArgumentParser` raises an exception).