### PR TITLE
Reimplement 'make_fastqs' command as a pipeline

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -2841,7 +2841,6 @@ class FastqStatistics(PipelineTask):
         self.add_cmd(PipelineCommandWrapper(
             "Run fastq_statistics",
             *fastq_statistics_cmd.command_line))
-
     def finish(self):
         if self.generate_stats:
             print("Moving stats files to final locations")
@@ -2852,9 +2851,9 @@ class FastqStatistics(PipelineTask):
                           self.final_per_lane_sample_stats)):
                 print("- %s -> %s" % (f,ff))
                 if not os.path.exists(f):
-                    raise Exception("'%s' not found in %s" % (f,os.get_cwd()))
+                    raise Exception("'%s' not found in %s" % (f,os.getcwd()))
                 elif not os.path.isdir(os.path.dirname(ff)):
-                    raise Exception("No path to '%s'" %ff)
+                    raise Exception("No path to '%s'" % ff)
                 os.rename(f,ff)
         # Assign outputs
         self.output.stats_file.set(self.final_stats)

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -1,0 +1,2740 @@
+#!/usr/bin/env python
+#
+#     bcl2fastq.pipeline.py: pipelines for Fastq generation
+#     Copyright (C) University of Manchester 2020 Peter Briggs
+#
+
+"""
+Pipeline components for generating Fastqs from Bcl files.
+
+Pipeline classes:
+
+- MakeFastqs
+
+Pipeline task classes:
+
+- FetchPrimaryData
+- MakeSampleSheet
+- GetBcl2Fastq
+- RestoreBackupDirectory
+- RunBcl2Fastq
+- GetBasesMaskIcell8
+- GetBasesMaskIcell8Atac
+- GetCellranger
+- DemultiplexIcell8Atac
+- MergeFastqDirs
+- RunCellrangerMkfastq
+- FastqStatistics
+- ReportProcessingQC
+
+Utility classes:
+
+- BaseParam
+- FunctionParam
+- PathJoinParam
+- PathExistsParam
+
+Utility functions:
+
+- subset
+"""
+
+######################################################################
+# Imports
+######################################################################
+
+import os
+import gzip
+import shutil
+import tempfile
+import time
+from bcftbx.IlluminaData import IlluminaRun
+from bcftbx.IlluminaData import IlluminaRunInfo
+from bcftbx.IlluminaData import IlluminaData
+from bcftbx.IlluminaData import IlluminaFastq
+from bcftbx.IlluminaData import SampleSheet
+from bcftbx.IlluminaData import samplesheet_index_sequence
+from bcftbx.IlluminaData import verify_run_against_sample_sheet
+from bcftbx.IlluminaData import list_missing_fastqs
+from bcftbx.utils import find_program
+from bcftbx.utils import mkdirs
+from bcftbx.utils import walk
+from ..applications import general as general_apps
+from ..applications import bcl2fastq as bcl2fastq_apps
+from ..applications import Command
+from ..barcodes.pipeline import AnalyseBarcodes
+from ..bcl2fastq_utils import available_bcl2fastq_versions
+from ..bcl2fastq_utils import bases_mask_is_valid
+from ..bcl2fastq_utils import bcl_to_fastq_info
+from ..bcl2fastq_utils import check_barcode_collisions
+from ..bcl2fastq_utils import get_bases_mask
+from ..bcl2fastq_utils import get_nmismatches
+from ..bcl2fastq_utils import get_sequencer_platform
+from ..bcl2fastq_utils import make_custom_sample_sheet
+from ..fastq_utils import group_fastqs_by_name
+from ..fileops import Location
+from ..icell8.utils import get_bases_mask_icell8
+from ..icell8.utils import get_bases_mask_icell8_atac
+from ..samplesheet_utils import barcode_is_10xgenomics
+from ..samplesheet_utils import SampleSheetLinter
+from ..pipeliner import Pipeline
+from ..pipeliner import PipelineTask
+from ..pipeliner import PipelineFunctionTask
+from ..pipeliner import PipelineCommandWrapper
+from ..pipeliner import PipelineFailure
+from ..pipeliner import PipelineParam as Param
+from ..pipeliner import resolve_parameter
+from ..tenx_genomics_utils import add_cellranger_args
+from ..tenx_genomics_utils import cellranger_info
+from ..tenx_genomics_utils import flow_cell_id
+from ..tenx_genomics_utils import get_bases_mask_10x_atac
+from ..tenx_genomics_utils import make_qc_summary_html
+from .reporting import ProcessingQCReport
+
+# Module specific logger
+import logging
+logger = logging.getLogger(__name__)
+
+######################################################################
+# Constants
+######################################################################
+
+# Valid attribute names for lane subsets
+
+LANE_SUBSET_ATTRS = (
+    'protocol',
+    'bases_mask',
+    'trim_adapters',
+    'adapter_sequence',
+    'adapter_sequence2',
+    'minimum_trimmed_read_length',
+    'mask_short_adapter_reads',
+    'create_fastq_for_index_read',
+    'no_lane_splitting',
+    'icell8_well_list',
+    'icell8_atac_swap_i1_and_i2',
+    'icell8_atac_reverse_complement',
+    'analyse_barcodes',
+    'masked_index',
+)
+
+######################################################################
+# Pipeline classes
+######################################################################
+
+class MakeFastqs(Pipeline):
+    """
+    Run the Fastq generation pipeline on one or more lane subsets
+
+    Pipeline to run Fastq generation on multiple projects.
+
+    Example usage for processing a standard run:
+
+    >>> make_fastqs = MakeFastqs(run_dir,sample_sheet)
+    >>> make_fastqs.run()
+
+    Example for splitting a run to use different protocols for
+    different lanes:
+
+    >>> make_fastqs = MakeFastqs(run_dir,sample_sheet,
+    ...                          lane_subsets=(
+    ...                             subset(lanes=[1,2,3,4,5,6],
+    ...                                    protocol="standard"),
+    ...                             subset(lanes=[7,8],
+    ...                                    protocol="10x_chromium_sc")))
+    >>> make_fastqs.run()
+
+    In this case subsets of lanes are defined by calling the
+    'subset' function; each subset is processed separately using
+    the protocol specified for that subset, before being merged
+    into a single output directory.
+
+    Parameters defined in the lane subsets override those defined
+    globally in the pipleine.
+    """
+    def __init__(self,run_dir,sample_sheet,protocol='standard',
+                 bases_mask="auto",platform=None,well_list=None,
+                 minimum_trimmed_read_length=None,
+                 mask_short_adapter_reads=None,
+                 adapter_sequence=None,adapter_sequence_read2=None,
+                 trim_adapters=True,fastq_statistics=True,
+                 analyse_barcodes=True,
+                 lane_subsets=None):
+        """
+        Create a new MakeFastqs pipeline instance
+
+        Arguments:
+          run_dir (str): path to directory with raw Bcl data
+            from sequencer run
+          sample_sheet (str): path to sample sheet file to use
+          protocol (str): default protocol to use (defaults to
+            "standard")
+          bases_mask (str): default bases mask to use (defaults
+            to "auto")
+          platform (str): optionally specify the platform for
+            the sequencer run (e.g. 'miseq', 'nextseq' etc)
+          well_list (str): optionally specify path to a well list
+            file for ICELL8 data
+          minimum_trimmed_read_length (int): optionally specify
+            the minimum length of reads after adapter trimming;
+            trimmed reads shorter than this length will be
+            padded with Ns (bcl2fastq --minimum-trimmed-read-length
+            option)
+          mask_short_adapter_reads (int): optionally specify
+            the length at which reads which should be completely
+            masked with Ns after adapter trimming (bcl2fastq
+            --mask-short-adapter-reads option)
+          adapter_sequence (str): optionally specify the adapter
+            sequence to use for trimming (overrides sequence set
+            in the sample sheet file)
+          adapter_sequence_read2 (str): optionally specify the
+            'read2' adapter sequence to use for trimming
+            (overrides sequence set in the sample sheet file)
+          trim_adapters (bool): if True (default) then perform
+            adapter trimming as part of Fastq generation
+          fastq_statistics (bool): if True (default) then generate
+            statistics from Fastq files
+          analyse_barcodes (bool): if True (default) then perform
+            barcode analysis after Fastq generation
+          lane_subsets (iterable): optionally define one or more
+            subsets of lanes to process separately
+        """
+        # Initialise the pipeline superclass
+        Pipeline.__init__(self,name="MakeFastqs")
+
+        # Inputs
+        self._run_dir = run_dir
+        self._sample_sheet = os.path.abspath(sample_sheet)
+        self._platform = platform
+
+        # Preflight checks
+        #
+        # Sample sheet
+        if not self._sample_sheet_is_valid(self._sample_sheet):
+            raise Exception("Problems detected in sample sheet")
+        # Consistent lane definitions
+        if lane_subsets:
+            defined_lanes = set()
+            for s in lane_subsets:
+                for l in s['lanes']:
+                    ll = int(l)
+                    if ll in defined_lanes:
+                        # Lane is defined multiple times
+                        raise Exception("Lane '%s' appears multiple "
+                                        "times in lane subset "
+                                        "definitions" % ll)
+                    else:
+                        defined_lanes.add(ll)
+
+        # Adapter sequences
+        sample_sheet = SampleSheet(self._sample_sheet)
+        if adapter_sequence is None:
+            try:
+                adapter_sequence = sample_sheet.settings['Adapter']
+            except KeyError:
+                adapter_sequence = ""
+        if adapter_sequence_read2 is None:
+            try:
+                adapter_sequence_read2 = sample_sheet.settings['AdapterRead2']
+            except KeyError:
+                adapter_sequence_read2 = ""
+        
+        # Defaults
+        self._trim_adapters = bool(trim_adapters)
+        self._adapter_sequence = adapter_sequence
+        self._adapter_sequence_read2 = adapter_sequence_read2
+        self._minimum_trimmed_read_length = minimum_trimmed_read_length
+        self._mask_short_adapter_reads = mask_short_adapter_reads
+        self._fastq_statistics = bool(fastq_statistics)
+        self._analyse_barcodes = bool(analyse_barcodes)
+        self._well_list = well_list
+
+        # Define parameters
+        self.add_param('data_dir',value=run_dir,type=str)
+        self.add_param('sample_sheet',value=self._sample_sheet,type=str)
+        self.add_param('analysis_dir',type=str)
+        self.add_param('primary_data_dir',type=str)
+        self.add_param('barcode_analysis_dir',type=str)
+        self.add_param('counts_dir',type=str)
+        self.add_param('qc_report',type=str)
+        self.add_param('nprocessors',type=int)
+        self.add_param('force_copy_of_primary_data',value=False,type=bool)
+        self.add_param('no_lane_splitting',value=False,type=bool)
+        self.add_param('create_fastq_for_index_read',value=False,type=bool)
+        self.add_param('create_empty_fastqs',value=False,type=bool)
+        self.add_param('cellranger_jobmode',value='local',type=str)
+        self.add_param('cellranger_mempercore',type=int)
+        self.add_param('cellranger_maxjobs',type=int)
+        self.add_param('cellranger_jobinterval',type=int)
+        self.add_param('cellranger_localcores',type=int)
+        self.add_param('cellranger_localmem',type=int)
+
+        # Define runners
+        self.add_runner('rsync_runner')
+        self.add_runner('bcl2fastq_runner')
+        self.add_runner('demultiplex_icell_atac_runner')
+        self.add_runner('cellranger_runner')
+        self.add_runner('cellranger_atac_runner')
+        self.add_runner('stats_runner')
+
+        # Define module environment modules
+        self.add_envmodules('bcl2fastq')
+        self.add_envmodules('cellranger')
+        self.add_envmodules('cellranger_atac')
+
+        # Lane subsets
+        self._subsets = []
+
+        # Create default lane subsets based on the lanes and
+        # index sequences in the sample sheet
+        sample_sheet_data = SampleSheet(self._sample_sheet)
+        if sample_sheet_data.has_lanes:
+            # Sample sheet has lanes
+            # Lanes with the same "masked index sequence"
+            # will be grouped together
+            masked_indexes = dict()
+            for data in sample_sheet_data:
+                # Get index sequence
+                index_sequence = samplesheet_index_sequence(data)
+                # Store lanes against unique masked index sequences
+                lane = data['Lane']
+                masked_index = self._mask_sequence(index_sequence)
+                try:
+                    masked_indexes[masked_index].add(lane)
+                except KeyError:
+                    masked_indexes[masked_index] = set((lane,))
+            # Build subsets grouped by masked index
+            for s in masked_indexes:
+                lanes = sorted(list(masked_indexes[s]))
+                self._add_subset(lanes=lanes,
+                                 protocol=protocol,
+                                 masked_index=s)
+        else:
+            # No lanes in sample sheet
+            index_sequence = samplesheet_index_sequence(
+                sample_sheet_data[0])
+            masked_index = self._mask_sequence(index_sequence)
+            self._add_subset(lanes=[],
+                             protocol=protocol,
+                             masked_index=masked_index)
+
+        # Set pipeline defaults for automatically generated
+        # lane subsets
+        for s in self.subsets:
+            self._update_subset(
+                s,
+                bases_mask=bases_mask,
+                trim_adapters=self._trim_adapters,
+                minimum_trimmed_read_length=\
+                self._minimum_trimmed_read_length,
+                mask_short_adapter_reads=\
+                self._mask_short_adapter_reads,
+                adapter_sequence=self._adapter_sequence,
+                adapter_sequence2=self._adapter_sequence_read2,
+                no_lane_splitting=self.params.no_lane_splitting,
+                create_fastq_for_index_read=\
+                self.params.create_fastq_for_index_read,
+                icell8_well_list=self._well_list,
+                icell8_atac_swap_i1_and_i2=False,
+                icell8_atac_reverse_complement=None,
+                analyse_barcodes=self._analyse_barcodes
+            )
+
+        # Add user-defined subsets
+        # The pipeline defaults will be inherited
+        if lane_subsets:
+            for user_subset in lane_subsets:
+                # Look for an existing subset
+                lanes = user_subset['lanes']
+                assigned_subset = None
+                for s in self.subsets:
+                    if lanes == s['lanes']:
+                        # Exact match
+                        assigned_subset = s
+                        break
+                    else:
+                        # Is it a subset of a subset?
+                        if all([l in s['lanes'] for l in lanes]):
+                            # Part of an existing subset
+                            # which will be split
+                            updated_lanes = [l for l in s['lanes']
+                                             if l not in lanes]
+                            # Make two new subsets copied from
+                            # the superset, with lanes updated
+                            self._copy_subset(updated_lanes,s)
+                            assigned_subset = self._copy_subset(lanes,s)
+                            # Remove the original superset
+                            self._remove_subset(s['lanes'])
+                            break
+                # Check a subset was located or created
+                if assigned_subset is None:
+                    raise Exception("Failed to assign a lane subset for "
+                                    "%s" % lanes)
+                # Assign protocol to user subset
+                try:
+                    self._update_subset(assigned_subset,
+                                        protocol=user_subset['protocol'])
+                except KeyError:
+                    pass
+
+        # Check that subsets don't split projects
+        if self._sample_sheet and len(self.subsets) > 1:
+            if self._subsets_split_project():
+                raise Exception("Subsets would split a project")
+            
+        # Update parameters on each subset according to the
+        # assigned protocol (overriding pipeline defaults)
+        for s in self.subsets:
+            protocol = s['protocol']
+            if protocol == 'standard':
+                pass
+            elif protocol == 'mirna':
+                # miRNA-seq protocol
+                # Set minimum trimmed read length and turn off masking
+                self._update_subset(s,
+                                    minimum_trimmed_read_length=10,
+                                    mask_short_adapter_reads=0)
+            elif protocol == 'icell8':
+                # ICELL8 protocol
+                # Set minimum trimmed read length and turn off masking
+                self._update_subset(s,
+                                    minimum_trimmed_read_length=21,
+                                    mask_short_adapter_reads=0)
+            elif protocol == 'icell8_atac':
+                # ICELL8 single-cell ATAC-seq
+                self._update_subset(s,
+                                    create_fastq_for_index_read=True)
+            elif protocol == '10x_chromium_sc':
+                # 10xGenomics Chromium SC
+                # Turn off barcode analysis
+                self._update_subset(s,
+                                    analyse_barcodes=False)
+            elif protocol == '10x_atac':
+                # 10xGenomics ATAC-seq
+                # Turn off barcode analysis
+                self._update_subset(s,
+                                    analyse_barcodes=False)
+            else:
+                # Unknown protocol
+                raise Exception("Unknown protocol '%s' assigned for "
+                                "lanes %s" % (protocol,s['lanes']))
+            
+        # Finally update parameters for user-defined
+        # lane subsets (overriding both pipeline and
+        # protocol defaults)
+        if lane_subsets:
+            for s in lane_subsets:
+                lanes = s['lanes']
+                assigned_subset = self._fetch_subset(lanes)
+                self._update_subset(assigned_subset,
+                                    **{ kw: s[kw] for kw in s
+                                        if (kw != 'lanes' and
+                                            kw != 'protocol') })
+
+        # Reset lanes for single subset
+        if len(self.subsets) == 1:
+            self.subsets[0]['lanes'] = []
+
+        # Build the pipeline
+        self._build_pipeline()
+
+    @property
+    def subsets(self):
+        """
+        Return list of lane subsets defined in pipeline
+        """
+        #return self._subsets
+        return sorted(self._subsets,
+                      key=lambda x: x['lanes'][0]
+                      if len(x['lanes']) else 0)
+
+    def _mask_sequence(self,s):
+        """
+        Internal: return 'masked' version of index sequence
+
+        For standard index sequences (e.g. 'ATGGAT',
+        'ATTGGGTA-TTATCCCA'), returns the sequence with
+        A,C,G and T's replaced by N (e.g. 'NNNNNN',
+        'NNNNNNNN-NNNNNNNN').
+
+        For sequences matching 10xGenomics indices, returns
+        the string '__10X__'.
+
+        For empty index sequences, returns the string
+        '__NO_SEQUENCE__'.
+
+        Arguments:
+          s (str): index sequence
+
+        Returns:
+          String: masked version of supplied index sequence.
+        """
+        if s is None or s == "":
+            # No sequence
+            return "__NO_SEQUENCE__"
+        if barcode_is_10xgenomics(s):
+            # 10xGenomics index sequence
+            return "__10X__"
+        for c in "ACGT":
+            # Mask bases with 'N's
+            s = s.replace(c,'N')
+        return s
+
+    def _sample_sheet_is_valid(self,sample_sheet):
+        """
+        Internal: checks that sample sheet is valid
+
+        Arguments:
+          sample_sheet (str): path to sample sheet file
+
+        Returns:
+          Boolean: True if sample sheet has valid barcodes
+            and doesn't contain non-ASCII characters; False
+            otherwise.
+        """
+        # Check for invalid barcodes
+        invalid_barcodes = SampleSheetLinter(
+            sample_sheet_file=self._sample_sheet).has_invalid_barcodes()
+        if invalid_barcodes:
+            logger.error("Invalid barcodes detected")
+            for line in invalid_barcodes:
+                logger.critical("%s" % line)
+        # Check for invalid characters
+        invalid_characters = SampleSheetLinter(
+            sample_sheet_file=self._sample_sheet).has_invalid_characters()
+        if invalid_characters:
+            logger.critical("Invalid non-printing/non-ASCII characters "
+                            "detected")
+        # Return boolean indicating if there's a problem
+        if invalid_barcodes or invalid_characters:
+            return False
+        else:
+            return True
+
+    def _subsets_split_project(self):
+        """
+        Internal: checks if subsets split any projects
+
+        Returns:
+          Boolean: True if a project from the sample sheet
+            is split between two or more subsets; False
+            otherwise.
+        """
+        # Need at least one subset
+        if len(self.subsets) == 1:
+            return False
+        # Load sample sheet
+        ss = SampleSheet(self._sample_sheet)
+        # Sample sheet must contain lane information
+        if not ss.has_lanes:
+            return False
+        sample_project = ss.sample_project_column
+        # Check projects in subsets
+        projects = set()
+        for s in self.subsets:
+            subset_projects = set()
+            for lane in s['lanes']:
+                for data in ss.data:
+                    if lane == data['Lane']:
+                        subset_projects.add(data[sample_project])
+                        break
+            for project in subset_projects:
+                if project in projects:
+                    logger.critical("Project '%s' appears in multiple "
+                                    "lane subsets" % project)
+                    return True
+            projects.update(subset_projects)
+        # No projects split
+        return False
+
+    def _add_subset(self,lanes,**kws):
+        """
+        Internal: creates a new lane subset
+
+        Arguments:
+          lanes (list): list of lane numbers in the
+            subset
+          kws (mapping): optional list of key-value
+            pairs assigning values to parameters for
+            the new subset
+
+        Returns:
+          Dictionary: new subset
+        """
+        lanes_ = sorted([int(l) for l in lanes])
+        s = subset(lanes=lanes_,**kws)
+        self._subsets.append(s)
+        return s
+
+    def _fetch_subset(self,lanes):
+        """
+        Internal: return existing lane subset
+
+        Arguments:
+          lanes (list): set of lane numbers to
+            match; all specified lanes must be 
+            present in a subset for it to be
+            returned
+
+        Returns:
+          Dictionary: subset matching the lane
+            specification
+
+        Raises:
+          KeyError (if no matching subset is
+            located)
+        """
+        lanes_ = sorted([int(l) for l in lanes])
+        for s in self._subsets:
+            if s['lanes'] == lanes_:
+                return s
+        raise KeyError("No subset matching '%s'" % lanes)
+
+    def _remove_subset(self,lanes):
+        """
+        Internal: remove a subset from the pipeline
+
+        Arguments:
+          lanes (list): set of lane numbers to
+            match; all specified lanes must be 
+            present in a subset for it to be
+            removed
+
+        Raises:
+          KeyError (if a subset is not located for
+            removal)
+        """
+        lanes_ = sorted([int(l) for l in lanes])
+        for i,s in enumerate(self._subsets):
+            if s['lanes'] == lanes_:
+                del(self._subsets[i])
+                return
+        raise KeyError("No subset matching '%s'" % lanes)
+
+    def _copy_subset(self,lanes,existing_subset):
+        """
+        Internal: duplicate an existing subset
+
+        Creates a new subset grouping the specified
+        lanes and with all other parameters copied
+        from the supplied subset.
+
+        Arguments:
+          lanes (list): list of lane numbers in the
+            new subset
+          existing_subset (dictionary): existing
+            subset to copy parameters from
+
+        Returns:
+          Dictionary: duplicated subset
+        """
+        data = { kw: existing_subset[kw]
+                 for kw in existing_subset if kw != 'lanes' }
+        return self._add_subset(lanes,**data)
+
+    def _update_subset(self,s,**kws):
+        """
+        Internal: update parameters in a lane subset
+
+        Arguments:
+          s (dictionary): lane subset to update
+          kws (mapping): optional set of key-value
+            pairs assigning new values to parameters
+            for the subset
+        """
+        for attr in kws:
+            if attr not in LANE_SUBSET_ATTRS:
+                raise KeyError("Unsupported subset attribute '%s'"
+                               % attr)
+            s[attr] = kws[attr]
+
+    def _build_pipeline(self):
+        """
+        Internal: construct the pipeline
+
+        Assembles the pipeline tasks according to the
+        data provided at instantiation
+        """
+        ####################
+        # Deal with platform
+        ####################
+        if self._platform is None:
+            # Try to get the platform from the run name
+            self._platform = get_sequencer_platform(self._run_dir)
+        if self._platform is None:
+            # Set a generic platform name if it can't be identified
+            self._platform = "illumina"
+
+        #################
+        # Report subsets
+        #################
+        self.report("Building pipeline for lane subsets:")
+        for s in self.subsets:
+            self.report("- Lanes: %s" % ','.join([str(l)
+                                                  for l in s['lanes']]))
+            for attr in s:
+                if attr != 'lanes' and s[attr] is not None:
+                    self.report("- %s: %s" % (attr,s[attr]))
+
+        #####################
+        # Fetch primary data
+        #####################
+        fetch_primary_data = FetchPrimaryData(
+            "Fetch primary data",
+            self.params.data_dir,
+            self.params.primary_data_dir,
+            force_copy=self.params.force_copy_of_primary_data
+        )
+        self.add_task(fetch_primary_data,
+                      runner=self.runners['rsync_runner'])
+
+        # Load sample sheet data
+        sample_sheet = SampleSheet(self._sample_sheet)
+
+        # Keep track of Fastq generation tasks
+        fastq_generation_tasks = []
+
+        # Keep track of bcl2fastq output directories
+        bcl2fastq_out_dirs = []
+
+        # Keep track of lanes to analyse barcodes for
+        lanes_for_barcode_analysis = []
+
+        # Placeholder for tasks acquiring software versions
+        get_bcl2fastq = None
+        get_bcl2fastq_for_10x = None
+        get_bcl2fastq_for_10x_atac = None
+        get_cellranger = None
+        get_cellranger_atac = None
+
+        # For each subset, add the appropriate set of
+        # tasks for the protocol
+        for subset in self.subsets:
+
+            # Lanes in this subset
+            lanes = subset['lanes']
+            self.report("Adding tasks for %s" %
+                        ("all lanes" if not lanes
+                         else "lanes %s" % ','.join([str(l) for l in lanes])))
+
+            # Protocol
+            protocol = subset['protocol']
+            self.report("- Protocol: %s" % protocol)
+
+            #############
+            # Bases mask
+            #############
+            bases_mask = subset['bases_mask']
+
+            ###################
+            # Adapter trimming
+            ###################
+            trim_adapters = subset['trim_adapters']
+
+            if trim_adapters:
+                minimum_trimmed_read_length = \
+                            subset['minimum_trimmed_read_length']
+                mask_short_adapter_reads = \
+                            subset['mask_short_adapter_reads']
+                adapter_sequence = subset['adapter_sequence']
+                adapter_sequence_read2 = subset['adapter_sequence2']
+            else:
+                # No adapter trimming
+                minimum_trimmed_read_length = 0
+                mask_short_adapter_reads = 0
+                adapter_sequence = ""
+                adapter_sequence_read2 = ""
+            # Report adapter settings
+            self.report("- Adapter sequence      : %s" % (adapter_sequence
+                                                          if adapter_sequence
+                                                          else "<none>"))
+            if adapter_sequence_read2:
+                self.report("  Adapter sequence read2: %s" %
+                            adapter_sequence_read2)
+
+            #################
+            # Lane splitting
+            #################
+            no_lane_splitting = subset['no_lane_splitting']
+
+            #####################
+            # Create index reads
+            #####################
+            create_fastq_for_index_read = \
+                subset['create_fastq_for_index_read']
+
+            #########
+            # ICELL8
+            #########
+            well_list = subset['icell8_well_list']
+            swap_i1_and_i2 = subset['icell8_atac_swap_i1_and_i2']
+            reverse_complement = subset['icell8_atac_reverse_complement']
+
+            ###################
+            # Barcode analysis
+            ###################
+            do_barcode_analysis = subset['analyse_barcodes']
+            if lanes and do_barcode_analysis:
+                lanes_for_barcode_analysis.extend(lanes)
+            self.report("  Analyse barcodes: %s" % (('yes'
+                                                     if do_barcode_analysis
+                                                     else 'no'),))
+            
+            ###################
+            # Make samplesheet
+            ###################
+            make_sample_sheet = MakeSampleSheet(
+                "Make sample sheet%s" % (" for lanes %s" %
+                                         ','.join([str(x)  for x in lanes])
+                                         if lanes else ""),
+                self._sample_sheet,
+                lanes=lanes,
+                adapter=adapter_sequence,
+                adapter_read2=adapter_sequence_read2)
+            self.add_task(make_sample_sheet)
+
+            # Construct a name for the output directory
+            if lanes:
+                lanes_id = ".L%s" % ''.join([str(l) for l in lanes])
+            else:
+                lanes_id = ""
+            bcl2fastq_out_dir = PathJoinParam(self.params.analysis_dir,
+                                              "bcl2fastq%s" % lanes_id)
+
+            # Flag if the final output directory exists
+            final_output_exists = PathExistsParam(
+                PathJoinParam(self.params.analysis_dir,
+                              "bcl2fastq"))
+                
+            ###############
+            # Set up tasks
+            ###############
+
+            # Attempt to restore backup for this lane set
+            restore_backup = RestoreBackupDirectory(
+                "Restore backup%s" % (" for lanes %s" %
+                                      ','.join([str(x) for x in lanes])
+                                      if lanes else ""),
+                bcl2fastq_out_dir,
+                skip_restore=final_output_exists)
+            self.add_task(restore_backup)
+
+            # Standard protocols
+            if protocol in ("standard","mirna"):
+                # Get bcl2fastq information
+                if get_bcl2fastq is None:
+                    # Create a new task only if one doesn't already
+                    # exist
+                    get_bcl2fastq = GetBcl2Fastq(
+                        "Get information on bcl2fastq")
+                    self.add_task(get_bcl2fastq,
+                                  envmodules=self.envmodules['bcl2fastq'])
+                # Run standard bcl2fastq
+                run_bcl2fastq = RunBcl2Fastq(
+                    "Run bcl2fastq%s" % (" for lanes %s" %
+                                         ','.join([str(x) for x in lanes])
+                                         if lanes else ""),
+                    fetch_primary_data.output.run_dir,
+                    bcl2fastq_out_dir,
+                    make_sample_sheet.output.custom_sample_sheet,
+                    bases_mask=bases_mask,
+                    minimum_trimmed_read_length=\
+                    minimum_trimmed_read_length,
+                    mask_short_adapter_reads=\
+                    mask_short_adapter_reads,
+                    nprocessors=self.params.nprocessors,
+                    no_lane_splitting=self.params.no_lane_splitting,
+                    create_fastq_for_index_read=\
+                    create_fastq_for_index_read,
+                    create_empty_fastqs=self.params.create_empty_fastqs,
+                    platform=self._platform,
+                    bcl2fastq_exe=get_bcl2fastq.output.bcl2fastq_exe,
+                    bcl2fastq_version=get_bcl2fastq.output.bcl2fastq_version,
+                    skip_bcl2fastq=final_output_exists)
+                self.add_task(run_bcl2fastq,
+                              runner=self.runners['bcl2fastq_runner'],
+                              envmodules=self.envmodules['bcl2fastq'],
+                              requires=(get_bcl2fastq,
+                                        make_sample_sheet,
+                                        restore_backup))
+                # Add task to list of tasks that downstream
+                # tasks need to wait for
+                fastq_generation_tasks.append(run_bcl2fastq)
+                # Add output directory to list
+                bcl2fastq_out_dirs.append(bcl2fastq_out_dir)
+
+            # ICELL8 RNA-seq
+            if protocol == "icell8":
+                # Get bcl2fastq information
+                if get_bcl2fastq is None:
+                    # Create a new task only if one doesn't already
+                    # exist
+                    get_bcl2fastq = GetBcl2Fastq(
+                        "Get information on bcl2fastq")
+                    self.add_task(get_bcl2fastq,
+                                  envmodules=self.envmodules['bcl2fastq'])
+                # Get ICELL8 bases mask
+                get_bases_mask = GetBasesMaskIcell8(
+                    "Get bases mask for ICELL8",
+                    fetch_primary_data.output.run_dir,
+                    make_sample_sheet.output.custom_sample_sheet)
+                self.add_task(get_bases_mask,
+                              requires=(fetch_primary_data,))
+                # Run standard bcl2fastq
+                run_bcl2fastq = RunBcl2Fastq(
+                    "Run bcl2fastq%s" % (" for lanes %s" %
+                                         ','.join([str(x) for x in lanes])
+                                         if lanes else ""),
+                    fetch_primary_data.output.run_dir,
+                    bcl2fastq_out_dir,
+                    make_sample_sheet.output.custom_sample_sheet,
+                    bases_mask=get_bases_mask.output.bases_mask,
+                    minimum_trimmed_read_length=\
+                    minimum_trimmed_read_length,
+                    mask_short_adapter_reads=\
+                    mask_short_adapter_reads,
+                    nprocessors=self.params.nprocessors,
+                    no_lane_splitting=self.params.no_lane_splitting,
+                    create_fastq_for_index_read=\
+                    create_fastq_for_index_read,
+                    create_empty_fastqs=self.params.create_empty_fastqs,
+                    bcl2fastq_exe=get_bcl2fastq.output.bcl2fastq_exe,
+                    bcl2fastq_version=get_bcl2fastq.output.bcl2fastq_version,
+                    skip_bcl2fastq=final_output_exists)
+                self.add_task(run_bcl2fastq,
+                              runner=self.runners['bcl2fastq_runner'],
+                              envmodules=self.envmodules['bcl2fastq'],
+                              requires=(get_bcl2fastq,
+                                        get_bases_mask,
+                                        make_sample_sheet,
+                                        restore_backup,))
+                # Add task to list of tasks that downstream
+                # tasks need to wait for
+                fastq_generation_tasks.append(run_bcl2fastq)
+                # Add output directory to list
+                bcl2fastq_out_dirs.append(bcl2fastq_out_dir)
+
+            # ICELL8 ATAC-seq
+            if protocol == "icell8_atac":
+                # Parameter to indicate if bcl2fastq needs to run
+                skip_bcl2fastq = FunctionParam(
+                    lambda x,y: x or y,
+                    final_output_exists,
+                    PathExistsParam(bcl2fastq_out_dir))
+                
+                # Temporary dir for intermediate Fastqs
+                tmp_bcl2fastq_dir = "bcl2fastq.icell8_atac%s" % lanes_id
+                # Get bcl2fastq information
+                if get_bcl2fastq is None:
+                    # Create a new task only if one doesn't already
+                    # exist
+                    get_bcl2fastq = GetBcl2Fastq(
+                        "Get information on bcl2fastq")
+                    self.add_task(get_bcl2fastq,
+                                  envmodules=self.envmodules['bcl2fastq'])
+                # Get ICELL8 bases mask
+                get_bases_mask = GetBasesMaskIcell8Atac(
+                    "Get bases mask for ICELL8",
+                    fetch_primary_data.output.run_dir)
+                self.add_task(get_bases_mask,
+                              requires=(fetch_primary_data,))
+                # Run standard bcl2fastq
+                run_bcl2fastq = RunBcl2Fastq(
+                    "Run bcl2fastq%s" % (" for lanes %s" %
+                                         ','.join([str(x) for x in lanes])
+                                         if lanes else ""),
+                    fetch_primary_data.output.run_dir,
+                    tmp_bcl2fastq_dir,
+                    make_sample_sheet.output.custom_sample_sheet,
+                    bases_mask=get_bases_mask.output.bases_mask,
+                    minimum_trimmed_read_length=\
+                    minimum_trimmed_read_length,
+                    mask_short_adapter_reads=\
+                    mask_short_adapter_reads,
+                    nprocessors=self.params.nprocessors,
+                    no_lane_splitting=self.params.no_lane_splitting,
+                    create_fastq_for_index_read=\
+                    create_fastq_for_index_read,
+                    create_empty_fastqs=self.params.create_empty_fastqs,
+                    bcl2fastq_exe=get_bcl2fastq.output.bcl2fastq_exe,
+                    bcl2fastq_version=get_bcl2fastq.output.bcl2fastq_version,
+                    skip_bcl2fastq=skip_bcl2fastq)
+                    ##skip_bcl2fastq=PathExistsParam(bcl2fastq_out_dir))
+                self.add_task(run_bcl2fastq,
+                              runner=self.runners['bcl2fastq_runner'],
+                              envmodules=self.envmodules['bcl2fastq'],
+                              requires=(get_bcl2fastq,
+                                        get_bases_mask,
+                                        make_sample_sheet,
+                                        restore_backup))
+                # Demultiplex ICELL8 ATAC Fastqs
+                demultiplex_fastqs = DemultiplexIcell8Atac(
+                    "Demultiplex ICELL8 ATAC fastqs%s" %
+                    (" for lanes %s" % ','.join([str(x) for x in lanes])
+                     if lanes else ""),
+                    tmp_bcl2fastq_dir,
+                    bcl2fastq_out_dir,
+                    well_list,
+                    nprocessors=self.params.nprocessors,
+                    swap_i1_and_i2=swap_i1_and_i2,
+                    reverse_complement=reverse_complement,
+                    skip_demultiplex=final_output_exists)
+                self.add_task(
+                    demultiplex_fastqs,
+                    runner=self.runners['demultiplex_icell_atac_runner'],
+                    requires=(run_bcl2fastq,))
+                # Add task to list of tasks that downstream
+                # tasks need to wait for
+                fastq_generation_tasks.append(demultiplex_fastqs)
+                # Add output directory to list
+                bcl2fastq_out_dirs.append(bcl2fastq_out_dir)
+
+            # 10x RNA-seq
+            if protocol == "10x_chromium_sc":
+                # Get bcl2fastq information
+                if get_bcl2fastq_for_10x is None:
+                    get_bcl2fastq_for_10x = GetBcl2Fastq(
+                        "Get information on bcl2fastq for cellranger")
+                    self.add_task(get_bcl2fastq_for_10x,
+                                  envmodules=self.envmodules['cellranger'])
+                # Get cellranger information
+                if get_cellranger is None:
+                    # Create a new task only if one doesn't already
+                    # exist
+                    get_cellranger = GetCellranger(
+                        "Get information on cellranger",
+                        require_cellranger="cellranger")
+                    self.add_task(get_cellranger,
+                                  envmodules=self.envmodules['cellranger'])
+                # Run cellranger mkfastq
+                run_cellranger_mkfastq = RunCellrangerMkfastq(
+                    "Run cellranger mkfastq%s" %
+                    (" for lanes %s" % ','.join([str(x) for x in lanes])
+                     if lanes else ""),
+                    fetch_primary_data.output.run_dir,
+                    bcl2fastq_out_dir,
+                    make_sample_sheet.output.custom_sample_sheet,
+                    bases_mask=bases_mask,
+                    minimum_trimmed_read_length=\
+                    minimum_trimmed_read_length,
+                    mask_short_adapter_reads=\
+                    mask_short_adapter_reads,
+                    cellranger_jobmode=self.params.cellranger_jobmode,
+                    cellranger_mempercore=self.params.cellranger_mempercore,
+                    cellranger_maxjobs=self.params.cellranger_maxjobs,
+                    cellranger_jobinterval=self.params.cellranger_jobinterval,
+                    cellranger_localcores=self.params.cellranger_localcores,
+                    cellranger_localmem=self.params.cellranger_localmem,
+                    cellranger_exe=get_cellranger.output.cellranger_exe,
+                    cellranger_version=get_cellranger.output.cellranger_version,
+                    bcl2fastq_exe=get_bcl2fastq_for_10x.output.bcl2fastq_exe,
+                    bcl2fastq_version=\
+                    get_bcl2fastq_for_10x.output.bcl2fastq_version,
+                    skip_cellranger=final_output_exists
+                )
+                self.add_task(run_cellranger_mkfastq,
+                              runner=self.runners['cellranger_runner'],
+                              envmodules=self.envmodules['cellranger'],
+                              requires=(get_cellranger,
+                                        get_bcl2fastq_for_10x,
+                                        make_sample_sheet,
+                                        restore_backup,))
+                # Add task to list of tasks that downstream
+                # tasks need to wait for
+                fastq_generation_tasks.append(run_cellranger_mkfastq)
+                # Add output directory to list
+                bcl2fastq_out_dirs.append(bcl2fastq_out_dir)
+
+            # 10x ATAC-seq
+            if protocol == "10x_atac":
+                # Get bcl2fastq information
+                if get_bcl2fastq_for_10x_atac is None:
+                    get_bcl2fastq_for_10x_atac = GetBcl2Fastq(
+                        "Get information on bcl2fastq for cellranger-atac")
+                    self.add_task(get_bcl2fastq_for_10x_atac,
+                                  envmodules=self.envmodules['cellranger_atac'])
+                # Get cellranger-atac information
+                if get_cellranger_atac is None:
+                    # Create a new task only if one doesn't already
+                    # exist
+                    get_cellranger_atac = GetCellranger(
+                        "Get information on cellranger-atac",
+                        require_cellranger="cellranger-atac")
+                    self.add_task(get_cellranger_atac,
+                                  envmodules=self.envmodules['cellranger_atac'])
+                # Run cellranger mkfastq
+                run_cellranger_mkfastq = RunCellrangerMkfastq(
+                    "Run cellranger-atac mkfastq%s" %
+                    (" for lanes %s" % ','.join([str(x) for x in lanes])
+                     if lanes else ""),
+                    fetch_primary_data.output.run_dir,
+                    bcl2fastq_out_dir,
+                    make_sample_sheet.output.custom_sample_sheet,
+                    bases_mask=bases_mask,
+                    minimum_trimmed_read_length=\
+                    minimum_trimmed_read_length,
+                    mask_short_adapter_reads=\
+                    mask_short_adapter_reads,
+                    cellranger_jobmode=self.params.cellranger_jobmode,
+                    cellranger_mempercore=self.params.cellranger_mempercore,
+                    cellranger_maxjobs=self.params.cellranger_maxjobs,
+                    cellranger_jobinterval=self.params.cellranger_jobinterval,
+                    cellranger_localcores=self.params.cellranger_localcores,
+                    cellranger_localmem=self.params.cellranger_localmem,
+                    cellranger_exe=get_cellranger_atac.output.cellranger_exe,
+                    cellranger_version=\
+                    get_cellranger_atac.output.cellranger_version,
+                    bcl2fastq_exe=\
+                    get_bcl2fastq_for_10x_atac.output.bcl2fastq_exe,
+                    bcl2fastq_version=\
+                    get_bcl2fastq_for_10x_atac.output.bcl2fastq_version,
+                    skip_cellranger=final_output_exists
+                )
+                self.add_task(run_cellranger_mkfastq,
+                              runner=self.runners['cellranger_runner'],
+                              envmodules=self.envmodules['cellranger_atac'],
+                              requires=(get_cellranger_atac,
+                                        get_bcl2fastq_for_10x_atac,
+                                        make_sample_sheet,
+                                        restore_backup,))
+                # Add task to list of tasks that downstream
+                # tasks need to wait for
+                fastq_generation_tasks.append(run_cellranger_mkfastq)
+                # Add output directory to list
+                bcl2fastq_out_dirs.append(bcl2fastq_out_dir)
+
+        # Merge Fastqs
+        if len(self.subsets) > 1:
+            bcl2fastq_out_dir = PathJoinParam(self.params.analysis_dir,
+                                              "bcl2fastq")
+            merge_fastq_dirs = MergeFastqDirs(
+                "Merge bcl2fastq output directories",
+                bcl2fastq_out_dirs,
+                bcl2fastq_out_dir
+            )
+            self.add_task(merge_fastq_dirs,
+                          requires=fastq_generation_tasks)
+            fastq_generation_tasks = (merge_fastq_dirs,)
+
+        if self._fastq_statistics:
+            # Generate statistics
+            fastq_statistics = FastqStatistics(
+                "Generate statistics for Fastqs",
+                bcl2fastq_out_dir,
+                self._sample_sheet,
+                self.params.analysis_dir,
+                nprocessors=self.params.nprocessors)
+            self.add_task(fastq_statistics,
+                          runner=self.runners['stats_runner'],
+                          requires=fastq_generation_tasks)
+
+            # Processing QC report
+            report_qc = ReportProcessingQC(
+                "Report Processing QC",
+                analysis_dir=self.params.analysis_dir,
+                stats_file=fastq_statistics.output.stats_full,
+                per_lane_stats_file=\
+                fastq_statistics.output.per_lane_stats,
+                per_lane_sample_stats_file=\
+                fastq_statistics.output.per_lane_sample_stats,
+                report_html=self.params.qc_report
+            )
+            self.add_task(report_qc,
+                          requires=(fastq_statistics,))
+
+        # Append pipeline for barcode analysis
+        if not self._fastq_statistics:
+            do_barcode_analysis = False
+        elif len(self.subsets) == 1:
+            try:
+                do_barcode_analysis = self.subsets[0]['analyse_barcodes']
+            except KeyError:
+                do_barcode_analysis = self._analyse_barcodes
+        else:
+            if lanes_for_barcode_analysis:
+                do_barcode_analysis = True
+                lanes_for_barcode_analysis = sorted(
+                    list(set(lanes_for_barcode_analysis)))
+            else:
+                do_barcode_analysis = False
+        if do_barcode_analysis:
+            self.report("Lanes for barcode analysis: %s" %
+                        lanes_for_barcode_analysis)
+            analyse_barcodes = AnalyseBarcodes(sample_sheet=self._sample_sheet)
+            self.add_pipeline(analyse_barcodes,
+                              params={
+                                  'bcl2fastq_dir': bcl2fastq_out_dir,
+                                  'lanes': lanes_for_barcode_analysis,
+                                  'mismatches': run_bcl2fastq.output.mismatches
+                              },
+                              requires=fastq_generation_tasks)
+
+    def run(self,analysis_dir,primary_data_dir=None,
+            nprocessors=1,force_copy_of_primary_data=False,
+            working_dir=None,log_file=None,batch_size=None,
+            no_lane_splitting=None,create_fastq_for_index_read=None,
+            create_empty_fastqs=None,
+            cellranger_jobmode='local',cellranger_mempercore=None,
+            cellranger_maxjobs=None,cellranger_jobinterval=None,
+            cellranger_localcores=None,cellranger_localmem=None,
+            max_jobs=1,poll_interval=5,runners=None,
+            default_runner=None,envmodules=None,verbose=False):
+        """
+        Run the tasks in the pipeline
+
+        Arguments:
+          analysis_dir (str): directory to perform the processing
+            and analyses in
+          primary_data_dir (str): top-level directory
+            holding the primary data
+          force_copy_of_primary_data (bool): if True then force
+            primary data to be copied (rsync'ed) even if it's on
+            the local system (default is to link to primary data
+            unless it's on a remote filesystem)
+          nprocessors (int): number of threads to use for
+            multithreaded applications (default is 1)
+          working_dir (str): optional path to a working
+            directory (defaults to temporary directory in
+            the current directory)
+          log_dir (str): path of directory where log files
+            will be written to
+          batch_size (int): if set then run commands in
+            each task in batches, with each batch running
+            this many commands at a time (default is to run
+            one command per job)
+          no_lane_splitting (bool):
+          create_fastq_for_index_read (bool):
+          create_empty_fastqs (bool):
+          cellranger_jobmode (str):
+          cellranger_mempercore (int):
+          cellranger_maxjobs (int):
+          cellranger_jobinterval (int):
+          cellranger_localcores (int):
+          cellranger_localmem (int):
+          max_jobs (int): optional maximum number of
+            concurrent jobs in scheduler (defaults to 1)
+          poll_interval (float): optional polling interval
+            (seconds) to set in scheduler (defaults to 5s)
+          runners (dict): mapping of names to JobRunner
+            instances; valid names are 'qc_runner',
+            'report_runner','cellranger_runner',
+            'verify_runner','default'
+          envmodules (mapping): mapping of names to
+            environment module file lists; valid names are
+            'illumina_qc','fastq_strand','cellranger',
+            'report_qc'
+          default_runner (JobRunner): optional default
+            job runner to use
+          verbose (bool): if True then report additional
+            information for diagnostics
+        """
+        # Working directory
+        clean_up_on_completion = False
+        if working_dir is None:
+            working_dir = tempfile.mkdtemp(prefix="__make_fastqs.",
+                                           suffix=".tmp",
+                                           dir=os.getcwd())
+            clean_up_on_completion = True
+        working_dir = os.path.abspath(working_dir)
+        if not os.path.exists(working_dir):
+            mkdir(working_dir)
+
+        # Log and script directories
+        log_dir = os.path.join(working_dir,"logs")
+        scripts_dir = os.path.join(working_dir,"scripts")
+
+        # Runners
+        if runners is None:
+            runners = dict()
+
+        # Parameters
+        analysis_dir = os.path.abspath(analysis_dir)
+        params = {
+            'analysis_dir': analysis_dir,
+            'primary_data_dir': (os.path.abspath(primary_data_dir)
+                                 if primary_data_dir
+                                 else os.path.join(analysis_dir,
+                                                   "primary_data")),
+            'barcode_analysis_dir': os.path.join(analysis_dir,
+                                                 "barcode_analysis"),
+            'counts_dir': os.path.join(analysis_dir,
+                                       "barcode_analysis",
+                                       "counts"),
+            'qc_report': os.path.join(analysis_dir,
+                                      "processing_qc.html"),
+            'force_copy_of_primary_data': force_copy_of_primary_data,
+            'nprocessors': nprocessors,
+            'no_lane_splitting': no_lane_splitting,
+            'create_fastq_for_index_read': create_fastq_for_index_read,
+            'create_empty_fastqs': create_empty_fastqs,
+            'cellranger_jobmode': cellranger_jobmode,
+            'cellranger_mempercore': cellranger_mempercore,
+            'cellranger_maxjobs': cellranger_maxjobs,
+            'cellranger_jobinterval': cellranger_jobinterval,
+            'cellranger_localcores': cellranger_localcores,
+            'cellranger_localmem': cellranger_localmem,
+        }
+
+        # Execute the pipeline
+        status = Pipeline.run(self,
+                              working_dir=working_dir,
+                              log_dir=log_dir,
+                              scripts_dir=scripts_dir,
+                              log_file=log_file,
+                              batch_size=batch_size,
+                              exit_on_failure=PipelineFailure.DEFERRED,
+                              params=params,
+                              poll_interval=poll_interval,
+                              max_jobs=max_jobs,
+                              runners=runners,
+                              default_runner=default_runner,
+                              envmodules=envmodules,
+                              verbose=verbose)
+
+        # Clean up working dir
+        if status == 0 and clean_up_on_completion:
+            shutil.rmtree(working_dir)
+
+        # Return pipeline status
+        return status
+
+######################################################################
+# Pipeline task classes
+######################################################################
+
+class FetchPrimaryData(PipelineTask):
+    """
+    Fetch the primary data for processing
+    """
+    def init(self,data_dir,primary_data_dir,force_copy=False):
+        """
+        Initialise the FetchPrimaryData task
+
+        Arguments:
+          data_dir (str): location of the source sequencing data
+          primary_data_dir (str): directory to copy data to (if
+            source is a remote location) or link data from (if
+            source is on the local system)
+          force_copy (bool): if True then force primary data to
+            be copied even if it's on the local system
+        """
+        self.tmp_dir = None
+        self.add_output('run_dir',Param(type='str'))
+    def setup(self):
+        # Check if primary data already exists
+        final_run_dir = os.path.join(
+            self.args.primary_data_dir,
+            os.path.basename(self.args.data_dir))
+        if os.path.exists(final_run_dir):
+            print("Primary data already acquired")
+            self.output.run_dir.set(final_run_dir)
+            return
+        # Create top level primary data directory
+        if not os.path.exists(self.args.primary_data_dir):
+            print("Making top-level primary data dir: %s" %
+                  self.args.primary_data_dir)
+            os.mkdir(self.args.primary_data_dir)
+        # Check if source data are local or remote
+        if not Location(self.args.data_dir).is_remote:
+            # Local data
+            print("Source data are on the local system")
+            if not self.args.force_copy:
+                # Make a symlink
+                print("Making a symlink to source data")
+                os.symlink(self.args.data_dir,
+                           os.path.join
+                           (self.args.primary_data_dir,
+                            os.path.basename(self.args.data_dir)))
+                return
+        # Copy remote data (and local data when 'force copy'
+        # was specified)
+        print("Copying source data")
+        # Make a temporary directory for rsyncing
+        self.tmp_dir = os.path.join(self.args.primary_data_dir,
+                                    "__%s.part" %
+                                    os.path.basename(self.args.data_dir))
+        # Construct the rsync command
+        rsync_cmd = general_apps.rsync(
+            "%s/" % self.args.data_dir,
+            self.tmp_dir,
+            prune_empty_dirs=True,
+            extra_options=('--copy-links',
+                           '--include=*/',
+                           '--include=Data/**',
+                           '--include=RunInfo.xml',
+                           '--include=SampleSheet.csv',
+                           '--include=RTAComplete.txt',
+                           '--include=runParameters.xml',
+                           '--include=RunParameters.xml',
+                           '--exclude=*'))
+        print("Running %s" % rsync_cmd)
+        self.add_cmd(PipelineCommandWrapper(
+            "Rsync primary data from %s" % self.args.data_dir,
+            *rsync_cmd.command_line))
+    def finish(self):
+        final_run_dir = os.path.join(
+            self.args.primary_data_dir,
+            os.path.basename(self.args.data_dir))
+        # If copying then move the tmp copy to the
+        # final location
+        if self.tmp_dir is not None:
+            print("Moving temporary copy of primary data to final "
+                  "location")
+            os.rename(self.tmp_dir,final_run_dir)
+        if os.path.exists(final_run_dir):
+            self.output.run_dir.set(final_run_dir)
+
+class MakeSampleSheet(PipelineTask):
+    """
+    Creates a custom sample sheet
+    """
+    def init(self,sample_sheet_file,lanes=(),adapter=None,
+             adapter_read2=None):
+        """
+        Initialise the MakeSampleSheet task
+
+        Arguments:
+          sample_sheet_file (str): name and path of the base
+            sample file to generate the new file from
+          lanes (list): (optional) list of lane numbers to
+            keep in the output sample sheet; if empty then all
+            lanes will be kept
+          adapter (str): (optional) if set then write to the
+            `Adapter` setting
+          adapter_read2 (str): (optional) if set then write to
+            the `AdapterRead2` setting
+
+        Outputs:
+          custom_sample_sheet (PipelineParam): pipeline
+            parameter instance that resolves to a string
+            with the path to the output sample sheet file.
+        """
+        self.add_output('custom_sample_sheet',Param(type=str))
+    def setup(self):
+        print("Generating custom sample sheet from %s" %
+              self.args.sample_sheet_file)
+        # Construct a name for the output file
+        if self.args.lanes:
+            lanes_id = ".L%s" % ''.join([str(l) for l in self.args.lanes])
+        else:
+            lanes_id = ""
+        output_sample_sheet = os.path.abspath("SampleSheet%s.%s.csv" %
+                                              (lanes_id,
+                                               time.strftime("%Y%m%d%H%M%S")))
+        # Generate the custom sample sheet
+        make_custom_sample_sheet(self.args.sample_sheet_file,
+                                 output_sample_sheet,
+                                 lanes=(None if not self.args.lanes
+                                        else self.args.lanes),
+                                 adapter=self.args.adapter,
+                                 adapter_read2=self.args.adapter_read2)
+        # Check the temporary sample sheet
+        print("Checking custom sample sheet %s" % output_sample_sheet)
+        linter = SampleSheetLinter(sample_sheet_file=output_sample_sheet)
+        # Invalid barcodes
+        invalid_barcodes = linter.has_invalid_barcodes()
+        if invalid_barcodes:
+            print("Invalid barcodes detected:")
+            for line in invalid_barcodes:
+                print("!!! %s" % line)
+        # Invalid characters
+        invalid_characters = linter.has_invalid_characters()
+        if invalid_characters:
+            print("Invalid non-printing/non-ASCII characters "
+                  "detected")
+        if invalid_barcodes or invalid_characters:
+            raise Exception("Errors detected in generated sample sheet")
+        # Sample sheet ok
+        self.output.custom_sample_sheet.set(output_sample_sheet)
+
+class GetBcl2Fastq(PipelineFunctionTask):
+    """
+    Get information on the bcl2fastq executable
+    """
+    def init(self,require_bcl2fastq=None):
+        """
+        Initialise the GetBcl2Fastq task
+
+        Arguments:
+          require_bcl2fastq (str): if set then should be a
+            string of the form '1.8.4' or '>2.0', explicitly
+            specifying the version of bcl2fastq to use. If
+            not set then no version check will be made
+
+        Outputs:
+          bcl2fastq_exe (str): path to the bcl2fastq executable
+          bcl2fastq_package (str): name of the bcl2fastq package
+          bcl2fastq_version (str): the bcl2fastq version
+        """
+        self.add_output('bcl2fastq_exe',Param(type=str))
+        self.add_output('bcl2fastq_package',Param(type=str))
+        self.add_output('bcl2fastq_version',Param(type=str))
+    def setup(self):
+        if self.args.require_bcl2fastq:
+            print("Requires bcl2fastq version %s" %
+                  self.args.require_bcl2fastq)
+        self.add_call("Check bcl2fastq version",
+                      self.get_bcl2fastq,
+                      self.args.require_bcl2fastq)
+    def get_bcl2fastq(self,require_bcl2fastq=None):
+        # Get bcl2fastq
+        bcl2fastq = available_bcl2fastq_versions(require_bcl2fastq)
+        if bcl2fastq:
+            bcl2fastq_exe = bcl2fastq[0]
+            bcl2fastq_info = bcl_to_fastq_info(bcl2fastq_exe)
+        else:
+            raise Exception("No appropriate bcl2fastq software "
+                            "located")
+        # Return the information on bcl2fastq
+        return (bcl2fastq_exe,bcl2fastq_info[1],bcl2fastq_info[2])
+    def finish(self):
+        bcl2fastq = self.result()[0]
+        bcl2fastq_exe = bcl2fastq[0]
+        bcl2fastq_package = bcl2fastq[1]
+        bcl2fastq_version = bcl2fastq[2]
+        # Set outputs with info on bcl2fastq executable
+        self.output.bcl2fastq_exe.set(bcl2fastq_exe)
+        self.output.bcl2fastq_package.set(bcl2fastq_package)
+        self.output.bcl2fastq_version.set(bcl2fastq_version)
+        # Report what was found
+        print("Bcl2fastq exe    : %s" % bcl2fastq_exe)
+        print("Bcl2fastq package: %s" % bcl2fastq_package)
+        print("Bcl2fastq version: %s" % bcl2fastq_version)
+
+class RestoreBackupDirectory(PipelineTask):
+    """
+    Check for and restore saved copy of directory
+
+    Looks for a backup version of a directory, and
+    restores it by renaming it back to the original
+    name if found.
+
+    Back up for directory `/path/to/dir` will be
+    called `/path/to/save.dir`.
+    """
+    def init(self,dirn,skip_restore=False):
+        """
+        Initialise the RestoreBackupDirectory task
+
+        Arguments:
+          dirn (str): path to the original directory
+            to look for backup of
+          skip_restore (bool): if True then check for
+            the backup but don't restore it if found
+        """
+        pass
+    def setup(self):
+        # Get path to for backup copy
+        backup_dirn = os.path.join(
+            os.path.dirname(self.args.dirn),
+            "save.%s" % os.path.basename(self.args.dirn)
+        )
+        print("Checking for backup directory: '%s'" % backup_dirn)
+        if os.path.exists(backup_dirn):
+            if not self.args.skip_restore:
+                print("Restoring to '%s'" % self.args.dirn)
+                os.rename(backup_dirn,self.args.dirn)
+            else:
+                print("Backup located but restore skipped")
+        else:
+            print("Not found, skipped restore")
+
+class RunBcl2Fastq(PipelineTask):
+    """
+    Run bcl2fastq to generate Fastqs from sequencing data
+    """
+    def init(self,run_dir,out_dir,sample_sheet,bases_mask='auto',
+             ignore_missing_bcl=False,no_lane_splitting=False,
+             minimum_trimmed_read_length=None,
+             mask_short_adapter_reads=None,
+             create_fastq_for_index_read=False,nprocessors=1,
+             create_empty_fastqs=False,
+             platform=None,bcl2fastq_exe=None,bcl2fastq_version=None,
+             skip_bcl2fastq=False):
+        """
+        Initialise the RunBcl2Fastq task
+
+        Arguments:
+          run_dir (str): path to the source sequencing data
+          out_dir (str): output directory for bcl2fastq
+          sample_sheet (str): path to input samplesheet file
+          bases_mask (str): if set then use this as an
+            alternative bases mask setting
+          ignore_missing_bcl (bool): if True then run
+            bcl2fastq with --ignore-missing-bcl
+          no_lane_splitting (bool): if True then run bcl2fastq
+            with --no-lane-splitting
+          minimum_trimmed_read_length (int): if set then supply
+            to bcl2fastq via --minimum-trimmed-read-length
+          mask_short_adapter_reads (int): if set then supply to
+            bcl2fastq via --mask-short-adapter-reads
+          create_fastq_for_index_read (boolean): if True then
+            also create Fastq files for index reads (default,
+            don't create index read Fastqs)
+          nprocessors (int): number of processors to use
+            (default is 1)
+          create_empty_fastqs (bool): if True then create empty
+            placeholder Fastq files for any that are missing
+            on successful completion of bcl2fastq
+          platform (str): optional, sequencing platform that
+            generated the data
+          bcl2fastq_exe (str): the path to the bcl2fastq
+            executable to use
+          bcl2fastq_version (str): the version string for the
+            bcl2fastq package
+          skip_bcl2fastq (bool): if True then sets the output
+            parameters but finishes before actually running
+            bcl2fastq
+
+        Outputs:
+          bases_mask: actual bases mask used
+          mismatches: number of mismatches allowed
+        """
+        self.supported_versions = ('1.8','2.17','2.20',)
+        self.tmp_out_dir = None
+        self.add_output('bases_mask',Param(type='str'))
+        self.add_output('mismatches',Param(type='int'))
+    def setup(self):
+        # Load input data
+        illumina_run = IlluminaRun(self.args.run_dir,
+                                   platform=self.args.platform)
+        # Set bases mask
+        if self.args.bases_mask == "auto":
+            print("Setting bases mask from RunInfo.xml")
+            bases_mask = get_bases_mask(illumina_run.runinfo_xml,
+                                        self.args.sample_sheet)
+        else:
+            bases_mask = self.args.bases_mask
+        if not bases_mask_is_valid(bases_mask):
+            raise Exception("Invalid bases mask: '%s'" %
+                            bases_mask)
+        self.output.bases_mask.set(bases_mask)
+        # Check sample sheet for collisions and set mismatches
+        mismatches = get_nmismatches(bases_mask)
+        while mismatches >= 0:
+            if check_barcode_collisions(self.args.sample_sheet,
+                                        mismatches):
+                mismatches -= 1
+            else:
+                break
+        if mismatches < 0:
+            raise Exception("Barcode collisions detected even with "
+                            "zero mismatches (indicates duplicated "
+                            "indexes?)")
+        self.output.mismatches.set(mismatches)
+        # Check if Fastq generation should be skipped
+        if self.args.skip_bcl2fastq:
+            print("Skipping bcl2fastq run")
+            return
+        # Check if outputs already exist
+        if os.path.exists(self.args.out_dir):
+            print("Output directory %s already exists" %
+                  self.args.out_dir)
+            # Verify outputs
+            illumina_data = IlluminaData(os.path.dirname(self.args.out_dir),
+                                         os.path.basename(self.args.out_dir))
+            if verify_run_against_sample_sheet(illumina_data,
+                                               self.args.sample_sheet):
+                print("Verified existing outputs against samplesheet")
+                return
+            else:
+                raise Exception("Failed to verify existing outputs "
+                                "against samplesheet")
+        # Check that bcl2fastq version is supported
+        supported_version = None
+        for version in self.supported_versions:
+            if self.args.bcl2fastq_version.startswith("%s." % version):
+                supported_version = version
+                break
+        if supported_version:
+            print("Bcl2fastq software matches supported version '%s'" %
+                  supported_version)
+        else:
+            raise Exception("Don't know how to run bcl2fastq "
+                            "version %s" % self.args.bcl2fastq_version)
+        # Set up parameters
+        params = {
+            'mismatches': mismatches,
+            'bases_mask': bases_mask,
+            'ignore_missing_bcl': self.args.ignore_missing_bcl,
+            'no_lane_splitting': self.args.no_lane_splitting,
+            'minimum_trimmed_read_length':
+            self.args.minimum_trimmed_read_length,
+            'mask_short_adapter_reads':
+            self.args.mask_short_adapter_reads,
+            'create_fastq_for_index_reads':
+            self.args.create_fastq_for_index_read,
+            'loading_threads': None,
+            'demultiplexing_threads': None,
+            'processing_threads': None,
+            'writing_threads': None,
+            'bcl2fastq_exe': self.args.bcl2fastq_exe,
+        }
+        # Update parameters based on bcl2fastq version
+        nprocessors = self.args.nprocessors
+        if supported_version in ('2.17',):
+            # bcl2fastq 2.17.*
+            if nprocessors is not None:
+                # Explicitly set number of threads for each stage
+                params['loading_threads'] = min(4,nprocessors)
+                params['writing_threads'] = min(4,nprocessors)
+                params['demultiplexing_threads'] = max(
+                    int(float(nprocessors)*0.2),
+                    nprocessors)
+                params['processing_threads'] = nprocessors
+        elif supported_version in ('2.20',):
+            # bcl2fastq 2.20.*
+            if nprocessors is not None:
+                params['loading_threads'] = min(4,nprocessors)
+                params['writing_threads'] = min(4,nprocessors)
+                params['processing_threads'] = nprocessors
+        # Report settings
+        print("%-22s: %s" % ("Run dir",self.args.run_dir))
+        print("%-22s: %s" % ("Sample sheet",
+                             os.path.basename(self.args.sample_sheet)))
+        print("%-22s: %s" % ("Output dir",self.args.out_dir))
+        for item,desc in (('bases_mask',"Bases mask"),
+                          ('mismatches',"Mismatches",),
+                          ('ignore_missing_bcl',"Ignore missing bcl"),
+                          ('no_lane_splitting',"No lane splitting"),
+                          ('minimum_trimmed_read_length',"Min trimmed read len"),
+                          ('mask_short_adapter_reads',"Mask short adptr reads"),
+                          ('create_fastq_for_index_read',"Create index Fastqs")):
+            if item in params:
+                print("%-22s: %s" % (desc,params[item]))
+        print("Threads for each stage:")
+        for item,desc in (('nprocessors',"Nprocessors"),
+                          ('loading_threads',"Loading (-r)"),
+                          ('demultiplexing_threads',"Demultiplexing (-d)"),
+                          ('processing_threads',"Processing (-p)"),
+                          ('writing_threads',"Writing (-w)")):
+            if item in params and params[item] is not None:
+                print("- %-20s: %s" % (desc,params[item]))
+        # Set up temporary output dir
+        self.tmp_out_dir = os.path.abspath("__%s.work" %
+                                           os.path.basename(
+                                               self.args.out_dir))
+        # Build command to run bcl2fastq
+        bcl2fastq2_cmd = bcl2fastq_apps.bcl2fastq2(
+            self.args.run_dir,
+            self.args.sample_sheet,
+            output_dir=self.tmp_out_dir,
+            **params)
+        print("Running %s" % bcl2fastq2_cmd)
+        self.add_cmd(PipelineCommandWrapper(
+            "Run bcl2fastq",
+            *bcl2fastq2_cmd.command_line))
+    def finish(self):
+        if self.tmp_out_dir:
+            # Verify outputs
+            illumina_data = IlluminaData(os.path.dirname(self.tmp_out_dir),
+                                         os.path.basename(self.tmp_out_dir))
+            if verify_run_against_sample_sheet(illumina_data,
+                                               self.args.sample_sheet):
+                print("Verified outputs against samplesheet")
+            else:
+                # Verification failed
+                print("Failed to verify outputs against samplesheet")
+                # List the missing Fastq files
+                missing_fastqs = list_missing_fastqs(illumina_data,
+                                                     self.args.sample_sheet)
+                print("Missing Fastqs:")
+                for fq in missing_fastqs:
+                    print("- %s" % fq)
+                if self.args.create_empty_fastqs:
+                    # Create empty placeholder Fastqs
+                    print("Making empty placeholder Fastqs")
+                    for fq in missing_fastqs:
+                        fastq = os.path.join(self.tmp_out_dir,fq)
+                        # Make intermediate directory if required
+                        if not os.path.exists(os.path.dirname(fastq)):
+                            os.mkdir(os.path.dirname(fastq))
+                        # Make empty file
+                        with gzip.GzipFile(filename=fastq,mode='wb') as fp:
+                            fp.write(''.encode())
+                else:
+                    # Terminate with an exception
+                    raise Exception("Failed to verify outputs against "
+                                    "samplesheet")
+            # Move to final location
+            print("Moving output to final location")
+            os.rename(self.tmp_out_dir,self.args.out_dir)
+
+class GetBasesMaskIcell8(PipelineTask):
+    """
+    Set the bases mask for ICELL8 RNA-seq data
+    """
+    def init(self,run_dir,sample_sheet):
+        """
+        Initialise the GetBasesMaskIcell8 task
+
+        Arguments:
+          run_dir (str): path to the directory with
+            data from the sequencer run
+          sample_sheet (str): path to the sample sheet
+            file to be used for processing these data
+
+        Outputs:
+          bases_mask (str): bases mask to use in
+            bcl2fastq for processing these data
+        """
+        self.add_output("bases_mask",Param(type='str'))
+    def setup(self):
+        # Reset the default bases mask
+        bases_mask = IlluminaRunInfo(
+            IlluminaRun(self.args.run_dir).runinfo_xml).bases_mask
+        print("Initial bases_mask  : %s" % bases_mask)
+        bases_mask = get_bases_mask_icell8(bases_mask,
+                                           sample_sheet=self.args.sample_sheet)
+        print("Corrected for ICELL8: %s" % bases_mask)
+        self.output.bases_mask.set(bases_mask)
+
+class GetBasesMaskIcell8Atac(PipelineTask):
+    """
+    Set the bases mask for ICELL8 ATAC-seq data
+    """
+    def init(self,run_dir):
+        """
+        Initialise the GetBasesMaskIcell8Atac task
+
+        Arguments:
+          run_dir (str): path to the directory with
+            data from the sequencer run
+          sample_sheet (str): path to the sample sheet
+            file to be used for processing these data
+
+        Outputs:
+          bases_mask (str): bases mask to use in
+            bcl2fastq for processing these data
+        """
+        self.add_output("bases_mask",Param(type='str'))
+    def setup(self):
+        # Get the bases mask
+        bases_mask = get_bases_mask_icell8_atac(
+            IlluminaRun(self.args.run_dir).runinfo_xml)
+        print("Bases mask for ICELL8 ATAC: %s" % bases_mask)
+        self.output.bases_mask.set(bases_mask)
+
+class GetCellranger(PipelineFunctionTask):
+    """
+    Get information on the cellranger executable
+    """
+    def init(self,require_cellranger):
+        """
+        Initialise the GetCellranger task
+
+        Arguments:
+          require_cellranger (str): name of the cellranger
+            executable that is required (should be either
+            'cellranger' or 'cellranger-atac')
+
+        Outputs:
+          cellranger_exe (str): path to the cellranger executable
+          cellranger_package (str): name of the cellranger package
+          cellranger_version (str): the cellranger version
+        """
+        self.add_output('cellranger_exe',Param(type=str))
+        self.add_output('cellranger_package',Param(type=str))
+        self.add_output('cellranger_version',Param(type=str))
+    def setup(self):
+        print("Look for %s" % self.args.require_cellranger)
+        self.add_call("Check %s" % self.args.require_cellranger,
+                      self.get_cellranger,
+                      self.args.require_cellranger)
+    def get_cellranger(self,require_cellranger):
+        # Look for cellranger
+        cellranger_exe = find_program(require_cellranger)
+        if not cellranger_exe:
+            raise Exception("No appropriate cellranger software "
+                            "located")
+        # Get information on the version etc
+        cellranger_package = cellranger_info(cellranger_exe)
+        # Return the information on cellranger
+        return (cellranger_exe,cellranger_package[1],cellranger_package[2])
+    def finish(self):
+        cellranger = self.result()[0]
+        cellranger_exe = cellranger[0]
+        cellranger_package = cellranger[1]
+        cellranger_version = cellranger[2]
+        # Set outputs with info on cellranger executable
+        self.output.cellranger_exe.set(cellranger_exe)
+        self.output.cellranger_package.set(cellranger_package)
+        self.output.cellranger_version.set(cellranger_version)
+        # Report what was found
+        print("Cellranger exe    : %s" % cellranger_exe)
+        print("Cellranger package: %s" % cellranger_package)
+        print("Cellranger version: %s" % cellranger_version)
+
+class DemultiplexIcell8Atac(PipelineTask):
+    """
+    Runs 'demultiplex_icell8_atac.py' to generate Fastqs
+    """
+    def init(self,fastq_dir,out_dir,well_list,
+             nprocessors=None,swap_i1_and_i2=False,
+             reverse_complement=None,
+             skip_demultiplex=False):
+        """
+        Initialise the DemultiplexIcell8Atac task
+
+        Arguments:
+          fastq_dir (str): path to directory with
+            Fastq files to demultiplex
+          out_dir (str): path to output directory
+          well_list (str): path to well list file
+            to use for demultiplexing samples
+          swap_i1_and_i2 (bool): if True then
+            swap the I1 and I2 indexes when
+            demultiplexing
+          reverse_complement (str): whether to
+            reverse I1, I2, or both, when
+            demultiplexing
+          skip_demultiplex (bool): if True then
+            skip running the demultiplexing
+        """
+        self.tmp_out_dirs = {}
+        self.illumina_data = None
+    def setup(self):
+        # Check if demultiplexing should be skipped
+        if self.args.skip_demultiplex:
+            print("Skipping demultiplexing")
+            return
+        # Check if outputs already exist
+        if os.path.exists(self.args.out_dir):
+            print("Output directory %s already exists" %
+                  self.args.out_dir)
+            return
+        # Collect Fastqs from bcl2fastq
+        self.illumina_data = IlluminaData(
+            os.path.dirname(self.args.fastq_dir),
+            os.path.basename(self.args.fastq_dir))
+        fastqs = []
+        for project in self.illumina_data.projects:
+            for sample in project.samples:
+                for fq in sample.fastq:
+                    fastqs.append(os.path.join(sample.dirn,fq))
+        if not fastqs:
+            raise Exception("No Fastqs found")
+        # Report settings
+        for desc,param in (("Fastq dir",self.args.fastq_dir),
+                           ("Well list file",self.args.well_list),
+                           ("Output dir",self.args.out_dir),
+                           ("Nprocessors",self.args.nprocessors),
+                           ("Swap I1/I2",self.args.swap_i1_and_i2),
+                           ("Reverse complement",
+                            self.args.reverse_complement)):
+            print("%-22s: %s" % (desc,param))
+        # Do demultiplexing into samples based on well list
+        for fqs in group_fastqs_by_name(fastqs):
+            # Get sample name and lane from Fastq name
+            illumina_fq = IlluminaFastq(fqs[0])
+            name = "%s%s" % (illumina_fq.sample_name,
+                             (".L%03d" % illumina_fq.lane_number
+                              if illumina_fq.lane_number else ""))
+            # Set up temporary output dir
+            tmp_out_dir = os.path.abspath("__demultiplex%s.work" % name)
+            # Build demultiplexer command
+            demultiplex_cmd = Command('demultiplex_icell8_atac.py',
+                                      '--mode=samples',
+                                      '--output-dir',tmp_out_dir,
+                                      '--update-read-headers')
+            if self.args.nprocessors:
+                demultiplex_cmd.add_args('-n',self.args.nprocessors)
+            if self.args.swap_i1_and_i2:
+                demultiplex_cmd.add_args('--swap-i1-i2')
+            if self.args.reverse_complement:
+                demultiplex_cmd.add_args('--reverse-complement=%s' %
+                                         self.args.reverse_complement)
+            demultiplex_cmd.add_args('--unassigned',
+                                     "Unassigned-%s" %
+                                     illumina_fq.sample_name)
+            demultiplex_cmd.add_args(self.args.well_list)
+            demultiplex_cmd.add_args(*fqs)
+            print("Running %s" % demultiplex_cmd)
+            self.add_cmd(PipelineCommandWrapper(
+                "Demultiplex ICELL8 ATAC Fastqs",
+                *demultiplex_cmd.command_line))
+            # Store the temporary output dir
+            self.tmp_out_dirs[name] = tmp_out_dir
+    def finish(self):
+        if self.tmp_out_dirs:
+            # Build bcl2fastq-style output directory
+            bcl2fastq_dir = os.path.abspath("%s.work" %
+                                            os.path.basename(self.args.out_dir))
+            print("Building output dir: %s" % bcl2fastq_dir)
+            for d in ('Stats','Reports',):
+                mkdirs(os.path.join(bcl2fastq_dir,d))
+            project = self.illumina_data.projects[0]
+            mkdirs(os.path.join(bcl2fastq_dir,project.name))
+            # Loop over samples
+            for name in self.tmp_out_dirs:
+                # Directory with demultiplexed Fastqs
+                tmp_out_dir = self.tmp_out_dirs[name]
+                print("Collecting data from %s" % tmp_out_dir)
+                # Copy (hard link) fastqs
+                for f in os.listdir(tmp_out_dir):
+                    if f.endswith(".fastq.gz"):
+                        # Undetermined goes to top level
+                        if f.startswith("Undetermined_S0_"):
+                            os.link(os.path.join(tmp_out_dir,f),
+                                    os.path.join(bcl2fastq_dir,f))
+                        else:
+                            os.link(os.path.join(tmp_out_dir,f),
+                                    os.path.join(bcl2fastq_dir,
+                                                 project.name,f))
+                # Copy the reports and JSON file
+                for f in ('icell8_atac_stats.xlsx',
+                          'icell8_atac_stats.json'):
+                    if len(self.tmp_out_dirs) > 1:
+                        ff = "%s.%s%s" % (os.path.splitext(f)[0],
+                                          name,
+                                          os.path.splitext(f)[1])
+                    else:
+                        ff = f
+                    os.link(os.path.join(tmp_out_dir,f),
+                            os.path.join(bcl2fastq_dir,'Reports',ff))
+            # Move outputs to final location
+            print("Moving output to final location: %s" % self.args.out_dir)
+            os.rename(bcl2fastq_dir,self.args.out_dir)
+
+class RunCellrangerMkfastq(PipelineTask):
+    """
+    Runs 'cellranger[-atac] mkfastq' to generate Fastqs
+    """
+    def init(self,run_dir,out_dir,sample_sheet,bases_mask='auto',
+             minimum_trimmed_read_length=None,
+             mask_short_adapter_reads=None,
+             cellranger_jobmode='local',cellranger_maxjobs=None,
+             cellranger_mempercore=None,cellranger_jobinterval=None,
+             cellranger_localcores=None,cellranger_localmem=None,
+             create_empty_fastqs=False,platform=None,
+             cellranger_exe=None,cellranger_version=None,
+             bcl2fastq_exe=None,bcl2fastq_version=None,
+             skip_cellranger=False):
+        """
+        Initialise the RunCellrangerMkfastq task
+
+        Arguments:
+          run_dir (str): path to the directory with
+            data from the sequencer run
+          out_dir (str): output directory for cellranger
+          sample_sheet (str): path to input samplesheet file
+          bases_mask (str): if set then use this as an
+            alternative bases mask setting
+          minimum_trimmed_read_length (int): if set then supply
+            to cellranger via --minimum-trimmed-read-length
+          mask_short_adapter_reads (int): if set then supply to
+            cellranger via --mask-short-adapter-reads
+          cellranger_jobmode (str): jobmode to use for
+            running cellranger
+          cellranger_maxjobs (int): maximum number of concurrent
+            jobs for cellrange to run
+          cellranger_mempercore (int): amount of memory available
+            per core (for jobmode other than 'local')
+          cellranger_jobinterval (int): time to pause inbetween
+            starting cellranger jobs
+          cellranger_localcores (int): number of cores available
+            to cellranger in jobmode 'local'
+          cellranger_localmem (int): amount of memory available
+            to cellranger in jobmode 'local'
+          create_empty_fastqs (bool): if True then create empty
+            placeholder Fastq files for any that are missing
+            on successful completion of cellranger
+          platform (str): optional, sequencing platform that
+            generated the data
+          cellranger_exe (str): the path to the cellranger
+            executable to use
+          cellranger_version (str): the version string for the
+            cellranger package
+          bcl2fastq_exe (str): the path to the bcl2fastq
+            executable to use
+          bcl2fastq_version (str): the version string for the
+            bcl2fastq package
+          skip_cellranger (bool): if True then skip running
+            cellranger mkfastq within the task
+        """
+        self.tmp_out_dir = None
+        self.lanes = None
+        self.cellranger_out_dir = None
+        self.mro_file = None
+    def setup(self):
+        # Check if cellranger should be skipped
+        if self.args.skip_cellranger:
+            print("Skipping cellranger mkfastq")
+            return
+        # Check if outputs already exist
+        if os.path.exists(self.args.out_dir):
+            print("Output directory %s already exists" %
+                  self.args.out_dir)
+            return
+        # Load input data
+        illumina_run = IlluminaRun(self.args.run_dir,
+                                   platform=self.args.platform)
+        # Deal with lanes
+        sample_sheet = SampleSheet(self.args.sample_sheet)
+        if sample_sheet.has_lanes:
+            self.lanes = sorted(list(set([line['Lane']
+                                          for line in sample_sheet])))
+        else:
+            self.lanes = None
+        # Determine expected names for cellranger outputs
+        if self.lanes is not None:
+            lanes_suffix = "_%s" % ''.join([str(l) for l in self.lanes])
+        else:
+            lanes_suffix = ""
+        self.cellranger_out_dir = "%s%s" % (flow_cell_id(self.args.run_dir),
+                                            lanes_suffix)
+        self.mro_file = "__%s.mro" % self.cellranger_out_dir
+        # Set bases mask
+        if self.args.cellranger_exe.endswith("-atac"):
+            # scATAC-seq
+            bases_mask = self.args.bases_mask
+            if bases_mask is None:
+                bases_mask = 'auto'
+            if bases_mask == 'auto':
+                # Update bases mask to only use first 8 bases from
+                # first index e.g. I8nnnnnnnn and convert second index
+                # to read e.g. Y16
+                print("Determining bases mask from RunInfo.xml")
+                bases_mask = get_bases_mask_10x_atac(illumina_run.runinfo_xml)
+                print("Bases mask: %s (updated for 10x scATAC-seq)" %
+                      bases_mask)
+                if not bases_mask_is_valid(bases_mask):
+                    raise Exception("Invalid bases mask: '%s'" %
+                                    bases_mask)
+        else:
+            # scRNA-seq
+            if self.args.bases_mask == "auto":
+                bases_mask = None
+            else:
+                bases_mask = self.args.bases_mask
+        # Check if outputs already exist
+        if os.path.exists(self.args.out_dir):
+            print("Output directory %s already exists" %
+                  self.args.out_dir)
+            return
+        # Set up parameters
+        params = {
+            'bases_mask': bases_mask,
+            'lanes': (','.join([str(l) for l in self.lanes])
+                      if self.lanes else 'all'),
+            'minimum_trimmed_read_length':
+            self.args.minimum_trimmed_read_length,
+            'mask_short_adapter_reads':
+            self.args.mask_short_adapter_reads,
+            'cellranger_jobmode': self.args.cellranger_jobmode,
+            'cellranger_maxjobs': self.args.cellranger_maxjobs,
+            'cellranger_mempercore': self.args.cellranger_mempercore,
+            'cellranger_jobinterval': self.args.cellranger_jobinterval,
+            'cellranger_localcores': self.args.cellranger_localcores,
+            'cellranger_localmem': self.args.cellranger_localmem,
+            'cellranger_working_dir': self.cellranger_out_dir,
+            'cellranger_mro_file': self.mro_file
+        }
+        # Report settings
+        print("%-22s: %s" % ("Run dir",self.args.run_dir))
+        print("%-22s: %s" % ("Sample sheet",
+                             os.path.basename(self.args.sample_sheet)))
+        print("%-22s: %s" % ("Output dir",self.args.out_dir))
+        for item,desc in (('bases_mask',"Bases mask"),
+                          ('lanes',"Lanes"),
+                          ('minimum_trimmed_read_length',"Min trimmed read len"),
+                          ('mask_short_adapter_reads',"Mask short adptr reads"),
+                          ('cellranger_jobmode',"Cellranger jobmode"),
+                          ('cellranger_maxjobs',"Cellranger maxjobs"),
+                          ('cellranger_mempercore',"Cellranger mempercore"),
+                          ('cellranger_jobinterval',"Cellranger jobinterval"),
+                          ('cellranger_localcores',"Cellranger localcores"),
+                          ('cellranger_localmem',"Cellranger localmem"),
+                          ('cellranger_working_dir',"Cellranger working dir"),
+                          ('cellranger_mro_file',"Cellranger .mro file")):
+            if item in params and params[item] is not None:
+                print("%-22s: %s" % (desc,params[item]))
+        # Set up temporary output dir
+        self.tmp_out_dir = os.path.abspath("__%s.work" %
+                                           os.path.basename(
+                                               self.args.out_dir))
+        # Build command to run cellranger
+        cellranger_cmd = Command(self.args.cellranger_exe,
+                                 "mkfastq",
+                                 "--run",self.args.run_dir,
+                                 "--samplesheet",self.args.sample_sheet,
+                                 "--output-dir",self.tmp_out_dir,
+                                 "--qc")
+        if self.lanes:
+            cellranger_cmd.add_args("--lanes",
+                                    ','.join([str(l) for l in self.lanes]))
+        if bases_mask:
+            cellranger_cmd.add_args("--use-bases-mask=%s" % bases_mask)
+        if self.args.minimum_trimmed_read_length:
+            cellranger_cmd.add_args('--minimum-trimmed-read-length',
+                                    self.args.minimum_trimmed_read_length)
+        if self.args.mask_short_adapter_reads:
+            cellranger_cmd.add_args('--mask-short-adapter-reads',
+                                    self.args.mask_short_adapter_reads)
+            add_cellranger_args(
+                cellranger_cmd,
+                jobmode=self.args.cellranger_jobmode,
+                mempercore=self.args.cellranger_mempercore,
+                maxjobs=self.args.cellranger_maxjobs,
+                jobinterval=self.args.cellranger_jobinterval,
+                localcores=self.args.cellranger_localcores,
+                localmem=self.args.cellranger_localmem
+            )
+        print("Running %s" % cellranger_cmd)
+        self.add_cmd(PipelineCommandWrapper(
+            "Run %s" % os.path.basename(self.args.cellranger_exe),
+            *cellranger_cmd.command_line))
+    def finish(self):
+        if self.tmp_out_dir:
+            # Verify outputs
+            illumina_data = IlluminaData(os.path.dirname(self.tmp_out_dir),
+                                         os.path.basename(self.tmp_out_dir))
+            if verify_run_against_sample_sheet(illumina_data,
+                                               self.args.sample_sheet,
+                                               include_sample_dir=True):
+                print("Verified outputs against samplesheet")
+            else:
+                # Verification failed
+                print("Failed to verify outputs against samplesheet")
+                # List the missing Fastq files
+                missing_fastqs = list_missing_fastqs(illumina_data,
+                                                     self.args.sample_sheet)
+                print("Missing Fastqs:")
+                for fq in missing_fastqs:
+                    print("- %s" % fq)
+                if self.args.create_empty_fastqs:
+                    # Create empty placeholder Fastqs
+                    print("Making empty placeholder Fastqs")
+                    for fq in missing_fastqs:
+                        fastq = os.path.join(self.tmp_out_dir,fq)
+                        # Make intermediate directory if required
+                        if not os.path.exists(os.path.dirname(fastq)):
+                            os.mkdir(os.path.dirname(fastq))
+                        # Make empty file
+                        with gzip.GzipFile(filename=fastq,mode='wb') as fp:
+                            fp.write(''.encode())
+                else:
+                    # Terminate with an exception
+                    raise Exception("Failed to verify outputs against "
+                                    "samplesheet")
+            # Check outputs and QC summary report
+            if not os.path.isdir(self.cellranger_out_dir):
+                raise Exception("No output directory '%s'" %
+                                self.cellranger_out_dir)
+            json_file = os.path.join(self.cellranger_out_dir,
+                                     "outs",
+                                     "qc_summary.json")
+            if not os.path.exists(json_file):
+                raise Exception("cellranger mkfastq failed to make "
+                                "JSON QC summary file (%s not found)"
+                                % json_file)
+            # Make HTML QC summary
+            html_file = "cellranger_qc_summary%s.html" % \
+                        (("_%s" % ''.join([str(l) for l in self.lanes])
+                         if self.lanes is not None else ""),)
+            make_qc_summary_html(json_file,html_file)
+            # Move outputs to final location
+            print("Moving output to final location")
+            os.rename(self.tmp_out_dir,self.args.out_dir)
+            print("Moving QC report '%s'" % html_file)
+            os.rename(html_file,
+                      os.path.join(os.path.dirname(self.args.out_dir),
+                                   os.path.basename(html_file)))
+
+class MergeFastqDirs(PipelineFunctionTask):
+    """
+    Merges directories with subsets of Fastqs
+    """
+    def init(self,fastq_dirs,merged_fastq_dir):
+        """
+        Initialise the MergeFastqDirs task
+
+        Arguments:
+          fastq_dirs (list): set of directories with
+            Fastqs in bcl2fastq-like structure, to
+            merge together
+          merged_fastq_dir (str): path to the output
+            directory where all the Fastqs will be
+            put together
+        """
+        self.tmp_merge_dir = None
+        self.fastq_dirs = None
+    def setup(self):
+        # Check if output already exists
+        if os.path.exists(self.args.merged_fastq_dir):
+            print("%s already exists, nothing to do" %
+                  self.args.merged_fastq_dir)
+            return
+        # Explicitly resolve the input parameters
+        self.fastq_dirs = [resolve_parameter(d)
+                           for d in self.args.fastq_dirs]
+        # Collect input directories
+        projects = []
+        undetermined_fastqs = []
+        for d in self.fastq_dirs:
+            # Check the projects
+            print("Examining %s" % d)
+            illumina_data = IlluminaData(os.path.dirname(d),
+                                         os.path.basename(d))
+            for project in illumina_data.projects:
+                if not [p for p in projects if p.name == project.name]:
+                    print("- %s: will be merged" % project.name)
+                    projects.append(project)
+                else:
+                    print("- %s: another project with the same name "
+                          "already found")
+                    raise Exception("collision: another project "
+                                    "called '%s' was already found" %
+                                    project.name)
+            # Collect Fastqs with undetermined reads
+            if illumina_data.undetermined:
+                for sample in illumina_data.undetermined.samples:
+                    for fq in sample.fastq:
+                        undetermined_fastqs.append(
+                            os.path.join(sample.dirn,fq))
+        # Make a new directory for the merging
+        self.tmp_merge_dir = "__mergefastqdirs.tmp"
+        os.mkdir(self.tmp_merge_dir)
+        print("Made temporary directory for merging: %s" %
+              self.tmp_merge_dir)
+        # Handle each project
+        for project in projects:
+            print("- Importing project '%s'" % project.name)
+            self.add_call("Copy project %s" % project.name,
+                          self.copy_project,
+                          project.dirn,
+                          os.path.join(self.tmp_merge_dir,
+                                       os.path.basename(project.dirn)))
+        # Handle the undetermined Fastqs
+        undetermined = {}
+        for fq in undetermined_fastqs:
+            illuminafq = IlluminaFastq(fq)
+            idx = "%s%s%d" % (('L%03d_' % illuminafq.lane_number
+                               if illuminafq.lane_number else ''),
+                              ('I' if illuminafq.is_index_read
+                               else 'R'),
+                              illuminafq.read_number)
+            try:
+                undetermined[idx].append(fq)
+            except KeyError:
+                undetermined[idx] = [fq]
+        for idx in undetermined:
+            fastqs_in = sorted(undetermined[idx])
+            fastq_out = os.path.join(self.tmp_merge_dir,
+                                     "Undetermined_S0_%s_001.fastq.gz"
+                                     % idx)
+            if len(fastqs_in) == 1:
+                # Only one Fastq in list, copy it
+                fq = fastqs_in[0]
+                print("Copying %s" % fq)
+                self.add_call("Linking to %s" % fq,
+                              os.link,
+                              fq,
+                              fastq_out)
+            else:
+                # Multiple Fastqs, concat them
+                print("Concatenting '%s' Fastqs:" % idx)
+                for fq in fastqs_in:
+                    print("- %s" % fq)
+                concat_cmd = Command('concat_fastqs.py')
+                concat_cmd.add_args(*fastqs_in)
+                concat_cmd.add_args(fastq_out)
+                self.add_cmd(PipelineCommandWrapper(
+                    "Concatenate %s undetermined Fastqs" % idx,
+                    *concat_cmd.command_line))
+        # Add 'Stats' and 'Reports' directories
+        for d in ("Stats","Reports"):
+            os.mkdir(os.path.join(self.tmp_merge_dir,d))
+            print("Made '%s' subdirectory" % d)
+    def copy_project(self,project_dir,dest):
+        # Copy contents of project to destination dir
+        if not os.path.exists(dest):
+            print("Making directory %s" % dest)
+            os.mkdir(dest)
+        # Walk through the project directory
+        for f in walk(project_dir):
+            if os.path.isdir(f):
+                # Make an equivalent subdirectory
+                d = os.path.join(dest,os.path.relpath(f,project_dir))
+                if not os.path.exists(d):
+                    print("Making subdirectory %s" % d)
+                    os.mkdir(d)
+            elif os.path.isfile(f):
+                # Make a hard link to the file
+                src = os.path.join(project_dir,f)
+                tgt = os.path.join(dest,os.path.relpath(f,project_dir))
+                print("Making link to file %s" % src)
+                os.link(src,tgt)
+            else:
+                raise Exception("Don't know how to handle %s" %
+                                os.path.join(project_dir,f))
+    def finish(self):
+        if self.tmp_merge_dir:
+            print("Moving merged Fastq dir files to final location")
+            os.rename(self.tmp_merge_dir,self.args.merged_fastq_dir)
+            for fastq_dir in self.fastq_dirs:
+                fastq_dir_backup = os.path.join(
+                    os.path.dirname(fastq_dir),
+                    "save.%s" % os.path.basename(fastq_dir))
+                print("Moving source directory '%s' out of the way" %
+                      fastq_dir)
+                os.rename(fastq_dir,fastq_dir_backup)
+
+class FastqStatistics(PipelineTask):
+    """
+    Generates statistics for Fastq files
+    """
+    def init(self,bcl2fastq_dir,sample_sheet,out_dir,
+             stats_file=None,per_lane_stats_file=None,
+             add_data=False,force=False,nprocessors=None):
+        """
+        Initialise the FastqStatistics task
+
+        Arguments:
+          bcl2fastq_dir (str): path to directory with
+            Fastqs from bcl2fastq
+          sample_sheet (str): path to sample sheet file
+          out_dir (str): path to directory to write the
+            output stats files to
+          add_data (bool): if True then add stats to the
+            existing stats files (default is to overwrite
+            existing stats files)
+          force (bool): if True then force update of the
+            stats files even if they are newer than the
+            Fastq files (by default stats are only updated
+            if they are older than the Fastqs)
+          nprocessors (int): number of cores to use when
+            running 'fastq_statistics.py'
+
+        Outputs:
+          stats_file: path to basic stats file
+          stats_full: path to full stats file
+          per_lane_stats: path to per-lane stats file
+          per_lane_sample_stats: path to per-lane sample
+            stats file
+        """
+        # Flag to indicate if statistics should be (re)generated
+        self.generate_stats = False
+        # Names for intermediate output stats files
+        self.stats_file = "statistics.info"
+        self.stats_full = "statistics_full.info"
+        self.per_lane_stats = "per_lane_statistics.info"
+        self.per_lane_sample_stats = "per_lane_sample_stats.info"
+        # Outputs
+        self.add_output("stats_file",Param(type=str))
+        self.add_output("stats_full",Param(type=str))
+        self.add_output("per_lane_stats",Param(type=str))
+        self.add_output("per_lane_sample_stats",Param(type=str))
+    def setup(self):
+        # Sort out final output file names
+        if self.args.stats_file:
+            self.final_stats = self.args.stats_file
+            self.stats_file = os.path.basename(self.final_stats)
+        else:
+            self.final_stats = os.path.join(self.args.out_dir,
+                                            self.stats_file)
+        if self.args.per_lane_stats_file:
+            self.final_per_lane_stats = \
+                                self.args.per_lane_stats_file
+        else:
+            self.final_per_lane_stats = os.path.join(
+                self.args.out_dir,self.per_lane_stats)
+            self.per_lane_stats = \
+                    os.path.basename(self.final_per_lane_stats)
+        self.final_stats_full = os.path.join(self.args.out_dir,
+                                             self.stats_full)
+        self.final_per_lane_sample_stats = os.path.join(
+            self.args.out_dir,self.per_lane_sample_stats)
+        # Get most recent timestamp on existing files
+        newest_mtime = 0
+        for f in (self.final_stats,
+                  self.final_per_lane_stats,
+                  self.final_stats_full,
+                  self.final_per_lane_sample_stats):
+            try:
+                # Update newest timestamp
+                newest_mtime = max(newest_mtime,
+                                   os.path.getmtime(f))
+            except OSError:
+                # File doesn't exist
+                newest_mtime = 0
+                self.generate_stats = True
+        # Load data from bcl2fastq outputs
+        try:
+            illumina_data = IlluminaData(
+                os.path.dirname(self.args.bcl2fastq_dir),
+                os.path.basename(self.args.bcl2fastq_dir))
+        except Exception as ex:
+            raise Exception("Failed to load bcl2fastq data from %s: "
+                            "%s" % (self.args.bcl2fastq_dir,ex))
+        # Check if any Fastqs are newer than stats
+        if newest_mtime > 0:
+            for project in illumina_data.projects:
+                for sample in project.samples:
+                    for fq in sample.fastq:
+                        fastq = os.path.join(sample.dirn,fq)
+                        if (os.path.getmtime(fastq) > newest_mtime):
+                            self.generate_stats = True
+                            break
+            if self.generate_stats:
+                print("Fastqs are newer than existing stats files")
+            else:
+                print("Stats files are newer than Fastqs")
+                if self.args.force:
+                    # Force regenerate the statistics
+                    self.generate_stats = True
+        # Don't continue if nothing to do
+        if not self.generate_stats:
+            print("Nothing to do")
+            return
+        # Run the fastq_statistics.py utility
+        fastq_statistics_cmd = Command(
+            'fastq_statistics.py',
+            '--unaligned',os.path.basename(self.args.bcl2fastq_dir),
+            '--sample-sheet',self.args.sample_sheet,
+            '--output',self.stats_file,
+            '--per-lane-stats',self.per_lane_stats,
+            '--nprocessors',self.args.nprocessors,
+            os.path.dirname(self.args.bcl2fastq_dir))
+        if self.args.add_data:
+            fastq_statistics_cmd.add_args('--update')
+        print("Running %s" % fastq_statistics_cmd)
+        self.add_cmd(PipelineCommandWrapper(
+            "Run fastq_statistics",
+            *fastq_statistics_cmd.command_line))
+
+    def finish(self):
+        if self.generate_stats:
+            print("Moving stats files to final locations")
+            for f in (self.final_stats,
+                      self.final_per_lane_stats,
+                      self.final_stats_full,
+                      self.final_per_lane_sample_stats):
+                print("- %s" % f)
+                os.rename(os.path.basename(f),f)
+        # Assign outputs
+        self.output.stats_file.set(self.final_stats)
+        self.output.stats_full.set(self.final_stats_full)
+        self.output.per_lane_stats.set(self.final_per_lane_stats)
+        self.output.per_lane_sample_stats.set(
+            self.final_per_lane_sample_stats)
+
+class ReportProcessingQC(PipelineTask):
+    """
+    Generate HTML report on the processing QC
+    """
+    def init(self,analysis_dir,stats_file,per_lane_stats_file,
+             per_lane_sample_stats_file,report_html):
+        """
+        Initialise the ReportProcessingQC task
+
+        Arguments:
+          analysis_dir (str): directory with the
+            statistics files
+          stats_file (str): path to full statistics
+            file
+          per_lane_stats_file (str): path to the
+            per-lane statistics file
+          per_lane_sample_stats_file (str): path to
+            the per-lane per-sample statistics file
+          report_html (str): path to the output
+            HTML QC report
+        """
+        self.tmp_report = None
+    def setup(self):
+        print("Generating processing QC report")
+        self.tmp_report = os.path.join(self.args.analysis_dir,
+                                       "processing_qc_report.html.tmp")
+        ProcessingQCReport(
+            self.args.analysis_dir,
+            self.args.stats_file,
+            self.args.per_lane_stats_file,
+            self.args.per_lane_sample_stats_file).\
+            write(self.tmp_report)
+    def finish(self):
+        print("Moving processing QC report to final location")
+        print("- %s" % self.args.report_html)
+        os.rename(self.tmp_report,self.args.report_html)
+
+import uuid
+class BaseParam(object):
+    """
+    Provide base class for PipelineParam-type classes
+    """
+    def __init__(self):
+        """
+        Base class for PipelineParam-type class
+        """
+        self._uuid = uuid.uuid4()
+    @property
+    def uuid(self):
+        """
+        Return the unique identifier (UUID) of the parameter
+        """
+        return self._uuid
+
+class FunctionParam(BaseParam):
+    """
+    Class for deferred function evaluation as pipeline parameter
+
+    This class wraps a function with a set of
+    parameters; the function evaluation is
+    deferred until the 'value' property is invoked.
+
+    Any parameters which are PipelineParam-like
+    instances will be replaced with their values
+    before being passed to the function.
+    """
+    def __init__(self,f,*args,**kws):
+        """
+        Create a new FunctionParam instance
+
+        Arguments:
+          f (object): function-like object to
+            be evaluated
+          args (list): positional arguments to
+            pass to the function on evaluation
+          kws (mapping): keyworded arguments to
+            pass to the function on evaluation
+        """
+        BaseParam.__init__(self)
+        self._f = f
+        self._args = args
+        self._kws = kws
+    @property
+    def value(self):
+        """
+        Return value from evaluated function
+        """
+        args = []
+        for arg in self._args:
+            try:
+                args.append(arg.value)
+            except AttributeError:
+                args.append(arg)
+        kws = {}
+        for kw in self._kws:
+            try:
+                kws[kw] = self._kws[kw].value
+            except AttributeError:
+                kws[kw] = self._kws[kw]
+        return self._f(*args,**kws)
+    
+class PathJoinParam(FunctionParam):
+    """
+    Class for joining file paths as pipeline parameter
+
+    This class implements the pipeline parameter
+    equivalent of the `os.path.join` function, taking
+    a set of path elements on instantiation (which
+    can be strings or PipelineParam-like objects)
+    and returning the joined path elements on
+    evaluation via the `value` property.
+
+    Example usage:
+
+    >>> pth = PathJoinParam("/path","to","file.txt")
+    >>> pth.value
+    "/path/to/file.txt"
+
+    >>> base_dir = PipelineParam(value="/path/to/base")
+    >>> pth = PathJoinParam(base_dir,"file.txt")
+    >>> pth.value
+    "/path/to/base/file.txt"
+    >>> base_dir.set("/path/to/new/base")
+    >>> pth.value
+    "/path/to/new/base/file.txt"
+
+    Note that this class doesn't implement a `set`
+    method (unlike the standard PipelineParam class)
+    so the path elements cannot be changed after
+    initialisation.
+    """
+    def __init__(self,*p):
+        """
+        Create a new PathJoinParam instance
+
+        Arguments:
+          p (iterable): list of path elements
+            to join; can be strings or
+            PipelineParam-like objects
+        """
+        FunctionParam.__init__(self,
+                               os.path.join,
+                               *p)
+
+class PathExistsParam(FunctionParam):
+    """
+    Class for checking file/directory existance as pipeline parameter
+
+    This class implements the pipeline parameter
+    equivalent of the `os.path.exists` function, taking
+    a path on instantiation (which can be a string
+    or PipelineParam-like object) and returning a
+    boolean value indicating whether the path is an
+    existing file system object via the `value`
+    property.
+
+    Example usage:
+
+    >>> exists = PathExistsParam("/path/to/file.txt")
+    >>> exists.value
+    True
+
+    >>> f = PipelineParam(value="/path/to/file.txt")
+    >>> exists = PathExistsParam(f)
+    >>> exists.value
+    True
+    >>> f.set("/path/to/missing.txt")
+    >>> exists.value
+    False
+
+    Note that this class doesn't implement a `set`
+    method (unlike the standard PipelineParam class)
+    so the path elements cannot be changed after
+    initialisation.
+    """
+    def __init__(self,p):
+        """
+        Create a new PathExistsParam instance
+
+        Arguments:
+          p (str): path to check existance of;
+            can be a string or a PipelineParam-like
+            object
+        """
+        FunctionParam.__init__(self,
+                               os.path.exists,
+                               p)
+
+def subset(lanes,**kws):
+    """
+    Create a dictionary representing a set of lanes
+
+    Returns a dictionary which holds information
+    about a set of lanes grouped together for
+    processing, along with values of parameters
+    that should be used for this set of lanes.
+
+    Keys must be one of the parameter names
+    listed in the LANE_SET_ATTRIBUTES constant;
+    specifying an unrecognised key will result
+    in a KeyError exception.
+
+    Arguments:
+      lanes (list): lanes that comprise the set
+      kws (mapping): set of key-value
+        pairs assigning values to parameters
+        for the group of lanes
+
+    Raises:
+      KeyError: if a supplied key is not a valid
+        attribute.
+    """
+    s = dict(lanes=sorted([int(l) for l in lanes]))
+    for attr in kws:
+        if attr not in LANE_SUBSET_ATTRS:
+            raise KeyError("Unsupported subset attribute '%s'"
+                           % attr)
+        s[attr] = kws[attr]
+    return s

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -348,8 +348,8 @@ class MakeFastqs(Pipeline):
 
         # Define module environment modules
         self.add_envmodules('bcl2fastq')
