### PR TITLE
pipeliner: enable PipelineParam to be assigned as value of another parameter

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -887,7 +887,19 @@ class PipelineParam(object):
     >>> p.name
     "user_name"
 
-    A parameter can be "replaced" with another parameter
+    The value of a parameter can be set to another parameter,
+    in which case the value of the first parameter will be
+    taken from the second:
+
+    >>> first_param = PipelineParam(value="first")
+    >>> first_param.value
+    "first"
+    >>> second_param = PipelineParam(value="second")
+    >>> first_param.set(second_param)
+    >>> first_param.value
+    "second"
+
+    A parameter can also be "replaced" with another parameter
     using its ``replace_with`` method:
 
     >>> p = PipelineParam(value="old")
@@ -974,14 +986,14 @@ class PipelineParam(object):
             try:
                 return self._default()
             except TypeError:
-                pass
-        # Return stored value
-        if self._value is not None:
+                return None
+        else:
+            # Return stored value
+            value = resolve_parameter(self._value)
             try:
-                return self._type(self._value)
+                return self._type(value)
             except TypeError:
-                pass
-        return self._value
+                return value
     @property
     def name(self):
         """

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -1764,8 +1764,27 @@ class TestPipelineParam(unittest.TestCase):
         # Create a new parameter
         pp = PipelineParam(name="param2",value=2)
         self.assertEqual(pp.value,2)
-        # Replace first parameter with the first
+        # Replace first parameter with the second
         p.replace_with(pp)
+        self.assertEqual(p.value,2)
+        # Change value of second parameter
+        pp.set(3)
+        self.assertEqual(pp.value,3)
+        # Value of first parameter should also have changed
+        self.assertEqual(p.value,3)
+
+    def test_pipelineparam_cascade_value_resolution(self):
+        """
+        PipelineParam: set value to another parameter
+        """
+        # Create initial parameter
+        p = PipelineParam(name="param1",value=1)
+        self.assertEqual(p.value,1)
+        # Create a new parameter
+        pp = PipelineParam(name="param2",value=2)
+        self.assertEqual(pp.value,2)
+        # Set first parameter to the second
+        p.set(pp)
         self.assertEqual(p.value,2)
         # Change value of second parameter
         pp.set(3)


### PR DESCRIPTION
PR which updates handling of `PipelineParam`s which are assigned to another parameter, implementing cascading of value resolution (so that the value returned from a parameter is extracted from the assigned parameter - rather than returning the parameter itself).

There would appear to be some overlap with the `replace_with` method (which was implemented to enable import of parameters from other pipelines), and that method could itself be replaced by this mechanism in future.