### PR TITLE
Enable 'AnalysisFastq' class to handle Fastq names from SRA

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -34,6 +34,7 @@ Functions:
 #######################################################################
 
 import os
+import re
 import fnmatch
 import logging
 import bcftbx.IlluminaData as IlluminaData
@@ -94,7 +95,18 @@ class AnalysisFastq(BaseFastqAttrs):
         # Initialise the base class
         BaseFastqAttrs.__init__(self,fastq)
         # Additional attributes
+        self.format = None
         self.extras = None
+        # Check for SRA format
+        sra = re.compile(r"(?P<sample_name>(SRR|ERR)[0-9]+)(_(?P<read_number>[1-2]))?$")
+        fq = sra.match(self.basename)
+        if fq is not None:
+            fq_attrs = fq.groupdict()
+            self.format = "SRA"
+            self.sample_name = fq_attrs['sample_name']
+            if fq_attrs['read_number'] is not None:
+                self.read_number = int(fq_attrs['read_number'])
+            return
         # Try to identify a canonical component of the
         # name by removing trailing parts and testing
         fastq_base = self.basename
@@ -119,6 +131,7 @@ class AnalysisFastq(BaseFastqAttrs):
         self.read_number = fq_attrs.read_number
         self.set_number = fq_attrs.set_number
         self.is_index_read = fq_attrs.is_index_read
+        self.format = "Illumina"
         # Store extras
         if extras:
             self.extras = "_%s" % '_'.join(extras[::-1])
@@ -129,18 +142,23 @@ class AnalysisFastq(BaseFastqAttrs):
         """
         Return the 'canonical' part of the name
         """
-        illumina_fastq_attrs = IlluminaFastqAttrs(self.fastq)
-        illumina_fastq_attrs.sample_name = self.sample_name
-        illumina_fastq_attrs.sample_number = self.sample_number
-        illumina_fastq_attrs.barcode_sequence = self.barcode_sequence
-        illumina_fastq_attrs.lane_number = self.lane_number
-        illumina_fastq_attrs.read_number = self.read_number
-        illumina_fastq_attrs.set_number = self.set_number
-        illumina_fastq_attrs.is_index_read = self.is_index_read
-        if illumina_fastq_attrs.sample_name != illumina_fastq_attrs.basename:
-            return str(illumina_fastq_attrs)
-        else:
-            return None
+        if self.format == "Illumina":
+            illumina_fastq_attrs = IlluminaFastqAttrs(self.fastq)
+            illumina_fastq_attrs.sample_name = self.sample_name
+            illumina_fastq_attrs.sample_number = self.sample_number
+            illumina_fastq_attrs.barcode_sequence = self.barcode_sequence
+            illumina_fastq_attrs.lane_number = self.lane_number
+            illumina_fastq_attrs.read_number = self.read_number
+            illumina_fastq_attrs.set_number = self.set_number
+            illumina_fastq_attrs.is_index_read = self.is_index_read
+            if illumina_fastq_attrs.sample_name != \
+               illumina_fastq_attrs.basename:
+                return str(illumina_fastq_attrs)
+        elif self.format == "SRA":
+            return "%s%s" % (self.sample_name,
+                             "_%s" % self.read_number if self.read_number
+                             else '')
+        return None
     def __repr__(self):
         """
         Implement __repr__ built-in

--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -54,6 +54,14 @@ from functools import reduce
 logger = logging.getLogger(__name__)
 
 #######################################################################
+# Constants
+#######################################################################
+
+# Regular expression for matching SRA-style Fastq names
+SRA_REGEX = re.compile(
+    r"(?P<sample_name>(SRR|ERR)[0-9]+)(_(?P<read_number>[1-2]))?$")
+
+#######################################################################
 # Classes
 #######################################################################
 
@@ -82,8 +90,10 @@ class AnalysisFastq(BaseFastqAttrs):
     set_number:       integer (or None if no set number)
     is_index_read:    boolean (True if index read, False if not)
 
-    There are two additional attributes:
+    There are three additional attributes:
 
+    format:           string identifying the format of the
+                      Fastq name ('Illumina', 'SRA', or None)
     canonical_name:   the 'canonical' part of the name (string,
                       or None if no canonical part could be
                       extracted)
@@ -98,8 +108,7 @@ class AnalysisFastq(BaseFastqAttrs):
         self.format = None
         self.extras = None
         # Check for SRA format
-        sra = re.compile(r"(?P<sample_name>(SRR|ERR)[0-9]+)(_(?P<read_number>[1-2]))?$")
-        fq = sra.match(self.basename)
+        fq = SRA_REGEX.match(self.basename)
         if fq is not None:
             fq_attrs = fq.groupdict()
             self.format = "SRA"

--- a/auto_process_ngs/fastq_utils.py
+++ b/auto_process_ngs/fastq_utils.py
@@ -627,11 +627,12 @@ def group_fastqs_by_name(fastqs,fastq_attrs=IlluminaFastqAttrs):
     fastq_sets = dict()
     for fastq in fastqs:
         fq = fastq_attrs(fastq)
+        read_number = fq.read_number if fq.read_number else 1
         if not fq.is_index_read:
-            read = "r%d" % fq.read_number
+            read = "r%d" % read_number
             reads.add(read)
         else:
-            read = "i%d" % fq.read_number
+            read = "i%d" % read_number
             index_reads.add(read)
         try:
             fastq_sets[read].append(fastq)

--- a/auto_process_ngs/qc/fastqc.py
+++ b/auto_process_ngs/qc/fastqc.py
@@ -159,6 +159,21 @@ class FastqcSummary(TabFile):
     """
     Class representing data from a Fastqc summary file
     """
+    # Names for Fastqc modules
+    module_names = (
+        'Basic Statistics',
+        'Per base sequence quality',
+        'Per tile sequence quality',
+        'Per sequence quality scores',
+        'Per base sequence content',
+        'Per sequence GC content',
+        'Per base N content',
+        'Sequence Length Distribution',
+        'Sequence Duplication Levels',
+        'Overrepresented sequences',
+        'Adapter Content',
+        'Kmer Content',
+    )
     def __init__(self,summary_file=None):
         """
         Create a new FastqcSummary instance