-        self.add_envmodules('cellranger')
-        self.add_envmodules('cellranger_atac')
+        self.add_envmodules('cellranger_mkfastq')
+        self.add_envmodules('cellranger_atac_mkfastq')
 
         # Pipeline outputs
         self.add_output('platform',self.params._platform)
@@ -1110,7 +1110,8 @@ class MakeFastqs(Pipeline):
                     get_bcl2fastq_for_10x = GetBcl2Fastq(
                         "Get information on bcl2fastq for cellranger")
                     self.add_task(get_bcl2fastq_for_10x,
-                                  envmodules=self.envmodules['cellranger'])
+                                  envmodules=\
+                                  self.envmodules['cellranger_mkfastq'])
                 # Get cellranger information
                 if get_cellranger is None:
                     # Create a new task only if one doesn't already
@@ -1119,7 +1120,8 @@ class MakeFastqs(Pipeline):
                         "Get information on cellranger",
                         require_cellranger="cellranger")
                     self.add_task(get_cellranger,
-                                  envmodules=self.envmodules['cellranger'])
+                                  envmodules=\
+                                  self.envmodules['cellranger_mkfastq'])
                 # Run cellranger mkfastq
                 run_cellranger_mkfastq = RunCellrangerMkfastq(
                     "Run cellranger mkfastq%s" %
@@ -1149,7 +1151,7 @@ class MakeFastqs(Pipeline):
                 )
                 self.add_task(run_cellranger_mkfastq,
                               runner=self.runners['cellranger_runner'],
-                              envmodules=self.envmodules['cellranger'],
+                              envmodules=self.envmodules['cellranger_mkfastq'],
                               requires=(get_cellranger,
                                         get_bcl2fastq_for_10x,
                                         make_sample_sheet,
@@ -1169,7 +1171,8 @@ class MakeFastqs(Pipeline):
                     get_bcl2fastq_for_10x_atac = GetBcl2Fastq(
                         "Get information on bcl2fastq for cellranger-atac")
                     self.add_task(get_bcl2fastq_for_10x_atac,
-                                  envmodules=self.envmodules['cellranger_atac'])
+                                  envmodules=\
+                                  self.envmodules['cellranger_atac_mkfastq'])
                 # Get cellranger-atac information
                 if get_cellranger_atac is None:
                     # Create a new task only if one doesn't already
@@ -1178,7 +1181,8 @@ class MakeFastqs(Pipeline):
                         "Get information on cellranger-atac",
                         require_cellranger="cellranger-atac")
                     self.add_task(get_cellranger_atac,
-                                  envmodules=self.envmodules['cellranger_atac'])
+                                  envmodules=\
+                                  self.envmodules['cellranger_atac_mkfastq'])
                 # Run cellranger mkfastq
                 run_cellranger_mkfastq = RunCellrangerMkfastq(
                     "Run cellranger-atac mkfastq%s" %
@@ -1210,7 +1214,8 @@ class MakeFastqs(Pipeline):
                 )
                 self.add_task(run_cellranger_mkfastq,
                               runner=self.runners['cellranger_runner'],
-                              envmodules=self.envmodules['cellranger_atac'],
+                              envmodules=\
+                              self.envmodules['cellranger_atac_mkfastq'],
                               requires=(get_cellranger_atac,
                                         get_bcl2fastq_for_10x_atac,
                                         make_sample_sheet,
@@ -1424,7 +1429,8 @@ class MakeFastqs(Pipeline):
             'verify_runner','default'
           envmodules (mapping): mapping of names to
             environment module file lists; valid names are
-            'bcl2fastq','cellranger','cellranger_atac'
+            'bcl2fastq','cellranger_mkfastq',
+            'cellranger_atac_mkfastq'
           default_runner (JobRunner): optional default
             job runner to use
           verbose (bool): if True then report additional

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -1322,6 +1322,9 @@ class FetchPrimaryData(PipelineTask):
             source is on the local system)
           force_copy (bool): if True then force primary data to
             be copied even if it's on the local system
+
+        Outputs:
+          run_dir: path to the local copy of the primary data
         """
         self.tmp_dir = None
         self.add_output('run_dir',Param(type='str'))
@@ -1332,7 +1335,6 @@ class FetchPrimaryData(PipelineTask):
             os.path.basename(self.args.data_dir))
         if os.path.exists(final_run_dir):
             print("Primary data already acquired")
-            self.output.run_dir.set(final_run_dir)
             return
         # Create top level primary data directory
         if not os.path.exists(self.args.primary_data_dir):

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -240,6 +240,7 @@ class MakeFastqs(Pipeline):
                 adapter_sequence_read2 = ""
         
         # Defaults
+        self._bases_mask = bases_mask
         self._trim_adapters = bool(trim_adapters)
         self._adapter_sequence = adapter_sequence
         self._adapter_sequence_read2 = adapter_sequence_read2
@@ -323,7 +324,7 @@ class MakeFastqs(Pipeline):
         for s in self.subsets:
             self._update_subset(
                 s,
-                bases_mask=bases_mask,
+                bases_mask=self._bases_mask,
                 trim_adapters=self._trim_adapters,
                 minimum_trimmed_read_length=\
                 self._minimum_trimmed_read_length,

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -735,7 +735,7 @@ class MakeFastqs(Pipeline):
         # Keep track of lanes to analyse barcodes for
         lanes_for_barcode_analysis = []
 
-        # Placeholder for tasks acquiring software versions
+        # Placeholders for tasks acquiring software versions
         get_bcl2fastq = None
         get_bcl2fastq_for_10x = None
         get_bcl2fastq_for_10x_atac = None
@@ -1325,8 +1325,7 @@ class MakeFastqs(Pipeline):
             'verify_runner','default'
           envmodules (mapping): mapping of names to
             environment module file lists; valid names are
-            'illumina_qc','fastq_strand','cellranger',
-            'report_qc'
+            'bcl2fastq','cellranger','cellranger_atac'
           default_runner (JobRunner): optional default
             job runner to use
           verbose (bool): if True then report additional

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -1647,11 +1647,16 @@ class RunBcl2Fastq(PipelineTask):
         Outputs:
           bases_mask: actual bases mask used
           mismatches: number of mismatches allowed
+          missing_fastqs: list of Fastqs missing after
+            Fastq generation
         """
+        # Internal variables
         self.supported_versions = ('1.8','2.17','2.20',)
         self.tmp_out_dir = None
+        # Outputs
         self.add_output('bases_mask',Param(type='str'))
         self.add_output('mismatches',Param(type='int'))
+        self.add_output('missing_fastqs',list())
     def setup(self):
         # Load input data
         illumina_run = IlluminaRun(self.args.run_dir,
@@ -1799,6 +1804,7 @@ class RunBcl2Fastq(PipelineTask):
                 print("Missing Fastqs:")
                 for fq in missing_fastqs:
                     print("- %s" % fq)
+                    self.output.missing_fastqs.append(fq)
                 if self.args.create_empty_fastqs:
                     # Create empty placeholder Fastqs
                     print("Making empty placeholder Fastqs")
@@ -2115,11 +2121,19 @@ class RunCellrangerMkfastq(PipelineTask):
             bcl2fastq package
           skip_cellranger (bool): if True then skip running
             cellranger mkfastq within the task
+
+        Outputs:
+            missing_fastqs: list of Fastqs missing after
+              Fastq generation
+
         """
+        # Internal variables
         self.tmp_out_dir = None
         self.lanes = None
         self.cellranger_out_dir = None
         self.mro_file = None
+        # Outputs
+        self.add_output('missing_fastqs',list())
     def setup(self):
         # Check if cellranger should be skipped
         if self.args.skip_cellranger:
@@ -2266,6 +2280,7 @@ class RunCellrangerMkfastq(PipelineTask):
                 print("Missing Fastqs:")
                 for fq in missing_fastqs:
                     print("- %s" % fq)
+                    self.output.missing_fastqs.append(fq)
                 if self.args.create_empty_fastqs:
                     # Create empty placeholder Fastqs
                     print("Making empty placeholder Fastqs")

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -171,6 +171,11 @@ class MakeFastqs(Pipeline):
         software used
     - cellranger_info: tuple with information on the cellranger
         software used
+    - stats_file: path to the statistics file
+    - stats_full: path to the full statistics file
+    - per_lane_stats: path to the per-lane statistics file
+    - per_lane_sample_stats: path to the per-lane per-sample
+        statistics file
     - missing_fastqs: list of Fastq files that bcl2fastq failed
         to generate
     """
@@ -348,6 +353,10 @@ class MakeFastqs(Pipeline):
         self.add_output('acquired_primary_data',Param())
         self.add_output('bcl2fastq_info',self.params._bcl2fastq_info)
         self.add_output('cellranger_info',self.params._cellranger_info)
+        self.add_output('stats_file',Param())
+        self.add_output('stats_full',Param())
+        self.add_output('per_lane_stats',Param())
+        self.add_output('per_lane_sample_stats',Param())
         self.add_output('missing_fastqs',self.params._missing_fastqs)
 
         # Lane subsets
@@ -1301,6 +1310,15 @@ class MakeFastqs(Pipeline):
         if get_cellranger:
             self.params._cellranger_info.set(
                 get_cellranger.output.cellranger_info)
+
+        # Update outputs associated with stats
+        if self._fastq_statistics:
+            self.output.stats_file.set(fastq_statistics.output.stats_file)
+            self.output.stats_full.set(fastq_statistics.output.stats_full)
+            self.output.per_lane_stats.set(
+                fastq_statistics.output.per_lane_stats)
+            self.output.per_lane_sample_stats.set(
+                fastq_statistics.output.per_lane_sample_stats)
 
         # Update lists of missing Fastqs
         self.params._missing_fastqs.set(

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -99,6 +99,15 @@ logger = logging.getLogger(__name__)
 # Constants
 ######################################################################
 
+# Protocols
+
+PROTOCOLS = ('standard',
+             'mirna',
+             'icell8',
+             'icell8_atac',
+             '10x_chromium_sc',
+             '10x_atac',)
+
 # Valid attribute names for lane subsets
 
 LANE_SUBSET_ATTRS = (

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -1517,10 +1517,13 @@ class GetBcl2Fastq(PipelineFunctionTask):
           bcl2fastq_exe (str): path to the bcl2fastq executable
           bcl2fastq_package (str): name of the bcl2fastq package
           bcl2fastq_version (str): the bcl2fastq version
+          bcl2fastq_info (tuple): tuple consisting of
+            (exe,package,version)
         """
         self.add_output('bcl2fastq_exe',Param(type=str))
         self.add_output('bcl2fastq_package',Param(type=str))
         self.add_output('bcl2fastq_version',Param(type=str))
+        self.add_output('bcl2fastq_info',Param())
     def setup(self):
         if self.args.require_bcl2fastq:
             print("Requires bcl2fastq version %s" %
@@ -1548,6 +1551,9 @@ class GetBcl2Fastq(PipelineFunctionTask):
         self.output.bcl2fastq_exe.set(bcl2fastq_exe)
         self.output.bcl2fastq_package.set(bcl2fastq_package)
         self.output.bcl2fastq_version.set(bcl2fastq_version)
+        self.output.bcl2fastq_info.set((bcl2fastq_exe,
+                                        bcl2fastq_package,
+                                        bcl2fastq_version))
         # Report what was found
         print("Bcl2fastq exe    : %s" % bcl2fastq_exe)
         print("Bcl2fastq package: %s" % bcl2fastq_package)
@@ -1884,10 +1890,13 @@ class GetCellranger(PipelineFunctionTask):
           cellranger_exe (str): path to the cellranger executable
           cellranger_package (str): name of the cellranger package
           cellranger_version (str): the cellranger version
+          cellranger_info (tuple): tuple consisting of
+            (exe,package,version)
         """
         self.add_output('cellranger_exe',Param(type=str))
         self.add_output('cellranger_package',Param(type=str))
         self.add_output('cellranger_version',Param(type=str))
+        self.add_output('cellranger_info',Param())
     def setup(self):
         print("Look for %s" % self.args.require_cellranger)
         self.add_call("Check %s" % self.args.require_cellranger,
@@ -1912,6 +1921,9 @@ class GetCellranger(PipelineFunctionTask):
         self.output.cellranger_exe.set(cellranger_exe)
         self.output.cellranger_package.set(cellranger_package)
         self.output.cellranger_version.set(cellranger_version)
+        self.output.cellranger_info.set((cellranger_exe,
+                                         cellranger_package,
+                                         cellranger_version))
         # Report what was found
         print("Cellranger exe    : %s" % cellranger_exe)
         print("Cellranger package: %s" % cellranger_package)

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -170,6 +170,8 @@ class MakeFastqs(Pipeline):
                  minimum_trimmed_read_length=None,
                  mask_short_adapter_reads=None,
                  adapter_sequence=None,adapter_sequence_read2=None,
+                 icell8_atac_swap_i1_and_i2=None,
+                 icell8_atac_reverse_complement=None,
                  trim_adapters=True,fastq_statistics=True,
                  analyse_barcodes=True,
                  lane_subsets=None):
@@ -203,6 +205,12 @@ class MakeFastqs(Pipeline):
           adapter_sequence_read2 (str): optionally specify the
             'read2' adapter sequence to use for trimming
             (overrides sequence set in the sample sheet file)
+          icell8_atac_swap_i1_and_i2 (bool): if True then
+            swap the I1 and I2 indexes when demultiplexing ICELL8
+            ATAC data
+          icell8_atac_reverse_complement (str): whether to reverse
+            complement I1, I2, or both, when demultiplexing ICELL8
+            ATAC data
           trim_adapters (bool): if True (default) then perform
             adapter trimming as part of Fastq generation
           fastq_statistics (bool): if True (default) then generate
@@ -254,14 +262,17 @@ class MakeFastqs(Pipeline):
         
         # Defaults
         self._bases_mask = bases_mask
-        self._trim_adapters = bool(trim_adapters)
         self._adapter_sequence = adapter_sequence
         self._adapter_sequence_read2 = adapter_sequence_read2
         self._minimum_trimmed_read_length = minimum_trimmed_read_length
         self._mask_short_adapter_reads = mask_short_adapter_reads
+        self._icell8_well_list = icell8_well_list
+        self._icell8_atac_swap_i1_and_i2 = icell8_atac_swap_i1_and_i2
+        self._icell8_atac_reverse_complement = \
+                                icell8_atac_reverse_complement
+        self._trim_adapters = bool(trim_adapters)
         self._fastq_statistics = bool(fastq_statistics)
         self._analyse_barcodes = bool(analyse_barcodes)
-        self._icell8_well_list = icell8_well_list
 
         # Define parameters
         self.add_param('data_dir',value=run_dir,type=str)
@@ -364,8 +375,10 @@ class MakeFastqs(Pipeline):
                 create_fastq_for_index_read=\
                 self.params.create_fastq_for_index_read,
                 icell8_well_list=self._icell8_well_list,
-                icell8_atac_swap_i1_and_i2=False,
-                icell8_atac_reverse_complement=None,
+                icell8_atac_swap_i1_and_i2=\
+                self._icell8_atac_swap_i1_and_i2,
+                icell8_atac_reverse_complement=\
+                self._icell8_atac_reverse_complement,
                 analyse_barcodes=self._analyse_barcodes
             )
 
@@ -2060,8 +2073,8 @@ class DemultiplexIcell8Atac(PipelineTask):
             swap the I1 and I2 indexes when
             demultiplexing
           reverse_complement (str): whether to
-            reverse I1, I2, or both, when
-            demultiplexing
+            reverse complement I1, I2, or both,
+            when demultiplexing
           skip_demultiplex (bool): if True then
             skip running the demultiplexing
         """

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -153,7 +153,7 @@ class MakeFastqs(Pipeline):
     globally in the pipleine.
     """
     def __init__(self,run_dir,sample_sheet,protocol='standard',
-                 bases_mask="auto",platform=None,well_list=None,
+                 bases_mask="auto",platform=None,icell8_well_list=None,
                  minimum_trimmed_read_length=None,
                  mask_short_adapter_reads=None,
                  adapter_sequence=None,adapter_sequence_read2=None,
@@ -173,8 +173,8 @@ class MakeFastqs(Pipeline):
             to "auto")
           platform (str): optionally specify the platform for
             the sequencer run (e.g. 'miseq', 'nextseq' etc)
-          well_list (str): optionally specify path to a well list
-            file for ICELL8 data
+          icell8_well_list (str): optionally specify path to a
+            well list file for ICELL8 data
           minimum_trimmed_read_length (int): optionally specify
             the minimum length of reads after adapter trimming;
             trimmed reads shorter than this length will be
@@ -247,7 +247,7 @@ class MakeFastqs(Pipeline):
         self._mask_short_adapter_reads = mask_short_adapter_reads
         self._fastq_statistics = bool(fastq_statistics)
         self._analyse_barcodes = bool(analyse_barcodes)
-        self._well_list = well_list
+        self._icell8_well_list = icell8_well_list
 
         # Define parameters
         self.add_param('data_dir',value=run_dir,type=str)
@@ -334,7 +334,7 @@ class MakeFastqs(Pipeline):
                 no_lane_splitting=self.params.no_lane_splitting,
                 create_fastq_for_index_read=\
                 self.params.create_fastq_for_index_read,
-                icell8_well_list=self._well_list,
+                icell8_well_list=self._icell8_well_list,
                 icell8_atac_swap_i1_and_i2=False,
                 icell8_atac_reverse_complement=None,
                 analyse_barcodes=self._analyse_barcodes

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -1217,7 +1217,8 @@ class MakeFastqs(Pipeline):
             self.add_pipeline(analyse_barcodes,
                               params={
                                   'bcl2fastq_dir': self.params.out_dir,
-                                  'lanes': lanes_for_barcode_analysis,
+                                  'lanes': Param(
+                                      value=lanes_for_barcode_analysis),
                                   'mismatches': run_bcl2fastq.output.mismatches
                               },
                               requires=fastq_generation_tasks)

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -1176,14 +1176,14 @@ class MakeFastqs(Pipeline):
 
     def run(self,analysis_dir,primary_data_dir=None,
             nprocessors=1,force_copy_of_primary_data=False,
-            working_dir=None,log_file=None,batch_size=None,
             no_lane_splitting=None,create_fastq_for_index_read=None,
-            create_empty_fastqs=None,
-            cellranger_jobmode='local',cellranger_mempercore=None,
-            cellranger_maxjobs=None,cellranger_jobinterval=None,
-            cellranger_localcores=None,cellranger_localmem=None,
-            max_jobs=1,poll_interval=5,runners=None,
-            default_runner=None,envmodules=None,verbose=False):
+            create_empty_fastqs=None,cellranger_jobmode='local',
+            cellranger_mempercore=None,cellranger_maxjobs=None,
+            cellranger_jobinterval=None,cellranger_localcores=None,
+            cellranger_localmem=None,working_dir=None,log_dir=None,
+            log_file=None,batch_size=None,max_jobs=1,poll_interval=5,
+            runners=None,default_runner=None,envmodules=None,
+            verbose=False):
         """
         Run the tasks in the pipeline
 
@@ -1198,6 +1198,23 @@ class MakeFastqs(Pipeline):
             unless it's on a remote filesystem)
           nprocessors (int): number of threads to use for
             multithreaded applications (default is 1)
+          no_lane_splitting (bool): if True then don't split
+            output Fastqs across lanes (--no-lane-splitting)
+          create_fastq_for_index_read (bool): if True then
+            also output Fastqs for the index (I1 etc) reads
+            (--create-fastq-for-index-read)
+          create_empty_fastqs (bool): if True then create empty
+            "placeholder" Fastqs if not created by bcl2fastq
+          cellranger_jobmode (str): job mode to run cellranger in
+          cellranger_mempercore (int): memory assumed per core
+          cellranger_maxjobs (int): maxiumum number of concurrent
+            jobs to run
+          cellranger_jobinterval (int): how often jobs are
+            submitted (in ms)
+          cellranger_localcores (int): maximum number of cores
+            cellranger can request in jobmode 'local'
+          cellranger_localmem (int): (optional) maximum memory
+            cellranger can request in jobmode 'local'
           working_dir (str): optional path to a working
             directory (defaults to temporary directory in
             the current directory)
@@ -1207,15 +1224,6 @@ class MakeFastqs(Pipeline):
             each task in batches, with each batch running
             this many commands at a time (default is to run
             one command per job)
-          no_lane_splitting (bool):
-          create_fastq_for_index_read (bool):
-          create_empty_fastqs (bool):
-          cellranger_jobmode (str):
-          cellranger_mempercore (int):
-          cellranger_maxjobs (int):
-          cellranger_jobinterval (int):
-          cellranger_localcores (int):
-          cellranger_localmem (int):
           max_jobs (int): optional maximum number of
             concurrent jobs in scheduler (defaults to 1)
           poll_interval (float): optional polling interval
@@ -1245,7 +1253,8 @@ class MakeFastqs(Pipeline):
             mkdir(working_dir)
 
         # Log and script directories
-        log_dir = os.path.join(working_dir,"logs")
+        if log_dir is None:
+            log_dir = os.path.join(working_dir,"logs")
         scripts_dir = os.path.join(working_dir,"scripts")
 
         # Runners

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -2510,11 +2510,14 @@ class FastqStatistics(PipelineTask):
             '--unaligned',os.path.basename(self.args.bcl2fastq_dir),
             '--sample-sheet',self.args.sample_sheet,
             '--output',self.stats_file,
-            '--per-lane-stats',self.per_lane_stats,
-            '--nprocessors',self.args.nprocessors,
-            os.path.dirname(self.args.bcl2fastq_dir))
+            '--per-lane-stats',self.per_lane_stats)
+        if self.args.nprocessors:
+            fastq_statistics_cmd.add_args('--nprocessors',
+                                          self.args.nprocessors)
         if self.args.add_data:
             fastq_statistics_cmd.add_args('--update')
+        fastq_statistics_cmd.add_args(
+            os.path.dirname(self.args.bcl2fastq_dir))
         print("Running %s" % fastq_statistics_cmd)
         self.add_cmd(PipelineCommandWrapper(
             "Run fastq_statistics",

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -962,7 +962,6 @@ class MakeFastqs(Pipeline):
                     bcl2fastq_exe=get_bcl2fastq.output.bcl2fastq_exe,
                     bcl2fastq_version=get_bcl2fastq.output.bcl2fastq_version,
                     skip_bcl2fastq=skip_bcl2fastq)
-                    ##skip_bcl2fastq=PathExistsParam(bcl2fastq_out_dir))
                 self.add_task(run_bcl2fastq,
                               runner=self.runners['bcl2fastq_runner'],
                               envmodules=self.envmodules['bcl2fastq'],

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -272,7 +272,7 @@ class MakeFastqs(Pipeline):
         # Define runners
         self.add_runner('rsync_runner')
         self.add_runner('bcl2fastq_runner')
-        self.add_runner('demultiplex_icell_atac_runner')
+        self.add_runner('demultiplex_icell8_atac_runner')
         self.add_runner('cellranger_runner')
         self.add_runner('cellranger_atac_runner')
         self.add_runner('stats_runner')
@@ -984,7 +984,7 @@ class MakeFastqs(Pipeline):
                     skip_demultiplex=final_output_exists)
                 self.add_task(
                     demultiplex_fastqs,
-                    runner=self.runners['demultiplex_icell_atac_runner'],
+                    runner=self.runners['demultiplex_icell8_atac_runner'],
                     requires=(run_bcl2fastq,))
                 # Add task to list of tasks that downstream
                 # tasks need to wait for

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -856,6 +856,7 @@ class MakeFastqs(Pipeline):
                               envmodules=self.envmodules['bcl2fastq'],
                               requires=(get_bcl2fastq,
                                         make_sample_sheet,
+                                        fetch_primary_data,
                                         restore_backup))
                 # Add task to list of tasks that downstream
                 # tasks need to wait for
@@ -907,6 +908,7 @@ class MakeFastqs(Pipeline):
                               requires=(get_bcl2fastq,
                                         get_bases_mask,
                                         make_sample_sheet,
+                                        fetch_primary_data,
                                         restore_backup,))
                 # Add task to list of tasks that downstream
                 # tasks need to wait for
@@ -966,6 +968,7 @@ class MakeFastqs(Pipeline):
                               requires=(get_bcl2fastq,
                                         get_bases_mask,
                                         make_sample_sheet,
+                                        fetch_primary_data,
                                         restore_backup))
                 # Demultiplex ICELL8 ATAC Fastqs
                 demultiplex_fastqs = DemultiplexIcell8Atac(
@@ -1038,6 +1041,7 @@ class MakeFastqs(Pipeline):
                               requires=(get_cellranger,
                                         get_bcl2fastq_for_10x,
                                         make_sample_sheet,
+                                        fetch_primary_data,
                                         restore_backup,))
                 # Add task to list of tasks that downstream
                 # tasks need to wait for
@@ -1096,6 +1100,7 @@ class MakeFastqs(Pipeline):
                               requires=(get_cellranger_atac,
                                         get_bcl2fastq_for_10x_atac,
                                         make_sample_sheet,
+                                        fetch_primary_data,
                                         restore_backup,))
                 # Add task to list of tasks that downstream
                 # tasks need to wait for

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -2735,7 +2735,6 @@ class FastqStatistics(PipelineTask):
         # Basic statistics
         if self.args.stats_file:
             self.final_stats = self.args.stats_file
-            self.stats_file = os.path.basename(self.final_stats)
         else:
             self.final_stats = os.path.join(self.args.out_dir,
                                             self.stats_file)
@@ -2743,15 +2742,12 @@ class FastqStatistics(PipelineTask):
         if self.args.per_lane_stats_file:
             self.final_per_lane_stats = \
                                 self.args.per_lane_stats_file
-            self.per_lane_stats = \
-                    os.path.basename(self.final_per_lane_stats)
         else:
             self.final_per_lane_stats = os.path.join(
                 self.args.out_dir,self.per_lane_stats)
         # Full statistics
         if self.args.stats_full_file:
             self.final_stats_full = self.args.stats_full_file
-            self.stats_full = os.path.basename(self.final_stats_full)
         else:
             self.final_stats_full = os.path.join(self.args.out_dir,
                                                  self.stats_full)
@@ -2759,8 +2755,6 @@ class FastqStatistics(PipelineTask):
         if self.args.per_lane_sample_stats_file:
             self.final_per_lane_sample_stats = \
                 self.args.per_lane_sample_stats_file
-            self.per_lane_sample_stats = os.path.basename(
-                self.final_per_lane_sample_stats)
         else:
             self.final_per_lane_sample_stats = os.path.join(
                 self.args.out_dir,self.per_lane_sample_stats)
@@ -2830,12 +2824,17 @@ class FastqStatistics(PipelineTask):
     def finish(self):
         if self.generate_stats:
             print("Moving stats files to final locations")
-            for f in (self.final_stats,
-                      self.final_per_lane_stats,
-                      self.final_stats_full,
-                      self.final_per_lane_sample_stats):
-                print("- %s" % f)
-                os.rename(os.path.basename(f),f)
+            for f,ff in ((self.stats_file,self.final_stats),
+                         (self.per_lane_stats,self.final_per_lane_stats),
+                         (self.stats_full,self.final_stats_full),
+                         (self.per_lane_sample_stats,
+                          self.final_per_lane_sample_stats)):
+                print("- %s -> %s" % (f,ff))
+                if not os.path.exists(f):
+                    raise Exception("'%s' not found in %s" % (f,os.get_cwd()))
+                elif not os.path.isdir(os.path.dirname(ff)):
+                    raise Exception("No path to '%s'" %ff)
+                os.rename(f,ff)
         # Assign outputs
         self.output.stats_file.set(self.final_stats)
         self.output.stats_full.set(self.final_stats_full)

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -1460,7 +1460,7 @@ class MakeFastqs(Pipeline):
             clean_up_on_completion = True
         working_dir = os.path.abspath(working_dir)
         if not os.path.exists(working_dir):
-            mkdir(working_dir)
+            os.mkdir(working_dir)
 
         # Output directory
         if out_dir is None:

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -292,6 +292,10 @@ class MakeFastqs(Pipeline):
                 adapter_sequence_read2 = sample_sheet.settings['AdapterRead2']
             except KeyError:
                 adapter_sequence_read2 = ""
+
+        # ICELL8 well list
+        if icell8_well_list:
+            icell8_well_list = os.path.abspath(icell8_well_list)
         
         # Defaults
         self._bases_mask = bases_mask

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -2654,9 +2654,10 @@ class MergeFastqDirs(PipelineFunctionTask):
                 print("Concatenting '%s' Fastqs:" % idx)
                 for fq in fastqs_in:
                     print("- %s" % fq)
-                concat_cmd = Command('concat_fastqs.py')
+                concat_cmd = Command('zcat')
                 concat_cmd.add_args(*fastqs_in)
-                concat_cmd.add_args(fastq_out)
+                concat_cmd.add_args('|','gzip','-c',
+                                    '>',fastq_out)
                 self.add_cmd(PipelineCommandWrapper(
                     "Concatenate %s undetermined Fastqs" % idx,
                     *concat_cmd.command_line))

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -493,16 +493,10 @@ class MakeFastqs(Pipeline):
                 self._update_subset(s,
                                     minimum_trimmed_read_length=21,
                                     mask_short_adapter_reads=0)
-                if not s['icell8_well_list']:
-                    raise Exception("No ICELL8 well list assigned for "
-                                    "lanes %s" % s['lanes'])
             elif protocol == 'icell8_atac':
                 # ICELL8 single-cell ATAC-seq
                 self._update_subset(s,
                                     create_fastq_for_index_read=True)
-                if not s['icell8_well_list']:
-                    raise Exception("No ICELL8 well list assigned for "
-                                    "lanes %s" % s['lanes'])
             elif protocol == '10x_chromium_sc':
                 # 10xGenomics Chromium SC
                 # Turn off barcode analysis
@@ -529,6 +523,15 @@ class MakeFastqs(Pipeline):
                                     **{ kw: s[kw] for kw in s
                                         if (kw != 'lanes' and
                                             kw != 'protocol') })
+
+        # Perform checks for subsets
+        for s in self.subsets:
+            if s['protocol'] == 'icell8_atac':
+                # ICELL8 ATAC
+                # Check well list file is defined
+                if not s['icell8_well_list']:
+                    raise Exception("No ICELL8 well list assigned for "
+                                    "lanes %s" % s['lanes'])
 
         # Reset lanes for single subset which implicitly
         # includes all lanes in the run

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -1994,8 +1994,9 @@ class RunBcl2Fastq(PipelineTask):
         print("%-22s: %s" % ("Sample sheet",
                              os.path.basename(self.args.sample_sheet)))
         print("%-22s: %s" % ("Output dir",self.args.out_dir))
+        print("%-22s: %s" % ("Create empty Fastqs",self.args.create_empty_fastqs))
         for item,desc in (('bases_mask',"Bases mask"),
-                          ('mismatches',"Mismatches",),
+                          ('mismatches',"Allowed mismatches",),
                           ('ignore_missing_bcl',"Ignore missing bcl"),
                           ('no_lane_splitting',"No lane splitting"),
                           ('minimum_trimmed_read_length',"Min trimmed read len"),

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -2850,7 +2850,10 @@ class FastqStatistics(PipelineTask):
                          (self.per_lane_sample_stats,
                           self.final_per_lane_sample_stats)):
                 print("- %s -> %s" % (f,ff))
-                if not os.path.exists(f):
+                if os.path.abspath(f) == os.path.abspath(ff):
+                    raise Exception("'%s' and '%s' are the same file?"
+                                    % (f,ff))
+                elif not os.path.exists(f):
                     raise Exception("'%s' not found in %s" % (f,os.getcwd()))
                 elif not os.path.isdir(os.path.dirname(ff)):
                     raise Exception("No path to '%s'" % ff)

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -493,10 +493,16 @@ class MakeFastqs(Pipeline):
                 self._update_subset(s,
                                     minimum_trimmed_read_length=21,
                                     mask_short_adapter_reads=0)
+                if not s['icell8_well_list']:
+                    raise Exception("No ICELL8 well list assigned for "
+                                    "lanes %s" % s['lanes'])
             elif protocol == 'icell8_atac':
                 # ICELL8 single-cell ATAC-seq
                 self._update_subset(s,
                                     create_fastq_for_index_read=True)
+                if not s['icell8_well_list']:
+                    raise Exception("No ICELL8 well list assigned for "
+                                    "lanes %s" % s['lanes'])
             elif protocol == '10x_chromium_sc':
                 # 10xGenomics Chromium SC
                 # Turn off barcode analysis
@@ -2227,6 +2233,9 @@ class DemultiplexIcell8Atac(PipelineTask):
                     fastqs.append(os.path.join(sample.dirn,fq))
         if not fastqs:
             raise Exception("No Fastqs found")
+        # Check well list
+        if not self.args.well_list:
+            raise Exception("No well list file supplied")
         # Report settings
         for desc,param in (("Fastq dir",self.args.fastq_dir),
                            ("Well list file",self.args.well_list),

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -400,7 +400,7 @@ def add_make_fastqs_command(cmdparser):
     else:
         default_nprocessors.append("%s" % __settings.bcl2fastq.nprocessors)
     default_nprocessors = ', '.join(default_nprocessors)
-    add_nprocessors_option(bcl_to_fastq,None,
+    add_nprocessors_option(bcl_to_fastq,default_nprocessors,
                            default_display=default_nprocessors)
     add_runner_option(bcl_to_fastq)
     # Adapter trimming/masking options

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -387,21 +387,23 @@ def add_make_fastqs_command(cmdparser):
                               help="explicitly specify version of bcl2fastq "
                               "software to use (e.g. '=1.8.4' or '>=2.0').")
     # Number of processors
-    default_nprocessors = []
+    display_nprocessors = []
     for platform in __settings.platform:
         if __settings.platform[platform].nprocessors is not None:
-            default_nprocessors.append(
+            display_nprocessors.append(
                 "%s: %s" % 
                 (platform,
                  __settings.platform[platform].nprocessors))
-    if default_nprocessors:
-        default_nprocessors.append("other platforms: %s" %
+    if display_nprocessors:
+        display_nprocessors.append("other platforms: %s" %
                                    __settings.bcl2fastq.nprocessors)
+    elif __settings.bcl2fastq.nprocessors:
+        display_nprocessors.append("%s" % __settings.bcl2fastq.nprocessors)
     else:
-        default_nprocessors.append("%s" % __settings.bcl2fastq.nprocessors)
-    default_nprocessors = ', '.join(default_nprocessors)
-    add_nprocessors_option(bcl_to_fastq,default_nprocessors,
-                           default_display=default_nprocessors)
+        display_nprocessors.append("taken from job runner")
+    display_nprocessors = ', '.join(display_nprocessors)
+    add_nprocessors_option(bcl_to_fastq,None,
+                           default_display=display_nprocessors)
     add_runner_option(bcl_to_fastq)
     # Adapter trimming/masking options
     adapters = p.add_argument_group('Adapter trimming and masking')

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -983,7 +983,13 @@ def add_update_fastq_stats_command(cmdparser):
     p.add_argument('--force',action="store_true",dest="force",
                    help="force statistics to be regenerated even if "
                    "existing statistics files are newer than fastqs ")
-    add_nprocessors_option(p,__settings.fastq_stats.nprocessors)
+    nprocessors = __settings.fastq_stats.nprocessors
+    if nprocessors:
+        display_nprocessors = nprocessors
+    else:
+        display_nprocessors = "taken from job runner"
+    add_nprocessors_option(p,nprocessors,
+                           default_display=display_nprocessors)
     add_runner_option(p)
     add_debug_option(p)
     p.add_argument('analysis_dir',metavar="ANALYSIS_DIR",nargs="?",

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -246,19 +246,17 @@ def add_make_fastqs_command(cmdparser):
                                   "created on setup.")
     fastq_generation.add_argument('--lanes',action='append',
                                   dest='lanes',
-                                  metavar="LANES[:PROTOCOL][:OPTION=VALUE"
-                                  "[:OPTION=VALUE...]]",
+                                  metavar="LANES[:OPTIONS]",
                                   help="define a set of lanes to group for "
                                   "processing. LANES can be a single lane "
-                                  "(e.g. 1), a list of lanes (e.g. 1,3,...), "
-                                  "a range (e.g. 1-3), or a combination "
-                                  "(e.g. 1,3-5,7); the specified lanes will "
-                                  "be processed separately. Optionally a "
-                                  "PROTOCOL can be specified for this set "
-                                  "of lanes, and custom options can be "
-                                  "specified as OPTION=VALUE' pairs, "
-                                  "separated by ':'s. For example: "
-                                  "'--lanes=1-4:standard:trim_adapters=no'")
+                                  "(e.g. '1'), a list ('1,2,3,7'), a range "
+                                  "('1-3'), or a combination ('1-3,7'). "
+                                  "Specified lanes are processed together "
+                                  "in a group, using OPTIONS (if supplied). "
+                                  "OPTIONS takes the form "
+                                  "'[PROTOCOL:][KEY=VALUE:[KEY=VALUE]...] "
+                                  "(for example "
+                                  "--lanes=1-4:standard:trim_adapters=no)")
     fastq_generation.add_argument('--output-dir',action='store',
                                   dest='out_dir',default=None,
                                   help="set the directory for the output "

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -542,6 +542,15 @@ def add_make_fastqs_command(cmdparser):
     p.add_argument('analysis_dir',metavar="ANALYSIS_DIR",nargs="?",
                    help="auto_process analysis directory (optional: defaults "
                    "to the current directory)")
+    # Advanced options
+    advanced = p.add_argument_group('Advanced/debugging options')
+    advanced.add_argument('--verbose',action="store_true",
+                          dest="verbose",default=False,
+                          help="run pipeline in 'verbose' mode")
+    advanced.add_argument('--work-dir',action="store",
+                          dest="working_dir",default=None,
+                          help="specify the working directory for the "
+                          "pipeline operations")
 
 def add_setup_analysis_dirs_command(cmdparser):
     """Create a parser for the 'setup_analysis_dirs' command
@@ -1218,7 +1227,9 @@ def make_fastqs(args):
         cellranger_jobinterval=args.job_interval,
         cellranger_localcores=args.local_cores,
         cellranger_localmem=args.local_mem,
-        cellranger_ignore_dual_index=args.ignore_dual_index)
+        cellranger_ignore_dual_index=args.ignore_dual_index,
+        working_dir=args.working_dir,
+        verbose=args.verbose)
 
 def setup_analysis_dirs(args):
     """

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -74,7 +74,7 @@ from bcftbx.cmdparse import add_arg
 from bcftbx.JobRunner import fetch_runner
 from .. import get_version
 from ..auto_processor import AutoProcess
-from ..commands.make_fastqs_cmd import MAKE_FASTQS_PROTOCOLS
+from ..bcl2fastq.pipeline import PROTOCOLS
 from ..commands.make_fastqs_cmd import BCL2FASTQ_DEFAULTS
 from ..commands.report_cmd import ReportingMode
 from ..envmod import load as envmod_load
@@ -241,7 +241,7 @@ def add_make_fastqs_command(cmdparser):
                               "symlinked)")
     # General Fastq generation options
     fastq_generation = p.add_argument_group('General Fastq generation')
-    fastq_generation.add_argument('--protocol',choices=MAKE_FASTQS_PROTOCOLS,
+    fastq_generation.add_argument('--protocol',choices=PROTOCOLS,
                                   dest='protocol',default='standard',
                                   help="specify Fastq generation protocol "
                                   "depending on the data being processed "
@@ -398,7 +398,7 @@ def add_make_fastqs_command(cmdparser):
     # Fastqs for index reads
     bcl_to_fastq.add_argument('--create-fastq-for-index-reads',
                               action='store_true',
-                              dest='create_fastq_for_index_reads',
+                              dest='create_fastq_for_index_read',
                               default=False,
                               help="also create FASTQs for index reads")
     # Number of processors
@@ -1203,7 +1203,7 @@ def make_fastqs(args):
         mask_short_adapter_reads=args.mask_short_adapter_reads,
         adapter_sequence=args.adapter_sequence,
         adapter_sequence_read2=args.adapter_sequence_read2,
-        create_fastq_for_index_reads=args.create_fastq_for_index_reads,
+        create_fastq_for_index_read=args.create_fastq_for_index_read,
         stats_file=args.stats_file,
         per_lane_stats_file=args.per_lane_stats_file,
         barcode_analysis_dir=args.barcode_analysis_dir,

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -36,7 +36,8 @@ BCL2FASTQ_DEFAULTS = {
 #######################################################################
 
 def make_fastqs(ap,protocol='standard',platform=None,
-                unaligned_dir=None,sample_sheet=None,lanes=None,
+                unaligned_dir=None,sample_sheet=None,
+                lanes=None,lane_subsets=None,
                 icell8_well_list=None,
                 ignore_missing_bcl=False,ignore_missing_stats=False,
                 skip_rsync=False,remove_primary_data=False,
@@ -96,6 +97,14 @@ def make_fastqs(ap,protocol='standard',platform=None,
       lanes (list): (optional) specify a list of lane numbers to
         use in the processing; lanes not in the list will be excluded
         (default is to include all lanes)
+      lane_subsets (list): (optional) specify a list of lane subsets
+        to process separately before merging at the end; each subset
+        is a dictionary which should be generated using the 'subset'
+        function, and can include custom values for processing
+        parameters (e.g. protocol, trimming and masking options etc)
+        to override the defaults for this lane. Lanes not in a subset
+        will still be processed unless excluded via the 'lanes'
+        keyword
       icell8_well_list (str): well list file for ICELL8 platforms
         (required for ICELL8 processing protocols)
       nprocessors (int) : number of processors to use
@@ -351,6 +360,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
                              icell8_swap_i1_and_i2,
                              icell8_atac_reverse_complement=\
                              icell8_reverse_complement,
+                             lane_subsets=lane_subsets,
                              lanes=lanes,
                              trim_adapters=trim_adapters,
                              fastq_statistics=generate_stats,

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -285,21 +285,21 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 BCL2FASTQ_DEFAULTS['mask_short_adapter_reads']
 
     # Require specific bcl2fastq version
-    if require_bcl2fastq is None:
+    if require_bcl2fastq_version is None:
         # Look for platform-specific requirement
         try:
-            require_bcl2fastq = \
+            require_bcl2fastq_version = \
                 ap.settings.platform[ap.metadata.platform].bcl2fastq
             print("Bcl2fastq version %s required for platform '%s'" %
-                  (ap.metadata.platform,require_bcl2fastq))
+                  (ap.metadata.platform,require_bcl2fastq_version))
         except (KeyError,AttributeError):
             pass
-    if require_bcl2fastq is None:
+    if require_bcl2fastq_version is None:
         # Look for default requirement
-        require_bcl2fastq = ap.settings.bcl2fastq.default_version
+        require_bcl2fastq_version = ap.settings.bcl2fastq.default_version
         print("Bcl2fastq version %s required by default" %
-              require_bcl2fastq)
-    if require_bcl2fastq is not None:
+              require_bcl2fastq_version)
+    if require_bcl2fastq_version is not None:
         # No version requirement
         print("No bcl2fastq version explicitly specified")
 

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -299,7 +299,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
         require_bcl2fastq = ap.settings.bcl2fastq.default_version
         print("Bcl2fastq version %s required by default" %
               require_bcl2fastq)
-    if require_bcl2fastq not None:
+    if require_bcl2fastq is not None:
         # No version requirement
         print("No bcl2fastq version explicitly specified")
 

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -40,8 +40,6 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 unaligned_dir=None,sample_sheet=None,
                 lanes=None,lane_subsets=None,
                 icell8_well_list=None,
-                ignore_missing_bcl=False,ignore_missing_stats=False,
-                skip_rsync=False,remove_primary_data=False,
                 nprocessors=None,require_bcl2fastq_version=None,
                 bases_mask=None,no_lane_splitting=None,
                 minimum_trimmed_read_length=None,
@@ -53,8 +51,6 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 generate_stats=True,stats_file=None,
                 per_lane_stats_file=None,
                 analyse_barcodes=True,barcode_analysis_dir=None,
-                skip_fastq_generation=False,
-                only_fetch_primary_data=False,
                 force_copy_of_primary_data=False,
                 create_empty_fastqs=None,runner=None,
                 icell8_swap_i1_and_i2=False,
@@ -109,14 +105,6 @@ def make_fastqs(ap,protocol='standard',platform=None,
       icell8_well_list (str): well list file for ICELL8 platforms
         (required for ICELL8 processing protocols)
       nprocessors (int) : number of processors to use
-      ignore_missing_bcl (bool): if True then run bcl2fastq with
-        --ignore-missing-bcl
-      ignore_missing_stats (bool): if True then run bcl2fastq with
-        --ignore-missing-stats
-      skip_rsync (bool): if True then don't rsync primary data at the
-        start of bcl2fastq conversion
-      remove_primary_data (bool): if True then remove primary data at
-        the end of bcl2fastq conversion (default is to keep it)
       generate_stats (bool): if True then (re)generate statistics file
         for fastqs
       analyse_barcodes (bool): if True then (re)analyse barcodes for
@@ -155,10 +143,6 @@ def make_fastqs(ap,protocol='standard',platform=None,
         the output per-lane stats file.
       barcode_analysis_dir (str): if set then specifies path to the
         output directory for barcode analysis
-      skip_fastq_generation (bool): if True then don't perform fastq
-        generation
-      only_fetch_primary_data (bool): if True then fetch primary data,
-        don't do anything else
       force_copy_of_primary_data (bool): if True then force primary
         data to be copied (rsync'ed) even if it's on the local system
         (default is to link to primary data unless it's on a remote
@@ -198,18 +182,6 @@ def make_fastqs(ap,protocol='standard',platform=None,
     if protocol not in PROTOCOLS:
         raise Exception("Unknown protocol: '%s' (must be one of "
                         "%s)" % (protocol,','.join(PROTOCOLS)))
-
-    # Trap for unsupported options
-    if only_fetch_primary_data:
-        raise Exception("'Only fetch primary data' not supported")
-    if skip_fastq_generation:
-        raise Exception("'Skip fastq generation' not supported")
-    if ignore_missing_bcl:
-        raise Exception("'Ignore missing bcl' not suppported")
-    if ignore_missing_stats:
-        raise Exception("'Ignore missing stats' not supported")
-    if remove_primary_data:
-        raise Exception("'Remove primary data' not supported")
 
     # Output (unaligned) dir
     if unaligned_dir is not None:

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -41,7 +41,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 lanes=None,lane_subsets=None,
                 icell8_well_list=None,
                 nprocessors=None,require_bcl2fastq_version=None,
-                bases_mask=None,no_lane_splitting=None,
+                bases_mask=None,no_lane_splitting=False,
                 minimum_trimmed_read_length=None,
                 mask_short_adapter_reads=None,
                 trim_adapters=True,
@@ -52,7 +52,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 per_lane_stats_file=None,
                 analyse_barcodes=True,barcode_analysis_dir=None,
                 force_copy_of_primary_data=False,
-                create_empty_fastqs=None,runner=None,
+                create_empty_fastqs=False,runner=None,
                 icell8_swap_i1_and_i2=False,
                 icell8_reverse_complement=None,
                 cellranger_jobmode=None,
@@ -265,6 +265,30 @@ def make_fastqs(ap,protocol='standard',platform=None,
     if mask_short_adapter_reads is None:
         mask_short_adapter_reads = \
                 BCL2FASTQ_DEFAULTS['mask_short_adapter_reads']
+
+    # No lane splitting
+    if no_lane_splitting is None:
+        # Look for platform-specific setting
+        try:
+            no_lane_splitting = \
+                ap.settings.platform[ap.metadata.platform].no_lane_splitting
+        except (KeyError,AttributeError):
+            pass
+    if no_lane_splitting is None:
+        # Look for default setting
+        no_lane_splitting = ap.settings.bcl2fastq.no_lane_splitting
+
+    # Create empty placeholder Fastqs
+    if create_empty_fastqs is None:
+        # Look for platform-specific setting
+        try:
+            create_empty_fastqs = \
+                ap.settings.platform[ap.metadata.platform].create_empty_fastqs
+        except (KeyError,AttributeError):
+            pass
+    if create_empty_fastqs is None:
+        # Look for default setting
+        create_empty_fastqs = ap.settings.bcl2fastq.create_empty_fastqs
 
     # Require specific bcl2fastq version
     if require_bcl2fastq_version is None:

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -16,6 +16,7 @@ import gzip
 import logging
 from ..bcl2fastq.pipeline import PROTOCOLS
 from ..bcl2fastq.pipeline import MakeFastqs
+from bcftbx.IlluminaData import SampleSheet
 
 # Module specific logger
 logger = logging.getLogger(__name__)
@@ -233,7 +234,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
                                           ','.join([str(l)
                                                     for l in lanes])))
     if lanes is not None:
-        s = IlluminaData.SampleSheet(ap.params.sample_sheet)
+        s = SampleSheet(ap.params.sample_sheet)
         if not s.has_lanes:
             raise Exception("Requested subset of lanes but "
                             "samplesheet doesn't contain any "

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -61,7 +61,8 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 cellranger_jobinterval=None,
                 cellranger_localcores=None,
                 cellranger_localmem=None,
-                cellranger_ignore_dual_index=False):
+                cellranger_ignore_dual_index=False,
+                verbose=False,working_dir=None):
     """
     Create and summarise FASTQ files
 
