### PR TITLE
Pipeliner: explicitly set the working directory in wrapper scripts

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2564,7 +2564,7 @@ class PipelineCommand(object):
         return sanitize_name(self._name)
 
     def make_wrapper_script(self,scripts_dir=None,shell="/bin/bash",
-                            envmodules=None):
+                            envmodules=None,working_dir=None):
         """
         Generate a uniquely-named wrapper script to run the command
 
@@ -2573,6 +2573,8 @@ class PipelineCommand(object):
             the wrapper scripts to
           shell (str): shell to use (defaults to '/bin/bash')
           envmodules (str): list of environment modules to load
+          working_dir (str): explicitly specify the directory
+            the script should be executed in
 
         Returns:
           String: name of the wrapper script.
@@ -2592,6 +2594,9 @@ class PipelineCommand(object):
             for module in envmodules:
                 if module is not None:
                     prologue.append("module load %s" % module)
+        if working_dir:
+            prologue.append("cd %s" % working_dir)
+            prologue.append("echo CWD now $(pwd)")
         epilogue = ["exit_code=$?",
                     "echo \"#### END $(date)\"",
                     "echo \"#### EXIT_CODE $exit_code\"",

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2589,7 +2589,6 @@ class PipelineCommand(object):
         prologue = ["echo \"#### COMMAND %s\"" % self._name,
                     "echo \"#### HOSTNAME $HOSTNAME\"",
                     "echo \"#### USER $USER\"",
-                    "echo \"#### CWD $(pwd)\"",
                     "echo \"#### START $(date)\""]
         if envmodules:
             shell += " --login"
@@ -2598,7 +2597,7 @@ class PipelineCommand(object):
                     prologue.append("module load %s" % module)
         if working_dir:
             prologue.append("cd %s" % working_dir)
-            prologue.append("echo CWD now $(pwd)")
+        prologue.append("echo \"#### CWD $(pwd)\"")
         epilogue = ["exit_code=$?",
                     "echo \"#### END $(date)\"",
                     "echo \"#### EXIT_CODE $exit_code\"",

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2315,7 +2315,8 @@ class PipelineTask(object):
                     self.report("%s" % command.cmd())
                 script_file = command.make_wrapper_script(
                     scripts_dir=scripts_dir,
-                    envmodules=envmodules)
+                    envmodules=envmodules,
+                    working_dir=self._working_dir)
                 cmd = Command('/bin/bash')
                 if envmodules:
                     cmd.add_args('-l')
@@ -2345,7 +2346,8 @@ class PipelineTask(object):
                     self.report("%s" % batch_cmd.cmd())
                 script_file = batch_cmd.make_wrapper_script(
                     scripts_dir=scripts_dir,
-                    envmodules=envmodules)
+                    envmodules=envmodules,
+                    working_dir=self._working_dir)
                 cmd = Command('/bin/bash')
                 if envmodules:
                     cmd.add_args('-l')

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -1673,6 +1673,46 @@ class TestPipelineCommand(unittest.TestCase):
                          "echo \"#### EXIT_CODE $exit_code\"\n"
                          "exit $exit_code")
 
+    def test_pipelinecommand_with_working_dir(self):
+        """
+        PipelineCommand: check command and wrapper script with working dir
+        """
+        # Subclass PipelineCommand
+        class EchoCmd(PipelineCommand):
+            def init(self,txt):
+                self._txt = txt
+            def cmd(self):
+                return Command(
+                    "echo",
+                    self._txt)
+        # Make an instance
+        cmd = EchoCmd("hello there")
+        # Check name
+        self.assertEqual(cmd.name(),"echocmd")
+        # Check command
+        self.assertEqual(str(cmd.cmd()),"echo hello there")
+        # Check wrapper script file
+        script_file = cmd.make_wrapper_script(
+            scripts_dir=self.working_dir,
+            working_dir="/tmp/command/wd")
+        self.assertTrue(os.path.isfile(script_file))
+        self.assertEqual(os.path.dirname(script_file),
+                         self.working_dir)
+        self.assertEqual(open(script_file,'r').read(),
+                         "#!/bin/bash\n"
+                         "echo \"#### COMMAND EchoCmd\"\n"
+                         "echo \"#### HOSTNAME $HOSTNAME\"\n"
+                         "echo \"#### USER $USER\"\n"
+                         "echo \"#### CWD $(pwd)\"\n"
+                         "echo \"#### START $(date)\"\n"
+                         "cd /tmp/command/wd\n"
+                         "echo CWD now $(pwd)\n"
+                         "echo 'hello there'\n"
+                         "exit_code=$?\n"
+                         "echo \"#### END $(date)\"\n"
+                         "echo \"#### EXIT_CODE $exit_code\"\n"
+                         "exit $exit_code")
+
 class TestPipelineCommandWrapper(unittest.TestCase):
 
     def test_piplinecommandwrapper(self):

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -1238,8 +1238,8 @@ class TestPipelineTask(unittest.TestCase):
         # #### COMMAND Echo text
         # #### HOSTNAME popov
         # #### USER pjb
-        # #### CWD /tmp/dir
         # #### START Thu Aug 17 08:38:14 BST 2017
+        # #### CWD /tmp/dir
         # Hello!
         # #### END Thu Aug 17 08:38:14 BST 2017
         # #### EXIT_CODE 0
@@ -1248,8 +1248,8 @@ class TestPipelineTask(unittest.TestCase):
         self.assertEqual(stdout[0],"#### COMMAND Echo text")
         self.assertEqual(stdout[1],"#### HOSTNAME %s" % self._hostname())
         self.assertEqual(stdout[2],"#### USER %s" % self._user())
-        self.assertEqual(stdout[3],"#### CWD %s" % self.working_dir)
-        self.assertTrue(stdout[4].startswith("#### START "))
+        self.assertTrue(stdout[3].startswith("#### START "))
+        self.assertEqual(stdout[4],"#### CWD %s" % self.working_dir)
         self.assertEqual(stdout[5],"Hello!")
         self.assertTrue(stdout[6].startswith("#### END "))
         self.assertEqual(stdout[7],"#### EXIT_CODE 0")
@@ -1288,16 +1288,16 @@ class TestPipelineTask(unittest.TestCase):
         # #### COMMAND Echo text
         # #### HOSTNAME popov
         # #### USER pjb
-        # #### CWD /tmp/dir
         # #### START Thu Aug 17 08:38:14 BST 2017
+        # #### CWD /tmp/dir
         # Hello!
         # #### END Thu Aug 17 08:38:14 BST 2017
         # #### EXIT_CODE 0
         # #### COMMAND Echo text
         # #### HOSTNAME popov
         # #### USER pjb
-        # #### CWD /tmp/dir
         # #### START Thu Aug 17 08:38:14 BST 2017
+        # #### CWD /tmp/dir
         # Goodbye!
         # #### END Thu Aug 17 08:38:14 BST 2017
         # #### EXIT_CODE 0
@@ -1306,16 +1306,16 @@ class TestPipelineTask(unittest.TestCase):
         self.assertEqual(stdout[0],"#### COMMAND Echo text")
         self.assertEqual(stdout[1],"#### HOSTNAME %s" % self._hostname())
         self.assertEqual(stdout[2],"#### USER %s" % self._user())
-        self.assertEqual(stdout[3],"#### CWD %s" % self.working_dir)
-        self.assertTrue(stdout[4].startswith("#### START "))
+        self.assertTrue(stdout[3].startswith("#### START "))
+        self.assertEqual(stdout[4],"#### CWD %s" % self.working_dir)
         self.assertEqual(stdout[5],"Hello!")
         self.assertTrue(stdout[6].startswith("#### END "))
         self.assertEqual(stdout[7],"#### EXIT_CODE 0")
         self.assertEqual(stdout[8],"#### COMMAND Echo text")
         self.assertEqual(stdout[9],"#### HOSTNAME %s" % self._hostname())
         self.assertEqual(stdout[10],"#### USER %s" % self._user())
-        self.assertEqual(stdout[11],"#### CWD %s" % self.working_dir)
-        self.assertTrue(stdout[12].startswith("#### START "))
+        self.assertTrue(stdout[11].startswith("#### START "))
+        self.assertEqual(stdout[12],"#### CWD %s" % self.working_dir)
         self.assertEqual(stdout[13],"Goodbye!")
         self.assertTrue(stdout[14].startswith("#### END "))
         self.assertEqual(stdout[15],"#### EXIT_CODE 0")
@@ -1355,8 +1355,8 @@ class TestPipelineTask(unittest.TestCase):
         # #### COMMAND Batch commands for Echo string
         # #### HOSTNAME popov
         # #### USER pjb
-        # #### CWD /tmp/dir
         # #### START Thu Aug 17 08:38:14 BST 2017
+        # #### CWD /tmp/dir
         # Hello!
         # Goodbye!
         # #### END Thu Aug 17 08:38:14 BST 2017
@@ -1367,8 +1367,8 @@ class TestPipelineTask(unittest.TestCase):
                          "#### COMMAND Batch commands for Echo string")
         self.assertEqual(stdout[1],"#### HOSTNAME %s" % self._hostname())
         self.assertEqual(stdout[2],"#### USER %s" % self._user())
-        self.assertEqual(stdout[3],"#### CWD %s" % self.working_dir)
-        self.assertTrue(stdout[4].startswith("#### START "))
+        self.assertTrue(stdout[3].startswith("#### START "))
+        self.assertEqual(stdout[4],"#### CWD %s" % self.working_dir)
         self.assertEqual(stdout[5],"Hello!")
         self.assertEqual(stdout[6],"Goodbye!")
         self.assertTrue(stdout[7].startswith("#### END "))
@@ -1406,8 +1406,8 @@ class TestPipelineTask(unittest.TestCase):
         # #### COMMAND Nonexistant
         # #### HOSTNAME popov
         # #### USER pjb
-        # #### CWD /tmp/dir
         # #### START Thu Aug 17 08:38:14 BST 2017
+        # #### CWD /tmp/dir
         # #### END Thu Aug 17 08:38:14 BST 2017
         # #### EXIT_CODE 127
         stdout = task.stdout.split("\n")
@@ -1415,8 +1415,8 @@ class TestPipelineTask(unittest.TestCase):
         self.assertEqual(stdout[0],"#### COMMAND Nonexistant")
         self.assertEqual(stdout[1],"#### HOSTNAME %s" % self._hostname())
         self.assertEqual(stdout[2],"#### USER %s" % self._user())
-        self.assertEqual(stdout[3],"#### CWD %s" % self.working_dir)
-        self.assertTrue(stdout[4].startswith("#### START "))
+        self.assertTrue(stdout[3].startswith("#### START "))
+        self.assertEqual(stdout[4],"#### CWD %s" % self.working_dir)
         self.assertTrue(stdout[5].startswith("#### END "))
         self.assertEqual(stdout[6],"#### EXIT_CODE 127")
 
@@ -1453,8 +1453,8 @@ class TestPipelineTask(unittest.TestCase):
         # #### COMMAND Echo text
         # #### HOSTNAME popov
         # #### USER pjb
-        # #### CWD /tmp/dir
         # #### START Thu Aug 17 08:38:14 BST 2017
+        # #### CWD /tmp/dir
         # Hello!
         # #### END Thu Aug 17 08:38:14 BST 2017
         # #### EXIT_CODE 0
@@ -1466,8 +1466,8 @@ class TestPipelineTask(unittest.TestCase):
             self.assertEqual(stdout[0+i*8],"#### COMMAND Echo text")
             self.assertEqual(stdout[1+i*8],"#### HOSTNAME %s" % self._hostname())
             self.assertEqual(stdout[2+i*8],"#### USER %s" % self._user())
-            self.assertEqual(stdout[3+i*8],"#### CWD %s" % self.working_dir)
-            self.assertTrue(stdout[4+i*8].startswith("#### START "))
+            self.assertTrue(stdout[3+i*8].startswith("#### START "))
+            self.assertEqual(stdout[4+i*8],"#### CWD %s" % self.working_dir)
             self.assertEqual(stdout[5+i*8],"Hello!")
             self.assertTrue(stdout[6+i*8].startswith("#### END "))
             self.assertEqual(stdout[7+i*8],"#### EXIT_CODE 0")
@@ -1624,8 +1624,8 @@ class TestPipelineCommand(unittest.TestCase):
                          "echo \"#### COMMAND EchoCmd\"\n"
                          "echo \"#### HOSTNAME $HOSTNAME\"\n"
                          "echo \"#### USER $USER\"\n"
-                         "echo \"#### CWD $(pwd)\"\n"
                          "echo \"#### START $(date)\"\n"
+                         "echo \"#### CWD $(pwd)\"\n"
                          "echo 'hello there'\n"
                          "exit_code=$?\n"
                          "echo \"#### END $(date)\"\n"
@@ -1663,10 +1663,10 @@ class TestPipelineCommand(unittest.TestCase):
                          "echo \"#### COMMAND EchoCmd\"\n"
                          "echo \"#### HOSTNAME $HOSTNAME\"\n"
                          "echo \"#### USER $USER\"\n"
-                         "echo \"#### CWD $(pwd)\"\n"
                          "echo \"#### START $(date)\"\n"
                          "module load apps/fastq-screen/0.13.0\n"
                          "module load apps/fastqc/0.11.8\n"
+                         "echo \"#### CWD $(pwd)\"\n"
                          "echo 'hello there'\n"
                          "exit_code=$?\n"
                          "echo \"#### END $(date)\"\n"
@@ -1703,10 +1703,9 @@ class TestPipelineCommand(unittest.TestCase):
                          "echo \"#### COMMAND EchoCmd\"\n"
                          "echo \"#### HOSTNAME $HOSTNAME\"\n"
                          "echo \"#### USER $USER\"\n"
-                         "echo \"#### CWD $(pwd)\"\n"
                          "echo \"#### START $(date)\"\n"
                          "cd /tmp/command/wd\n"
-                         "echo CWD now $(pwd)\n"
+                         "echo \"#### CWD $(pwd)\"\n"
                          "echo 'hello there'\n"
                          "exit_code=$?\n"
                          "echo \"#### END $(date)\"\n"


### PR DESCRIPTION
PR which updates the `PipelineTask` `run` method so that the working directory for each job in a task is explicitly set when generating the wrapper scripts for each command.

Previously the working directory appears to have been set implicitly, with the wrapper scripts being generated and launched while from the same working directory as the `setup` task was run in. However this mechanism doesn't appear to be robust, with occasional failures which appeared to be due to tasks running in the wrong directory. This PR should hopefully address these failures in future.