### PR TITLE
qc/plots: fix bug in 'uscreenplot' when reporting low percentage mapped reads

### DIFF
--- a/auto_process_ngs/qc/plots.py
+++ b/auto_process_ngs/qc/plots.py
@@ -98,12 +98,12 @@ def uscreenplot(screen_files,outfile=None,inline=None):
         for n,library in enumerate(screen.libraries):
             data = list(filter(lambda x:
                                x['Library'] == library,screen))[0]
+            x = xorigin
+            y = n*(barwidth+1) + 1
             # Get the total percentage for the stack
             total_percent = sum([data[m] for m in mappings])
             if total_percent > 2.0:
                 # Plot the stack as-is
-                x = xorigin
-                y = n*(barwidth+1) + 1
                 for mapping,rgb in zip(mappings,colors):
                     # Round up to nearest pixel (so that non-zero
                     # percentages are always represented)


### PR DESCRIPTION
PR which fixes a bug in the `uscreenplot` micro-plot generation function (in `qc/plots`) introduced in PR #567, when the total percentage of mapped reads for a library is <2%.