@@ -176,6 +177,10 @@ def make_fastqs(ap,protocol='standard',platform=None,
       cellranger_ignore_dual_index (bool): (optional) on a dual-indexed
          flowcell where the second index was not used for the 10x
          sample, ignore it (10xGenomics Chromium SC data only)
+      working_dir (str): path to a working directory (defaults to
+         temporary directory in the current directory)
+      verbose (bool): if True then report additional information for
+         pipeline diagnostics
     """
     # Report protocol
     print("Protocol              : %s" % protocol)
@@ -392,7 +397,9 @@ def make_fastqs(ap,protocol='standard',platform=None,
                              log_dir=ap.log_dir,
                              log_file=pipeline_log,
                              max_jobs=max_jobs,
-                             poll_interval=poll_interval)
+                             poll_interval=poll_interval,
+                             working_dir=working_dir,
+                             verbose=verbose)
 
     # Update the parameters
     ap.params['primary_data_dir'] = make_fastqs.output.primary_data_dir

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -314,6 +314,14 @@ def make_fastqs(ap,protocol='standard',platform=None,
         # No version requirement
         print("No bcl2fastq version explicitly specified")
 
+    # Number of processors
+    if not nprocessors:
+        # Look for platform-specific number of processors
+        if platform in ap.settings.platform:
+            nprocessors = ap.settings.platform[platform].nprocessors
+        if not nprocessors:
+            nprocessors = ap.settings.bcl2fastq.nprocessors
+
     # Set up pipeline runners
     default_runner = ap.settings.general.default_runner
     runners = {

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -286,6 +286,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
         print("No bcl2fastq version explicitly specified")
 
     # Set up pipeline runners
+    default_runner = ap.settings.general.default_runner
     runners = {
         'rsync_runner': ap.settings.runners.rsync,
         'bcl2fastq_runner': ap.settings.runners.bcl2fastq,
@@ -296,6 +297,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
     }
     if runner is not None:
         # Override configured runners
+        default_runner = runner
         for r in runners:
             runner[r] = runner
 
@@ -351,6 +353,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
                              stats_file=stats_file,
                              per_lane_stats=per_lane_stats_file,
                              nprocessors=nprocessors,
+                             default_runner=default_runner,
                              require_bcl2fastq=require_bcl2fastq_version,
                              cellranger_jobmode=cellranger_jobmode,
                              cellranger_mempercore=cellranger_mempercore,

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -316,6 +316,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
 
     # Other pipeline settings
     poll_interval = ap.settings.general.poll_interval
+    max_jobs = ap.settings.general.max_concurrent_jobs
 
     # Construct and run pipeline
     make_fastqs = MakeFastqs(ap.params.data_dir,
@@ -366,6 +367,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
                              envmodules=envmodules,
                              log_dir=ap.log_dir,
                              log_file=pipeline_log,
+                             max_jobs=max_jobs,
                              poll_interval=poll_interval)
 
     # Update the parameters

--- a/auto_process_ngs/commands/setup_cmd.py
+++ b/auto_process_ngs/commands/setup_cmd.py
@@ -19,7 +19,6 @@ except ImportError:
 from ..bcl2fastq_utils import get_sequencer_platform
 from ..bcl2fastq_utils import make_custom_sample_sheet
 from ..applications import general as general_applications
-from ..commands.make_fastqs_cmd import fastq_statistics
 from ..fileops import exists
 from ..fileops import Location
 from ..samplesheet_utils import predict_outputs

--- a/auto_process_ngs/commands/update_fastq_stats_cmd.py
+++ b/auto_process_ngs/commands/update_fastq_stats_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     update_fastq_stats_cmd.py: implement update_fastq_stats command
-#     Copyright (C) University of Manchester 2019 Peter Briggs
+#     Copyright (C) University of Manchester 2019-2020 Peter Briggs
 #
 #########################################################################
 
@@ -9,8 +9,12 @@
 # Imports
 #######################################################################
 
+import os
+from bcftbx import IlluminaData
+from ..applications import Command
+from ..bcl2fastq.reporting import ProcessingQCReport
+from ..simple_scheduler import SchedulerJob
 import logging
-from .make_fastqs_cmd import fastq_statistics
 
 # Module specific logger
 logger = logging.getLogger(__name__)
@@ -60,3 +64,192 @@ def update_fastq_stats(ap,stats_file=None,per_lane_stats_file=None,
                      force=force,
                      nprocessors=nprocessors,
                      runner=runner)
+
+def fastq_statistics(ap,stats_file=None,per_lane_stats_file=None,
+                     unaligned_dir=None,sample_sheet=None,add_data=False,
+                     force=False,nprocessors=None,runner=None):
+    """Generate statistics for Fastq files
+
+    Generates statistics for all Fastq files found in the
+    'unaligned' directory, by running the 'fastq_statistics.py'
+    program.
+
+    Arguments
+      ap (AutoProcessor): autoprocessor pointing to the analysis
+        directory to create Fastqs for
+      stats_file (str): path of a non-default file to write the
+        statistics to (defaults to 'statistics.info' unless
+        over-ridden by local settings)
+      per_lane_stats_file (str): path for per-lane statistics
+        output file (defaults to 'per_lane_statistics.info'
+        unless over-ridden by local settings)
+      unaligned_dir (str): output directory for bcl-to-fastq
+        conversion
+      sample_sheet (str): path to sample sheet file used in
+        bcl-to-fastq conversion
+      add_data (bool): if True then add stats to the existing
+        stats files (default is to overwrite existing stats
+        files)
+      force (bool): if True then force update of the stats
+        files even if they are newer than the Fastq files
+        (by default stats are only updated if they are older
+        than the Fastqs)
+      nprocessors (int): number of cores to use when running
+        'fastq_statistics.py'
+      runner (JobRunner): (optional) specify a non-default job
+        runner to use for running 'fastq_statistics.py'
+    """
+    # Get file names for output files
+    if stats_file is None:
+        if ap.params['stats_file'] is not None:
+            stats_file = ap.params['stats_file']
+        else:
+            stats_file='statistics.info'
+        if per_lane_stats_file is None:
+            if ap.params['per_lane_stats_file'] is not None:
+                per_lane_stats_file = ap.params['per_lane_stats_file']
+            else:
+                per_lane_stats_file='per_lane_statistics.info'
+    # Sort out unaligned_dir
+    if unaligned_dir is None:
+        if ap.params.unaligned_dir is None:
+            ap.params['unaligned_dir'] = 'bcl2fastq'
+        unaligned_dir = ap.params.unaligned_dir
+    if not os.path.exists(os.path.join(ap.params.analysis_dir,unaligned_dir)):
+        logger.error("Unaligned dir '%s' not found" % unaligned_dir)
+    # Check for sample sheet
+    if sample_sheet is None:
+        sample_sheet = ap.params['sample_sheet']
+    # Check if any Fastqs are newer than stats files
+    newest_mtime = 0
+    for f in (stats_file,per_lane_stats_file,):
+        try:
+            newest_mtime = max(newest_mtime,
+                               os.path.getmtime(f))
+        except OSError:
+            # Missing file
+            newest_mtime = 0
+            break
+    illumina_data = IlluminaData.IlluminaData(ap.params.analysis_dir,
+                                              unaligned_dir)
+    if newest_mtime > 0:
+        regenerate_stats = False
+        for project in illumina_data.projects:
+            for sample in project.samples:
+                for fq in sample.fastq:
+                    if (os.path.getmtime(os.path.join(sample.dirn,fq)) >
+                        newest_mtime):
+                        regenerate_stats = True
+                        break
+        if regenerate_stats:
+            logger.warning("Fastqs are newer than stats files")
+        else:
+            logger.warning("Stats files are newer than Fastqs")
+            if not force:
+                # Don't rerun the stats, just regenerate the report
+                processing_qc_html = os.path.join(ap.analysis_dir,
+                                                  "processing_qc.html")
+                report_processing_qc(ap,processing_qc_html)
+                return
+    # Set up runner
+    if runner is None:
+        runner = ap.settings.runners.stats
+    runner.set_log_dir(ap.log_dir)
+    # Number of cores
+    if nprocessors is None:
+        nprocessors = ap.settings.fastq_stats.nprocessors
+    # Generate statistics
+    fastq_statistics_cmd = Command(
+        'fastq_statistics.py',
+        '--unaligned',unaligned_dir,
+        '--sample-sheet',sample_sheet,
+        '--output',os.path.join(ap.params.analysis_dir,stats_file),
+        '--per-lane-stats',os.path.join(ap.params.analysis_dir,
+                                        per_lane_stats_file),
+        ap.params.analysis_dir,
+        '--nprocessors',nprocessors
+    )
+    if add_data:
+        fastq_statistics_cmd.add_args('--update')
+    print("Generating statistics: running %s" % fastq_statistics_cmd)
+    fastq_statistics_job = SchedulerJob(
+        runner,
+        fastq_statistics_cmd.command_line,
+        name='fastq_statistics',
+        working_dir=ap.analysis_dir
+    )
+    fastq_statistics_job.start()
+    try:
+        fastq_statistics_job.wait(
+            poll_interval=ap.settings.general.poll_interval
+        )
+    except KeyboardInterrupt as ex:
+        logger.warning("Keyboard interrupt, terminating fastq_statistics")
+        fastq_statistics_job.terminate()
+        raise ex
+    exit_code = fastq_statistics_job.exit_code
+    print("fastq_statistics completed: exit code %s" % exit_code)
+    if exit_code != 0:
+        raise Exception("fastq_statistics exited with an error")
+    ap.params['stats_file'] = stats_file
+    ap.params['per_lane_stats_file'] = per_lane_stats_file
+    print("Statistics generation completed: %s" % ap.params.stats_file)
+    print("Generating processing QC report")
+    processing_qc_html = os.path.join(ap.analysis_dir,
+                                      "processing_qc.html")
+    report_processing_qc(ap,processing_qc_html)
+
+def report_processing_qc(ap,html_file):
+    """
+    Generate HTML report for processing statistics
+
+    Arguments:
+      ap (AutoProcess): AutoProcess instance to report the
+        processing from
+      html_file (str): destination path and file name for
+        HTML report
+    """
+    # Per-lane statistics
+    per_lane_stats_file = ap.params.per_lane_stats_file
+    if per_lane_stats_file is None:
+        per_lane_stats_file = "per_lane_statistics.info"
+    per_lane_stats_file = get_absolute_file_path(per_lane_stats_file,
+                                                 base=ap.analysis_dir)
+    # Per lane by sample statistics
+    per_lane_sample_stats_file = get_absolute_file_path(
+        "per_lane_sample_stats.info",
+        base=ap.analysis_dir)
+    # Per fastq statistics
+    stats_file = get_absolute_file_path("statistics_full.info",
+                                        base=ap.analysis_dir)
+    if not os.path.exists(stats_file):
+        if ap.params.stats_file is not None:
+            stats_file = ap.params.stats_file
+        else:
+            stats_file = "statistics.info"
+    stats_file = get_absolute_file_path(stats_file,
+                                        base=ap.analysis_dir)
+    # Generate the report
+    ProcessingQCReport(ap.analysis_dir,
+                       stats_file,
+                       per_lane_stats_file,
+                       per_lane_sample_stats_file).write(html_file)
+
+def get_absolute_file_path(p,base=None):
+    """
+    Get absolute path for supplied path
+
+    Arguments:
+      p (str): path
+      base (str): optional, base directory to
+        use if p is relative
+
+    Returns:
+      String: absolute path for p.
+    """
+    if not os.path.isabs(p):
+        if base is not None:
+            p = os.path.join(os.path.abspath(base),p)
+        else:
+            p = os.path.abspath(p)
+    return p

--- a/auto_process_ngs/commands/update_fastq_stats_cmd.py
+++ b/auto_process_ngs/commands/update_fastq_stats_cmd.py
@@ -157,7 +157,10 @@ def fastq_statistics(ap,stats_file=None,per_lane_stats_file=None,
     runner.set_log_dir(ap.log_dir)
     # Number of cores
     if nprocessors is None:
-        nprocessors = ap.settings.fastq_stats.nprocessors
+        if ap.settings.fastq_stats.nprocessors:
+            nprocessors = ap.settings.fastq_stats.nprocessors
+        else:
+            nprocessors = runner.nslots
     # Generate statistics
     fastq_statistics_cmd = Command(
         'fastq_statistics.py',

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -125,7 +125,13 @@ class Settings(object):
                                                         'poll_interval',5)
         # modulefiles
         self.add_section('modulefiles')
-        self.modulefiles['make_fastqs'] = config.get('modulefiles','make_fastqs')
+        self.modulefiles['make_fastqs'] = config.get('modulefiles',
+                                                     'make_fastqs')
+        self.modulefiles['bcl2fastq'] = config.get('modulefiles','bcl2fastq')
+        self.modulefiles['cellranger_mkfastq'] = config.get('modulefiles',
+                                                    'cellranger_mkfastq')
+        self.modulefiles['cellranger_atac_mkfastq'] = config.get('modulefiles',
+                                                    'cellranger_atac_mkfastq')
         self.modulefiles['run_qc'] = config.get('modulefiles','run_qc')
         self.modulefiles['publish_qc'] = config.get('modulefiles','publish_qc')
         self.modulefiles['process_icell8'] = config.get('modulefiles','process_icell8')

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -234,7 +234,7 @@ class Settings(object):
             logging.debug("No 10xgenomics scATAC-seq genome references defined")
         # fastq_stats
         self.add_section('fastq_stats')
-        self.fastq_stats['nprocessors'] = config.getint('fastq_stats','nprocessors',1)
+        self.fastq_stats['nprocessors'] = config.getint('fastq_stats','nprocessors',None)
         # Define runners for specific jobs
         self.add_section('runners')
         for name in ('bcl2fastq',
@@ -308,7 +308,7 @@ class Settings(object):
         if section == 'bcl2fastq':
             values['default_version'] = config.get(section,'default_version',
                                                    None)
-            values['nprocessors'] = config.getint(section,'nprocessors',1)
+            values['nprocessors'] = config.getint(section,'nprocessors',None)
             values['no_lane_splitting'] = config.getboolean(section,'no_lane_splitting',
                                                             False)
             values['create_empty_fastqs'] = config.getboolean(

--- a/auto_process_ngs/stats.py
+++ b/auto_process_ngs/stats.py
@@ -396,7 +396,8 @@ class FastqStatistics(object):
                                 column_names=('Project','Sample',lane)))
                 # Sort into order
                 samples = sorted(samples,
-                                 key=lambda x: (x['Project'],x['Sample']))
+                                 key=lambda x: (str(x['Project']),
+                                                str(x['Sample'])))
             try:
                 total_reads = sum([int(s[lane]) for s in samples])
             except Exception as ex:

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -2939,18 +2939,18 @@ class TestSubsetFunction(unittest.TestCase):
         self.assertEqual(s['icell8_well_list'],
                          "/files/well_list.txt")
 
-    def test_subset_setting_missing_parameter_raises_keyerror(self):
+    def test_subset_setting_unrecognised_parameter_raises_keyerror(self):
         """
-        subset: setting missing parameter raises KeyError
+        subset: setting unrecognised parameter raises KeyError
         """
         with self.assertRaises(KeyError) as ex:
             s = subset([1,2],
                        protocol="standard",
                        missing="not_here")
 
-    def test_subset_accessing_missing_parameter_raises_keyerror(self):
+    def test_subset_accessing_unrecognised_parameter_raises_keyerror(self):
         """
-        subset: accessing missing parameter raises KeyError
+        subset: accessing unrecognised parameter raises KeyError
         """
         s = subset([1,2],protocol="standard")
         with self.assertRaises(KeyError) as ex:

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -52,7 +52,7 @@ class TestMakeFastqs(unittest.TestCase):
     #@unittest.skip("Skipped")
     def test_makefastqs_standard_protocol_bcl2fastq_2_17(self):
         """
-        MakeFastqs: standard protocol with bcl2fastq v2.17
+        MakeFastqs: standard protocol: use bcl2fastq v2.17
         """
         # Create mock source data
         illumina_run = MockIlluminaRun(
@@ -124,7 +124,7 @@ class TestMakeFastqs(unittest.TestCase):
     #@unittest.skip("Skipped")
     def test_makefastqs_standard_protocol_bcl2fastq_2_20(self):
         """
-        MakeFastqs: standard protocol with bcl2fastq v2.20
+        MakeFastqs: standard protocol: use bcl2fastq v2.20
         """
         # Create mock source data
         illumina_run = MockIlluminaRun(

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -274,6 +274,85 @@ class TestMakeFastqs(unittest.TestCase):
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_set_stats_files(self):
+        """
+        MakeFastqs: standard protocol: set custom names for stats files
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 version="2.20.0.422")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Custom names for statistics files
+        stats_file = os.path.join(self.wd,"the_stats.txt")
+        stats_full = os.path.join(self.wd,"the_stats_full.txt")
+        per_lane_stats = os.path.join(analysis_dir,
+                                      "the_per_lane_stats.txt")
+        per_lane_sample_stats = os.path.join(analysis_dir,
+                                             "the_per_lane_sample_stats.txt")
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet)
+        status = p.run(analysis_dir,
+                       stats_file=stats_file,
+                       stats_full=stats_full,
+                       per_lane_stats=os.path.basename(per_lane_stats),
+                       per_lane_sample_stats=\
+                       os.path.basename(per_lane_sample_stats),
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,stats_file)
+        self.assertEqual(p.output.stats_full,stats_full)
+        self.assertEqual(p.output.per_lane_stats,per_lane_stats)
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         per_lane_sample_stats)
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertEqual(p.output.missing_fastqs,[])
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in (stats_file,
+                      stats_full,
+                      per_lane_stats,
+                      per_lane_sample_stats,
+                      os.path.join(analysis_dir,"processing_qc.html")):
+            self.assertTrue(os.path.isfile(filen),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
     def test_makefastqs_standard_protocol_create_fastq_for_index_read(self):
         """
         MakeFastqs: standard protocol: create Fastqs for index reads

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -2781,10 +2781,10 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
         analysis_dir = os.path.join(self.wd,"analysis")
         os.mkdir(analysis_dir)
         # Do the test
-        p = MakeFastqs(run_dir,sample_sheet,platform="miseq")
+        p = MakeFastqs(run_dir,sample_sheet)
         status = p.run(analysis_dir,
                        poll_interval=0.5)
-        self.assertEqual(status,0)
+        self.assertEqual(status,1)
         # Check outputs
         self.assertEqual(p.output.platform,None)
         self.assertEqual(p.output.primary_data_dir,
@@ -2798,9 +2798,7 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
-                                    "171020_UNKNOWN_00002_AHGXXXX"),
-                       "bcl2fastq",
-                       "barcode_analysis",):
+                                    "171020_UNKNOWN_00002_AHGXXXX"),):
             self.assertTrue(os.path.isdir(
                 os.path.join(analysis_dir,subdir)),
                             "Missing subdir: %s" % subdir)
@@ -2808,12 +2806,17 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
             os.path.join(analysis_dir,
                          "primary_data",
                          "171020_UNKNOWN_00002_AHGXXXX")))
+        for subdir in ("bcl2fastq",
+                       "barcode_analysis",):
+            self.assertFalse(os.path.exists(
+                os.path.join(analysis_dir,subdir)),
+                            "Found subdir: %s" % subdir)
         for filen in ("statistics.info",
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
                       "processing_qc.html"):
-            self.assertTrue(os.path.isfile(
+            self.assertFalse(os.path.exists(
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
 

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -79,6 +79,17 @@ class TestMakeFastqs(unittest.TestCase):
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.17.1.14"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -130,6 +141,17 @@ class TestMakeFastqs(unittest.TestCase):
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -183,6 +205,17 @@ class TestMakeFastqs(unittest.TestCase):
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -235,6 +268,17 @@ class TestMakeFastqs(unittest.TestCase):
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
                        "bcl2fastq",):
@@ -289,6 +333,17 @@ class TestMakeFastqs(unittest.TestCase):
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
                        "bcl2fastq",):
@@ -346,6 +401,17 @@ class TestMakeFastqs(unittest.TestCase):
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -399,6 +465,17 @@ class TestMakeFastqs(unittest.TestCase):
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -452,6 +529,17 @@ class TestMakeFastqs(unittest.TestCase):
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -510,6 +598,17 @@ class TestMakeFastqs(unittest.TestCase):
                        ##verbose=True)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -612,6 +711,17 @@ class TestMakeFastqs(unittest.TestCase):
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -682,6 +792,18 @@ class TestMakeFastqs(unittest.TestCase):
                        ##verbose=True,
                        poll_interval=0.5)
         self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
                        "bcl2fastq",):
@@ -733,6 +855,17 @@ class TestMakeFastqs(unittest.TestCase):
         status = p.run(analysis_dir,
                        poll_interval=0.5)
         # Check outputs
+        self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -830,6 +963,17 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -928,6 +1072,17 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -1019,6 +1174,20 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         status = p.run(analysis_dir,
                        poll_interval=0.5)
         # Check outputs
+        self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,
+                         (os.path.join(self.bin,"cellranger"),
+                          "cellranger",
+                          "2.2.0"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -1123,6 +1292,20 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,
+                         (os.path.join(self.bin,"cellranger"),
+                          "cellranger",
+                          "2.2.0"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -1235,6 +1418,20 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,
+                         (os.path.join(self.bin,"cellranger"),
+                          "cellranger",
+                          "2.2.0"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -1323,6 +1520,17 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         status = p.run(analysis_dir,
                        poll_interval=0.5)
         # Check outputs
+        self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -1393,6 +1601,17 @@ AB1,AB1,,,,,AB,
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -1444,6 +1663,17 @@ AB1,AB1,,,,,AB,
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -1498,6 +1728,17 @@ AB1,AB1,,,,,AB,
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -1577,6 +1818,17 @@ AB1,AB1,,,,,AB,
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
                        "bcl2fastq",):
@@ -1651,6 +1903,17 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,ICELL8_ATAC,
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -1757,6 +2020,17 @@ Unassigned-Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,ICELL8_ATAC,
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
                        "bcl2fastq",):
@@ -1824,6 +2098,20 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,
+                         (os.path.join(self.bin,"cellranger"),
+                          "cellranger",
+                          "2.2.0"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
                        "bcl2fastq",):
@@ -1916,6 +2204,20 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,
+                         (os.path.join(self.bin,"cellranger"),
+                          "cellranger",
+                          "2.2.0"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
                        "bcl2fastq",):
@@ -1988,6 +2290,20 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,
+                         (os.path.join(self.bin,"cellranger-atac"),
+                          "cellranger-atac",
+                          "2.2.0"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
                        "bcl2fastq",):
@@ -2081,6 +2397,20 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,
+                         (os.path.join(self.bin,"cellranger-atac"),
+                          "cellranger-atac",
+                          "2.2.0"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
                        "bcl2fastq",):
@@ -2137,6 +2467,17 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -2190,6 +2531,19 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                        poll_interval=0.5)
         self.assertEqual(status,1)
         # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,
+                         ["Sample1/Sample1_S1_L001_R1_001.fastq.gz",
+                          "Sample1/Sample1_S1_L001_R2_001.fastq.gz"])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),):
             self.assertTrue(os.path.isdir(
@@ -2247,6 +2601,19 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,
+                         ["Sample1/Sample1_S1_L001_R1_001.fastq.gz",
+                          "Sample1/Sample1_S1_L001_R2_001.fastq.gz"])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -2292,6 +2659,14 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                        poll_interval=0.5)
         self.assertEqual(status,1)
         # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,None)
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),):
             self.assertTrue(os.path.isdir(
@@ -2346,6 +2721,17 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
         status = p.run(analysis_dir,poll_interval=0.5)
         self.assertEqual(status,1)
         # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),):
             self.assertTrue(os.path.isdir(
@@ -2400,6 +2786,17 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,None)
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_UNKNOWN_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -2451,6 +2848,17 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_UNKNOWN_00002_AHGXXXX"),
                        "bcl2fastq",

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -1,0 +1,2960 @@
+#######################################################################
+# Tests for bcl2fastq/pipeline.py module
+#######################################################################
+
+import unittest
+import tempfile
+import shutil
+import os
+from bcftbx.mock import MockIlluminaRun
+from bcftbx.mock import SampleSheets
+from auto_process_ngs.mock import MockBcl2fastq2Exe
+from auto_process_ngs.mock import MockCellrangerExe
+from auto_process_ngs.mock import make_mock_bcl2fastq2_output
+from auto_process_ngs.pipeliner import PipelineParam
+from auto_process_ngs.bcl2fastq.pipeline import MakeFastqs
+from auto_process_ngs.bcl2fastq.pipeline import PathJoinParam
+from auto_process_ngs.bcl2fastq.pipeline import PathExistsParam
+from auto_process_ngs.bcl2fastq.pipeline import FunctionParam
+from auto_process_ngs.bcl2fastq.pipeline import subset
+from auto_process_ngs.bcl2fastq_utils import make_custom_sample_sheet
+
+# Set to False to keep test output dirs
+REMOVE_TEST_OUTPUTS = True
+
+class TestMakeFastqs(unittest.TestCase):
+    """
+    Tests for MakeFastqs pipeline
+    """
+    def setUp(self):
+        # Create a temp working dir
+        self.wd = tempfile.mkdtemp(suffix='TestMakeFastqs')
+        # Create a temp 'bin' dir
+        self.bin = os.path.join(self.wd,"bin")
+        os.mkdir(self.bin)
+        # Store original location
+        self.pwd = os.getcwd()
+        # Store original PATH
+        self.path = os.environ['PATH']
+        # Move to working dir
+        os.chdir(self.wd)
+
+    def tearDown(self):
+        # Return to original dir
+        os.chdir(self.pwd)
+        # Restore PATH
+        os.environ['PATH'] = self.path
+        # Remove the temporary test directory
+        if REMOVE_TEST_OUTPUTS:
+            shutil.rmtree(self.wd)
+            
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_bcl2fastq_2_17(self):
+        """
+        MakeFastqs: standard protocol with bcl2fastq v2.17
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 version='2.17.1.14')
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet)
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_bcl2fastq_2_20(self):
+        """
+        MakeFastqs: standard protocol with bcl2fastq v2.20
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 version="2.20.0.422")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet)
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_create_fastq_for_index_read(self):
+        """
+        MakeFastqs: standard protocol: create Fastqs for index reads
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        # Check that --create-fastq-for-index-read is set
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 assert_create_fastq_for_index_read=True)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet)
+        status = p.run(analysis_dir,
+                       create_fastq_for_index_read=True,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_disable_fastq_statistics(self):
+        """
+        MakeFastqs: standard protocol: disable Fastq statistics
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        # Check adapter sequences
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,
+                       fastq_statistics=False)
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertFalse(os.path.exists(
+            os.path.join(analysis_dir,"barcode_analysis")),
+                         "Found subdir: barcode_analysis")
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertFalse(os.path.exists(
+                os.path.join(analysis_dir,filen)),
+                            "Found file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_disable_barcode_analysis(self):
+        """
+        MakeFastqs: standard protocol: disable barcode analysis
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        # Check adapter sequences
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,
+                       analyse_barcodes=False)
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertFalse(os.path.exists(
+            os.path.join(analysis_dir,"barcode_analysis")),
+                         "Found subdir: barcode_analysis")
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_set_adapters(self):
+        """
+        MakeFastqs: standard protocol: set adapter sequences
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        # Check adapter sequences
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 assert_adapter="ACGTACGTACGT",
+                                 assert_adapter2="TGCATGCATGCA")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,
+                       adapter_sequence="ACGTACGTACGT",
+                       adapter_sequence_read2="TGCATGCATGCA")
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_set_minimum_trimmed_read_length(self):
+        """
+        MakeFastqs: standard protocol: set minimum trimmed read length
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        # Check adapter sequences
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 assert_minimum_trimmed_read_length=26)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,
+                       minimum_trimmed_read_length=26)
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_set_mask_short_adapter_reads(self):
+        """
+        MakeFastqs: standard protocol: set mask short adapter reads
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        # Check adapter sequences
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 assert_mask_short_adapter_reads=10)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,
+                       mask_short_adapter_reads=10)
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_disable_adapter_trimming(self):
+        """
+        MakeFastqs: standard protocol: disable adapter trimming
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        # Check adapter trimming is disabled
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 assert_minimum_trimmed_read_length=0,
+                                 assert_mask_short_adapter_reads=0,
+                                 assert_adapter="",
+                                 assert_adapter2="")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,
+                       trim_adapters=False)
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+                       ##default_runner=SimpleJobRunner(join_logs=True),
+                       ##verbose=True)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_multiple_lanes(self):
+        """
+        MakeFastqs: standard protocol: multiple lanes
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_SN7001250_00002_AHGXXXX",
+            "hiseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.hiseq)
+        # Create mock bcl2fastq
+        # Check that bases mask is as expected
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="standard")
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_SN7001250_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_SN7001250_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_multiple_lanes_no_lane_splitting(self):
+        """
+        MakeFastqs: standard protocol: multiple lanes, no lane splitting
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_SN7001250_00002_AHGXXXX",
+            "hiseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.hiseq)
+        # Create mock bcl2fastq
+        # Check that --no-lane-splitting is set
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 assert_no_lane_splitting=True)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="standard")
+        status = p.run(analysis_dir,
+                       no_lane_splitting=True,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_SN7001250_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_SN7001250_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_rerun_completed_pipeline(self):
+        """
+        MakeFastqs: standard protocol: rerun completed pipeline
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Set up mock outputs in analysis directory to mimic
+        # output from a previous successful pipeline run
+        analysis_dir = os.path.join(self.wd,"analysis")
+        make_mock_bcl2fastq2_output(os.path.join(analysis_dir,
+                                                 "bcl2fastq"),
+                                    lanes=(1,),
+                                    sample_sheet=sample_sheet)
+        # Make a primary data directory
+        os.mkdir(os.path.join(analysis_dir,"primary_data"))
+        os.symlink(run_dir,
+                   os.path.join(analysis_dir,
+                                "primary_data",
+                                os.path.basename(run_dir)))
+        # Make empty stats files
+        for f in ("statistics_full.info",
+                  "statistics.info",
+                  "per_lane_statistics.info",
+                  "per_lane_sample_stats.info",
+                  "processing_qc.html",):
+            with open(os.path.join(analysis_dir,f),'wt') as fp:
+                fp.write("")
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="standard",
+                       analyse_barcodes=False)
+        status = p.run(analysis_dir,
+                       ##default_runner=SimpleJobRunner(join_logs=True),
+                       ##verbose=True,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_multiple_lanes_multiple_subsets(self):
+        """
+        MakeFastqs: multiple lanes (explicitly define multiple subsets)
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_SN7001250_00002_AHGXXXX",
+            "hiseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.hiseq)
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,
+                       protocol="standard",
+                       lane_subsets=(
+                           subset(lanes=(1,2,)),
+                           subset(lanes=(3,4,5,6,7,8,))))
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_SN7001250_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "save.bcl2fastq.L12",
+                       "save.bcl2fastq.L345678",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_SN7001250_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_multiple_subsets_rerun_completed_pipeline(self):
+        """
+        MakeFastqs: multiple subsets: rerun completed pipeline
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_SN7001250_00002_AHGXXXX",
+            "hiseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write("""[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,AB1,,,N701,TAAGGCGA,S504,AGAGTAGA,AB,
+2,TM2,TM1,,,N701,TAAGGCGA,S517,GCGTAAGA,TM,
+3,CD3,CD3,,,N701,GTGAAACG,S503,TCTTTCCC,CD,
+4,EB4,EB4,,A1,N701,TAAGGCGA,S501,TAGATCGC,EB,
+5,EB5,EB5,,A3,N703,AGGCAGAA,S501,TAGATCGC,EB,
+6,EB6,EB6,,F3,N703,AGGCAGAA,S506,ACTGCATA,EB,
+7,ML7,ML7,,,N701,GCCAATAT,S502,TCTTTCCC,ML,
+8,VL8,VL8,,,N701,GCCAATAT,S503,TCTTTCCC,VL,
+""")
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Set up mock outputs in analysis directory to mimic
+        # output from a previous successful pipeline run
+        analysis_dir = os.path.join(self.wd,"analysis")
+        make_mock_bcl2fastq2_output(os.path.join(analysis_dir,
+                                                 "bcl2fastq"),
+                                    lanes=(1,2,3,4,5,6,7,8),
+                                    sample_sheet=sample_sheet)
+        dir2 = os.path.join(self.wd,"analysis.L3456768")
+        make_mock_bcl2fastq2_output(os.path.join(dir2,"bcl2fastq"),
+                                    lanes=(3,4,5,6,7,8),
+                                    sample_sheet=sample_sheet)
+        dir1 = os.path.join(self.wd,"analysis.L12")
+        make_mock_bcl2fastq2_output(os.path.join(dir1,"bcl2fastq"),
+                                    lanes=(1,2),
+                                    sample_sheet=sample_sheet)
+        os.rename(os.path.join(dir1,"bcl2fastq"),
+                  os.path.join(analysis_dir,"save.bcl2fastq.L12"))
+        os.rename(os.path.join(dir2,"bcl2fastq"),
+                  os.path.join(analysis_dir,"save.bcl2fastq.L345678"))
+        # Make a primary data directory
+        os.mkdir(os.path.join(analysis_dir,"primary_data"))
+        os.symlink(run_dir,
+                   os.path.join(analysis_dir,
+                                "primary_data",
+                                os.path.basename(run_dir)))
+        # Make empty stats files
+        for f in ("statistics_full.info",
+                  "statistics.info",
+                  "per_lane_statistics.info",
+                  "per_lane_sample_stats.info",
+                  "processing_qc.html",):
+            with open(os.path.join(analysis_dir,f),'wt') as fp:
+                fp.write("")
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,
+                       protocol="standard",
+                       lane_subsets=(
+                           subset(lanes=(1,2,)),
+                           subset(lanes=(3,4,5,6,7,8,))),
+                       analyse_barcodes=False)
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_SN7001250_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "save.bcl2fastq.L12",
+                       "save.bcl2fastq.L345678",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        for subdir in ("bcl2fastq.L12",
+                       "bcl2fastq.L345678",):
+            self.assertFalse(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Found subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_SN7001250_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_multiple_subsets_rerun_incomplete_pipeline(self):
+        """
+        MakeFastqs: multiple subsets: rerun incomplete pipeline
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_SN7001250_00002_AHGXXXX",
+            "hiseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write("""[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,AB1,,,N701,TAAGGCGA,S504,AGAGTAGA,AB,
+2,TM2,TM1,,,N701,TAAGGCGA,S517,GCGTAAGA,TM,
+3,CD3,CD3,,,N701,GTGAAACG,S503,TCTTTCCC,CD,
+4,EB4,EB4,,A1,N701,TAAGGCGA,S501,TAGATCGC,EB,
+5,EB5,EB5,,A3,N703,AGGCAGAA,S501,TAGATCGC,EB,
+6,EB6,EB6,,F3,N703,AGGCAGAA,S506,ACTGCATA,EB,
+7,ML7,ML7,,,N701,GCCAATAT,S502,TCTTTCCC,ML,
+8,VL8,VL8,,,N701,GCCAATAT,S503,TCTTTCCC,VL,
+""")
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Set up mock outputs in analysis directory to mimic
+        # output from a previous incomplete pipeline run
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        dir1 = os.path.join(self.wd,"analysis.L12")
+        make_mock_bcl2fastq2_output(os.path.join(dir1,"bcl2fastq"),
+                                    lanes=(1,2),
+                                    sample_sheet=sample_sheet)
+        dir2 = os.path.join(self.wd,"analysis.L3456768")
+        make_mock_bcl2fastq2_output(os.path.join(dir2,"bcl2fastq"),
+                                    lanes=(3,4,5,6,7,8),
+                                    sample_sheet=sample_sheet)
+        os.rename(os.path.join(dir1,"bcl2fastq"),
+                  os.path.join(analysis_dir,"save.bcl2fastq.L12"))
+        os.rename(os.path.join(dir2,"bcl2fastq"),
+                  os.path.join(analysis_dir,"save.bcl2fastq.L345678"))
+        # Make a primary data directory
+        os.mkdir(os.path.join(analysis_dir,"primary_data"))
+        os.symlink(run_dir,
+                   os.path.join(analysis_dir,
+                                "primary_data",
+                                os.path.basename(run_dir)))
+        # Make empty stats files
+        for f in ("statistics_full.info",
+                  "statistics.info",
+                  "per_lane_statistics.info",
+                  "per_lane_sample_stats.info",
+                  "processing_qc.html",):
+            with open(os.path.join(analysis_dir,f),'wt') as fp:
+                fp.write("")
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,
+                       protocol="standard",
+                       lane_subsets=(
+                           subset(lanes=(1,2,)),
+                           subset(lanes=(3,4,5,6,7,8,))),
+                       analyse_barcodes=False)
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_SN7001250_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "save.bcl2fastq.L12",
+                       "save.bcl2fastq.L345678",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        for subdir in ("bcl2fastq.L12",
+                       "bcl2fastq.L345678",):
+            self.assertFalse(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Found subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_SN7001250_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_multiple_lanes_multiple_protocols(self):
+        """
+        MakeFastqs: multiple lanes (explicitly use multiple protocols)
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_SN7001250_00002_AHGXXXX",
+            "hiseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        samplesheet_multiple_protocols = """[Header]
+IEMFileVersion,4
+Date,11/11/2015
+Workflow,GenerateFASTQ
+Application,HiSeq FASTQ Only
+Assay,Nextera XT
+Description,
+Chemistry,Amplicon
+
+[Reads]
+101
+101
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,AB1,,,N701,SI-GA-A1,,,AB,
+2,TM2,TM1,,,N701,SI-GA-B1,,,TM,
+3,CD3,CD3,,,N701,GTGAAACG,S503,TCTTTCCC,CD,
+4,EB4,EB4,,A1,N701,TAAGGCGA,S501,TAGATCGC,EB,
+5,EB5,EB5,,A3,N703,AGGCAGAA,S501,TAGATCGC,EB,
+6,EB6,EB6,,F3,N703,AGGCAGAA,S506,ACTGCATA,EB,
+7,ML7,ML7,,,N701,GCCAATAT,S502,TCTTTCCC,ML,
+8,VL8,VL8,,,N701,GCCAATAT,S503,TCTTTCCC,VL,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_multiple_protocols)
+        # Create mock bcl2fastq and cellranger
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        MockCellrangerExe.create(os.path.join(self.bin,
+                                              "cellranger"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,
+                       lane_subsets=(
+                           subset(lanes=(1,2,),
+                                  protocol='10x_chromium_sc'),
+                           subset(lanes=(3,4,5,6,),
+                                  protocol='standard'),
+                           subset(lanes=(7,8,),
+                                  protocol='mirna')))
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_SN7001250_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "save.bcl2fastq.L12",
+                       "save.bcl2fastq.L3456",
+                       "save.bcl2fastq.L78",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_SN7001250_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_multiple_protocols_rerun_completed_pipeline(self):
+        """
+        MakeFastqs: multiple protocols: rerun completed pipeline
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_SN7001250_00002_AHGXXXX",
+            "hiseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write("""[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,AB1,,,N701,TAAGGCGA,S504,AGAGTAGA,AB,
+2,TM2,TM1,,,N701,TAAGGCGA,S517,GCGTAAGA,TM,
+3,CD3,CD3,,,N701,GTGAAACG,S503,TCTTTCCC,CD,
+4,EF4,EF4,,A1,N701,TAAGGCGA,S501,TAGATCGC,EF,
+5,GH5,GH5,,A3,N703,AGGCAGAA,S501,TAGATCGC,GH,
+6,IJB6,IJ6,,F3,N703,AGGCAGAA,S506,ACTGCATA,IJ,
+7,KL7,KL7,,,N701,GCCAATAT,S502,TCTTTCCC,KL,
+8,MN8,MN8,,,N701,GCCAATAT,S503,TCTTTCCC,MN,
+""")
+        # Create mock bcl2fastq and cellranger
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        MockCellrangerExe.create(os.path.join(self.bin,
+                                              "cellranger"))
+        MockCellrangerExe.create(os.path.join(self.bin,
+                                              "cellranger-atac"),
+                                 reads=('R1','R2','R3','I1',))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Set up mock outputs in analysis directory to mimic
+        # output from a previous successful pipeline run
+        analysis_dir = os.path.join(self.wd,"analysis")
+        make_mock_bcl2fastq2_output(os.path.join(analysis_dir,
+                                                 "bcl2fastq"),
+                                    lanes=(1,2,3,4,5,6,7,8),
+                                    sample_sheet=sample_sheet)
+        for lanes in ((1,2,3),(4,),(5,),(6,),(7,),(8,)):
+            lanes_id = ''.join([str(l) for l in lanes])
+            dirn = os.path.join(self.wd,"analysis.L%s" % lanes_id)
+            make_mock_bcl2fastq2_output(os.path.join(dirn,"bcl2fastq"),
+                                        lanes=lanes,
+                                        sample_sheet=sample_sheet)
+            os.rename(os.path.join(dirn,"bcl2fastq"),
+                      os.path.join(analysis_dir,
+                                   "save.bcl2fastq.L%s" % lanes_id))
+        # Make a primary data directory
+        os.mkdir(os.path.join(analysis_dir,"primary_data"))
+        os.symlink(run_dir,
+                   os.path.join(analysis_dir,
+                                "primary_data",
+                                os.path.basename(run_dir)))
+        # Make empty stats files
+        for f in ("statistics_full.info",
+                  "statistics.info",
+                  "per_lane_statistics.info",
+                  "per_lane_sample_stats.info",
+                  "processing_qc.html",):
+            with open(os.path.join(analysis_dir,f),'wt') as fp:
+                fp.write("")
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,
+                       protocol="standard",
+                       lane_subsets=(
+                           subset(lanes=(1,2,3,),protocol="standard"),
+                           subset(lanes=(4,),protocol="mirna"),
+                           subset(lanes=(5,),protocol="icell8"),
+                           subset(lanes=(6,),protocol="icell8_atac"),
+                           subset(lanes=(7,),protocol="10x_chromium_sc"),
+                           subset(lanes=(8,),protocol="10x_atac")),
+                       analyse_barcodes=False)
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_SN7001250_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "save.bcl2fastq.L123",
+                       "save.bcl2fastq.L4",
+                       "save.bcl2fastq.L5",
+                       "save.bcl2fastq.L6",
+                       "save.bcl2fastq.L7",
+                       "save.bcl2fastq.L8",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        for subdir in ("bcl2fastq.L123",
+                       "bcl2fastq.L4",
+                       "bcl2fastq.L4",
+                       "bcl2fastq.L6",
+                       "bcl2fastq.L7",
+                       "bcl2fastq.L8",):
+            self.assertFalse(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Found subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_SN7001250_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_multiple_protocols_rerun_incomplete_pipeline(self):
+        """
+        MakeFastqs: multiple protocols: rerun incomplete pipeline
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_SN7001250_00002_AHGXXXX",
+            "hiseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write("""[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,AB1,,,N701,TAAGGCGA,S504,AGAGTAGA,AB,
+2,TM2,TM1,,,N701,TAAGGCGA,S517,GCGTAAGA,TM,
+3,CD3,CD3,,,N701,GTGAAACG,S503,TCTTTCCC,CD,
+4,EF4,EF4,,A1,N701,TAAGGCGA,S501,TAGATCGC,EF,
+5,GH5,GH5,,A3,N703,AGGCAGAA,S501,TAGATCGC,GH,
+6,IJB6,IJ6,,F3,N703,AGGCAGAA,S506,ACTGCATA,IJ,
+7,KL7,KL7,,,N701,GCCAATAT,S502,TCTTTCCC,KL,
+8,MN8,MN8,,,N701,GCCAATAT,S503,TCTTTCCC,MN,
+""")
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        MockCellrangerExe.create(os.path.join(self.bin,
+                                              "cellranger"))
+        MockCellrangerExe.create(os.path.join(self.bin,
+                                              "cellranger-atac"),
+                                 reads=('R1','R2','R3','I1',))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Set up mock outputs in analysis directory to mimic
+        # output from a previous incomplete pipeline run
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        for lanes in ((1,2,3,),(4,),(5,),(6,),(7,),(8,)):
+            lanes_id = ''.join([str(l) for l in lanes])
+            dirn = os.path.join(self.wd,"analysis.L%s" % lanes_id)
+            make_mock_bcl2fastq2_output(os.path.join(dirn,"bcl2fastq"),
+                                        lanes=lanes,
+                                        sample_sheet=sample_sheet)
+            os.rename(os.path.join(dirn,"bcl2fastq"),
+                      os.path.join(analysis_dir,
+                                   "save.bcl2fastq.L%s" % lanes_id))
+        # Make a primary data directory
+        os.mkdir(os.path.join(analysis_dir,"primary_data"))
+        os.symlink(run_dir,
+                   os.path.join(analysis_dir,
+                                "primary_data",
+                                os.path.basename(run_dir)))
+        # Make empty stats files
+        for f in ("statistics_full.info",
+                  "statistics.info",
+                  "per_lane_statistics.info",
+                  "per_lane_sample_stats.info",
+                  "processing_qc.html",):
+            with open(os.path.join(analysis_dir,f),'wt') as fp:
+                fp.write("")
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,
+                       protocol="standard",
+                       lane_subsets=(
+                           subset(lanes=(1,2,3,),protocol="standard"),
+                           subset(lanes=(4,),protocol="mirna"),
+                           subset(lanes=(5,),protocol="icell8"),
+                           subset(lanes=(6,),protocol="icell8_atac"),
+                           subset(lanes=(7,),protocol="10x_chromium_sc"),
+                           subset(lanes=(8,),protocol="10x_atac")),
+                       analyse_barcodes=False)
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_SN7001250_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "save.bcl2fastq.L123",
+                       "save.bcl2fastq.L4",
+                       "save.bcl2fastq.L5",
+                       "save.bcl2fastq.L6",
+                       "save.bcl2fastq.L7",
+                       "save.bcl2fastq.L8",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        for subdir in ("bcl2fastq.L12",
+                       "bcl2fastq.L345678",):
+            self.assertFalse(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Found subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_SN7001250_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_multiple_lanes_automatically_split_by_indices(self):
+        """
+        MakeFastqs: multiple lanes (automatically split by indices)
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_SN7001250_00002_AHGXXXX",
+            "hiseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        samplesheet_multiple_protocols = """[Header]
+IEMFileVersion,4
+Date,11/11/2015
+Workflow,GenerateFASTQ
+Application,HiSeq FASTQ Only
+Assay,Nextera XT
+Description,
+Chemistry,Amplicon
+
+[Reads]
+101
+101
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,AB1,,,N701,TAAGGCGA,,,AB,
+2,TM2,TM1,,,N701,GCGTAAGA,,,TM,
+3,CD3,CD3,,,N701,GTGAAACG,S503,TCTTTCCC,CD,
+4,EB4,EB4,,A1,N701,TAAGGCGA,S501,TAGATCGC,EB,
+5,EB5,EB5,,A3,N703,AGGCAGAA,S501,TAGATCGC,EB,
+6,EB6,EB6,,F3,N703,AGGCAGAA,S506,ACTGCATA,EB,
+7,ML7,ML7,,,N701,GCCAATAT,S502,TCTTTCCC,ML,
+8,VL8,VL8,,,N701,GCCAATAT,S503,TCTTTCCC,VL,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_multiple_protocols)
+        # Create mock bcl2fastq and cellranger
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        MockCellrangerExe.create(os.path.join(self.bin,
+                                              "cellranger"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="standard")
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_SN7001250_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "save.bcl2fastq.L12",
+                       "save.bcl2fastq.L345678",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_SN7001250_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_no_demultiplexing(self):
+        """
+        MakeFastqs: standard protocol: no demultiplexing
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with no barcodes
+        samplesheet_no_demultiplexing = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+AB1,AB1,,,,,AB,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_no_demultiplexing)
+        # Create mock bcl2fastq
+        # Check that bases mask is as expected
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 assert_bases_mask="y76,nnnnnn,y76")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet)
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_with_bases_mask(self):
+        """
+        MakeFastqs: standard protocol: set bases mask
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="standard",
+                       bases_mask="y101,I8,I8,y101")
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_icell8_protocol(self):
+        """
+        MakeFastqs: 'icell8' protocol
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        # Check that bases mask, --minimum-trimmed-read-length and
+        # --mask-short-adapter-reads are as expected
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 assert_bases_mask="y25n51,I8,y76",
+                                 assert_minimum_trimmed_read_length=21,
+                                 assert_mask_short_adapter_reads=0)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="icell8")
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_icell8_protocol_rerun_completed_pipeline(self):
+        """
+        MakeFastqs: 'icell8' protocol: rerun completed pipeline
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        # Check that bases mask, --minimum-trimmed-read-length and
+        # --mask-short-adapter-reads are as expected
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 assert_bases_mask="y25n51,I8,y76",
+                                 assert_minimum_trimmed_read_length=21,
+                                 assert_mask_short_adapter_reads=0)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Set up mock outputs in analysis directory to mimic
+        # output from a previous successful pipeline run
+        analysis_dir = os.path.join(self.wd,"analysis")
+        updated_sample_sheet = os.path.join(self.wd,
+                                            "SampleSheet.updated.csv")
+        make_custom_sample_sheet(sample_sheet,updated_sample_sheet)
+        make_mock_bcl2fastq2_output(os.path.join(analysis_dir,
+                                                 "bcl2fastq"),
+                                    lanes=(1,2,3,4),
+                                    sample_sheet=updated_sample_sheet)
+        # Make a primary data directory
+        os.mkdir(os.path.join(analysis_dir,"primary_data"))
+        os.symlink(run_dir,
+                   os.path.join(analysis_dir,
+                                "primary_data",
+                                os.path.basename(run_dir)))
+        # Make empty stats files
+        for f in ("statistics_full.info",
+                  "statistics.info",
+                  "per_lane_statistics.info",
+                  "per_lane_sample_stats.info",
+                  "processing_qc.html",):
+            with open(os.path.join(analysis_dir,f),'wt') as fp:
+                fp.write("")
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="icell8",
+                       analyse_barcodes=False)
+        status = p.run(analysis_dir,
+                       #default_runner=SimpleJobRunner(join_logs=True),
+                       #verbose=True,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_icell8_atac_protocol(self):
+        """
+        MakeFastqs: 'icell8_atac' protocol
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            bases_mask="y101,I8,I8,y101",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write("""[Header]
+IEMFileVersion,4
+
+[Reads]
+101
+101
+
+[Settings]
+ReverseComplement,0
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+Sample1,Sample1,,,D701,CGTGTAGG,D501,GACCTGTA,ICELL8_ATAC,
+Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,ICELL8_ATAC,
+""")
+        # Well list file
+        well_list = os.path.join(self.wd,"WellList.txt")
+        with open(well_list,'wt') as fp:
+            fp.write("""Row	Col	Candidate	For dispense	Sample	Barcode	State	Cells1	Cells2	Signal1	Signal2	Size1	Size2	Integ Signal1	Integ Signal2	Circularity1	Circularity2	Confidence	Confidence1	Confidence2	Dispense tip	Drop index	Global drop index	Source well	Sequencing count	Image1	Image2
+0	57	True	True	Smpl1	TAACCAAG+TAAGGCGA	Good	1	0	105		33		3465		1		1	1	1	1	10	10	A1		img1.tif	img2.tif
+""")
+        # Create mock bcl2fastq
+        # Check that --create-fastq-for-index-read is set
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 assert_create_fastq_for_index_read=True)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="icell8_atac",
+                       well_list=well_list)
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_icell8_atac_protocol_rerun_completed_pipeline(self):
+        """
+        MakeFastqs: 'icell8_atac' protocol: rerun completed pipeline
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            bases_mask="y101,I8,I8,y101",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write("""[Header]
+IEMFileVersion,4
+
+[Reads]
+101
+101
+
+[Settings]
+ReverseComplement,0
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+Sample1,Sample1,,,D701,CGTGTAGG,D501,GACCTGTA,ICELL8_ATAC,
+Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,ICELL8_ATAC,
+""")
+        # Well list file
+        well_list = os.path.join(self.wd,"WellList.txt")
+        with open(well_list,'wt') as fp:
+            fp.write("""Row	Col	Candidate	For dispense	Sample	Barcode	State	Cells1	Cells2	Signal1	Signal2	Size1	Size2	Integ Signal1	Integ Signal2	Circularity1	Circularity2	Confidence	Confidence1	Confidence2	Dispense tip	Drop index	Global drop index	Source well	Sequencing count	Image1	Image2
+0	57	True	True	Smpl1	TAACCAAG+TAAGGCGA	Good	1	0	105		33		3465		1		1	1	1	1	10	10	A1		img1.tif	img2.tif
+""")
+        # Create mock bcl2fastq
+        # Check that --create-fastq-for-index-read is set
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 assert_create_fastq_for_index_read=True)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Set up mock outputs in analysis directory to mimic
+        # output from a previous successful pipeline run
+        analysis_dir = os.path.join(self.wd,"analysis")
+        sample_sheet_icell8_atac = os.path.join(
+            self.wd,"SampleSheet.icell8_atac.csv")
+        with open(sample_sheet_icell8_atac,'wt') as fp:
+            fp.write("""[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+Unassigned-Sample1,Sample1,,,D701,CGTGTAGG,D501,GACCTGTA,ICELL8_ATAC,
+Unassigned-Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,ICELL8_ATAC,
+""")
+        make_mock_bcl2fastq2_output(os.path.join(analysis_dir,
+                                                 "bcl2fastq"),
+                                    lanes=(1,2,3,4),
+                                    reads=('R1','R2','I1','I2'),
+                                    sample_sheet=sample_sheet_icell8_atac)
+        # Make a primary data directory
+        os.mkdir(os.path.join(analysis_dir,"primary_data"))
+        os.symlink(run_dir,
+                   os.path.join(analysis_dir,
+                                "primary_data",
+                                os.path.basename(run_dir)))
+        # Make empty stats files
+        for f in ("statistics_full.info",
+                  "statistics.info",
+                  "per_lane_statistics.info",
+                  "per_lane_sample_stats.info",
+                  "processing_qc.html",):
+            with open(os.path.join(analysis_dir,f),'wt') as fp:
+                fp.write("")
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="icell8_atac",
+                       well_list=well_list,
+                       analyse_barcodes=False)
+        status = p.run(analysis_dir,
+                       #default_runner=SimpleJobRunner(join_logs=True),
+                       #verbose=True,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_10x_chromium_sc_protocol(self):
+        """
+        MakeFastqs: '10x_chromium_sc' protocol
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics Chromium SC indices
+        samplesheet_chromium_sc_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-GA-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_chromium_sc_indices)
+        # Create mock bcl2fastq and cellranger
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        MockCellrangerExe.create(os.path.join(self.bin,
+                                              "cellranger"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="10x_chromium_sc")
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertFalse(os.path.exists(
+            os.path.join(analysis_dir,"barcode_analysis")),
+                         "Found subdir: barcode_analysis")
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_10x_chromium_sc_protocol_rerun_completed_pipeline(self):
+        """
+        MakeFastqs: '10x_chromium_sc' protocol: rerun completed pipeline
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics Chromium SC indices
+        samplesheet_chromium_sc_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-GA-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_chromium_sc_indices)
+        # Create mock bcl2fastq and cellranger
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        MockCellrangerExe.create(os.path.join(self.bin,
+                                              "cellranger"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Set up mock outputs in analysis directory to mimic
+        # output from a previous successful pipeline run
+        analysis_dir = os.path.join(self.wd,"analysis")
+        make_mock_bcl2fastq2_output(os.path.join(analysis_dir,
+                                                 "bcl2fastq"),
+                                    lanes=(1,2,3,4),
+                                    sample_sheet=sample_sheet,
+                                    force_sample_dir=True)
+        # Make a primary data directory
+        os.mkdir(os.path.join(analysis_dir,"primary_data"))
+        os.symlink(run_dir,
+                   os.path.join(analysis_dir,
+                                "primary_data",
+                                os.path.basename(run_dir)))
+        # Make empty stats files
+        for f in ("statistics_full.info",
+                  "statistics.info",
+                  "per_lane_statistics.info",
+                  "per_lane_sample_stats.info",
+                  "processing_qc.html",):
+            with open(os.path.join(analysis_dir,f),'wt') as fp:
+                fp.write("")
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="10x_chromium_sc")
+        status = p.run(analysis_dir,
+                       #default_runner=SimpleJobRunner(join_logs=True),
+                       #verbose=True,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertFalse(os.path.exists(
+            os.path.join(analysis_dir,"barcode_analysis")),
+                         "Found subdir: barcode_analysis")
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_10x_atac_protocol(self):
+        """
+        MakeFastqs: '10x_atac' protocol
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            bases_mask="y101,I8,I8,y101",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics Chromium SC ATAC-seq indices
+        samplesheet_chromium_sc_atac_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-NA-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_chromium_sc_atac_indices)
+        # Create mock bcl2fastq and cellranger-atac
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        MockCellrangerExe.create(os.path.join(self.bin,
+                                              "cellranger-atac"),
+                                 reads=('R1','R2','R3','I1',))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="10x_atac")
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertFalse(os.path.exists(
+            os.path.join(analysis_dir,"barcode_analysis")),
+                         "Found subdir: barcode_analysis")
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_10x_atac_protocol_rerun_completed_pipeline(self):
+        """
+        MakeFastqs: '10x_atac' protocol: rerun completed pipeline
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            bases_mask="y101,I8,I8,y101",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics Chromium SC ATAC-seq indices
+        samplesheet_chromium_sc_atac_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-NA-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_chromium_sc_atac_indices)
+        # Create mock bcl2fastq and cellranger-atac
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        MockCellrangerExe.create(os.path.join(self.bin,
+                                              "cellranger-atac"),
+                                 reads=('R1','R2','R3','I1',))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Set up mock outputs in analysis directory to mimic
+        # output from a previous successful pipeline run
+        analysis_dir = os.path.join(self.wd,"analysis")
+        make_mock_bcl2fastq2_output(os.path.join(analysis_dir,
+                                                 "bcl2fastq"),
+                                    lanes=(1,2,3,4),
+                                    reads=('R1','R2','R3','I1'),
+                                    sample_sheet=sample_sheet,
+                                    force_sample_dir=True)
+        # Make a primary data directory
+        os.mkdir(os.path.join(analysis_dir,"primary_data"))
+        os.symlink(run_dir,
+                   os.path.join(analysis_dir,
+                                "primary_data",
+                                os.path.basename(run_dir)))
+        # Make empty stats files
+        for f in ("statistics_full.info",
+                  "statistics.info",
+                  "per_lane_statistics.info",
+                  "per_lane_sample_stats.info",
+                  "processing_qc.html",):
+            with open(os.path.join(analysis_dir,f),'wt') as fp:
+                fp.write("")
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="10x_atac")
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertFalse(os.path.exists(
+            os.path.join(analysis_dir,"barcode_analysis")),
+                         "Found subdir: barcode_analysis")
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_mirna_protocol(self):
+        """
+        MakeFastqs: 'mirna' protocol
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        # Check --minimum-trimmed-read-length and
+        # --mask-short-adapter-reads
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 assert_minimum_trimmed_read_length=10,
+                                 assert_mask_short_adapter_reads=0)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="mirna")
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_missing_fastqs_no_placeholders(self):
+        """
+        MakeFastqs: standard protocol: missing fastqs, no placeholders
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 missing_fastqs=(
+                                     "Sample1_S1_L001_R1_001.fastq.gz",
+                                     "Sample1_S1_L001_R2_001.fastq.gz",))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet)
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,1)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        for subdir in ("bcl2fastq",
+                       "barcode_analysis",):
+            self.assertFalse(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Found subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertFalse(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Found file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_missing_fastqs_with_placeholders(self):
+        """
+        MakeFastqs: standard protocol: missing fastqs with placeholders
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 missing_fastqs=(
+                                     "Sample1_S1_L001_R1_001.fastq.gz",
+                                     "Sample1_S1_L001_R2_001.fastq.gz",))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet)
+        status = p.run(analysis_dir,
+                       create_empty_fastqs=True,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+            
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_fails_for_missing_bcl2fastq(self):
+        """
+        MakeFastqs: standard protocol: fails for missing bcl2fastq
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet)
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,1)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for subdir in ("bcl2fastq",
+                       "barcode_analysis",):
+            self.assertFalse(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Found subdir: %s" % subdir)
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertFalse(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Found file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_handle_bcl2fastq2_failure(self):
+        """
+        MakeFastqs: standard protocol: handle bcl2fastq2 failure
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq which will fail (i.e.
+        # return non-zero exit code)
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 exit_code=1)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet)
+        status = p.run(analysis_dir,poll_interval=0.5)
+        self.assertEqual(status,1)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for subdir in ("bcl2fastq",
+                       "barcode_analysis",):
+            self.assertFalse(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Found subdir: %s" % subdir)
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertFalse(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Found file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_unknown_sequencer(self):
+        """
+        MakeFastqs: unknown sequencer and no platform specified
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_UNKNOWN_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 platform="miseq")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,platform="miseq")
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_UNKNOWN_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_UNKNOWN_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_explicitly_specify_platform(self):
+        """
+        MakeFastqs: explicitly specify the platform
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_UNKNOWN_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 platform="miseq")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,platform="miseq")
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_UNKNOWN_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_UNKNOWN_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_exception_for_invalid_barcodes(self):
+        """
+        MakeFastqs: raise exception for invalid barcodes
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with special character (backspace)
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write("""[Header],,,,,,,,,
+IEMFileVersion,4
+Date,11/23/2015
+Workflow,GenerateFASTQ
+Application,FASTQ Only
+Assay,TruSeq HT
+Description,
+Chemistry,Amplicon
+
+[Reads]
+101
+101
+
+[Settings]
+ReverseComplement,0
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+Sample1,Sample1,,,D701,CGTGTAGG,D501,GACCTGNN,,
+Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
+""")
+        # Using a samplesheet with invalid barcodes
+        # should raise an exception
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_exception_for_samplesheet_with_invalid_characters(self):
+        """
+        MakeFastqs: raise exception for invalid characters in sample sheet
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with special character (backspace)
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write("""[Header],,,,,,,,,
+IEMFileVersion,4
+Date,11/23/2015
+Workflow,GenerateFASTQ
+Application,FASTQ Only
+Assay,TruSeq HT
+Description,
+Chemistry,Amplicon
+
+[Reads]
+101
+101
+
+[Settings]
+ReverseComplement,0
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+Sample1,Sample1,,,D701,CGTGTAGG,D501,GACCTGTC,,\b
+Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
+""")
+        # Using a samplesheet with invalid characters
+        # should raise an exception
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_exception_for_inconsistent_subsets(self):
+        """
+        MakeFastqs: raise exception for inconsistent subsets
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_SN7001250_00002_AHGXXXX",
+            "hiseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.hiseq)
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Defining subsets with overlapping lanes
+        # should raise an exception
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet,
+                          protocol="standard",
+                          lane_subsets=(
+                              subset(lanes=(1,2,)),
+                              subset(lanes=(3,4,5,6,7,8,)),
+                              subset(lanes=(7,8,))))
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_exception_if_project_is_split(self):
+        """
+        MakeFastqs: raise exception if project is split by subsets
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_SN7001250_00002_AHGXXXX",
+            "hiseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write("""[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,AB1,,,N701,TAAGGCGA,S504,AGAGTAGA,AB,
+2,TM2,TM1,,,N701,TAAGGCGA,S517,GCGTAAGA,TM,
+3,CD3,CD3,,,N701,GTGAAACG,S503,TCTTTCCC,CD,
+4,EB4,EB4,,A1,N701,TAAGGCGA,S501,TAGATCGC,EB,
+5,EB5,EB5,,A3,N703,AGGCAGAA,S501,TAGATCGC,EB,
+6,EB6,EB6,,F3,N703,AGGCAGAA,S506,ACTGCATA,EB,
+7,ML7,ML7,,,N701,GCCAATAT,S502,TCTTTCCC,ML,
+8,VL8,VL8,,,N701,GCCAATAT,S503,TCTTTCCC,VL,
+""")
+        # Create mock bcl2fastq
+        # Check that bases mask is as expected
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Specifying subsets which split a project
+        # should raise an exception
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet,
+                          lane_subsets=(
+                              subset(lanes=(1,2,3,4)),
+                              subset(lanes=(5,6,7,8,))
+                          ))
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_force_copy_of_primary_data(self):
+        """
+        MakeFastqs: force copying of primary data
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet)
+        status = p.run(analysis_dir,
+                       force_copy_of_primary_data=True,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertFalse(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        self.assertTrue(os.path.isdir(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_exception_for_unknown_protocol(self):
+        """
+        MakeFastqs: raise exception for unknown protocol
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Specifying unrecognised protocol should raise an
+        # exception
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet,
+                          protocol="undefined_protocol")
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_fails_for_chromium_sc_indices(self):
+        """
+        MakeFastqs: standard protocol: fails for Chromium SC indices
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics Chromium SC indices
+        samplesheet_chromium_sc_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-GA-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
+smpl3,smpl3,,,A006,SI-GA-C1,10xGenomics,
+smpl4,smpl4,,,A007,SI-GA-D1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_chromium_sc_indices)
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="standard")
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,1)
+
+class TestPathJoinParam(unittest.TestCase):
+    """
+    Tests for the 'PathJoinParam' class
+    """
+    def test_pathjoinparam_with_strings(self):
+        """
+        PathJoinParam: handle static strings
+        """
+        p1 = "/mnt/data"
+        p2 = "test.txt"
+        pth = PathJoinParam(p1,p2)
+        self.assertEqual(pth.value,"/mnt/data/test.txt")
+
+    def test_pathjoinparam_with_pipelineparams(self):
+        """
+        PathJoinParam: handle PipelineParams
+        """
+        p1 = PipelineParam(value="/mnt/data")
+        p2 = PipelineParam(value="test.txt")
+        pth = PathJoinParam(p1,p2)
+        self.assertEqual(pth.value,"/mnt/data/test.txt")
+        p2.set("updated.txt")
+        self.assertEqual(pth.value,"/mnt/data/updated.txt")
+
+    def test_pathjoinparam_with_mixed_input(self):
+        """
+        PathJoinParam: handle mixture of string and PipelineParam
+        """
+        p1 = PipelineParam(value="/mnt/data")
+        p2 = "test.txt"
+        pth = PathJoinParam(p1,p2)
+        self.assertEqual(pth.value,"/mnt/data/test.txt")
+
+class TestPathExistsParam(unittest.TestCase):
+    """
+    Tests for the 'PathExistsParam' class
+    """
+    def setUp(self):
+        # Create a temp working dir
+        self.wd = tempfile.mkdtemp(suffix='TestPathExistsParam')
+
+    def tearDown(self):
+        # Remove the temporary test directory
+        if REMOVE_TEST_OUTPUTS:
+            shutil.rmtree(self.wd)
+    
+    def test_pathexistsparam_with_strings(self):
+        """
+        PathExistsParam: handle static strings
+        """
+        dir_path = self.wd
+        file_path = os.path.join(self.wd,"file.txt")
+        with open(file_path,'wt') as fp:
+            fp.write("test\n")
+        missing_path = os.path.join(self.wd,"missing.txt")
+        self.assertTrue(PathExistsParam(dir_path).value)
+        self.assertTrue(PathExistsParam(file_path).value)
+        self.assertFalse(PathExistsParam(missing_path).value)
+
+    def test_pathexistsparam_with_pipelineparams(self):
+        """
+        PathExistsParam: handle PipelineParams
+        """
+        dir_path = PipelineParam(value=self.wd)
+        file_path = PipelineParam(value=os.path.join(self.wd,"file.txt"))
+        with open(file_path.value,'wt') as fp:
+            fp.write("test\n")
+        missing_path = PipelineParam(
+            value=os.path.join(self.wd,"missing.txt"))
+        self.assertTrue(PathExistsParam(dir_path).value)
+        self.assertTrue(PathExistsParam(file_path).value)
+        self.assertFalse(PathExistsParam(missing_path).value)
+
+    def test_pathexistsparam_with_pathjoinparams(self):
+        """
+        PathExistsParam: handle PathJoinParams
+        """
+        dir_path = PathJoinParam(self.wd)
+        file_path = PathJoinParam(self.wd,"file.txt")
+        with open(file_path.value,'wt') as fp:
+            fp.write("test\n")
+        missing_path = PathJoinParam(self.wd,"missing.txt")
+        self.assertTrue(PathExistsParam(dir_path).value)
+        self.assertTrue(PathExistsParam(file_path).value)
+        self.assertFalse(PathExistsParam(missing_path).value)
+
+class TestFunctionParam(unittest.TestCase):
+    """
+    Tests for the 'FunctionParam' class
+    """
+    #@unittest.skip("Skipped")
+    def test_lambdaparam_with_static_values(self):
+        """
+        FunctionParam: handle static values
+        """
+        # Lambda function
+        lambda_param = FunctionParam(lambda x: x,"hello")
+        self.assertEqual(lambda_param.value,"hello")
+        lambda_param = FunctionParam(lambda x,y: x + y,1,2)
+        self.assertEqual(lambda_param.value,3)
+        # Function with keywords
+        def func(x,y,z=None):
+            return (x,y,z)
+        lambda_param = FunctionParam(func,"hello","goodbye")
+        self.assertEqual(lambda_param.value,("hello","goodbye",None))
+        lambda_param = FunctionParam(func,"hello","goodbye",z="surprise!")
+        self.assertEqual(lambda_param.value,("hello","goodbye","surprise!"))
+
+    def test_lambdaparam_with_parameters(self):
+        """
+        FunctionParam: handle pipeline parameters
+        """
+        # Lambda function
+        p = PipelineParam(value="hello")
+        lambda_param = FunctionParam(lambda x: x,p)
+        self.assertEqual(lambda_param.value,"hello")
+        p.set("goodbye")
+        self.assertEqual(lambda_param.value,"goodbye")
+        px = PipelineParam(value=1)
+        py = PipelineParam(value=2)
+        lambda_param = FunctionParam(lambda x,y: x + y,px,py)
+        self.assertEqual(lambda_param.value,3)
+        px.set(3)
+        py.set(4)
+        self.assertEqual(lambda_param.value,7)
+        # Function with keywords
+        def func(x,y,z=None):
+            return (x,y,z)
+        px = PipelineParam(value="hello")
+        py = PipelineParam(value="goodbye")
+        pz = PipelineParam(value="surprise!")
+        lambda_param = FunctionParam(func,px,py)
+        self.assertEqual(lambda_param.value,("hello","goodbye",None))
+        lambda_param = FunctionParam(func,px,py,z=pz)
+        self.assertEqual(lambda_param.value,("hello","goodbye","surprise!"))
+        px.set("goodbye")
+        py.set("hello")
+        pz.set("backwards")
+        self.assertEqual(lambda_param.value,("goodbye","hello","backwards"))
+
+class TestSubsetFunction(unittest.TestCase):
+    """
+    Tests for 'subset' function
+    """
+    def test_subset_lanes_only(self):
+        """
+        subset: create subset with lanes only
+        """
+        # Basic lane list
+        s = subset([1,2,7,8])
+        self.assertEqual(s['lanes'],[1,2,7,8])
+        # Lanes in random order
+        s = subset([8,7,1,2])
+        self.assertEqual(s['lanes'],[1,2,7,8])
+        # Lanes specified as strings
+        s = subset(['1','2','7','8'])
+        self.assertEqual(s['lanes'],[1,2,7,8])
+
+    def test_subset_set_parameters(self):
+        """
+        subset: create subset with parameters
+        """
+        # Single parameter
+        s = subset([1,2],protocol="standard")
+        self.assertEqual(s['lanes'],[1,2])
+        self.assertEqual(s['protocol'],"standard")
+        # Multiple parameters
+        s = subset([1,2],
+                   protocol="icell8",
+                   icell8_well_list="/files/well_list.txt")
+        self.assertEqual(s['lanes'],[1,2])
+        self.assertEqual(s['protocol'],"icell8")
+        self.assertEqual(s['icell8_well_list'],
+                         "/files/well_list.txt")
+
+    def test_subset_setting_missing_parameter_raises_keyerror(self):
+        """
+        subset: setting missing parameter raises KeyError
+        """
+        with self.assertRaises(KeyError) as ex:
+            s = subset([1,2],
+                       protocol="standard",
+                       missing="not_here")
+
+    def test_subset_accessing_missing_parameter_raises_keyerror(self):
+        """
+        subset: accessing missing parameter raises KeyError
+        """
+        s = subset([1,2],protocol="standard")
+        with self.assertRaises(KeyError) as ex:
+            value = s['missing']
+        
+        
+                   

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -874,6 +874,146 @@ class TestMakeFastqs(unittest.TestCase):
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_makefastqs_require_bcl2fastq_version(self):
+        """
+        MakeFastqs: standard protocol: specify bcl2fastq version
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 version='2.17.1.14')
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet)
+        status = p.run(analysis_dir,
+                       require_bcl2fastq=">=2.17",
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.17.1.14"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_require_bcl2fastq_version_not_found(self):
+        """
+        MakeFastqs: standard protocol: specify bcl2fastq version (not found)
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 version='2.17.1.14')
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Pipeline fails for unsatisfied version requirement
+        p = MakeFastqs(run_dir,sample_sheet)
+        status = p.run(analysis_dir,
+                       require_bcl2fastq="=>2.20",
+                       poll_interval=0.5)
+        self.assertEqual(status,1)
+        # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,None)
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,None)
+        self.assertEqual(p.output.stats_full,None)
+        self.assertEqual(p.output.per_lane_stats,None)
+        self.assertEqual(p.output.per_lane_sample_stats,None)
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        for subdir in ("bcl2fastq",
+                       "barcode_analysis",):
+            self.assertFalse(os.path.exists(
+                os.path.join(analysis_dir,subdir)),
+                            "Found subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertFalse(os.path.exists(
+                os.path.join(analysis_dir,filen)),
+                            "Found file: %s" % filen)
+
+    #@unittest.skip("Skipped")
     def test_makefastqs_standard_protocol_multiple_lanes(self):
         """
         MakeFastqs: standard protocol: multiple lanes

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -1509,8 +1509,6 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         # Create mock bcl2fastq and cellranger
         MockBcl2fastq2Exe.create(os.path.join(self.bin,
                                               "bcl2fastq"))
-        MockCellrangerExe.create(os.path.join(self.bin,
-                                              "cellranger"))
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         analysis_dir = os.path.join(self.wd,"analysis")

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -90,6 +90,16 @@ class TestMakeFastqs(unittest.TestCase):
                           "2.17.1.14"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -152,6 +162,16 @@ class TestMakeFastqs(unittest.TestCase):
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -216,6 +236,16 @@ class TestMakeFastqs(unittest.TestCase):
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -286,6 +316,16 @@ class TestMakeFastqs(unittest.TestCase):
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -349,6 +389,10 @@ class TestMakeFastqs(unittest.TestCase):
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,None)
+        self.assertEqual(p.output.stats_full,None)
+        self.assertEqual(p.output.per_lane_stats,None)
+        self.assertEqual(p.output.per_lane_sample_stats,None)
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -414,6 +458,16 @@ class TestMakeFastqs(unittest.TestCase):
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -482,6 +536,16 @@ class TestMakeFastqs(unittest.TestCase):
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -546,6 +610,16 @@ class TestMakeFastqs(unittest.TestCase):
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -610,6 +684,16 @@ class TestMakeFastqs(unittest.TestCase):
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -679,6 +763,16 @@ class TestMakeFastqs(unittest.TestCase):
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -730,6 +824,27 @@ class TestMakeFastqs(unittest.TestCase):
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -792,6 +907,16 @@ class TestMakeFastqs(unittest.TestCase):
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
@@ -844,6 +969,27 @@ class TestMakeFastqs(unittest.TestCase):
                        poll_interval=0.5)
         self.assertEqual(status,0)
         # Check outputs
+        self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
                        "bcl2fastq",
@@ -927,6 +1073,16 @@ class TestMakeFastqs(unittest.TestCase):
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -989,6 +1145,16 @@ class TestMakeFastqs(unittest.TestCase):
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
@@ -1097,6 +1263,16 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
@@ -1206,6 +1382,16 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
@@ -1311,6 +1497,16 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                           "cellranger",
                           "2.2.0"))
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
@@ -1429,6 +1625,16 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                           "cellranger",
                           "2.2.0"))
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
@@ -1555,6 +1761,16 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                           "cellranger",
                           "2.2.0"))
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
@@ -1652,6 +1868,16 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
@@ -1719,6 +1945,16 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
@@ -1805,6 +2041,16 @@ AB1,AB1,,,,,AB,
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -1867,6 +2113,16 @@ AB1,AB1,,,,,AB,
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -1932,6 +2188,16 @@ AB1,AB1,,,,,AB,
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -2022,6 +2288,16 @@ AB1,AB1,,,,,AB,
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -2107,6 +2383,16 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,ICELL8_ATAC,
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -2224,6 +2510,16 @@ Unassigned-Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,ICELL8_ATAC,
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -2305,6 +2601,16 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                           "cellranger",
                           "2.2.0"))
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -2411,6 +2717,16 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                           "cellranger",
                           "2.2.0"))
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -2497,6 +2813,16 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                           "cellranger-atac",
                           "2.2.0"))
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -2604,6 +2930,16 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                           "cellranger-atac",
                           "2.2.0"))
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -2671,6 +3007,16 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -2735,6 +3081,10 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,None)
+        self.assertEqual(p.output.stats_full,None)
+        self.assertEqual(p.output.per_lane_stats,None)
+        self.assertEqual(p.output.per_lane_sample_stats,None)
         self.assertEqual(p.output.missing_fastqs,
                          ["Sample1/Sample1_S1_L001_R1_001.fastq.gz",
                           "Sample1/Sample1_S1_L001_R2_001.fastq.gz"])
@@ -2805,6 +3155,16 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,
                          ["Sample1/Sample1_S1_L001_R1_001.fastq.gz",
                           "Sample1/Sample1_S1_L001_R2_001.fastq.gz"])
@@ -2860,6 +3220,10 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
         self.assertEqual(p.output.bcl2fastq_info,None)
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,None)
+        self.assertEqual(p.output.stats_full,None)
+        self.assertEqual(p.output.per_lane_stats,None)
+        self.assertEqual(p.output.per_lane_sample_stats,None)
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),):
@@ -2925,6 +3289,10 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,None)
+        self.assertEqual(p.output.stats_full,None)
+        self.assertEqual(p.output.per_lane_stats,None)
+        self.assertEqual(p.output.per_lane_sample_stats,None)
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),):
@@ -2990,6 +3358,10 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,None)
+        self.assertEqual(p.output.stats_full,None)
+        self.assertEqual(p.output.per_lane_stats,None)
+        self.assertEqual(p.output.per_lane_sample_stats,None)
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_UNKNOWN_00002_AHGXXXX"),):
@@ -3055,6 +3427,16 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                           "2.20.0.422"))
         self.assertEqual(p.output.cellranger_info,None)
         self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_UNKNOWN_00002_AHGXXXX"),

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -2855,54 +2855,54 @@ class TestFunctionParam(unittest.TestCase):
     Tests for the 'FunctionParam' class
     """
     #@unittest.skip("Skipped")
