### PR TITLE
AnalysisProject: make it optional to supply a project name on initialisation

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -398,15 +398,17 @@ class AnalysisProject(object):
     of the project directory). It can be changed using the
     'set_primary_fastq_dir' method.
     """
-    def __init__(self,name,dirn,user=None,PI=None,library_type=None,
+    def __init__(self,name,dirn=None,user=None,PI=None,library_type=None,
                  single_cell_platform=None,organism=None,run=None,
                  comments=None,platform=None,fastq_attrs=None,
                  fastq_dir=None):
         """Create a new AnalysisProject instance
 
         Arguments:
-          name: name of the project
-          dirn: project directory (can be full or relative path)
+          name: name of the project (or path to project directory,
+            if 'dirn' not supplied)
+          dirn: optional, project directory (can be full or relative
+            path)
           user: optional, specify name of the user
           PI: optional, specify name of the principal investigator
           library_type: optional, specify library type e.g. 'RNA-seq',
@@ -428,8 +430,10 @@ class AnalysisProject(object):
             'fastq' (if present) or to the top-level of the project
             directory (if absent).
         """
-        self.name = name
-        self.dirn = os.path.abspath(dirn)
+        if dirn is not None:
+            self.dirn = os.path.abspath(dirn)
+        else:
+            self.dirn = os.path.abspath(name)
         self.fastq_dir = None
         self.fastq_dirs = []
         self.fastq_format = None
@@ -444,7 +448,18 @@ class AnalysisProject(object):
             self.fastq_attrs = fastq_attrs
         # Populate from the directory contents
         self.populate(fastq_dir=fastq_dir)
+        # Set project name
+        if dirn is not None:
+            # Name was explicitly supplied
+            self.name = name
+        elif self.info.name is not None:
+            # Get name from metadata
+            self.name = self.info.name
+        else:
+            # Default name from directory
+            self.name = os.path.basename(self.dirn)
         # (Re)set metadata
+        self.info['name'] = self.name
         if run is not None:
             self.info['run'] = run
         if user is not None:

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -364,6 +364,7 @@ class AnalysisProjectInfo(MetadataDict):
 
     The data items are:
 
+    name: the project name
     run: the name of the sequencing run
     platform: the sequencing platform name e.g. 'miseq'
     user: the user associated with the project
@@ -389,6 +390,7 @@ class AnalysisProjectInfo(MetadataDict):
         """
         MetadataDict.__init__(self,
                               attributes = {
+                                  'name':'Project name',
                                   'run':'Run',
                                   'platform':'Platform',
                                   'user':'User',
@@ -404,6 +406,7 @@ class AnalysisProjectInfo(MetadataDict):
                                   'comments':'Comments',
                               },
                               order = (
+                                  'name',
                                   'run',
                                   'platform',
                                   'user',

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -38,8 +38,6 @@ from bcftbx.JobRunner import SimpleJobRunner
 from bcftbx.utils import mkdir
 from bcftbx.utils import mkdirs
 from bcftbx.utils import find_program
-from ..analysis import AnalysisProject
-from ..analysis import AnalysisFastq
 from ..analysis import copy_analysis_project
 from ..applications import Command
 from ..fastq_utils import pair_fastqs_by_name

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -254,7 +254,7 @@ class TestAnalysisProject(unittest.TestCase):
             self.fastqs.append(fastq)
 
     def make_mock_project_dir(self,name,fastq_list,fastq_dir='fastqs',
-                              primary_fastq_dir=None):
+                              primary_fastq_dir=None,project_name=None):
         # Make a mock project directory
         if primary_fastq_dir is None:
             primary_fastq_dir = fastq_dir
@@ -268,6 +268,8 @@ class TestAnalysisProject(unittest.TestCase):
                         ', '.join(sample_names))
         metadata = { 'Primary fastqs': primary_fastq_dir,
                      'Samples': sample_names }
+        if project_name:
+            metadata['Project name'] = project_name
         MockAnalysisProject(name,
                             fastq_list,
                             fastq_dir=fastq_dir,
@@ -310,6 +312,7 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertTrue(os.path.isdir(project.dirn))
         self.assertFalse(project.multiple_fastqs)
         self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.info.primary_fastq_dir,'fastqs')
         self.assertEqual(project.info.samples,'2 samples (PJB1-A, PJB1-B)')
         self.assertEqual(project.samples[0].name,'PJB1-A')
@@ -332,6 +335,7 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertTrue(os.path.isdir(project.dirn))
         self.assertTrue(project.multiple_fastqs)
         self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.info.primary_fastq_dir,'fastqs')
         self.assertEqual(project.info.samples,
                          '2 samples (PJB1-A, PJB1-B, multiple fastqs per sample)')
