### PR TITLE
'mock': bugfix and update to 'MockCellrangerExe' class

### DIFF
--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1405,7 +1405,7 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
                         "Undetermined_S0_L%03d_%s_001.fastq.gz"
                         % (lane,r))
             # Build the output directory
-            output.create()
+            output.create(force_sample_dir=True)
             # Move to final location
             os.rename(os.path.join(tmpname,"bcl2fastq"),
                       output_dir)

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1371,7 +1371,7 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
             elif s.has_lanes:
                 lanes = [line['Lane'] for line in s.data]
             else:
-                lanes = IlluminaRun(runfolder).lanes
+                lanes = IlluminaRun(args.run).lanes
             print("Lanes: %s" % lanes)
             # Generate mock output based on inputs
             tmpname = "tmp.%s" % uuid.uuid4()

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -449,8 +449,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
                                     "171020_SN7001250_00002_AHGXXXX"),
                        os.path.join("logs",
                                     "002_make_fastqs_10x_chromium_sc"),
-                       "bcl2fastq",
-                       "barcode_analysis",):
+                       "bcl2fastq",):
             self.assertTrue(os.path.isdir(
                 os.path.join(analysis_dir,subdir)),
                             "Missing subdir: %s" % subdir)
@@ -1033,94 +1032,6 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
         self.assertRaises(Exception,
                           make_fastqs,
                           ap)
-
-    #@unittest.skip("Skipped")
-    def test_make_fastqs_10x_chromium_sc_protocol(self):
-        """make_fastqs: 10x_chromium_sc protocol
-        """
-        # Create mock source data
-        illumina_run = MockIlluminaRun(
-            "171020_SN7001250_00002_AHGXXXX",
-            "hiseq",
-            top_dir=self.wd)
-        illumina_run.create()
-        # Create mock bcl2fastq and cellranger executables
-        MockBcl2fastq2Exe.create(os.path.join(self.bin,"bcl2fastq"))
-        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"))
-        os.environ['PATH'] = "%s:%s" % (self.bin,
-                                        os.environ['PATH'])
-        # Do the test
-        ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_SN7001250_00002_AHGXXXX"))
-        self.assertTrue(ap.params.sample_sheet is not None)
-        self.assertEqual(ap.params.bases_mask,"auto")
-        self.assertTrue(ap.params.primary_data_dir is None)
-        self.assertFalse(ap.params.acquired_primary_data)
-        make_fastqs(ap,protocol="10x_chromium_sc")
-        # Check parameters
-        self.assertEqual(ap.params.primary_data_dir,
-                         os.path.join(self.wd,
-                                      "171020_SN7001250_00002_AHGXXXX_analysis",
-                                      "primary_data"))
-        self.assertTrue(ap.params.acquired_primary_data)
-        # Check outputs
-        analysis_dir = os.path.join(
-            self.wd,
-            "171020_SN7001250_00002_AHGXXXX_analysis")
-        for subdir in (os.path.join("primary_data",
-                                    "171020_SN7001250_00002_AHGXXXX"),
-                       os.path.join("logs",
-                                    "002_make_fastqs_10x_chromium_sc"),
-                       "bcl2fastq",
-                       "HGXXXX",):
-            self.assertTrue(os.path.isdir(
-                os.path.join(analysis_dir,subdir)),
-                            "Missing subdir: %s" % subdir)
-        for filen in ("statistics.info",
-                      "statistics_full.info",
-                      "per_lane_statistics.info",
-                      "per_lane_sample_stats.info",
-                      "projects.info",
-                      "processing_qc.html",
-                      "cellranger_qc_summary.html"):
-            self.assertTrue(os.path.isfile(
-                os.path.join(analysis_dir,filen)),
-                            "Missing file: %s" % filen)
-
-    def test_make_fastqs_primary_data_is_link(self):
-        """make_fastqs: check primary data is a link by default
-        """
-        # Create mock source data
-        illumina_run = MockIlluminaRun(
-            "171020_SN7001250_00002_AHGXXXX",
-            "hiseq",
-            top_dir=self.wd)
-        illumina_run.create()
-        # Create mock bcl2fastq and cellranger executables
-        MockBcl2fastq2Exe.create(os.path.join(self.bin,"bcl2fastq"))
-        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"))
-        os.environ['PATH'] = "%s:%s" % (self.bin,
-                                        os.environ['PATH'])
-        # Do the test
-        ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_SN7001250_00002_AHGXXXX"))
-        self.assertTrue(ap.params.sample_sheet is not None)
-        self.assertEqual(ap.params.bases_mask,"auto")
-        self.assertTrue(ap.params.primary_data_dir is None)
-        self.assertFalse(ap.params.acquired_primary_data)
-        make_fastqs(ap,only_fetch_primary_data=True)
-        # Check parameters
-        self.assertEqual(ap.params.primary_data_dir,
-                         os.path.join(self.wd,
-                                      "171020_SN7001250_00002_AHGXXXX_analysis",
-                                      "primary_data"))
-        self.assertTrue(ap.params.acquired_primary_data)
-        # Check primary data is a link
-        primary_data = os.path.join(ap.params.primary_data_dir,
-                                    "171020_SN7001250_00002_AHGXXXX")
-        self.assertTrue(os.path.islink(primary_data))
 
     def test_make_fastqs_force_rsync_of_primary_data(self):
         """make_fastqs: force rsync of primary data


### PR DESCRIPTION
PR updating the `MockCellrangerExe` class in the `mock` module:

* Fix a bug when handling the `--run` option
* Force creation of a sample subdirectory when mocking outputs from the `mkfastq` subcommand