-    def test_lambdaparam_with_static_values(self):
+    def test_functionparam_with_static_values(self):
         """
         FunctionParam: handle static values
         """
         # Lambda function
-        lambda_param = FunctionParam(lambda x: x,"hello")
-        self.assertEqual(lambda_param.value,"hello")
-        lambda_param = FunctionParam(lambda x,y: x + y,1,2)
-        self.assertEqual(lambda_param.value,3)
+        func_param = FunctionParam(lambda x: x,"hello")
+        self.assertEqual(func_param.value,"hello")
+        func_param = FunctionParam(lambda x,y: x + y,1,2)
+        self.assertEqual(func_param.value,3)
         # Function with keywords
         def func(x,y,z=None):
             return (x,y,z)
-        lambda_param = FunctionParam(func,"hello","goodbye")
-        self.assertEqual(lambda_param.value,("hello","goodbye",None))
-        lambda_param = FunctionParam(func,"hello","goodbye",z="surprise!")
-        self.assertEqual(lambda_param.value,("hello","goodbye","surprise!"))
+        func_param = FunctionParam(func,"hello","goodbye")
+        self.assertEqual(func_param.value,("hello","goodbye",None))
+        func_param = FunctionParam(func,"hello","goodbye",z="surprise!")
+        self.assertEqual(func_param.value,("hello","goodbye","surprise!"))
 
