### PR TITLE
pipeliner: refactor how tasks acquire number of CPUs (aka 'nslots') from runners

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2468,6 +2468,14 @@ class PipelineTask(object):
                 remaining_cmds = remaining_cmds[batch_size:]
         # Run the commands
         if cmds:
+            # Report runner and nslots
+            if verbose:
+                if self._runner:
+                    self.report("Runner: %s%s" %
+                                (self._runner,
+                                 '' if self.runner_nslots == 1
+                                 else ' [nslots=%s]' %
+                                 self.runner_nslots))
             use_group = (len(cmds)!=1)
             if use_group:
                 # Run as a group

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -1775,9 +1775,13 @@ class Pipeline(object):
         self.report("Runners:")
         width = max([len(r) for r in self.runners])
         for r in sorted(self.runners):
-            self.report("-- %s%s: %s" % (r,
+            runner = self.runners[r].value
+            self.report("-- %s%s: %s%s" % (r,
                                          ' '*(width-len(r)),
-                                         self.runners[r].value))
+                                           runner,
+                                           '' if runner.nslots == 1
+                                           else ' [nslots=%s]' %
+                                           runner.nslots))
         # Report modules environments
         if self.envmodules:
             self.report("Modules environments:")

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2055,6 +2055,7 @@ class PipelineTask(object):
         # Working directory
         self._working_dir = None
         # Running jobs
+        self._runner = None
         self._jobs = []
         self._groups = []
         # Monitoring
@@ -2433,6 +2434,10 @@ class PipelineTask(object):
             self._log_file = os.path.abspath(log_file)
         if lock_manager:
             self._lock_manager = lock_manager
+        if runner:
+            self._runner = runner
+        elif sched:
+            self._runner = sched.default_runner
         # Do setup
         self.invoke(self.setup)
         # Generate commands to run
@@ -2498,7 +2503,7 @@ class PipelineTask(object):
                     group.add(cmd,
                               wd=self._working_dir,
                               name=name,
-                              runner=runner,
+                              runner=self._runner,
                               log_dir=log_dir,
                               wait_for=wait_for)
                 group.close()
@@ -2512,7 +2517,7 @@ class PipelineTask(object):
                 job = sched.submit(cmd,
                                    wd=self._working_dir,
                                    name=name,
-                                   runner=runner,
+                                   runner=self._runner,
                                    log_dir=log_dir,
                                    wait_for=wait_for)
                 callback_name = job.name

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -799,7 +799,7 @@ class SetupFastqStrandConf(PipelineFunctionTask):
             return
         # Create the conf file
         print("Writing conf file: %s" % fastq_strand_conf)
-        with open(fastq_strand_conf,'w') as fp:
+        with open(fastq_strand_conf,'wt') as fp:
             fp.write("%s\n" % fastq_strand_indexes)
     def finish(self):
         if os.path.exists(self.fastq_strand_conf):

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -10,6 +10,7 @@ import os
 import io
 import getpass
 import platform
+import cloudpickle
 from builtins import range
 import auto_process_ngs.envmod as envmod
 from auto_process_ngs.simple_scheduler import SimpleScheduler
@@ -1546,6 +1547,26 @@ class TestPipelineTask(unittest.TestCase):
         self.assertFalse(task.output)
         self.assertEqual(task.stdout,"")
 
+    def test_pipelinetask_cloudpickle(self):
+        """
+        PipelineTask: check serialization using 'cloudpickle'
+        """
+        # Define a task with a command
+        # Echoes text via shell command
+        class Echo(PipelineTask):
+            def init(self,s):
+                pass
+            def setup(self):
+                self.add_cmd(
+                    PipelineCommandWrapper(
+                        "Echo text","echo",self.args.s))
+        # Make a task instance
+        task = Echo("Echo string","Hello!")
+        # Pickle it
+        pickled = cloudpickle.dumps(task)
+        # Unpickle it
+        unpickled = cloudpickle.loads(pickled)
+
 class TestPipelineFunctionTask(unittest.TestCase):
 
     def setUp(self):
@@ -1655,6 +1676,27 @@ class TestPipelineFunctionTask(unittest.TestCase):
         self.assertEqual(task.exit_code,0)
         self.assertEqual(task.result(),["NSLOTS=8"])
         self.assertFalse(task.output)
+
+    def test_pipelinefunctiontask_cloudpickle(self):
+        """
+        PipelineFunctionTask: check serialization using 'cloudpickle'
+        """
+        # Define a task with a function call
+        class Hello(PipelineFunctionTask):
+            def init(self,name):
+                pass
+            def setup(self):
+                self.add_call("Emit greeting",
+                              self.hello,
+                              self.args.name)
+            def hello(self,name):
+                return "Hello %s!" % name
+        # Make a task instance
+        task = Hello("Hello world","World")
+        # Pickle it
+        pickled = cloudpickle.dumps(task)
+        # Unpickle it
+        unpickled = cloudpickle.loads(pickled)
 
 class TestPipelineCommand(unittest.TestCase):
 


### PR DESCRIPTION
PR which updates the implementation of the functionality in PR #578, which enabled tasks to fetch the number of CPUs available in a runner and use this when setting up commands to be executed.

The original implementation did this indirectly by making use of the `BCFTBX_RUNNER_NSLOTS` environment variable set by the job runners; however it turns out that as the job runner is supplied to the task before commands are generated, it is actually more straightforward to get the number of CPU's directly from the runner's `nslots` property.

The PR also adds some reporting of the numbers of CPUs/slots available to runners from within `Pipeline` and `PipelineTask` instances.