### PR TITLE
Update QC pipeline to handle 10xGenomics data when no reference dataset is available

### DIFF
--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -594,6 +594,8 @@ class AnalysisProjectQCDirInfo(MetadataDict):
 
     fastq_dir: the name of the associated Fastq subdirectory
     protocol: the QC protocol used
+    organism: the organism(s) that the QC was run with
+    cellranger_refdata: reference datasets used with cellranger
     """
     def __init__(self,filen=None):
         """Create a new AnalysisProjectQCDirInfo instance
@@ -606,9 +608,13 @@ class AnalysisProjectQCDirInfo(MetadataDict):
                               attributes = {
                                   'fastq_dir':'Fastq dir',
                                   'protocol':'QC protocol',
+                                  'organism':'Organism',
+                                  'cellranger_refdata':
+                                  'Cellranger reference datasets',
                               },
                               order = (
                                   'fastq_dir',
                                   'protocol',
+                                  'organism',
                               ),
                               filen=filen)

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -770,6 +770,11 @@ class UpdateAnalysisProject(DirectoryUpdater):
             zip_file.add(os.path.join(self._project.dirn,
                                       "cellranger_count"))
             zip_file.close()
+        # Update cellranger reference data in qc.info
+        if not legacy:
+            qc_info = self._project.qc_info(self._project.qc_dir)
+            qc_info['cellranger_refdata'] = "/data/refdata-cellranger-1.2.0"
+            qc_info.save()
         self._reload_project()
 
 #######################################################################