-    def test_lambdaparam_with_parameters(self):
+    def test_functionparam_with_parameters(self):
         """
         FunctionParam: handle pipeline parameters
         """
         # Lambda function
         p = PipelineParam(value="hello")
-        lambda_param = FunctionParam(lambda x: x,p)
-        self.assertEqual(lambda_param.value,"hello")
+        func_param = FunctionParam(lambda x: x,p)
+        self.assertEqual(func_param.value,"hello")
         p.set("goodbye")
-        self.assertEqual(lambda_param.value,"goodbye")
+        self.assertEqual(func_param.value,"goodbye")
         px = PipelineParam(value=1)
         py = PipelineParam(value=2)
-        lambda_param = FunctionParam(lambda x,y: x + y,px,py)
-        self.assertEqual(lambda_param.value,3)
+        func_param = FunctionParam(lambda x,y: x + y,px,py)
+        self.assertEqual(func_param.value,3)
         px.set(3)
         py.set(4)
-        self.assertEqual(lambda_param.value,7)
+        self.assertEqual(func_param.value,7)
         # Function with keywords
         def func(x,y,z=None):
             return (x,y,z)
         px = PipelineParam(value="hello")
         py = PipelineParam(value="goodbye")
         pz = PipelineParam(value="surprise!")
-        lambda_param = FunctionParam(func,px,py)
-        self.assertEqual(lambda_param.value,("hello","goodbye",None))
-        lambda_param = FunctionParam(func,px,py,z=pz)
-        self.assertEqual(lambda_param.value,("hello","goodbye","surprise!"))
+        func_param = FunctionParam(func,px,py)
+        self.assertEqual(func_param.value,("hello","goodbye",None))
+        func_param = FunctionParam(func,px,py,z=pz)
+        self.assertEqual(func_param.value,("hello","goodbye","surprise!"))
         px.set("goodbye")
         py.set("hello")
         pz.set("backwards")
