### PR TITLE
QC pipeline: get default number of threads from job runners

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -686,7 +686,16 @@ def add_run_qc_command(cmdparser):
                    "<QC_DIR>_report.html)")
     add_runner_option(p)
     add_modulefiles_option(p)
-    add_debug_option(p)
+    # Advanced options
+    advanced = p.add_argument_group('Advanced/debugging options')
+    advanced.add_argument('--verbose',action="store_true",
+                          dest="verbose",default=False,
+                          help="run pipeline in 'verbose' mode")
+    advanced.add_argument('--work-dir',action="store",
+                          dest="working_dir",default=None,
+                          help="specify the working directory for the "
+                          "pipeline operations")
+    add_debug_option(advanced)
     # Deprecated options
     deprecated = p.add_argument_group('Deprecated/defunct options')
     deprecated.add_argument('--no-ungzip-fastqs',action='store_true',
@@ -1264,7 +1273,9 @@ def run_qc(args):
                        cellranger_premrna_references=
                        cellranger_premrna_references,
                        report_html=args.html_file,
-                       runner=runner)
+                       runner=runner,
+                       working_dir=args.working_dir,
+                       verbose=args.verbose)
     sys.exit(retcode)
 
 def publish_qc(args):

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -473,6 +473,10 @@ def add_make_fastqs_command(cmdparser):
                         "the specified indices from the well list when "
                         "matching ATAC barcodes against well list")
     # Cellranger (10xgenomics Chromium SC 3') options
+    default_cellranger_localcores = __settings['10xgenomics'].\
+                                    cellranger_localcores
+    if not default_cellranger_localcores:
+        default_cellranger_localcores = 1
     cellranger = p.add_argument_group('Cellranger options (10xGenomics '
                                       'Chromium SC 3\' and ATAC data only)')
     cellranger.add_argument("--jobmode",
@@ -491,12 +495,13 @@ def add_make_fastqs_command(cmdparser):
                             __settings['10xgenomics'].cellranger_mempercore)
     cellranger.add_argument("--localcores",
                             dest="local_cores",
-                            default=__settings['10xgenomics'].\
-                            cellranger_localcores,
+                            default=default_cellranger_localcores,
                             help="maximum cores cellranger can request at one"
                             "time for jobmode 'local' (ignored for other "
                             "jobmodes) (default: %s)" %
-                            __settings['10xgenomics'].cellranger_localcores)
+                            ("taken from job runner"
+                             if not default_cellranger_localcores
+                             else default_cellranger_localcores))
     cellranger.add_argument("--localmem",
                             dest="local_mem",
                             default=__settings['10xgenomics'].\

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -640,7 +640,9 @@ def add_run_qc_command(cmdparser):
     p.add_argument('-t','--threads',action='store',dest="nthreads",
                    type=int,default=default_nthreads,
                    help="number of threads to use for QC script "
-                   "(default: %d)" % default_nthreads)
+                   "(default: %s)" % ('taken from job runner'
+                                      if not default_nthreads
+                                      else default_nthreads,))
     p.add_argument('--ungzip-fastqs',action='store_true',dest='ungzip_fastqs',
                    help="create decompressed copies of fastq.gz files")
     p.add_argument('--max-jobs',action='store',

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -31,6 +31,7 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
            cellranger_transcriptomes=None,
            cellranger_premrna_references=None,
            report_html=None,run_multiqc=True,
+           working_dir=None,verbose=None,
            poll_interval=None):
     """Run QC pipeline script for projects
 
@@ -78,6 +79,10 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
         report (default: '<QC_DIR>_report.html')
       run_multiqc (bool): if True then run MultiQC at the end of
         the QC run (default)
+      working_dir (str): path to a working directory (defaults to
+         temporary directory in the current directory)
+      verbose (bool): if True then report additional information
+         for pipeline diagnostics
       poll_interval (float): specifies non-default polling
         interval for scheduler used for running QC
 
@@ -191,5 +196,7 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
                        max_jobs=max_jobs,
                        runners=runners,
                        default_runner=default_runner,
-                       envmodules=envmodules)
+                       envmodules=envmodules,
+                       working_dir=working_dir,
+                       verbose=verbose)
     return status

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 #######################################################################
 
 def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
-           fastq_screen_subset=100000,nthreads=1,
+           fastq_screen_subset=100000,nthreads=None,
            runner=None,fastq_dir=None,qc_dir=None,
            cellranger_chemistry='auto',
            cellranger_transcriptomes=None,

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1093,7 +1093,7 @@ class RunCellrangerCount(PipelineTask):
             cellranger (default: None)
           cellranger_localcores (int): maximum number of cores
             cellranger can request in jobmode 'local'
-            (default: None)
+            (defaults to number of slots set in runner)
           cellranger_localmem (int): maximum memory cellranger
             can request in jobmode 'local' (default: None)
           qc_protocol (str): QC protocol to use
@@ -1135,12 +1135,21 @@ class RunCellrangerCount(PipelineTask):
                 cmd.add_args("--chemistry",self.args.chemistry)
             elif cellranger_exe == "cellranger-atac":
                 cmd.add_args("--reference",self.args.reference_data_path)
+            # Set number of local cores
+            if self.args.cellranger_localcores:
+                localcores = self.args.cellranger_localcores
+            elif self.args.cellranger_jobmode == "local":
+                # Get number of local cores from runner
+                localcores = self.runner_nslots
+            else:
+                # Not in jobmode 'local'
+                localcores = None
             add_cellranger_args(cmd,
                                 jobmode=self.args.cellranger_jobmode,
                                 mempercore=self.args.cellranger_mempercore,
                                 maxjobs=self.args.cellranger_maxjobs,
                                 jobinterval=self.args.cellranger_jobinterval,
-                                localcores=self.args.cellranger_localcores,
+                                localcores=localcores,
                                 localmem=self.args.cellranger_localmem)
             self.add_cmd(cmd)
     def finish(self):

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -411,8 +411,9 @@ class QCPipeline(Pipeline):
             cellranger_maxjobs=None,cellranger_mempercore=None,
             cellranger_jobinterval=None,cellranger_localcores=None,
             cellranger_localmem=None,working_dir=None,log_file=None,
-            batch_size=None,max_jobs=1,poll_interval=5,runners=None,
-            default_runner=None,envmodules=None,verbose=False):
+            batch_size=None,max_jobs=1,max_slots=None,poll_interval=5,
+            runners=None,default_runner=None,envmodules=None,
+            verbose=False):
         """
         Run the tasks in the pipeline
 
