### PR TITLE
pipeliner: enable per-runner slots to be accessed in tasks & set maximum slots in pipelines

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2054,6 +2054,31 @@ class PipelineTask(object):
                 stdout.append(fp.read())
         return ''.join(stdout)
 
+    @property
+    def runner_nslots(self):
+        """
+        Get number of slots (i.e. available CPUs) set by runner
+
+        This returns the code to use when constructing
+        commands in task `setup`, to access the number
+        of CPUs available to the command as set in the
+        job runner which is used at runtime.
+
+        For example:
+
+        >>> cmd = PipelineCommandWrapper(
+        ...     "Run bowtie",
+        ...     "bowtie2",
+        ...     "-x",self.args.index_basename,
+        ...     "-U",self.args.fastq,
+        ...     "-S",self.args.sam_out,
+        ...     "--threads",self.runner_nslots)
+
+        Returns:
+          String: environment variable to get slots from.
+        """
+        return "$BCFTBX_RUNNER_NSLOTS"
+
     def name(self):
         """
         Get the name of the task
@@ -2516,6 +2541,23 @@ class PipelineFunctionTask(PipelineTask):
         PipelineTask.__init__(self,_name,*args,**kws)
         self._dispatchers = []
         self._result = None
+
+    @property
+    def runner_nslots(self):
+        """
+        Get number of slots (i.e. available CPUs) set by runner
+
+        This returns the number of CPUs available at
+        runtime by fetching the value of the
+        `BCFTBX_RUNNER_NSLOTS` environment variable.
+
+        It should be invoked from within the function
+        being run.
+
+        Returns:
+          String: number of slots.
+        """
+        return os.environ["BCFTBX_RUNNER_NSLOTS"]
 
     def add_call(self,name,f,*args,**kwds):
         """

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2025,6 +2025,9 @@ class PipelineTask(object):
     or more 'PipelineCommand' instances.
 
     """
+    # Environment variable with slots set by job runners
+    _NSLOTS_ENV_VAR="BCFTBX_RUNNER_NSLOTS"
+
     def __init__(self,_name,*args,**kws):
         """
         Create a new PipelineTask instance
@@ -2146,7 +2149,7 @@ class PipelineTask(object):
         Returns:
           String: environment variable to get slots from.
         """
-        return "$BCFTBX_RUNNER_NSLOTS"
+        return "$%s" % self._NSLOTS_ENV_VAR
 
     def name(self):
         """
@@ -2626,7 +2629,7 @@ class PipelineFunctionTask(PipelineTask):
         Returns:
           String: number of slots.
         """
-        return os.environ["BCFTBX_RUNNER_NSLOTS"]
+        return os.environ[self._NSLOTS_ENV_VAR]
 
     def add_call(self,name,f,*args,**kwds):
         """


### PR DESCRIPTION
PR that attempts to enable more flexible CPU-resource allocation within pipelines:

- `PipelineTask` and `PipelineFunctionTask` objects can use new method `runner_nslots` to access the number of slots/CPUs assigned to a job runner (using the mechanism implemented in https://github.com/fls-bioinformatics-core/genomics/pull/152).
- `Pipeline.run()` exposes the `max_slots` parameter (introduced in PR #564) and sets this creating the scheduler for running jobs. If this is set to a non-null/non-zero value then the total number of slots across all running jobs cannot exceed this limit.

(Limiting the total number of CPUs in use at once probably only really makes sense for pipelines exclusively using `SimpleJobRunner`s.)