### PR TITLE
run_qc.py: fix bug in setting up default runners

### DIFF
--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -119,7 +119,7 @@ if __name__ == "__main__":
                    help="number of threads to use for QC script "
                    "(default: %d)" % __settings.qc.nprocessors)
     p.add_argument('-r','--runner',metavar='RUNNER',action='store',
-                   dest="runner",default=str(__settings.runners.qc),
+                   dest="runner",default=None,
                    help="explicitly specify runner definition for "
                    "running QC script. RUNNER must be a valid job "
                    "runner specification e.g. 'GEJobRunner(-j y)' "
@@ -203,8 +203,8 @@ if __name__ == "__main__":
         qc_runner = fetch_runner(args.runner)
         cellranger_runner = fetch_runner(args.runner)
     else:
-        qc_runner = self._settings.runners.qc
-        cellranger_runner = self._settings.runners.cellranger
+        qc_runner = __settings.runners.qc
+        cellranger_runner = __settings.runners.cellranger
     verify_runner = default_runner
     report_runner = default_runner
 


### PR DESCRIPTION
PR which fixes a bug setting up the default job runners in the `run_qc.py` utility if they're not specified explicitly via the `--runner` option on the command line.

The bug meant that the defaults specified in the configuration were always being ignored, whereas these should be used unless overridden by the user. The fix means that the behaviour should now be correct.