-        self.assertEqual(lambda_param.value,("goodbye","hello","backwards"))
+        self.assertEqual(func_param.value,("goodbye","hello","backwards"))
 
 class TestSubsetFunction(unittest.TestCase):
     """

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -1646,7 +1646,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,ICELL8_ATAC,
         os.mkdir(analysis_dir)
         # Do the test
         p = MakeFastqs(run_dir,sample_sheet,protocol="icell8_atac",
-                       well_list=well_list)
+                       icell8_well_list=well_list)
         status = p.run(analysis_dir,
                        poll_interval=0.5)
         self.assertEqual(status,0)
@@ -1749,7 +1749,7 @@ Unassigned-Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,ICELL8_ATAC,
                 fp.write("")
         # Do the test
         p = MakeFastqs(run_dir,sample_sheet,protocol="icell8_atac",
-                       well_list=well_list,
+                       icell8_well_list=well_list,
                        analyse_barcodes=False)
         status = p.run(analysis_dir,
                        #default_runner=SimpleJobRunner(join_logs=True),

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -1776,6 +1776,12 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 7,KL7,KL7,,,N701,GCCAATAT,S502,TCTTTCCC,KL,
 8,MN8,MN8,,,N701,GCCAATAT,S503,TCTTTCCC,MN,
 """)
