### PR TITLE
Update ICELL8 processing pipeline to enable per-task environment modules

### DIFF
--- a/auto_process_ngs/icell8/pipeline.py
+++ b/auto_process_ngs/icell8/pipeline.py
@@ -167,6 +167,10 @@ class ICell8QCFilter(Pipeline):
         self.add_runner("contaminant_filter")
         self.add_runner("qc")
 
+        # Define module environment modules
+        self.add_envmodules('cutadapt')
+        self.add_envmodules('fastq_screen')
+
         ###################
         # Do internal setup
         ###################
@@ -306,6 +310,7 @@ class ICell8QCFilter(Pipeline):
             pair_fastqs_for_poly_g.output.fastq_pairs,
             poly_g_dir)
         self.add_task(get_poly_g_reads,
+                      envmodules=self.envmodules['cutadapt'],
                       requires=(pair_fastqs_for_poly_g,))
         collect_poly_g_fastqs = CollectFiles("Collect poly-G fastqs",
                                              poly_g_dir,
@@ -332,7 +337,9 @@ class ICell8QCFilter(Pipeline):
         trim_reads = TrimReads("Read trimming",
                                pair_fastqs_for_trimming.output.fastq_pairs,
                                trim_dir)
-        self.add_task(trim_reads,requires=(pair_fastqs_for_trimming,))
+        self.add_task(trim_reads,
+                      envmodules=self.envmodules['cutadapt'],
+                      requires=(pair_fastqs_for_trimming,))
         collect_trimmed_fastqs = CollectFiles("Collect trimmed fastqs",
                                               trim_dir,
                                               trim_reads.output.pattern)
@@ -370,6 +377,7 @@ class ICell8QCFilter(Pipeline):
                 threads=nprocessors['contaminant_filter'])
             self.add_task(contaminant_filter,
                           requires=(pair_fastqs_for_contaminant_filtering,),
+                          envmodules=self.envmodules['fastq_screen'],
                           runner=self.runners['contaminant_filter'])
             collect_contaminant_filtered = CollectFiles(
                 "Collect contaminant-filtered fastqs",

--- a/auto_process_ngs/icell8/pipeline.py
+++ b/auto_process_ngs/icell8/pipeline.py
@@ -1701,7 +1701,7 @@ class MergeBarcodeFastqs(PipelineTask):
             shutil.rmtree(self.tmp_merge_dir)
         mkdir(self.tmp_merge_dir)
         # Extract the barcodes from the fastq groups dict
-        barcodes = self.args.fastq_groups.keys()
+        barcodes = list(self.args.fastq_groups.keys())
         # Group barcodes into batches
         barcode_batches = [barcodes[i:i+self.args.batch_size]
                            for i in range(0,len(barcodes),

--- a/auto_process_ngs/icell8/pipeline.py
+++ b/auto_process_ngs/icell8/pipeline.py
@@ -80,6 +80,7 @@ from ..pipeliner import FileCollector
 from .utils import ICell8WellList
 from .utils import ICell8Read1
 from .utils import normalize_sample_name
+from builtins import range
 
 #######################################################################
 # Constants
@@ -1703,8 +1704,8 @@ class MergeBarcodeFastqs(PipelineTask):
         barcodes = self.args.fastq_groups.keys()
         # Group barcodes into batches
         barcode_batches = [barcodes[i:i+self.args.batch_size]
-                           for i in xrange(0,len(barcodes),
-                                           self.args.batch_size)]
+                           for i in range(0,len(barcodes),
+                                          self.args.batch_size)]
         # Concat fastqs
         for i,barcode_batch in enumerate(barcode_batches):
             batch_name = "barcodes%06d" % i

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -1501,9 +1501,13 @@ class Pipeline(object):
         # Deal with environment modules
         if envmodules:
             for name in envmodules:
-                if envmodules[name] is not None:
-                    for m in envmodules[name].split(','):
-                        self.envmodules[name].value.append(m)
+                if name in self.envmodules:
+                   if envmodules[name] is not None:
+                       for m in envmodules[name].split(','):
+                           self.envmodules[name].value.append(m)
+                else:
+                    self.report("WARNING ignoring undefined environment "
+                                "module '%s'" % name)
         # Deal with scheduler
         if sched is None:
             # Create and start a scheduler

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -1,7 +1,7 @@
 #!/bin/env python
 #
 #     settings.py: handle configuration settings for autoprocessing
-#     Copyright (C) University of Manchester 2014-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2014-2020 Peter Briggs
 #
 #########################################################################
 #
@@ -135,6 +135,8 @@ class Settings(object):
         self.modulefiles['fastq_strand'] = config.get('modulefiles','fastq_strand')
         self.modulefiles['cellranger'] = config.get('modulefiles','cellranger')
         self.modulefiles['report_qc'] = config.get('modulefiles','report_qc')
+        self.modulefiles['cutadapt'] = config.get('modulefiles','cutadapt')
+        self.modulefiles['fastq_screen'] = config.get('modulefiles','fastq_screen')
         # bcl2fastq
         self.add_section('bcl2fastq')
         self.bcl2fastq = self.get_bcl2fastq_config('bcl2fastq',config)

--- a/config/auto_process.ini.sample
+++ b/config/auto_process.ini.sample
@@ -18,6 +18,8 @@ illumina_qc = None
 fastq_strand = None
 cellranger = None
 report_qc = None
+cutadapt = None
+fastq_screen = None
 
 # bcl2fastq settings
 [bcl2fastq]


### PR DESCRIPTION
PR to workaround issue #505 when running the ICELL8 processing pipeline via `process_icell8.py`.

The PR adds new `modulefiles` settings in the configuration file for `cutadapt` and `fastq_screen`, and associates these with the appropriate individual tasks in the pipeline defined in `icell8/pipeline`. Also the appropriate task-specific modulefiles are now supplied to the QC pipeline.

This means that the generic `process_icell8` module environment no longer needs to be used when running the pipeline.