@@ -464,6 +465,10 @@ class QCPipeline(Pipeline):
             one command per job)
           max_jobs (int): optional maximum number of
             concurrent jobs in scheduler (defaults to 1)
+          max_slots (int): optional maximum number of 'slots'
+            (i.e. concurrent threads or maximum number of
+            CPUs) available to the scheduler (defaults to
+            no limit)
           poll_interval (float): optional polling interval
             (seconds) to set in scheduler (defaults to 5s)
           runners (dict): mapping of names to JobRunner
@@ -526,6 +531,7 @@ class QCPipeline(Pipeline):
                               },
                               poll_interval=poll_interval,
                               max_jobs=max_jobs,
+                              max_slots=max_slots,
                               runners=runners,
                               default_runner=default_runner,
                               envmodules=envmodules,

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -870,7 +870,7 @@ class RunFastqStrand(PipelineTask):
     Run the fastq_strand.py utility
     """
     def init(self,fastq_pairs,qc_dir,fastq_strand_conf,
-             fastq_strand_subset=None,nthreads=1,
+             fastq_strand_subset=None,nthreads=None,
              qc_protocol=None):
         """
         Initialise the RunFastqStrand task.
@@ -887,7 +887,8 @@ class RunFastqStrand(PipelineTask):
           fastq_strand_subset (int): explicitly specify
             the subset size for running fastq_strand
           nthreads (int): number of threads/processors to
