### PR TITLE
barcodes/pipeline: update handling of missing projects in 'CountBarcodes' task

### DIFF
--- a/auto_process_ngs/barcodes/pipeline.py
+++ b/auto_process_ngs/barcodes/pipeline.py
@@ -397,13 +397,13 @@ class CountBarcodes(PipelineTask):
                     break
         else:
             # Undetermined reads
-            if self.args.illumina_data.undetermined is None:
-                # No undetermined reads
-                # Exit without an error
-                print("No undetermined reads, nothing to do")
-                return
-            else:
-                project = self.args.illumina_data.undetermined
+            project = self.args.illumina_data.undetermined
+        # Check project was located
+        # If not then exit without an error
+        if not project:
+            print("Unable to locate project '%s': nothing to do" %
+                  project_name)
+            return
         # Collect Fastq files
         fastqs = []
         for sample in project.samples:


### PR DESCRIPTION
PR which updates the `CountBarcodes` task used in the `AnalyseBarcodes` pipeline (in `barcodes/pipeline`, to ignore missing projects without an error. Previously only missing `undetermined` was ignored, and an exception was raised for other projects if they weren't found.