### PR TITLE
run_qc: fix bug when explicitly specifying runner for QC pipeline.

### DIFF
--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -121,6 +121,9 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
     if runner is None:
         qc_runner = ap.settings.runners.qc
         cellranger_runner = ap.settings.runners.cellranger
+    else:
+        qc_runner = runner
+        cellranger_runner = runner
     # Get environment modules
     envmodules = dict()
     for name in ('illumina_qc',


### PR DESCRIPTION
PR which fixes a bug in the `run_qc` command, where explicitly specified job runners were being ignored and the defaults from the configuration file were still used. This fix means that the specified job runners will be respected.