### PR TITLE
qc/plots: fix edge case bug for Fastq_screen microplots when bars add up to 100%

### DIFF
--- a/auto_process_ngs/qc/plots.py
+++ b/auto_process_ngs/qc/plots.py
@@ -98,16 +98,19 @@ def uscreenplot(screen_files,outfile=None,inline=None):
         for n,library in enumerate(screen.libraries):
             data = list(filter(lambda x:
                                x['Library'] == library,screen))[0]
-            x = xorigin
-            y = n*(barwidth+1) + 1
             # Get the total percentage for the stack
             total_percent = sum([data[m] for m in mappings])
             if total_percent > 2.0:
                 # Plot the stack as-is
+                x = xorigin
+                y = n*(barwidth+1) + 1
                 for mapping,rgb in zip(mappings,colors):
                     # Round up to nearest pixel (so that non-zero
                     # percentages are always represented)
                     npx = int(ceil(data[mapping]/2.0))
+                    # Don't exceed plot limit
+                    if x+npx > width:
+                        npx = width-x
                     for i in range(x,x+npx):
                         for j in range(y,y+barwidth):
                             pixels[i,j] = rgb


### PR DESCRIPTION
PR which addresses a bug in the `uscreenplot` function (in `qc/plots`) used to generate micro-plots for Fastq_screen output.

The bug is an edge case and occurs when all the components of a bar in the plot add to 100%; in this case due to the rounding of small components (less than 2%), the plotted bar can grow to exceed the plot limits (causing an exception in the PIL `Image` class). The fix is to cap the length of the plotted bars so they never exceed the plot size.