### PR TITLE
QC pipeline: improve setting cell count for 10xGenomics projects

### DIFF
--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -221,6 +221,11 @@ class MetadataDict(bcf_utils.AttributeDictionary):
         # Write data to temporary file
         if filen is not None:
             self.__filen = filen
+        if self.__filen is None:
+            # Nowehere to write to
+            logger.warning("Cannot save metadata: no destination file "
+                           "defined")
+            return
         tmp_filen = os.path.join(
             os.path.dirname(self.__filen),
             "%s.%s.tmp" % (os.path.basename(self.__filen),

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     qc.pipeline.py: pipelines for running QC
-#     Copyright (C) University of Manchester 2019 Peter Briggs
+#     Copyright (C) University of Manchester 2019-2020 Peter Briggs
 #
 
 """
@@ -172,11 +172,17 @@ class QCPipeline(Pipeline):
         if not os.path.isabs(qc_dir):
             qc_dir = os.path.join(project.dirn,qc_dir)
 
+        # Sort out other parameters
+        if organism is None:
+            organism = project.info.organism
+
         # Report details
         self.report("-- Protocol  : %s" % qc_protocol)
         self.report("-- Directory : %s" % project.dirn)
         self.report("-- Fastqs dir: %s" % project.fastq_dir)
         self.report("-- QC dir    : %s" % qc_dir)
+        self.report("-- Library   : %s" % project.info.library_type)
+        self.report("-- Organism  : %s" % organism)
 
         ####################
         # Build the pipeline

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -775,6 +775,8 @@ class TestQCPipeline(unittest.TestCase):
                                        "PJB2_S2_R2_001.fastq.gz"),
                                 metadata={})
         p.create(top_dir=self.wd)
+        # Remove the README.info file
+        os.remove(os.path.join(self.wd,"PJB","README.info"))
         # Set up and run the QC
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject("PJB",

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -896,6 +896,34 @@ class TestAnalysisProject(unittest.TestCase):
                          os.path.join(unpickled.dirn,'fastqs'))
         self.assertEqual(unpickled.fastq_dirs,['fastqs',])
 
+    def test_handle_metadata_for_analysis_project_with_no_readme_info(self):
+        """AnalysisProject: handle metadata when there is no README.info file
+        """
+        # Set up directory without README.info file
+        self.make_mock_project_dir(
+            'PJB',
+            ('PJB1-A_ACAGTG_L001_R1_001.fastq.gz',
+             'PJB1-B_ACAGTG_L002_R1_001.fastq.gz',))
+        os.remove(os.path.join(self.dirn,'PJB','README.info'))
+        # Load data and check it's what we expect
+        dirn = os.path.join(self.dirn,'PJB')
+        project = AnalysisProject('PJB',dirn)
+        self.assertEqual(project.name,'PJB')
+        self.assertTrue(os.path.isdir(project.dirn))
+        self.assertFalse(project.multiple_fastqs)
+        self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.samples[0].name,'PJB1-A')
+        self.assertEqual(project.samples[1].name,'PJB1-B')
+        self.assertEqual(project.fastq_dir,
+                         os.path.join(project.dirn,'fastqs'))
+        self.assertEqual(project.info.samples,None)
+        self.assertEqual(project.fastq_dirs,['fastqs',])
+        self.assertEqual(project.info.primary_fastq_dir,'fastqs')
+        # Try altering and saving metadata
+        project.info.samples = '2 samples (PJB1-A, PJB1-B)'
+        self.assertEqual(project.info.samples,'2 samples (PJB1-A, PJB1-B)')
+        project.info.save()
+
 class TestAnalysisSample(unittest.TestCase):
     """Tests for the AnalysisSample class
 

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -56,6 +56,17 @@ class TestMetadataDict(unittest.TestCase):
         self.assertEqual(metadata2.valediction,"goodbye")
         self.assertEqual(metadata2.chat,None)
 
+    def test_dont_save_to_missing_file(self):
+        """Check 'save' operation is ignored if no file is specified
+        """
+        self.metadata_file = tempfile.mkstemp()[1]
+        metadata = MetadataDict(attributes={'salutation':'Salutation',
+                                            'valediction': 'Valediction',
+                                            'chat': 'Chit chat'})
+        metadata['salutation'] = "hello"
+        metadata['valediction'] = "goodbye"
+        metadata.save()
+
     def test_get_non_existent_attribute(self):
         """Check that accessing non-existent attribute raises exception
         """

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -651,3 +651,34 @@ class TestSetCellCountForProject(unittest.TestCase):
         self.assertEqual(AnalysisProject("PJB1",
                                          project_dir).info.number_of_cells,
                          5682)
+    def test_set_cell_count_project_missing_library_type(self):
+        """
+        set_cell_count_for_project: test for scRNA-seq when library not set
+        """
+        # Set up mock project with library type not set
+        project_dir = self._make_mock_analysis_project(
+            "10xGenomics Chromium 3'v3",
+            None)
+        # Add metrics_summary.csv
+        counts_dir = os.path.join(project_dir,
+                                  "qc",
+                                  "cellranger_count",
+                                  "PJB1",
+                                  "outs")
+        mkdirs(counts_dir)
+        metrics_summary_file = os.path.join(counts_dir,
+                                            "metrics_summary.csv")
+        with open(metrics_summary_file,'w') as fp:
+            fp.write(METRICS_SUMMARY)
+        # Check initial cell count
+        print("Checking number of cells")
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         None)
+        # Update the cell counts
+        print("Updating number of cells")
+        set_cell_count_for_project(project_dir)
+        # Check updated cell count
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         2272)


### PR DESCRIPTION
PR which reimplements the `set_cell_count_for_project` function so that it doesn't need to know what the library type of the project is.

This should mean that the QC pipeline can be run with a 10xGenomics protocol (e.g. `10x_RNAseq`) via the `run_qc.py` utility on arbitrary project-like directories which don't have metadata defined (most likely because they don't have a `README.info` file) without an error occurring when trying to set the cell count (which is what currently happens).