-            use (defaults to 1)
+            use (defaults to number of slots set in job
+            runner)
           qc_protocol (str): QC protocol to use
         """
         pass
@@ -904,13 +905,16 @@ class RunFastqStrand(PipelineTask):
                 "Run fastq_strand.py for %s" %
                 os.path.basename(fastq_pair[0]),
                 'fastq_strand.py',
-                '-n',self.args.nthreads,
                 '--conf',self.args.fastq_strand_conf,
                 '--outdir',
                 os.path.abspath(self.args.qc_dir))
             if self.args.fastq_strand_subset:
                 cmd.add_args('--subset',
                              self.args.fastq_strand_subset)
+            if self.args.nthreads:
+                cmd.add_args('-n',self.args.nthreads)
+            else:
+                cmd.add_args('-n',self.runner_nslots)
             cmd.add_args(*fastq_pair)
             # Add the command
             self.add_cmd(cmd)

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -94,7 +94,7 @@ class QCPipeline(Pipeline):
         Pipeline.__init__(self,name="QC")
 
         # Define parameters
-        self.add_param('nthreads',type=int,value=1)
+        self.add_param('nthreads',type=int)
         self.add_param('fastq_subset',type=int)
         self.add_param('fastq_strand_indexes',type=dict)
         self.add_param('cellranger_chemistry',type=str)
@@ -418,7 +418,8 @@ class QCPipeline(Pipeline):
 
         Arguments:
           nthreads (int): number of threads/processors to
-            use for QC jobs (defaults to 1)
+            use for QC jobs (defaults to number of slots set
+            in job runners)
           fastq_strand_indexes (dict): mapping of organism
             IDs to directories with STAR index
           fastq_subset (int): explicitly specify

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -687,7 +687,7 @@ class RunIlluminaQC(PipelineTask):
     """
     Run the illumina_qc.sh script
     """
-    def init(self,fastqs,qc_dir,fastq_screen_subset=None,nthreads=1,
+    def init(self,fastqs,qc_dir,fastq_screen_subset=None,nthreads=None,
              qc_protocol=None,fastq_attrs=None):
         """
         Initialise the RunIlluminaQC task.
@@ -702,7 +702,7 @@ class RunIlluminaQC(PipelineTask):
           fastq_screen_subset (int): explicitly specify
             the subset size for running Fastq_screen
           nthreads (int): number of threads/processors to
-            use (defaults to 1)
+            use (defaults to number of slots set in runner)
           qc_protocol (str): QC protocol to use
           fastq_attrs (BaseFastqAttrs): class to use for
             extracting data from Fastq names
@@ -717,8 +717,11 @@ class RunIlluminaQC(PipelineTask):
             cmd = PipelineCommandWrapper(
                 "Run illumina_qc.sh for %s" % os.path.basename(fastq),
                 'illumina_qc.sh',fastq,
-                '--threads',self.args.nthreads,
                 '--qc_dir',os.path.abspath(self.args.qc_dir))
+            if self.args.nthreads:
+                cmd.add_args('--threads',self.args.nthreads)
+            else:
+                cmd.add_args('--threads',self.runner_nslots)
             if self.args.fastq_screen_subset is not None:
                 cmd.add_args('--subset',self.args.fastq_screen_subset)
             # No screens for R1 reads for single cell

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -142,7 +142,7 @@ class Settings(object):
         self.bcl2fastq = self.get_bcl2fastq_config('bcl2fastq',config)
         # qc
         self.add_section('qc')
-        self.qc['nprocessors'] = config.getint('qc','nprocessors',1)
+        self.qc['nprocessors'] = config.getint('qc','nprocessors',None)
         self.qc['fastq_screen_subset'] = config.getint('qc',
                                                        'fastq_screen_subset',
                                                        100000)

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -204,7 +204,7 @@ class Settings(object):
         self['10xgenomics']['cellranger_mempercore'] = config.getint('10xgenomics','cellranger_mempercore',5)
         self['10xgenomics']['cellranger_jobinterval'] = config.getint('10xgenomics','cellranger_jobinterval',100)
         self['10xgenomics']['cellranger_localmem'] = config.getint('10xgenomics','cellranger_localmem',5)
-        self['10xgenomics']['cellranger_localcores'] = config.getint('10xgenomics','cellranger_localcores',1)
+        self['10xgenomics']['cellranger_localcores'] = config.getint('10xgenomics','cellranger_localcores',None)
         # 10xgenomics transcriptomes
         self.add_section('10xgenomics_transcriptomes')
         try:

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -80,6 +80,9 @@ if __name__ == "__main__":
     p = argparse.ArgumentParser(
         description="Run the QC pipeline standalone on an arbitrary "
         "set of Fastq files.")
