### PR TITLE
Use 'with' statements to release resources after use

### DIFF
--- a/auto_process_ngs/applications.py
+++ b/auto_process_ngs/applications.py
@@ -228,12 +228,12 @@ class Command(object):
         else:
             stderr = None
         # Create a temporary file-like object to capture output
-        ftmp = tempfile.TemporaryFile(mode='w+t')
-        status = subprocess.call(self.command_line,stdout=ftmp,
-                                 cwd=working_dir,stderr=stderr)
-        # Read the output
-        ftmp.seek(0)
-        output = ftmp.read()
+        with tempfile.TemporaryFile(mode='w+t') as ftmp:
+            status = subprocess.call(self.command_line,stdout=ftmp,
+                                     cwd=working_dir,stderr=stderr)
+            # Read the output
+            ftmp.seek(0)
+            output = ftmp.read()
         return (status,output)
 
     def make_wrapper_script(self,shell=None,filen=None,fp=None,

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -357,7 +357,7 @@ class AutoProcess(object):
         if self.readme_file is None:
             readme_file = os.path.join(self.analysis_dir,'README')
             print("Initialising %s" % readme_file)
-            with open(readme_file,'w') as fp:
+            with open(readme_file,'wt') as fp:
                 title = "Processing notes for %s" % \
                         os.path.basename(self.analysis_dir)
                 fp.write("%s\n%s\n" % (title,'='*len(title)))

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -654,8 +654,9 @@ class AutoProcess(object):
         # not pruned on subsequent rsync operations
         readme = os.path.join(script_code,'README.txt')
         if not os.path.exists(readme):
-            open(readme,'w').write("The ScriptCode directory is a "
-                                   "place to put custom scripts and programs\n")
+            with open(readme,'wt') as fp:
+                fp.write("The ScriptCode directory is a place to put "
+                         "custom scripts and programs\n")
 
     @property
     def readme_file(self):

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -279,9 +279,10 @@ class MockAnalysisDir(MockIlluminaData):
         if self.readme is not None:
             open(os.path.join(self.dirn,'README'),'w').write(self.readme)
         # Add empty original sample sheet
-        open(os.path.join(self.dirn,'SampleSheet.orig.csv'),'w').write('')
+        with open(os.path.join(self.dirn,'SampleSheet.orig.csv'),'wt') as fp:
+            fp.write('')
         # Initialise a custom_SampleSheet.csv
-        with open(os.path.join(self.dirn,'custom_SampleSheet.csv'),'w') as fp:
+        with open(os.path.join(self.dirn,'custom_SampleSheet.csv'),'wt') as fp:
             fp.write('[Data]\n')
             fp.write('Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description\n')
         # Add top-level ScriptCode directory


### PR DESCRIPTION
PR which updates the code to use the `with` statement where appropriate, so that resources (such as files) are released in a timely fashion after they've been used.

Without these fixes the Travis CI tests have complaints like:

    /home/travis/build/fls-bioinformatics-core/auto_process_ngs/auto_process_ngs/fileops.py:378: ResourceWarning: unclosed file <_io.TextIOWrapper name=3 mode='w+t' encoding='UTF-8'>

when running the tests under Python 3.