### PR TITLE
mock: fix setting lanes in 'make_mock_bcl2fastq2_output' function

### DIFF
--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1980,6 +1980,10 @@ def make_mock_bcl2fastq2_output(out_dir,lanes,sample_sheet=None,
                     i += 1
                 else:
                     del(sample_sheet_[i])
+        # Get lanes from modified sample sheet
+        if sample_sheet_.has_lanes:
+            lanes = sorted(list(set([int(line['Lane'])
+                                     for line in sample_sheet_])))
         # Predict outputs
         s = SampleSheetPredictor(sample_sheet=sample_sheet_)
         s.set(reads=reads,


### PR DESCRIPTION
PR which fixes a bug in the `make_mock_bcl2fastq2_output` function in the `mock` module, when mocking output from a multi-lane sequencing run where outputs are only requested for a subset of lanes. Without the fix the function always produces output for all lanes, rather than just for the requested subset.