+        # Well list file
+        well_list = os.path.join(self.wd,"WellList.txt")
+        with open(well_list,'wt') as fp:
+            fp.write("""Row	Col	Candidate	For dispense	Sample	Barcode	State	Cells1	Cells2	Signal1	Signal2	Size1	Size2	Integ Signal1	Integ Signal2	Circularity1	Circularity2	Confidence	Confidence1	Confidence2	Dispense tip	Drop index	Global drop index	Source well	Sequencing count	Image1	Image2
+0	57	True	True	Smpl1	TAACCAAG+TAAGGCGA	Good	1	0	105		33		3465		1		1	1	1	1	10	10	A1		img1.tif	img2.tif
+""")
         # Create mock bcl2fastq and cellranger
         MockBcl2fastq2Exe.create(os.path.join(self.bin,
                                               "bcl2fastq"))
@@ -1823,7 +1829,8 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                            subset(lanes=(1,2,3,),protocol="standard"),
                            subset(lanes=(4,),protocol="mirna"),
                            subset(lanes=(5,),protocol="icell8"),
-                           subset(lanes=(6,),protocol="icell8_atac"),
+                           subset(lanes=(6,),protocol="icell8_atac",
+                                  icell8_well_list=well_list),
                            subset(lanes=(7,),protocol="10x_chromium_sc"),
                            subset(lanes=(8,),protocol="10x_atac")),
                        analyse_barcodes=False)