+    # Defaults
+    default_nthreads = __settings.qc.nprocessors
+    # Build parser
     p.add_argument('--version', action='version',
                    version=("%%(prog)s %s" % __version__))
     p.add_argument("project_dir",metavar="DIR",
@@ -115,9 +118,11 @@ if __name__ == "__main__":
                    default=False,
                    help="also generate MultiQC report")
     p.add_argument('-t','--threads',action='store',dest="nthreads",
-                   type=int,default=__settings.qc.nprocessors,
+                   type=int,default=default_nthreads,
                    help="number of threads to use for QC script "
-                   "(default: %d)" % __settings.qc.nprocessors)
+                   "(default: %s)" % ('taken from job runner'
+                                      if not default_nthreads
+                                      else default_nthreads,))
     p.add_argument('-r','--runner',metavar='RUNNER',action='store',
                    dest="runner",default=None,
                    help="explicitly specify runner definition for "

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -177,6 +177,15 @@ if __name__ == "__main__":
                    "modules to load before executing commands "
                    "(overrides any modules specified in the global "
                    "settings)")
+    # Advanced options
+    advanced = p.add_argument_group('Advanced/debugging options')
+    advanced.add_argument('--verbose',action="store_true",
+                          dest="verbose",default=False,
+                          help="run pipeline in 'verbose' mode")
+    advanced.add_argument('--work-dir',action="store",
+                          dest="working_dir",default=None,
+                          help="specify the working directory for the "
+                          "pipeline operations")
 
     # Parse the command line
     args = p.parse_args()
@@ -292,7 +301,9 @@ if __name__ == "__main__":
                        batch_size=args.batch_size,
                        runners=runners,
                        default_runner=default_runner,
-                       envmodules=envmodules)
+                       envmodules=envmodules,
+                       working_dir=args.working_dir,
+                       verbose=args.verbose)
     if status:
         logger.critical("QC failed (see warnings above)")
     sys.exit(status)

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -60,7 +60,7 @@ process_icell8      `bowtie2`_         Required by fastq_screen
 
 These programs provided by these packages must be found on the
 ``PATH`` when the appropriate autoprocessor commands are issued.
-:ref:`environment-modules` can be used to help manage this.
+:ref:`environment_modules` can be used to help manage this.
 Alternatively many of these packages can be obtained from the
 `bioconda project <https://bioconda.github.io/>`_.
 

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -17,9 +17,9 @@ can be used to run the QC pipeline on an arbitrary subdirectory.
 The QC pipeline protocol used for each project will differ slightly
 depending on the nature of the data within that project:
 
-================  ========================
+================= ==========================
 QC protocol       Used for
-================  ========================
+================= ==========================
 ``standardPE``    Standard paired-end data i.e. R1/R2 Fastq pairs
 ``standardSE``    Standard single-end data i.e. R1 Fastqs only
 ``10x_scATAC``    10xGenomics single cell & single nuclei ATAC-seq
@@ -27,7 +27,7 @@ QC protocol       Used for
 ``10x_snRNAseq``  10xGenomics single nuclei RNA-seq
 ``singlecell``    ICELL8 single cell RNA-seq
 ``ICELL8_scATAC`` ICELL8 single cell ATAC-seq
-================= ========================
+================= ==========================
 
 The protocol is determined automatically for each project.
 
@@ -79,8 +79,10 @@ Configuring the QC pipeline
 See :ref:`software_dependencies` for details of the additional
 software required to run the QC pipeline. Environment modules can be
 used to set up the runtime environment for the pipeline (see
-:ref:`environment_modules`) and suitable job runners should be
-defined if running the pipeline on a compute cluster (see
+:ref:`environment_modules`).
+
+Suitable :ref:`job runners <job_runners>` should be defined,
+particularly if running the pipeline on a compute cluster (see
 :ref:`running_on_compute_cluster`).
 
 Some of the pipeline stages also require appropriate reference


### PR DESCRIPTION
PR which updates the QC pipeline in `qc.pipeline` to get the default numbers of threads in specific tasks from the supplied job runners (using the mechanism implemented in PR #578), unless explicitly supplied via the appropriate arguments.

The affected tasks are:

* `RunIlluminaQC`
* `RunFastqStrand`
* `RunCellrangerCount`

The PR also exposes the `max_slots` pipeline option, which enables the number of CPUs to the pipeline at runtime.