@@ -355,6 +359,7 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertTrue(os.path.isdir(project.dirn))
         self.assertFalse(project.multiple_fastqs)
         self.assertTrue(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.info.primary_fastq_dir,'fastqs')
         self.assertEqual(project.info.samples,'2 samples (PJB1-A, PJB1-B)')
         self.assertEqual(project.samples[0].name,'PJB1-A')
@@ -378,6 +383,7 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertEqual(project.samples[0].name,'PJB1-B')
         self.assertTrue(project.multiple_fastqs)
         self.assertTrue(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.fastq_dir,
                          os.path.join(project.dirn,'fastqs'))
         self.assertEqual(project.fastq_dirs,['fastqs',])
@@ -400,12 +406,34 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertEqual(project.samples[0].name,'PJB1-B')
         self.assertTrue(project.multiple_fastqs)
         self.assertTrue(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.fastq_dir,
                          os.path.join(project.dirn,'fastqs.test'))
         self.assertEqual(project.info.samples,
                          '1 sample (PJB1-B, multiple fastqs per sample)')
         self.assertEqual(project.fastq_dirs,['fastqs.test',])
         self.assertEqual(project.info.primary_fastq_dir,'fastqs.test')
+
+    def test_create_project_only_supply_dirname(self):
+        """Check creation of new AnalysisProject (only supply directory)
+        """
+        self.make_data_dir(('PJB1-A_ACAGTG_L001_R1_001.fastq.gz',
+                            'PJB1-B_ACAGTG_L002_R1_001.fastq.gz',))
+        dirn = os.path.join(self.dirn,'PJB')
+        project = AnalysisProject(dirn)
+        project.create_directory(fastqs=self.fastqs)
+        self.assertEqual(project.name,'PJB')
+        self.assertTrue(os.path.isdir(project.dirn))
+        self.assertFalse(project.multiple_fastqs)
+        self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
+        self.assertEqual(project.info.primary_fastq_dir,'fastqs')
+        self.assertEqual(project.info.samples,'2 samples (PJB1-A, PJB1-B)')
+        self.assertEqual(project.samples[0].name,'PJB1-A')
+        self.assertEqual(project.samples[1].name,'PJB1-B')
+        self.assertEqual(project.fastq_dir,
+                         os.path.join(project.dirn,'fastqs'))
+        self.assertEqual(project.fastq_dirs,['fastqs',])
 
     def test_load_single_end_analysis_project(self):
         """Check loading of an existing single-end AnalysisProject directory
@@ -420,6 +448,30 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertTrue(os.path.isdir(project.dirn))
         self.assertFalse(project.multiple_fastqs)
         self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
+        self.assertEqual(project.samples[0].name,'PJB1-A')
+        self.assertEqual(project.samples[1].name,'PJB1-B')
+        self.assertEqual(project.fastq_dir,
+                         os.path.join(project.dirn,'fastqs'))
+        self.assertEqual(project.info.samples,'2 samples (PJB1-A, PJB1-B)')
+        self.assertEqual(project.fastq_dirs,['fastqs',])
+        self.assertEqual(project.info.primary_fastq_dir,'fastqs')
+
+    def test_load_analysis_project_only_supply_dirname_diff_project_name(self):
+        """Check loading of an existing AnalysisProject (only supply directory, name different from dir)
+        """
+        self.make_mock_project_dir(
+            'PJB',
+            ('PJB1-A_ACAGTG_L001_R1_001.fastq.gz',
+             'PJB1-B_ACAGTG_L002_R1_001.fastq.gz',),
+            project_name='PeterBriggs')
+        dirn = os.path.join(self.dirn,'PJB')
+        project = AnalysisProject(dirn)
+        self.assertEqual(project.name,'PeterBriggs')
+        self.assertTrue(os.path.isdir(project.dirn))
+        self.assertFalse(project.multiple_fastqs)
+        self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.name,'PeterBriggs')
         self.assertEqual(project.samples[0].name,'PJB1-A')
         self.assertEqual(project.samples[1].name,'PJB1-B')
         self.assertEqual(project.fastq_dir,
@@ -442,6 +494,7 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertTrue(os.path.isdir(project.dirn))
         self.assertFalse(project.multiple_fastqs)
         self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.samples[0].name,'PJB1-A')
         self.assertEqual(project.samples[1].name,'PJB1-B')
         self.assertEqual(project.fastq_dir,
@@ -463,6 +516,7 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertTrue(os.path.isdir(project.dirn))
         self.assertFalse(project.multiple_fastqs)
         self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.fastq_dir,
                          os.path.join(project.dirn,'fastqs'))
         self.assertEqual(project.info.samples,
@@ -489,6 +543,7 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertTrue(os.path.isdir(project.dirn))
         self.assertFalse(project.multiple_fastqs)
         self.assertTrue(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.samples[0].name,'PB02')
         self.assertEqual(project.fastq_dir,
                          os.path.join(project.dirn,'fastqs'))
@@ -522,6 +577,7 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertTrue(os.path.isdir(project.dirn))
         self.assertFalse(project.multiple_fastqs)
         self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.samples[0].name,'PJB1-A')
         self.assertEqual(project.samples[1].name,'PJB1-B')
         self.assertEqual(project.fastq_dir,
@@ -537,6 +593,7 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertTrue(os.path.isdir(project.dirn))
         self.assertFalse(project.multiple_fastqs)
         self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.samples[0].name,'PJB1-A-untrimmed')
         self.assertEqual(project.samples[1].name,'PJB1-B-untrimmed')
         self.assertEqual(project.fastq_dir,
@@ -571,6 +628,7 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertTrue(os.path.isdir(project.dirn))
         self.assertFalse(project.multiple_fastqs)
         self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.samples[0].name,'PJB1-A')
         self.assertEqual(project.samples[1].name,'PJB1-B')
         self.assertEqual(project.fastq_dir,
@@ -583,6 +641,7 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertTrue(os.path.isdir(project.dirn))
         self.assertFalse(project.multiple_fastqs)
         self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.samples[0].name,'PJB1-A-untrimmed')
         self.assertEqual(project.samples[1].name,'PJB1-B-untrimmed')
         self.assertEqual(project.fastq_dir,
@@ -617,6 +676,7 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertTrue(os.path.isdir(project.dirn))
         self.assertFalse(project.multiple_fastqs)
         self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.samples[0].name,'PJB1-A-untrimmed')
         self.assertEqual(project.samples[1].name,'PJB1-B-untrimmed')
         self.assertEqual(project.fastq_dir,
@@ -631,6 +691,7 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertTrue(os.path.isdir(project.dirn))
         self.assertFalse(project.multiple_fastqs)
         self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.samples[0].name,'PJB1-A')
         self.assertEqual(project.samples[1].name,'PJB1-B')
         self.assertEqual(project.fastq_dir,
@@ -762,6 +823,7 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertTrue(os.path.isdir(project.dirn))
         self.assertFalse(project.multiple_fastqs)
         self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.samples[0].name,'PJB1-A')
         self.assertEqual(project.samples[1].name,'PJB1-B')
         self.assertEqual(project.fastq_dir,
@@ -780,6 +842,7 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertTrue(os.path.isdir(project.dirn))
         self.assertFalse(project.multiple_fastqs)
         self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.samples[0].name,'PJB1-A-untrimmed')
         self.assertEqual(project.samples[1].name,'PJB1-B-untrimmed')
         self.assertEqual(project.fastq_dir,
@@ -807,6 +870,7 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertTrue(os.path.isdir(project.dirn))
         self.assertFalse(project.multiple_fastqs)
         self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.samples[0].name,'PJB1-A')
         self.assertEqual(project.samples[1].name,'PJB1-B')
         self.assertEqual(project.fastq_dir,project.dirn)
@@ -983,6 +1047,7 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertTrue(os.path.isdir(project.dirn))
         self.assertFalse(project.multiple_fastqs)
         self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.name,'PJB')
         self.assertEqual(project.samples[0].name,'PJB1-A')
         self.assertEqual(project.samples[1].name,'PJB1-B')
         self.assertEqual(project.fastq_dir,

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -449,6 +449,7 @@ class TestAnalysisProjectInfo(unittest.TestCase):
         """Check creation of an empty AnalysisProjectInfo object
         """
         info = AnalysisProjectInfo()
+        self.assertEqual(info.name,None)
         self.assertEqual(info.run,None)
         self.assertEqual(info.platform,None)
         self.assertEqual(info.user,None)


### PR DESCRIPTION
PR which updates the `AnalysisProject` class (in the `analysis` module) so that it can be initialised with just the project directory path supplied as an argument, without an explicit project name, i.e.  both

    >>> p = AnalysisProject('/path/to/project/PJB')

and the old style:

    >>> p = AnalysisProject('PJB','/path/to/project/PJB')

will work.

The project name is now also stored in the project metadata (the `AnalysisProjectInfo` class in the `metadata` module). If the name is not supplied then the name is taken from the metadata, or if that isn't set then it's taken as the basename of the project directory.