@@ -239,7 +254,7 @@ class FastqcSummary(TabFile):
             full_path is True)
 
         """
-        i = self.modules.index(name)
+        i = self.module_names.index(name)
         link = "#M%d" % i
         if full_path:
             link = self.html_report() + link

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -668,10 +668,10 @@ class QCReport(Document):
                                       s.endswith("_screen.txt"),
                                       screens)):
                 screen_base = os.path.splitext(screen)[0]
-                fq = self.fastq_attrs(screen)
                 s = os.path.basename(screen_base)[:-len("_screen")]
                 for name in FASTQ_SCREENS:
                     if s.endswith("_%s" % name):
+                        fq = self.fastq_attrs(s[:-len("_%s" % name)])
                         outputs.add("screens_%s%s" %
                                     (('i' if fq.is_index_read else 'r'),
                                      (fq.read_number
@@ -692,8 +692,9 @@ class QCReport(Document):
             # Pull out the Fastq names from the Fastqc files
             for fastqc in fastqcs:
                 fastqc = os.path.splitext(fastqc)[0]
-                fq = self.fastq_attrs(fastqc)
-                fastq_names.add(os.path.basename(fastqc)[:-len("_fastqc")])
+                f = os.path.basename(fastqc)[:-len("_fastqc")]
+                fastq_names.add(f)
+                fq = self.fastq_attrs(f)
                 outputs.add("fastqc_%s%s" %
                             (('i' if fq.is_index_read else 'r'),
                              (fq.read_number

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -1388,11 +1388,11 @@ class QCReportFastqGroup(object):
                 # for the field
                 fastqs = ", ".join([self.reporters[r].name
                                     for r in self.reads])
-                logger.error("Exception setting '%s' in summary table "
-                              "for Fastq group { %s }: %s (ignored)"
-                             % (field,
-                                fastqs,
-                                ex))
+                logger.warning("Exception setting '%s' in summary table "
+                              "for Fastq group { %s }: %s"
+                               % (field,
+                                  fastqs,
+                                  ex))
                 # Put error value into the table
                 summary_table.set_value(idx,field,
                                         WarningIcon("Unable to get value for "

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -1299,6 +1299,19 @@ class QCReportFastqGroup(object):
                           'boxplot_r1',
                           'fastqc_r1',
                           'screens_r1')
+        else:
+            # Drop fields for reads that aren't present
+            # For example if there are a mixture of
+            # single and paired-end Fastqs
+            updated_fields = []
+            for field in fields:
+                if field[:-1].endswith("_r"):
+                    read = field.split("_")[-1]
+                    if read not in self.reads:
+                        print("Dropping %s" % field)
+                        continue
+                updated_fields.append(field)
+            fields = updated_fields
         # Add row to summary table
         if idx is None:
             idx = summary_table.add_row()

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -672,9 +672,10 @@ class QCReport(Document):
                 s = os.path.basename(screen_base)[:-len("_screen")]
                 for name in FASTQ_SCREENS:
                     if s.endswith("_%s" % name):
-                        outputs.add("screens_%s%s" % (('i' if fq.is_index_read
-                                                       else 'r'),
-                                                      fq.read_number))
+                        outputs.add("screens_%s%s" %
+                                    (('i' if fq.is_index_read else 'r'),
+                                     (fq.read_number
+                                      if fq.read_number is not None else '1')))
                         fastq_names.add(s[:-len("_%s" % name)])
                 versions.add(Fastqscreen(
                     os.path.join(self.qc_dir,screen)).version)
@@ -693,9 +694,10 @@ class QCReport(Document):
                 fastqc = os.path.splitext(fastqc)[0]
                 fq = self.fastq_attrs(fastqc)
                 fastq_names.add(os.path.basename(fastqc)[:-len("_fastqc")])
-                outputs.add("fastqc_%s%s" % (('i' if fq.is_index_read
-                                              else 'r'),
-                                             fq.read_number))
+                outputs.add("fastqc_%s%s" %
+                            (('i' if fq.is_index_read else 'r'),
+                             (fq.read_number
+                              if fq.read_number is not None else '1')))
                 versions.add(Fastqc(
                     os.path.join(self.qc_dir,fastqc)).version)
             if versions:
@@ -758,9 +760,11 @@ class QCReport(Document):
         for fastq in self.fastqs:
             fq = self.fastq_attrs(fastq)
             if fq.is_index_read:
-                reads.add("i%s" % fq.read_number)
+                reads.add("i%s" % (fq.read_number
+                                   if fq.read_number is not None else '1'))
             else:
-                reads.add("r%s" % fq.read_number)
+                reads.add("r%s" % (fq.read_number
+                                   if fq.read_number is not None else '1'))
         self.reads = sorted(list(reads))
         # Samples
         samples = set([self.fastq_attrs(fq).sample_name
@@ -1048,7 +1052,9 @@ class QCReportFastqGroup(object):
                 read = 'i'
             else:
                 read = 'r'
-            read = "%s%d" % (read,fq.read_number)
+            read = "%s%d" % (read,
+                             fq.read_number
+                             if fq.read_number is not None else 1)
             self.fastqs[read] = fastq
             self.reporters[read] = QCReportFastq(fastq,
                                                  self.qc_dir,

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -951,13 +951,25 @@ class QCReport(Document):
                    self.fastq_attrs(fq).sample_name == sample,
                    self.fastqs)))
         fastq_groups = group_fastqs_by_name(fastqs,self.fastq_attrs)
-        # Number of fastqs
-        if len(self.reads) > 1:
-            sample_report.add("%d fastq R1/R2 pairs" %
-                              len(fastq_groups))
+        # Report number of fastqs and reads
+        reads = QCReportFastqGroup(fastq_groups[0],
+                                   qc_dir=self.qc_dir,
+                                   fastq_attrs=self.fastq_attrs).reads
+        if len(reads) == 1:
+            sample_report.add("%d %s Fastq%s" %
+                              (len(fastq_groups),
+                               reads[0].upper(),
+                               's' if len(fastq_groups) > 1 else ''))
+        elif len(reads) == 2:
+            sample_report.add("%d %s Fastq pair%s" %
+                              (len(fastq_groups),
+                               '/'.join([r.upper() for r in reads]),
+                              's' if len(fastq_groups) > 1 else ''))
         else:
-            sample_report.add("%d fastqs" %
-                              len(fastq_groups))
+            sample_report.add("%d %s Fastq group%s" %
+                              (len(fastq_groups),
+                               '/'.join([r.upper() for r in reads]),
+                              's' if len(fastq_groups) > 1 else ''))
         # Keep track of the first line in the summary
         # table, as per-sample metrics (and name)
         # should only be reported on the first line

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -20,10 +20,45 @@ class TestAnalysisFastq(unittest.TestCase):
     """
     Tests for the AnalysisFastq class
     """
+    def test_canonical_illumina_format(self):
+        """AnalysisFastq: canonical Illumina formatted names
+        """
+        # Canonical with barcode (Illumina pre-1.8)
+        fq = AnalysisFastq("PJB-1_AGGTATAC-AAGGTATA_L001_R1_001.fastq")
+        self.assertEqual(fq.format,"Illumina")
+        self.assertEqual(fq.sample_name,'PJB-1')
+        self.assertEqual(fq.basename,'PJB-1_AGGTATAC-AAGGTATA_L001_R1_001')
+        self.assertEqual(fq.extension,'.fastq')
+        self.assertEqual(fq.sample_number,None)
+        self.assertEqual(fq.barcode_sequence,'AGGTATAC-AAGGTATA')
+        self.assertEqual(fq.lane_number,1)
+        self.assertEqual(fq.read_number,1)
+        self.assertEqual(fq.set_number,1)
+        self.assertFalse(fq.is_index_read)
+        self.assertEqual(fq.canonical_name,
+                         'PJB-1_AGGTATAC-AAGGTATA_L001_R1_001')
+        self.assertEqual(fq.extras,None)
+        self.assertEqual(str(fq),'PJB-1_AGGTATAC-AAGGTATA_L001_R1_001')
+        # Canonical with sample number (Illumina 1.8+)
+        fq = AnalysisFastq("PJB-1_S1_L001_R1_001.fastq")
+        self.assertEqual(fq.format,"Illumina")
+        self.assertEqual(fq.sample_name,'PJB-1')
+        self.assertEqual(fq.basename,'PJB-1_S1_L001_R1_001')
+        self.assertEqual(fq.extension,'.fastq')
+        self.assertEqual(fq.sample_number,1)
+        self.assertEqual(fq.barcode_sequence,None)
+        self.assertEqual(fq.lane_number,1)
+        self.assertEqual(fq.read_number,1)
+        self.assertEqual(fq.set_number,1)
+        self.assertFalse(fq.is_index_read)
+        self.assertEqual(fq.canonical_name,'PJB-1_S1_L001_R1_001')
+        self.assertEqual(fq.extras,None)
+        self.assertEqual(str(fq),'PJB-1_S1_L001_R1_001')
     def test_illumina_style_with_extras(self):
         """AnalysisFastq: Illumina-style fastq name with extra elements appended
         """
         fq = AnalysisFastq('M_19_0040_S13-A40h-R_D709-D505_L007_R1_001_repeated_1')
+        self.assertEqual(fq.format,"Illumina")
         self.assertEqual(fq.sample_name,'M_19_0040_S13-A40h-R_D709-D505')
         self.assertEqual(fq.basename,
                          'M_19_0040_S13-A40h-R_D709-D505_L007_R1_001_repeated_1')
@@ -42,6 +77,7 @@ class TestAnalysisFastq(unittest.TestCase):
         """AnalysisFastq: Illumina-style fastq name with extra elements appended
         """
         fq = AnalysisFastq('PB04_trimmoPE_bowtie2_notHg38.1')
+        self.assertEqual(fq.format,"Illumina")
         self.assertEqual(fq.sample_name,'PB04_trimmoPE_bowtie2_notHg38.1')
         self.assertEqual(fq.basename,'PB04_trimmoPE_bowtie2_notHg38.1')
         self.assertEqual(fq.extension,'')
@@ -72,6 +108,7 @@ class TestAnalysisFastq(unittest.TestCase):
                      'NH1_ChIP-seq_Gli1_ACAGTG_L001_R2',):
             illumina_fastq_attrs = IlluminaFastqAttrs(name)
             fq = AnalysisFastq(name)
+            self.assertEqual(fq.format,"Illumina")
             self.assertEqual(fq.sample_name,illumina_fastq_attrs.sample_name)
             self.assertEqual(fq.basename,illumina_fastq_attrs.basename)
             self.assertEqual(fq.extension,illumina_fastq_attrs.extension)
@@ -95,6 +132,39 @@ class TestAnalysisFastq(unittest.TestCase):
         fq.read_number = 2
         self.assertEqual(str(fq),
                          'M_19_0040_S13-A40h-R_D709-D505_L007_R2_001_repeated_1')
+    def test_sra_format(self):
+        """AnalysisFastq: handle SRA-style names
+        """
+        # SRR* Fastqs with read ID
+        fq = AnalysisFastq('SRR6833752_1.fastq.gz')
+        self.assertEqual(fq.format,"SRA")
+        self.assertEqual(fq.sample_name,'SRR6833752')
+        self.assertEqual(fq.basename,'SRR6833752_1')
+        self.assertEqual(fq.extension,'.fastq.gz')
+        self.assertEqual(fq.sample_number,None)
+        self.assertEqual(fq.barcode_sequence,None)
+        self.assertEqual(fq.lane_number,None)
+        self.assertEqual(fq.read_number,1)
+        self.assertEqual(fq.set_number,None)
+        self.assertFalse(fq.is_index_read)
+        self.assertEqual(fq.canonical_name,'SRR6833752_1')
+        self.assertEqual(fq.extras,None)
+        self.assertEqual(str(fq),'SRR6833752_1')
+        # ERR* Fastqs without read ID
+        fq = AnalysisFastq('ERR3310320.fastq.gz')
+        self.assertEqual(fq.format,"SRA")
+        self.assertEqual(fq.sample_name,'ERR3310320')
+        self.assertEqual(fq.basename,'ERR3310320')
+        self.assertEqual(fq.extension,'.fastq.gz')
+        self.assertEqual(fq.sample_number,None)
+        self.assertEqual(fq.barcode_sequence,None)
+        self.assertEqual(fq.lane_number,None)
+        self.assertEqual(fq.read_number,None)
+        self.assertEqual(fq.set_number,None)
+        self.assertFalse(fq.is_index_read)
+        self.assertEqual(fq.canonical_name,'ERR3310320')
+        self.assertEqual(fq.extras,None)
+        self.assertEqual(str(fq),'ERR3310320')
 
 class TestAnalysisDir(unittest.TestCase):
     """Tests for the AnalysisDir class

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -198,15 +198,22 @@ if __name__ == "__main__":
             envmodules[name] = None
 
     # Job runners
