### PR TITLE
10xgenomics: enable explicitly specifying library type for 'set_cell_count_for_project'

### DIFF
--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -651,3 +651,35 @@ class TestSetCellCountForProject(unittest.TestCase):
         self.assertEqual(AnalysisProject("PJB1",
                                          project_dir).info.number_of_cells,
                          5682)
+
+    def test_set_cell_count_for_project_explicitly_set_library_type(self):
+        """
+        set_cell_count_for_project: test setting library type explicitly
+        """
+        # Set up mock project with library type not set
+        project_dir = self._make_mock_analysis_project(
+            "10xGenomics Chromium 3'v3",
+            None)
+        # Add metrics_summary.csv
+        counts_dir = os.path.join(project_dir,
+                                  "qc",
+                                  "cellranger_count",
+                                  "PJB1",
+                                  "outs")
+        mkdirs(counts_dir)
+        metrics_summary_file = os.path.join(counts_dir,
+                                            "metrics_summary.csv")
+        with open(metrics_summary_file,'w') as fp:
+            fp.write(METRICS_SUMMARY)
+        # Check initial cell count
+        print("Checking number of cells")
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         None)
+        # Update the cell counts
+        print("Updating number of cells")
+        set_cell_count_for_project(project_dir,library_type="scRNA-seq")
+        # Check updated cell count
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         2272)


### PR DESCRIPTION
PR which enables the library type to be set explicitly for the `set_cell_count_for_project` function in the `tenx_genomics_utils` module, to override the value set in the project metadata.