### PR TITLE
Fix QC pipeline unit test (wrong reference data)

### DIFF
--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -786,7 +786,7 @@ class TestQCPipeline(unittest.TestCase):
                           organism="human")
         status = runqc.run(fastq_strand_indexes=
                            { 'human': '/data/hg38/star_index' },
-                           cellranger_premrna_references=
+                           cellranger_transcriptomes=
                            { 'human': '/data/hg38/cellranger' },
                            poll_interval=0.5,
                            max_jobs=1,


### PR DESCRIPTION
PR which fixes a unit test for the `qc.pipeline` module (the incorrect reference was being supplied to the test for 10x scRNA-seq data with no project metadata).