### PR TITLE
report_qc.py: fix missing 'cellranger count' outputs in zip file

### DIFF
--- a/bin/reportqc.py
+++ b/bin/reportqc.py
@@ -79,6 +79,8 @@ def zip_report(project,report_html,qc_dir=None,qc_protocol=None):
     for f in expected_outputs(project,qc_dir,
                               fastq_strand_conf=
                               os.path.join(qc_dir,"fastq_strand.conf"),
+                              cellranger_refdata=
+                              project.qc_info(qc_dir).cellranger_refdata,
                               qc_protocol=qc_protocol):
         if f.endswith('.zip'):
             # Exclude .zip file


### PR DESCRIPTION
PR to fix an issue with `cellranger count` outputs not being included in the zip file produced by `report_qc.py` when summarising the QC for a project.

The bug seems to have been introduced as a side effect of PR #540, which updated the `expected_outputs` function (in `qc.outputs`) so that the cellranger reference data needed to be explitcitly specified for 'cellranger count' outputs to be included (it's stored in the QC metadata so just needed to be pulled out). 