### PR TITLE
publish_qc: enable runner to be specified on the command line

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1267,6 +1267,12 @@ def publish_qc(args):
     analysis_dir = args.analysis_dir
     if not analysis_dir:
         analysis_dir = os.getcwd()
+    # Handle job runner specification
+    if args.runner is not None:
+        runner = fetch_runner(args.runner)
+    else:
+        runner = None
+    # Do the publish_qc step
     d = AutoProcess(analysis_dir)
     d.publish_qc(projects=args.project_pattern,
                  location=args.qc_dir,

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     cli/auto_process.py: command line interface for auto_process_ngs
-#     Copyright (C) University of Manchester 2013-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2020 Peter Briggs
 #
 #########################################################################
 #
@@ -744,6 +744,7 @@ def add_publish_qc_command(cmdparser):
                    dest='legacy_mode',default=False,
                    help="legacy mode: include links to MultiQC, cellranger "
                    "count and ICELL8 reports in the top-level index page")
+    add_runner_option(p)
     add_debug_option(p)
     p.add_argument('analysis_dir',metavar="ANALYSIS_DIR",nargs="?",
                    help="auto_process analysis directory (optional: defaults "
@@ -1273,7 +1274,8 @@ def publish_qc(args):
                  exclude_zip_files=(args.exclude_zip_files == 'yes'),
                  ignore_missing_qc=args.ignore_missing_qc,
                  regenerate_reports=args.regenerate_reports,
-                 force=args.force,legacy=args.legacy_mode)
+                 force=args.force,legacy=args.legacy_mode,
+                 runner=args.runner)
 
 def archive(args):
     """

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1281,7 +1281,7 @@ def publish_qc(args):
                  ignore_missing_qc=args.ignore_missing_qc,
                  regenerate_reports=args.regenerate_reports,
                  force=args.force,legacy=args.legacy_mode,
-                 runner=args.runner)
+                 runner=runner)
 
 def archive(args):
     """

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -65,7 +65,7 @@ div.footer { font-style: italic;
 
 def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                regenerate_reports=False,force=False,use_hierarchy=False,
-               exclude_zip_files=False,legacy=False):
+               exclude_zip_files=False,legacy=False,runner=None):
     """
     Copy the QC reports to the webserver
 
@@ -131,6 +131,8 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
         files)
       legacy (bool): if True then operate in 'legacy' mode (i.e.
         explicitly include MultiQC reports for each project)
+      runner (JobRunner): explicitly specify the job runner to
+        send jobs to (overrides runner set in the configuration)
     """
     # Turn off saving of parameters etc
     ap._save_params = False
@@ -364,8 +366,8 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
     if projects:
         # Make log directory and set up scheduler
         # to farm out the intensive operations to
-        runner = ap.settings.general.default_runner
-        runner.set_log_dir(ap.log_dir)
+        if runner is None:
+            runner = ap.settings.general.default_runner
         sched = SimpleScheduler(
             runner=runner,
             max_concurrent=ap.settings.general.max_concurrent_jobs,
@@ -521,7 +523,8 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                         copy_job = sched.submit(
                             fileops.copy_command(qc_zip,dirn),
                             name="copy.qc_report.%s.%s" % (project.name,
-                                                           qc_dir))
+                                                           qc_dir),
+                            log_dir=ap.log_dir)
                         unzip_job = sched.submit(
                             fileops.unzip_command(os.path.join(
                                 dirn,
@@ -529,6 +532,7 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                                                   fileops.Location(dirn).path),
                             name="unzip.qc_report.%s.%s" % (project.name,
                                                             qc_dir),
+                            log_dir=ap.log_dir,
                             wait_for=(copy_job.name,))
                         sched.wait()
                         # Check the jobs completed ok
@@ -583,13 +587,15 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                     # Copy and unzip ICELL8 report
                     copy_job = sched.submit(
                         fileops.copy_command(icell8_zip,dirn),
-                        name="copy.icell8_report.%s" % project.name)
+                        name="copy.icell8_report.%s" % project.name,
+                        log_dir=ap.log_dir)
                     unzip_job = sched.submit(
                         fileops.unzip_command(os.path.join(
                             dirn,
                             os.path.basename(icell8_zip)),
                                               fileops.Location(dirn).path),
                         name="unzip.icell8_report.%s" % project.name,
+                        log_dir=ap.log_dir,
                         wait_for=(copy_job.name,))
                     sched.wait()
                     # Check the jobs completed ok
@@ -623,13 +629,15 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                     # Copy and unzip cellranger report
                     copy_job = sched.submit(
                         fileops.copy_command(cellranger_zip,dirn),
-                        name="copy.cellranger_report.%s" % project.name)
+                        name="copy.cellranger_report.%s" % project.name,
+                        log_dir=ap.log_dir)
                     unzip_job = sched.submit(
                         fileops.unzip_command(os.path.join(
                             dirn,
                             os.path.basename(cellranger_zip)),
                                               fileops.Location(dirn).path),
                         name="unzip.cellranger_report.%s" % project.name,
+                        log_dir=ap.log_dir,
                         wait_for=(copy_job.name,))
                     sched.wait()
                     # Check the jobs completed ok

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -274,6 +274,7 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                 fastq_dir=fastq_dir,
                 qc_dir=os.path.join(project.dirn,qc_dir),
                 qc_protocol=qc_protocol,
+                runner=runner,
                 log_dir=ap.log_dir)
             if verified:
                 print("...%s: verified QC" % qc_dir)
@@ -294,6 +295,7 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                                               qc_dir=qc_dir,
                                               multiqc=True,
                                               force=force,
+                                              runner=runner,
                                               log_dir=ap.log_dir)
                     if report_status == 0:
                         print("...%s: (re)generated report" % qc_dir)


### PR DESCRIPTION
PR that adds a new `--runner` option to the `publish_qc` command which allows the configured runner definitions to be overridden from the command line.