### PR TITLE
Fix to 'publish_qc' command for Python 3

### DIFF
--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -332,8 +332,8 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                 print("...%s: found cellranger count report" % project.name)
                 project_qc[project.name]['cellranger_zip'] = cellranger_zip
     # Projects with no QC
-    no_qc_projects = filter(lambda p: not project_qc[p.name].qc_dirs,
-                            projects)
+    no_qc_projects = list(filter(lambda p: not project_qc[p.name].qc_dirs,
+                                 projects))
     # Determine what projects are left and if we can proceed
     if no_qc_projects:
         # Failed to generate results for some projects

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     publish_qc_cmd.py: implement auto process publish_qc command
-#     Copyright (C) University of Manchester 2017-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2017-2020 Peter Briggs
 #
 #########################################################################
 


### PR DESCRIPTION
PR which fixes `commands/publish_qc_cmd` to work under Python 3, by wrapping the output from the `filter` function in a `list()` when checking for projects without QC outputs.