@@ -1915,6 +1922,12 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 7,KL7,KL7,,,N701,GCCAATAT,S502,TCTTTCCC,KL,
 8,MN8,MN8,,,N701,GCCAATAT,S503,TCTTTCCC,MN,
 """)
+        # Well list file
+        well_list = os.path.join(self.wd,"WellList.txt")
+        with open(well_list,'wt') as fp:
+            fp.write("""Row	Col	Candidate	For dispense	Sample	Barcode	State	Cells1	Cells2	Signal1	Signal2	Size1	Size2	Integ Signal1	Integ Signal2	Circularity1	Circularity2	Confidence	Confidence1	Confidence2	Dispense tip	Drop index	Global drop index	Source well	Sequencing count	Image1	Image2
+0	57	True	True	Smpl1	TAACCAAG+TAAGGCGA	Good	1	0	105		33		3465		1		1	1	1	1	10	10	A1		img1.tif	img2.tif
+""")
         # Create mock bcl2fastq
         MockBcl2fastq2Exe.create(os.path.join(self.bin,
                                               "bcl2fastq"))
@@ -1959,7 +1972,8 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                            subset(lanes=(1,2,3,),protocol="standard"),
                            subset(lanes=(4,),protocol="mirna"),
                            subset(lanes=(5,),protocol="icell8"),
-                           subset(lanes=(6,),protocol="icell8_atac"),
+                           subset(lanes=(6,),protocol="icell8_atac",
+                                  icell8_well_list=well_list),
                            subset(lanes=(7,),protocol="10x_chromium_sc"),
                            subset(lanes=(8,),protocol="10x_atac")),
                        analyse_barcodes=False)

--- a/auto_process_ngs/test/commands/test_update_fastq_stats_cmd.py
+++ b/auto_process_ngs/test/commands/test_update_fastq_stats_cmd.py
@@ -9,6 +9,7 @@ import os
 from auto_process_ngs.auto_processor import AutoProcess
 from auto_process_ngs.mock import MockAnalysisDirFactory
 from auto_process_ngs.commands.update_fastq_stats_cmd import update_fastq_stats
+from auto_process_ngs.commands.update_fastq_stats_cmd import report_processing_qc
 
 # Set to False to keep test output dirs
 REMOVE_TEST_OUTPUTS = True
@@ -66,3 +67,85 @@ class TestAutoProcessUpdateFastqStats(unittest.TestCase):
         for filen in stats_files:
             self.assertTrue(os.path.exists(os.path.join(mockdir.dirn,filen)),
                              "%s: missing" % filen)
+
+class TestReportProcessingQC(unittest.TestCase):
+    """
+    Tests for report_processing_qc function
+    """
+    def setUp(self):
+        # Create a temp working dir
+        self.wd = tempfile.mkdtemp(suffix='TestReportProcessingQC')
+
+    def tearDown(self):
+        if REMOVE_TEST_OUTPUTS:
+            shutil.rmtree(self.wd)
+
+    #@unittest.skip("Skipped")
+    def test_report_processing_qc(self):
+        """report_processing_qc: standard report
+        """
+        # Create test data
+        analysis_dir = os.path.join(self.wd,
+                                    "180430_K00311_0001_ABCDEFGHXX_analysis")
+        os.mkdir(analysis_dir)
+        per_lane_sample_stats = os.path.join(analysis_dir,
+                                             "per_lane_sample_stats.info")
+        with open(per_lane_sample_stats,'w') as fp:
+            fp.write("""
+Lane 1
+Total reads = 136778255
+- AB/AB1	25058003	18.3%
+- AB/AB2	22330927	16.3%
+- AB/AB3	34509382	25.2%
+- AB/AB4	27283286	19.9%
+- Undetermined_indices/undetermined	27596657	20.2%
+
+Lane 2
+Total reads = 136778255
+- CDE/CDE1	25058003	18.3%
+- CDE/CDE2	22330927	16.3%
+- CDE/CDE3	34509382	25.2%
+- CDE/CDE4	27283286	19.9%
+- Undetermined_indices/undetermined	27596657	20.2%
+""")
+        per_lane_statistics = os.path.join(analysis_dir,
+                                           "per_lane_statistics.info")
+        with open(per_lane_statistics,'w') as fp:
+            fp.write("""#Lane	Total reads	Assigned reads	Unassigned reads	%assigned	%unassigned
+Lane 1	136778255	109181598	27596657	79.8	20.2
+Lane 2	136778255	109181598	27596657	79.8	20.2
+""")
+        statistics_full = os.path.join(analysis_dir,
+                                       "statistics_full.info")
+        with open(statistics_full,'w') as fp:
+            fp.write("""#Project	Sample	Fastq	Size	Nreads	Paired_end	Read_number	L1	L2
+AB	AB1	AB1_S1_R1_001.fastq.gz	1.0G	25058003	Y	1	25058003	
+AB	AB1	AB1_S1_R2_001.fastq.gz	1.1G	25058003	Y	2	25058003	
+AB	AB2	AB2_S2_R1_001.fastq.gz	941.7M	22330927	Y	1	22330927	
+AB	AB2	AB2_S2_R2_001.fastq.gz	1.0G	22330927	Y	2	22330927	
+AB	AB3	AB3_S3_R1_001.fastq.gz	1.4G	34509382	Y	1	34509382	
+AB	AB3	AB3_S3_R2_001.fastq.gz	1.6G	34509382	Y	2	34509382	
+AB	AB4	AB4_S4_R1_001.fastq.gz	1.1G	27283286	Y	1	27283286	
+AB	AB4	AB4_S4_R2_001.fastq.gz	1.2G	27283286	Y	2	27283286	
+CDE	CDE1	CDE1_S5_R1_001.fastq.gz	1.0G	25058003	Y	1		25058003
+CDE	CDE1	CDE1_S5_R2_001.fastq.gz	1.1G	25058003	Y	2		25058003
+CDE	CDE2	CDE2_S6_R1_001.fastq.gz	941.7M	22330927	Y	1		22330927
+CDE	CDE2	CDE2_S6_R2_001.fastq.gz	1.0G	22330927	Y	2		22330927
+CDE	CDE3	CDE3_S7_R1_001.fastq.gz	1.4G	34509382	Y	1		34509382
+CDE	CDE3	CDE3_S7_R2_001.fastq.gz	1.6G	34509382	Y	2		34509382
+CDE	CDE4	CDE4_S8_R1_001.fastq.gz	1.1G	27283286	Y	1		27283286
+CDE	CDE4	CDE4_S8_R2_001.fastq.gz	1.2G	27283286	Y	2		27283286
+Undetermined_indices	undetermined	Undetermined_S0_R1_001.fastq.gz	22.0G	27596657	Y	1	27596657	27596657
+Undetermined_indices	undetermined	Undetermined_S0_R2_001.fastq.gz	24.0G	27596657	Y	2	27596657	27596657
+""")
+        # Generate QC report
+        output_html = os.path.join(analysis_dir,
+                                   "processing_report.html")
+        self.assertFalse(os.path.exists(output_html))
+        report_processing_qc(AutoProcess(analysis_dir),output_html)
+        self.assertTrue(os.path.exists(output_html))
+        # Check the HTML
+        with open(output_html,'rt') as fp:
+            html = fp.read()
+        # No warnings
+        self.assertTrue(html.find("<p>Status: OK</p>") > -1)

--- a/auto_process_ngs/test/test_settings.py
+++ b/auto_process_ngs/test/test_settings.py
@@ -41,6 +41,9 @@ class TestSettings(unittest.TestCase):
         self.assertEqual(s.modulefiles.publish_qc,None)
         self.assertEqual(s.modulefiles.process_icell8,None)
         self.assertEqual(s.modulefiles.process_10xgenomics,None)
+        self.assertEqual(s.modulefiles.bcl2fastq,None)
+        self.assertEqual(s.modulefiles.cellranger_mkfastq,None)
+        self.assertEqual(s.modulefiles.cellranger_atac_mkfastq,None)
         self.assertEqual(s.modulefiles.illumina_qc,None)
         self.assertEqual(s.modulefiles.fastq_strand,None)
         self.assertEqual(s.modulefiles.cellranger,None)
@@ -87,6 +90,9 @@ nprocessors = 8
         self.assertEqual(s.general.poll_interval,5.0)
         # Modulefiles
         self.assertEqual(s.modulefiles.make_fastqs,None)
+        self.assertEqual(s.modulefiles.bcl2fastq,None)
+        self.assertEqual(s.modulefiles.cellranger_mkfastq,None)
+        self.assertEqual(s.modulefiles.cellranger_atac_mkfastq,None)
         self.assertEqual(s.modulefiles.run_qc,None)
         # Fastq_stats
         self.assertEqual(s.fastq_stats.nprocessors,8)

--- a/config/auto_process.ini.sample
+++ b/config/auto_process.ini.sample
@@ -10,16 +10,19 @@ poll_interval = 5
 # Specify modulefiles as a comma-separated list
 [modulefiles]
 make_fastqs = None
+bcl2fastq = None
+cellranger_mkfastq = None
+cellranger_atac_mkfastq = None
 run_qc = None
-publish_qc = None
-process_icell8 = None
-process_10xgenomics = None
 illumina_qc = None
 fastq_strand = None
 cellranger = None
 report_qc = None
+publish_qc = None
+process_icell8 = None
 cutadapt = None
 fastq_screen = None
+process_10xgenomics = None
 
 # bcl2fastq settings
 [bcl2fastq]

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -292,7 +292,7 @@ The ``[modulefiles]`` section in ``auto_process.ini`` allows specific module
 files to be loaded before a specific step, for example::
 
     [modulefiles]
-    make_fastqs = apps/bcl2fastq/1.8.4
+    make_fastqs = apps/bcl2fastq/2.20
 
 These can be defined for the following stages:
 
@@ -309,6 +309,22 @@ for each of these stages.)
 
    These can be overridden for the ``make_fastqs`` and ``run_qc`` stages
    using the ``--modulefiles`` option.
+
+Environment modules for Fastq generation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For the ``make_fastqs`` stage, additional module files can be specified
+for individual tasks with the Fastq generation pipeline:
+
+* ``bcl2fastq``
+* ``cellranger_mkfastq``
+* ``cellranger_atac_mkfastq``
+
+If any of these are defined then they will be loaded for the relevant
+tasks in the Fastq generation pipeline.
+
+Environment modules for the QC pipeline
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For the ``run_qc`` stage, additional module files can be specified for
 individual tasks within the QC pipeline:

--- a/docs/source/single_cell/10xgenomics.rst
+++ b/docs/source/single_cell/10xgenomics.rst
@@ -24,7 +24,7 @@ The recommended steps are:
 
 1. Generate the Fastqs as described in
    :ref:`make_fastqs-10x_chromium_sc-protocol` or
-   :ref:`make_fastqs-10x_chromium_sc_atac-protocol`
+   :ref:`make_fastqs-10x_atac-protocol`
 2. Set up analysis directories and run initial QC as per the standard
    protocol
 3. Perform initial single library analysis by running the

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -28,7 +28,7 @@ Protocol option          Used for
 ``icell8_atac``          ICELL8 single-cell ATAC-seq data
 ``10x_chromium_sc``      10xGenomics Chromium single-cell
                          RNA-seq data
-``10x_chromium_sc_atac`` 10xGenomics Chromium single-cell
+``10x_atac``             10xGenomics Chromium single-cell
                          ATAC-seq data
 ======================== =====================================
 
@@ -55,7 +55,7 @@ subsequent sections:
 * :ref:`make_fastqs-icell8-protocol`
 * :ref:`make_fastqs-icell8-atac-protocol`
 * :ref:`make_fastqs-10x_chromium_sc-protocol`
-* :ref:`make_fastqs-10x_chromium_sc_atac-protocol`
+* :ref:`make_fastqs-10x_atac-protocol`
 * :ref:`make_fastqs-adapter-trimming-and-masking`
 * :ref:`make_fastqs-mixed-protocols`
 
@@ -227,18 +227,17 @@ This will generate the Fastqs in the specified output directory
    behaviour of ``cellranger mkfastqs``, for example setting the
    jobmode (see :ref:`10xgenomics-additional-options`).
 
-.. _make_fastqs-10x_chromium_sc_atac-protocol:
+.. _make_fastqs-10x_atac-protocol:
 
-Fastq generation for 10xGenomics Chromium single-cell ATAC-seq data (``--protocol=10x_chromium_sc_atac``)
+Fastq generation for 10xGenomics single-cell ATAC-seq data (``--protocol=10x_atac``)
 ---------------------------------------------------------------------------------------------------------
 
-Fastq generation can be performed for 10xGenomics Chromium
-single-cell ATAC-seq data by using the ``--protocol=10x_chromium_sc_atac``
-option:
+Fastq generation can be performed for 10xGenomics single-cell
+ATAC-seq data by using the ``--protocol=10x_atac`` option:
 
 ::
 
-    auto_process.py make_fastqs --protocol=10x_chromium_sc_atac ...
+    auto_process.py make_fastqs --protocol=10x_atac ...
 
 which fetches the data and runs ``cellranger-atac mkfastq``.
 

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -32,6 +32,10 @@ Protocol option          Used for
                          ATAC-seq data
 ======================== =====================================
 
+The protocols are described in the section :ref:`make_fastqs-protocols`;
+information on most useful options can be found in
+:ref:`make_fastqs-commonly-used-options`.
+
 By default ``make_fastqs`` performs the following steps:
 
 * Fetches the BCL data and copies it to the ``primary_data`` subdirectory
@@ -50,66 +54,40 @@ Various options are available to skip or control each of these stages;
 more detail on the different usage modes can be found in the
 subsequent sections:
 
+* :ref:`make_fastqs-adapter-trimming-and-masking`
+* :ref:`make_fastqs-mixed-protocols`
+
+The outputs produced on successful completion are described below
+in the section :ref:`make_fastqs-outputs`.
+
+.. note::
+
+   Advice on handling unusual cases and problems can be found
+   in the section :doc:`troubleshooting`.
+
+Once the Fastqs have been generated, the next step is to set up the
+project directories - see
+:doc:`Setting up project directories <setup_analysis_dirs>`.
+
+.. _make_fastqs-protocols:
+
+Fastq generation protocols
+--------------------------
+
+The pre-defined protocols for Fastq generation are described in
+the sections below:
+
 * :ref:`make_fastqs-standard-protocol`
 * :ref:`make_fastqs-mirna-protocol`
 * :ref:`make_fastqs-icell8-protocol`
 * :ref:`make_fastqs-icell8-atac-protocol`
 * :ref:`make_fastqs-10x_chromium_sc-protocol`
 * :ref:`make_fastqs-10x_atac-protocol`
-* :ref:`make_fastqs-adapter-trimming-and-masking`
-* :ref:`make_fastqs-mixed-protocols`
-
-Information on other commonly used options can be found
-:ref:`below <make_fastqs-commonly-used-options>`.
-
-Advice on handling other unusual cases and problems can be found
-here:
-
-* :doc:`Troubleshooting unusual situations <troubleshooting>`
-
-Once the Fastqs have been generated, the next step is to set up the
-project directories - see
-:doc:`Setting up project directories <setup_analysis_dirs>`.
-
-.. _make_fastqs-commonly-used-options:
-
-Commonly used options
----------------------
-
-Some of the most commonly used options are:
-
-* ``--output-dir``: specifies the directory to write the output
-  Fastqs to (defaults to ``bcl2fastq``)
-* ``--sample-sheet``: specifies a non-default sample sheet file
-  to use (defaults to ``custom_SampleSheet.csv``; the new sample
-  sheet file will become the default for subsequent runs)
-* ``--lanes``: allows a subset of lanes to be processed (useful
-  for multi-lane sequencers when samples with a mixture
-  of processing protocols have been run). Lanes can be specified
-  as a range (e.g. ``1-4``), a list (e.g. ``6,8``) or a
-  combination (e.g. ``1-4,6,8``)
-* ``--use-bases-mask``: allows a custom bases mask string (which
-  controls how each cycle of raw data is used) to be specified
-  (default is to determine the bases mask automatically; set to
-  ``auto`` to restore this behaviour)
-* ``--platform``: if the sequencer platform cannot be identified
-  from the instrument name it can be explicitly specified using
-  this option (see :ref:`config_sequencer_platforms` for how to
-  associate sequencers and platforms in the configuration)
-* ``--no-barcode-analysis`` skips the barcode analysis for
-  standard runs (helpful when handling runs requiring multiple
-  rounds of processing; see :ref:`make_fastqs-mixed-protocols`)
-* ``--no-stats`` skips the generation of statistics and processing
-  QC reporting (helpful when handling runs requiring multiple
-  rounds of processing; see :ref:`make_fastqs-mixed-protocols`)
-
-The full set of options can be found in the
-:ref:`'make_fastqs' section of the command reference <commands_make_fastqs>`.
 
 .. _make_fastqs-standard-protocol:
 
-Standard Fastq generation (``--protocol=standard``)
----------------------------------------------------
+Standard data (``--protocol=standard``)
+***************************************
 
 The Fastq generation for standard data is performed using a command
 of the form:
@@ -126,8 +104,8 @@ will highlight issues with the demultiplexing.
 
 .. _make_fastqs-mirna-protocol:
 
-miRNA-seq Fastq generation (``--protocol=mirna``)
--------------------------------------------------
+miRNA-seq data (``--protocol=mirna``)
+*************************************
 
 Initial Fastqs can be generated from miRNA-seq data using the
 ``--protocol=mirna`` option:
@@ -150,8 +128,8 @@ found in the section :ref:`make_fastqs-adapter-trimming-and-masking`.
 
 .. _make_fastqs-icell8-protocol:
 
-Fastq generation for ICELL8 single-cell RNA-seq data (``--protocol=icell8``)
-----------------------------------------------------------------------------
+ICELL8 single-cell RNA-seq data (``--protocol=icell8``)
+*******************************************************
 
 Initial Fastqs can be generated from ICELL8 single-cell8 RNA-seq data
 using the ``--protocol=icell8`` option:
@@ -183,8 +161,8 @@ the Fastqs.
 
 .. _make_fastqs-icell8-atac-protocol:
 
-Fastq generation for ICELL8 single-cell ATAC-seq data (``--protocol=icell8_atac``)
-----------------------------------------------------------------------------------
+ICELL8 single-cell ATAC-seq data (``--protocol=icell8_atac``)
+*************************************************************
 
 Initial Fastqs can be generated from ICELL8 single-cell8 ATAC-seq data
 using the ``--protocol=icell8_atac`` option:
@@ -204,8 +182,8 @@ file which must be supplied via the mandatory ``--well-list`` argument.
 
 .. _make_fastqs-10x_chromium_sc-protocol:
 
-Fastq generation for 10xGenomics Chromium single-cell RNA-seq data (``--protocol=10x_chromium_sc``)
----------------------------------------------------------------------------------------------------
+10xGenomics Chromium single-cell RNA-seq data (``--protocol=10x_chromium_sc``)
+******************************************************************************
 
 Fastq generation can be performed for 10xGenomics Chromium
 single-cell RNA-seq data by using the ``--protocol=10x_chromium_sc``
@@ -229,8 +207,8 @@ This will generate the Fastqs in the specified output directory
 
 .. _make_fastqs-10x_atac-protocol:
 
-Fastq generation for 10xGenomics single-cell ATAC-seq data (``--protocol=10x_atac``)
----------------------------------------------------------------------------------------------------------
+10xGenomics single-cell ATAC-seq data (``--protocol=10x_atac``)
+***************************************************************
 
 Fastq generation can be performed for 10xGenomics single-cell
 ATAC-seq data by using the ``--protocol=10x_atac`` option:
@@ -250,6 +228,41 @@ This will generate the Fastqs in the specified output directory
    ``make_fastqs`` offers various options for controlling the
    behaviour of ``cellranger-atac mkfastqs``, for example setting the
    jobmode (see :ref:`10xgenomics-additional-options`).
+
+.. _make_fastqs-commonly-used-options:
+
+Commonly used options
+---------------------
+
+Some of the most commonly used options are:
+
+* ``--protocol``: specifies the Fastq generation protocol
+* ``--output-dir``: specifies the directory to write the output
+  Fastqs to (defaults to ``bcl2fastq``)
+* ``--sample-sheet``: specifies a non-default sample sheet file
+  to use (defaults to ``custom_SampleSheet.csv``; the new sample
+  sheet file will become the default for subsequent runs)
+* ``--lanes``: allows a subset of lanes to be processed (useful
+  for multi-lane sequencers when samples with a mixture
+  of processing protocols have been run). Lanes can be specified
+  as a range (e.g. ``1-4``), a list (e.g. ``6,8``) or a
+  combination (e.g. ``1-4,6,8``). See
+  :ref:`make_fastqs-mixed-protocols` for more details.
+* ``--use-bases-mask``: allows a custom bases mask string (which
+  controls how each cycle of raw data is used) to be specified
+  (default is to determine the bases mask automatically; set to
+  ``auto`` to restore this behaviour)
+* ``--platform``: if the sequencer platform cannot be identified
+  from the instrument name it can be explicitly specified using
+  this option (see :ref:`config_sequencer_platforms` for how to
+  associate sequencers and platforms in the configuration)
+* ``--no-barcode-analysis`` skips the barcode analysis for
+  standard runs
+* ``--no-stats`` skips the generation of statistics and processing
+  QC reporting
+
+The full set of options can be found in the
+:ref:`'make_fastqs' section of the command reference <commands_make_fastqs>`.
 
 .. _make_fastqs-adapter-trimming-and-masking:
 
@@ -292,10 +305,10 @@ off masking.
 
 .. _make_fastqs-mixed-protocols:
 
-Fastq generation for runs with mixed protocols
-----------------------------------------------
+Fastq generation for runs with mixed protocols and options
+----------------------------------------------------------
 
-Multi-lane instruments such as the HISeq platform provide the
+Multi-lane instruments such as the HiSeq platform provide the
 option to run mixtures of samples requiring different processing
 protocols in a single sequencing run, for example:
 
@@ -305,89 +318,134 @@ protocols in a single sequencing run, for example:
 * Some lanes contain standard samples whilst others contain
   10xGenomics or ICELL8 single-cell samples
 
-In these cases the data cannot be processed in a single
-``make_fastqs`` run. Instead the recommended procedure for
-handling these situations is:
+``make_fastqs`` is able to process these in a single run provided
+that:
 
-1. Prepare a single sample sheet with the appropriate indexes
-   for each lane (for example truncating index sequences, or
-   inserting the appropriate 10xGenomics indexes)
-2. Run ``make_fastqs`` multiple times to process each subset of
-   lanes on their own using the ``--lanes`` option, specifying the
-   appropriate protocol and processing options and writing the
-   Fastqs for each to a different output directory using the
-   ``--output-dir`` option
-3. Combine the outputs from each subset into a single output
-   directory using the ``merge_fastq_dirs`` command
-4. (Re)generate the statistics and QC report on the merged
-   data using the ``update_fastq_stats`` command
+* the sample sheet has the appropriate index sequences for
+  each lane (for example, truncating index sequences, or
+  inserting the appropriate 10xGenomics indexes); and
+* where different protocols or processing options need to
+  be specified for groups of lanes, that these are specified
+  via multiple ``--lanes`` options.
 
-For example: say we have a HISeq run with non-standard samples
-in lanes 5 and 6, and standard samples in all other lanes. In
-this case, after updating the samplesheet the standard samples
-would be processed first:
+``make_fastqs`` will process each set of lanes separately
+before combining them into a single output directory at the
+end.
+
+For example: say we have a HiSeq run with non-standard samples
+in lanes 5 and 6, and standard samples in all other lanes.
+
+If the samples in lanes 5 and 6 have different barcode lengths
+to those in the other lanes, but should otherwise be treated
+the same, then the following command line would be sufficient
+to handle this:
 
 ::
 
+   auto_process.py make_fastqs \
+	    --sample-sheet=SampleSheet.updated.csv
+
+However if the samples in lanes 5 and 6 were 10xGenomics
+Chromium single cell data, then it is necessary to explicitly
+specify which lanes to group together and how each group should
+be handled. This is done using the ``--lanes`` option to
+indicate that the ``10x_chromium_sc`` protocol should be used
+with lanes 5 and 6, and that the ``standard`` protocol should
+be used with the other lanes:
+
+::
+
+   auto_process.py make_fastqs \
+            --lanes=1-4,7-8:standard \
+	    --lanes=5,6:10x_chromium_sc \
+	    --sample-sheet=SampleSheet.updated.csv
+
+
+.. note::
+
+   If the ``--lanes`` option is used one or more times then
+   only those lanes explicitly listed will be processed.
+   Lanes that aren't specified will be excluded from the
+   processing.
+
+More generally it's possible to set multiple options on a
+set of lanes using the lanes option, for example to explicitly
+specify the adapter sequences for lane 8:
+
+::
+
+   auto_process.py make_fastqs \
+            --lanes=1-7 \
+	    --lanes=8:adapter=CTGTCTCTTATACACATCT \
+	    --sample-sheet=SampleSheet.updated.csv
+
+The general form of the ``--lanes`` option is:
+
+::
+
+   --lanes=LANES[:protocol][:OPTION=VALUE[:OPTION=VALUE...]]
+
+The available options are:
+
+===================================== ==================================
+Option                                Description
+===================================== ==================================
+``bases_mask=BASES_MASK``             Set bases mask
+``trim_adapters=yes|no``              Turn adapter trimming on or off
+``adapter=SEQUENCE``                  Set adapter sequence for trimming
+``adapter_read2=SEQUENCE``            Set read2 adapter sequence
+``minimum_trimmed_read_length=N``     Set minimum trimmed read length
+``mask_short_adapter_reads=N``        Set minimum read length below
+                                      which sequences are masked
+``icell8_well_list=FILE``             Well list file (``icell8`` and
+                                      ``icell8_atac`` protocols only)
+``icell8_atac_swap_i1_and_i2=yes|no`` Turn I1/I2 swapping on or off
+                                      (``icell8_atac`` protocol only)
+``icell8_atac_reverse_complement``    Set reverse complementing option
+                                      (``icell8_atac`` protocol only)
+``analyse_barcodes=yes|no``           Turn barcode analysis on or off
+===================================== ==================================
+
+These options will override the defaults and any global values
+set by the top-level options.
+
+It is also possible to process subsets of lanes manually, and
+then use the ``merge_fastq_dirs``, ``update_fastq_stats`` and
+``analyse_barcodes`` commands to combine and analyse the Fastqs.
+
+For example, for the mixture of standard and 10xGenomics samples
+previously described this might look like:
+
+::
+
+   # Process lanes 1-4,7-8 (standard samples)
    auto_process.py make_fastqs \
             --lanes=1-4,7-8 \
 	    --sample-sheet=SampleSheet.updated.csv \
             --output-dir=bcl2fastq.L123478 \
-            --no-barcode-analysis \
-	    --no-stats
-
-The ``--lanes`` option restricts the lanes to just those with
-the standard samples. ``--output-dir`` writes the Fastqs to a
-custom output directory. Specifying ``--no-stats`` suppresses
-the statistics generation at this stage.
-
-Next process the non-standard samples, for example: if the
-samples in lanes 5 and 6 had different barcode lengths:
-
-::
-
-   auto_process.py make_fastqs \
-            --lanes=5-6 \
-            --output-dir=bcl2fastq.L56 \
             --use-bases-mask=auto \
             --no-barcode-analysis \
 	    --no-stats
 
-Alternatively if the data in these lanes were 10xGenomics
-Chromium single cell data:
-
-::
-
+   # Process lanes 5-6 (10xGenomics samples)
    auto_process.py make_fastqs \
             --lanes=5-6 \
+	    --sample-sheet=SampleSheet.updated.csv \
 	    --protocol=10x_chromium_sc \
             --output-dir=bcl2fastq.L56 \
             --use-bases-mask=auto \
 	    --no-stats
 
-The outputs from each subset of lanes can be merged into a
-single output directory using the ``merge_fastq_dirs`` command.
-For example:
-
-::
-
+   # Combine outputs
    auto_process.py merge_fastq_dirs \
              --primary-unaligned-dir=bcl2fastq.L123478 \
 	     --output-dir=bcl2fastq
 
-To generate the statistics and processing QC report for the
-merged data use the ``update_fastq_stats`` command:
-
-::
-
+   # Generate statistics
    auto_process.py update_fastq_stats
 
-To perform the barcode analysis for the merged data use the
-``analyse_barcodes`` command:
-
-::
-
-   auto_process.py analyse_barcodes
+   # Analyse barcodes (standard samples only)
+   auto_process.py analyse_barcodes --lanes=1-4,7-8
 
 See the appropriate sections of the command reference for
 the full set of available options:


### PR DESCRIPTION
PR which reimplements the code underlying the `make_fastqs` command as a `Pipeline` instance.

The pipeline code is in a new module `bcl2fastq/pipeline.py`, with most of the original (non-pipeline) code moved from the `commands/make_fastq.py` module. The changes include:

* `make_fastqs` can now handle splitting the processing of a multilane sequencing run within a single invocation (issue #5), by specifying the `--lanes` option multiple times and setting protocol and other processing options for subsets of lanes. Groups of lanes with different barcode lengths defined in the sample sheet are automatically processed separately, and merging of split runs is also performed automatically;
* Pipeline uses per-task environment modules, so it's not necessary to use the command-level modulefile setting for `make_fastqs` (avoiding problem with issue #505 under Python3)
* `make_fastqs` and `update_fastq_stats` will take the number of processors from the job runner if values are not explicitly supplied via the settings or command line;
* `icell8_atac` protocol handles the full pipeline for ICELL8 ATAC data;
* `10x_chromium_sc_atac` protocol has been renamed to `10x_atac`;
* Several deprecated command line options have been removed.