-    default_runner = __settings.general.default_runner
-    if args.runner:
-        qc_runner = fetch_runner(args.runner)
-        cellranger_runner = fetch_runner(args.runner)
+    if args.runner is None:
+        default_runner = __settings.general.default_runner
+        runners = {
+            'cellranger_runner': __settings.runners.cellranger,
+            'qc_runner': __settings.runners.qc,
+            'verify_runner': default_runner,
+            'report_runner': default_runner,
+        }
     else:
-        qc_runner = __settings.runners.qc
-        cellranger_runner = __settings.runners.cellranger
-    verify_runner = default_runner
-    report_runner = default_runner
+        default_runner = fetch_runner(args.runner)
+        runners = {
+            'cellranger_runner': default_runner,
+            'qc_runner': default_runner,
+            'verify_runner': default_runner,
+            'report_runner': default_runner,
+        }
 
     # Load the project
     announce("Loading project data")
@@ -278,12 +285,7 @@ if __name__ == "__main__":
                        cellranger_localmem=cellranger_localmem,
                        max_jobs=args.max_jobs,
                        batch_size=args.batch_size,
-                       runners={
-                           'cellranger_runner': cellranger_runner,
-                           'qc_runner': qc_runner,
-                           'verify_runner': verify_runner,
-                           'report_runner': report_runner,
-                       },
+                       runners=runners,
                        default_runner=default_runner,
                        envmodules=envmodules)
     if status:


### PR DESCRIPTION
PR which updates the `AnalysisFastq` class in `analysis` so that it can recognise and handle Fastq file names coming from the NCBI Short Read Archive (SRA). These files have the form:

    (SRR|ERR)[0-9]+(_1|_2)?.fastq.gz

e.g. `SRR6833752_1.fastq.gz` or `ERR3310318.fastq.gz`.

With this update the names and read numbers should be correctly identified, enabling pairing by name to operate correctly.

There are some additional updates:

* Pairing and QC reporting functions to handle unset read numbers (for example the single ended SRA files) by automatically assuming these are read 1;
* QC output detection patched to better handle outputs from FastQC and Fastq_screen associated with non-Illumina-style Fastq file names;
* For Fastq sets with a mixture of single- and paired-end data, drop summary table fields that have no data for the single-end Fastqs without reporting an error; also update reporting of number of Fastqs in a group for these data sets;
* Fix linking to modules in the FastQC HTML reports when some modules (e.g. tile quality) are missing;
* Fix the handling of `--runner` option in standalone `run_qc.py`, to apply to all pipeline runners