### PR TITLE
AnalysisProject: implement stricter tests in the 'is_analysis_dir' property

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -873,10 +873,28 @@ class AnalysisProject(object):
 
     @property
     def is_analysis_dir(self):
-        """Determine if directory really is an analysis project
-
         """
-        return len(self.samples) > 0
+        Determine if directory really is an analysis project
+
+        This is a strict test:
+
+        - the project must contain Fastqs
+        - the project must contain a valid metadata file
+        """
+        if not self.fastqs:
+            # No Fastqs
+            return False
+        if not os.path.exists(self.info_file):
+            # No metadata file
+            return False
+        try:
+            AnalysisProjectInfo().load(self.info_file,
+                                       fail_on_error=True)
+        except Exception:
+            # Failed to load valid metadata file
+            return False
+        # All tests passed
+        return True
 
     @property
     def qc_dir(self):

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -186,6 +186,58 @@ class TestMetadataDict(unittest.TestCase):
         self.assertEqual(unpickled.valediction,'goodbye')
         self.assertEqual(unpickled.chit_chat,'stuff')
 
+    def test_fail_on_error(self):
+        """
+        Metadata: check 'fail_on_error' operates correctly for loading
+        """
+        # Set up a metadata dictionary
+        metadata = MetadataDict(attributes={'salutation':'salutation',
+                                            'valediction': 'valediction'})
+        # Create a valid file
+        self.metadata_file = tempfile.mkstemp()[1]
+        contents = ('salutation\thello',
+                    'valediction\tgoodbye')
+        with open(self.metadata_file,'wt') as fp:
+            for line in contents:
+                fp.write("%s\n" % line)
+        # Load into the dictionary and check that all
+        # items are present
+        metadata.load(self.metadata_file,
+                      strict=False,
+                      fail_on_error=True)
+        self.assertEqual(metadata.salutation,'hello')
+        self.assertEqual(metadata.valediction,'goodbye')
+        # Load into the dictionary in 'strict' mode
+        metadata.load(self.metadata_file,
+                      strict=True,
+                      fail_on_error=True)
+        self.assertEqual(metadata.salutation,'hello')
+        self.assertEqual(metadata.valediction,'goodbye')
+        # Create a valid file with an additional item
+        self.metadata_file = tempfile.mkstemp()[1]
+        contents = ('salutation\thello',
+                    'valediction\tgoodbye',
+                    'chit_chat\tstuff')
+        with open(self.metadata_file,'wt') as fp:
+            for line in contents:
+                fp.write("%s\n" % line)
+        # Loading should raise exception when 'strict'
+        # is also turned on
+        self.assertRaises(Exception,
+                          metadata.load,
+                          self.metadata_file,
+                          strict=True,
+                          fail_on_error=True)
+        # Loading an invalid file should raise exception
+        self.metadata_file = tempfile.mkstemp()[1]
+        with open(self.metadata_file,'wt') as fp:
+            fp.write("This is not valid content\n")
+        self.assertRaises(Exception,
+                          metadata.load,
+                          self.metadata_file,
+                          strict=False,
+                          fail_on_error=True)
+
 class TestAnalysisDirParameters(unittest.TestCase):
     """Tests for the AnalysisDirParameters class
     """


### PR DESCRIPTION
PR that reimplements the internals of the `AnalysisProject.is_analysis_dir` property (in the `analysis` module) to use stricter tests for project directories, specifically:

* There must be Fastqs
* There must be a valid metadata file

The PR also makes the following updates:

* Adds a new `fail_on_error` option to the `MetadataDict.load()` method (in the `metadata` module), which causes exceptions to be raised if a loaded file contains invalid content; this change is needed to check the validity of the metadata file in `is_analysis_dir`.
* Changes the default check on discovered projects in the `AutoProcess.get_analysis_projects_from_dirs()` method (in the `auto_processor` module) to use a basic check on samples by default, and adds a new `strict` flag to enforce the stricter tests now implemented in `is_analysis_dir`