### PR TITLE
Fix to 'make_fastqs' command for Python 3 compatibility

### DIFF
--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -602,7 +602,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
                     if not os.path.exists(os.path.dirname(fastq)):
                         mkdirs(os.path.dirname(fastq))
                     with gzip.GzipFile(filename=fastq,mode='wb') as fp:
-                        fp.write('')
+                        fp.write(''.encode())
             else:
                 raise Exception("Fastq generation failed to produce "
                                 "expected outputs")

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     make_fastqs_cmd.py: implement auto process make_fastqs command
-#     Copyright (C) University of Manchester 2018-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2020 Peter Briggs
 #
 #########################################################################
 


### PR DESCRIPTION
PR which fixes a bug in the `make_fastqs` command when running tests under Python 3.