--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -347,7 +347,7 @@ def check_cellranger_atac_count_outputs(project,qc_dir=None):
     return sorted(list(samples))
 
 def expected_outputs(project,qc_dir,fastq_strand_conf=None,
-                     qc_protocol=None):
+                     cellranger_refdata=None,qc_protocol=None):
     """
     Return expected QC outputs for a project
 
@@ -362,6 +362,10 @@ def expected_outputs(project,qc_dir,fastq_strand_conf=None,
         included unless the path is `None` or the
         config file doesn't exist. Relative path is
         assumed to be a subdirectory of the project
+      cellranger_refdata (str): path to a cellranger
+        reference dataset; cellranger count outputs will
+        be included for 10x protocols unless this path
+        is set to `None`
       qc_protocol (str): QC protocol to predict outputs
         for; if not set then defaults to standard QC
         based on ended-ness
@@ -419,8 +423,8 @@ def expected_outputs(project,qc_dir,fastq_strand_conf=None,
                                       fastq_strand_output(fq_group[0]))
             outputs.add(output)
     # Cellranger count output
-    if qc_protocol in ('10x_scRNAseq',
-                       '10x_snRNAseq',):
+    if qc_protocol in ('10x_scRNAseq','10x_snRNAseq',) and \
+       cellranger_refdata is not None:
         for output in cellranger_count_output(project):
             outputs.add(os.path.join(qc_dir,output))
     elif qc_protocol == '10x_scATAC':

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -844,6 +844,9 @@ class QCReport(Document):
                     elif item == 'cellranger_reference':
                         path = self.project.qc_info(self.qc_dir).\
                                cellranger_refdata
+                        if path is None:
+                            # No reference dataset
+                            continue
                         if os.path.dirname(path):
                             value = "...%s%s" % (os.sep,
                                                  os.path.basename(path))

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -33,6 +33,7 @@ from ..docwriter import List
 from ..docwriter import Para
 from ..docwriter import WarningIcon
 from ..metadata import AnalysisDirMetadata
+from ..metadata import AnalysisProjectQCDirInfo
 from ..fastq_utils import group_fastqs_by_name
 from .fastqc import Fastqc
 from .fastq_screen import Fastqscreen
@@ -241,9 +242,20 @@ class QCReporter(object):
             fastq_strand_conf = None
         logger.debug("QCReporter.verify: fastq_strand conf file : %s" %
                      fastq_strand_conf)
+        cellranger_refdata = None
+        qc_info_file = os.path.join(qc_dir,"qc.info")
+        if os.path.exists(qc_info_file):
+            qc_info = AnalysisProjectQCDirInfo(filen=qc_info_file)
+            try:
+                cellranger_refdata = qc_info['cellranger_refdata']
+            except KeyError:
+                pass
+        logger.debug("QCReporter.verify: cellranger reference data : %s" %
+                     cellranger_refdata)
         verified = True
         for f in expected_outputs(self._project,qc_dir,
-                                  fastq_strand_conf,
+                                  fastq_strand_conf=fastq_strand_conf,
+                                  cellranger_refdata=cellranger_refdata,
                                   qc_protocol=qc_protocol):
             if not os.path.exists(f):
                 print("Missing: %s" % f)
@@ -720,7 +732,7 @@ class QCReport(Document):
             outputs.add("icell8_report")
         # Look for cellranger_count outputs
         cellranger_count_dir = os.path.join(self.qc_dir,
-                                             "cellranger_count")
+                                            "cellranger_count")
         cellranger_samples = []
         if os.path.isdir(cellranger_count_dir):
             for d in filter(

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -955,6 +955,8 @@ class TestExpectedOutputs(unittest.TestCase):
                                                                  p.name)),
                                     "qc",
                                     fastq_strand_conf=mock_fastq_strand_conf,
+                                    cellranger_refdata=
+                                    "/data/refdata-cellranger-GRCh38-1.2.0",
                                     qc_protocol="10x_scRNAseq")
         for e in expected:
             print(e)
@@ -1015,6 +1017,8 @@ class TestExpectedOutputs(unittest.TestCase):
                                                                  p.name)),
                                     "qc",
                                     fastq_strand_conf=mock_fastq_strand_conf,
+                                    cellranger_refdata=
+                                    "/data/refdata-cellranger-atac-GRCh38-1.2.0",
                                     qc_protocol="10x_scATAC")
         for e in expected:
             print(e)
@@ -1025,3 +1029,48 @@ class TestExpectedOutputs(unittest.TestCase):
             self.assertTrue(os.path.join(self.wd,p.name,r) in expected,
                             "%s not found in expected" % r)
 
+    def test_expected_outputs_10x_scRNA_seq_with_no_cellranger_reference(self):
+        """
+        expected_outputs: 10xGenomics scRNA-seq with no cellranger reference data
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           "10xGenomics Chromium 3'v3" })
+        p.create(top_dir=self.wd)
+        # Make mock fastq_strand
+        mock_fastq_strand_conf = os.path.join(self.wd,
+                                              p.name,
+                                              "fastq_strand.conf")
+        with open(mock_fastq_strand_conf,'w') as fp:
+            fp.write("")
+        reference_outputs = ("qc/PJB1_S1_R1_001_fastqc",
+                             "qc/PJB1_S1_R1_001_fastqc.html",
+                             "qc/PJB1_S1_R1_001_fastqc.zip",
+                             "qc/PJB1_S1_R2_001_fastqc",
+                             "qc/PJB1_S1_R2_001_fastqc.html",
+                             "qc/PJB1_S1_R2_001_fastqc.zip",
+                             "qc/PJB1_S1_R2_001_model_organisms_screen.png",
+                             "qc/PJB1_S1_R2_001_model_organisms_screen.txt",
+                             "qc/PJB1_S1_R2_001_other_organisms_screen.png",
+                             "qc/PJB1_S1_R2_001_other_organisms_screen.txt",
+                             "qc/PJB1_S1_R2_001_rRNA_screen.png",
+                             "qc/PJB1_S1_R2_001_rRNA_screen.txt",
+                             "qc/PJB1_S1_R2_001_fastq_strand.txt",)
+        expected = expected_outputs(AnalysisProject(p.name,
+                                                    os.path.join(self.wd,
+                                                                 p.name)),
+                                    "qc",
+                                    fastq_strand_conf=mock_fastq_strand_conf,
+                                    cellranger_refdata=None,
+                                    qc_protocol="10x_scRNAseq")
+        for e in expected:
+            print(e)
+            self.assertTrue(e in [os.path.join(self.wd,p.name,r)
+                                  for r in reference_outputs],
+                            "%s not found in reference" % e)
+        for r in reference_outputs:
+            self.assertTrue(os.path.join(self.wd,p.name,r) in expected,
+                            "%s not found in expected" % r)


### PR DESCRIPTION
PR to address issue #425 (handle 10xGenomics data when there is no appropriate reference dataset for single library analysis), by updating the QC pipeline to store information on the reference dataset used for `cellranger count` in the QC metadata file. This data is used when verifying the QC outputs to determine whether `cellranger count` outputs are expected.

(Storage of the `cellranger` reference dataset also addresses part of issue #467; the PR updated the QC reporting to include the reference dataset, which addresses the remainder of this second issue.)