### PR TITLE
Update the QC ZIP file naming convention and construction in QC pipeline

### DIFF
--- a/auto_process_ngs/commands/import_project_cmd.py
+++ b/auto_process_ngs/commands/import_project_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     import_project_cmd.py: implement auto process import_project command
-#     Copyright (C) University of Manchester 2019 Peter Briggs
+#     Copyright (C) University of Manchester 2019-2020 Peter Briggs
 #
 #########################################################################
 

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -282,12 +282,23 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                 print("...%s: failed to verify QC" % qc_dir)
             status[project.name][qc_dir] = verified
             if verified or force:
-                # Check for an existing report
-                qc_zip = os.path.join(
-                    project.dirn,
-                    "%s_report.%s.%s.zip" %
-                    (qc_dir,project.name,
-                     os.path.basename(ap.analysis_dir)))
+                # Check for an existing report ZIP file
+                # Various naming styles exist
+                qc_zip = None
+                for zip_name in (
+                        # Old-style ZIP name
+                        "%s_report.%s.%s" % (qc_dir,
+                                             project.name,
+                                             os.path.basename(
+                                                 ap.analysis_dir)),
+                        # Current ZIP name format
+                        "%s_report.%s.%s" % (qc_dir,
+                                             project.name,
+                                             project.info.run)):
+                    qc_zip = os.path.join(project.dirn,
+                                          "%s.zip" % zip_name)
+                    if os.path.exists(qc_zip):
+                        break
                 # Check if we need to (re)generate report
                 if (regenerate_reports or
                     not os.path.exists(qc_zip)):
@@ -549,13 +560,12 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                         fastq_set_name = (" (%s)" % fastq_set
                                           if fastq_set is not None
                                           else "")
+                        report_dir = os.path.splitext(
+                            os.path.basename(qc_zip))[0]
                         report_html.add(
                             Link("[Report%s]" % fastq_set_name,
-                                 "%s.%s.%s/%s.html"
-                                 % (qc_base,
-                                    project.name,
-                                    os.path.basename(ap.analysis_dir),
-                                    qc_base)))
+                                 os.path.join(report_dir,
+                                              "%s.html" % qc_base)))
                         if not exclude_zip_files:
                             report_html.add(
                                 Link("[ZIP%s]" % fastq_set_name,

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -670,9 +670,10 @@ class UpdateAnalysisProject(DirectoryUpdater):
         # Make mock ZIP archive
         analysis_name = os.path.basename(self._parent_dir())
         if not legacy_zip_name:
-            zip_prefix = "%s.%s.%s" % (qc_name,
-                                       self._project.name,
-                                       self._project.info.run)
+            zip_prefix = "%s.%s%s" % (qc_name,
+                                      self._project.name,
+                                      ".%s" % self._project.info.run
+                                      if self._project.info.run else '')
         else:
             zip_prefix = "%s.%s.%s" % (qc_name,
                                        self._project.name,

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1,5 +1,5 @@
 #     mock.py: module providing mock Illumina data for testing
-#     Copyright (C) University of Manchester 2012-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2012-2020 Peter Briggs
 #
 ########################################################################
 

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -600,7 +600,8 @@ class UpdateAnalysisProject(DirectoryUpdater):
     def add_qc_outputs(self,fastq_set=None,qc_dir=None,
                        protocol="standardPE",
                        include_fastq_strand=True,
-                       include_multiqc=True):
+                       include_multiqc=True,
+                       legacy_zip_name=False):
         """
         Add mock QC outputs
 
@@ -615,6 +616,9 @@ class UpdateAnalysisProject(DirectoryUpdater):
             add mock fastq_strand.py outputs
           include_multiqc (bool): if True then add
             mock MultiQC outputs
+          legacy_zip_name (bool): if True then use
+            old-style naming convention for ZIP file
+            with QC outputs
         """
         print("Adding mock QC outputs to %s" %
               self._project.dirn)
@@ -665,18 +669,20 @@ class UpdateAnalysisProject(DirectoryUpdater):
         self.add_file("%s.html" % qc_name)
         # Make mock ZIP archive
         analysis_name = os.path.basename(self._parent_dir())
+        if not legacy_zip_name:
+            zip_prefix = "%s.%s.%s" % (qc_name,
+                                       self._project.name,
+                                       self._project.info.run)
+        else:
+            zip_prefix = "%s.%s.%s" % (qc_name,
+                                       self._project.name,
+                                       analysis_name)
         report_zip = os.path.join(self._project.dirn,
-                                  "%s.%s.%s.zip" %
-                                  (qc_name,
-                                   self._project.name,
-                                   analysis_name))
+                                  "%s.zip" % zip_prefix)
         print("Building ZIP archive: %s" % report_zip)
         zip_file = ZipArchive(report_zip,
                               relpath=self._project.dirn,
-                              prefix="%s.%s.%s" %
-                              (qc_name,
-                               self._project.name,
-                               analysis_name))
+                              prefix=zip_prefix)
         zip_file.add_file(os.path.join(self._project.dirn,
                                        "%s.html" % qc_name))
         zip_file.add(self._project.qc_dir)

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -119,7 +119,7 @@ class QCPipeline(Pipeline):
         self.add_envmodules('report_qc')
 
     def add_project(self,project,qc_dir=None,organism=None,fastq_dir=None,
-                    qc_protocol=None,multiqc=False,
+                    qc_protocol=None,report_html=None,multiqc=False,
                     sample_pattern=None,log_dir=None):
         """
         Add a project to the QC pipeline
@@ -181,6 +181,7 @@ class QCPipeline(Pipeline):
         self.report("-- QC dir    : %s" % qc_dir)
         self.report("-- Library   : %s" % project.info.library_type)
         self.report("-- Organism  : %s" % organism)
+        self.report("-- Report    : %s" % report_html)
 
         ####################
         # Build the pipeline
@@ -393,6 +394,7 @@ class QCPipeline(Pipeline):
             "%s: make QC report" % project_name,
             project,
             qc_dir,
+            report_html=report_html,
             multiqc=multiqc
         )
         self.add_task(report_qc,

--- a/auto_process_ngs/test/commands/test_import_project.py
+++ b/auto_process_ngs/test/commands/test_import_project.py
@@ -127,7 +127,7 @@ Comments\t1% PhiX spike in
         print(os.listdir(os.path.join(ap2.analysis_dir,'NewProj')))
         for f in ("qc_report.html",
                   "multiqc_report.html",
-                  "qc_report.NewProj.160621_M00879_0087_000000000-AGEW9_analysis.zip",):
+                  "qc_report.NewProj.160621_M00879_0087_000000000-AGEW9.zip",):
             f = os.path.join(ap2.analysis_dir,'NewProj',f)
             self.assertTrue(os.path.exists(f),"Missing %s" % f)
 

--- a/auto_process_ngs/test/commands/test_publish_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_publish_qc_cmd.py
@@ -1038,11 +1038,6 @@ poll_interval = 0.5
                              "160621_K00879_0087_000000000-AGEW9_analysis",
                              item)
             self.assertTrue(os.path.exists(f),"Missing %s" % f)
-        for item in outputs:
-            f = os.path.join(publication_dir,
-                             "160621_K00879_0087_000000000-AGEW9_analysis",
-                             item)
-            self.assertTrue(os.path.exists(f),"Missing %s" % f)
         # Check the ZIP files were excluded
         for zip_file in zip_files:
             self.assertFalse(os.path.exists(

--- a/auto_process_ngs/test/commands/test_publish_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_publish_qc_cmd.py
@@ -174,8 +174,7 @@ poll_interval = 0.5
                    "processing_qc.html"]
         for project in ap.get_analysis_projects():
             project_qc = "qc_report.%s.%s" % (project.name,
-                                              os.path.basename(
-                                                  ap.analysis_dir))
+                                              project.info.run)
             outputs.append(project_qc)
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
@@ -215,6 +214,46 @@ poll_interval = 0.5
         for project in ap.get_analysis_projects():
             # Standard QC outputs
             project_qc = "qc_report.%s.%s" % (project.name,
+                                              project.info.run)
+            outputs.append(project_qc)
+            outputs.append("%s.zip" % project_qc)
+            outputs.append(os.path.join(project_qc,"qc_report.html"))
+            outputs.append(os.path.join(project_qc,"qc"))
+        for item in outputs:
+            f = os.path.join(publication_dir,
+                             "160621_K00879_0087_000000000-AGEW9_analysis",
+                             item)
+            self.assertTrue(os.path.exists(f),"Missing %s" % f)
+
+    def test_publish_qc_with_projects_old_zip_names(self):
+        """publish_qc: projects with all QC outputs (old-style ZIP names)
+        """
+        # Make an auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '160621_K00879_0087_000000000-AGEW9',
+            'hiseq',
+            metadata={ "run_number": 87,
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
+            top_dir=self.dirn)
+        mockdir.create()
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
+        # Add processing report and QC outputs
+        UpdateAnalysisDir(ap).add_processing_report()
+        for project in ap.get_analysis_projects():
+            UpdateAnalysisProject(project).add_qc_outputs(legacy_zip_name=True)
+        # Make a mock publication area
+        publication_dir = os.path.join(self.dirn,'QC')
+        os.mkdir(publication_dir)
+        # Publish
+        publish_qc(ap,location=publication_dir)
+        # Check outputs
+        outputs = ["index.html",
+                   "processing_qc.html"]
+        for project in ap.get_analysis_projects():
+            # Standard QC outputs with old-style ZIP file names
+            project_qc = "qc_report.%s.%s" % (project.name,
                                               os.path.basename(
                                                   ap.analysis_dir))
             outputs.append(project_qc)
@@ -250,7 +289,7 @@ poll_interval = 0.5
             qc_reports = []
             qc_reports.append("qc_report.%s.%s.zip" %
                               (project.name,
-                               os.path.basename(ap.analysis_dir)))
+                               project.info.run))
             qc_reports.append("qc_report.html")
             qc_reports.append("multiqc_report.html")
             for f in qc_reports:
@@ -270,8 +309,7 @@ poll_interval = 0.5
         for project in ap.get_analysis_projects():
             # Standard QC outputs
             project_qc = "qc_report.%s.%s" % (project.name,
-                                              os.path.basename(
-                                                  ap.analysis_dir))
+                                              project.info.run)
             outputs.append(project_qc)
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
@@ -319,16 +357,14 @@ poll_interval = 0.5
         for project in ap.get_analysis_projects():
             # Standard QC outputs
             project_qc = "qc_report.%s.%s" % (project.name,
-                                              os.path.basename(
-                                                  ap.analysis_dir))
+                                              project.info.run)
             outputs.append(project_qc)
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
             outputs.append(os.path.join(project_qc,"qc"))
         # Additional QC for second fastq set in first project
         project_qc = "qc.extra_report.%s.%s" % (multi_fastqs_project.name,
-                                                os.path.basename(
-                                                    ap.analysis_dir))
+                                                project.info.run)
         outputs.append(project_qc)
         outputs.append("%s.zip" % project_qc)
         outputs.append(os.path.join(project_qc,"qc.extra_report.html"))
@@ -402,8 +438,7 @@ poll_interval = 0.5
         for project in projects:
             # Standard QC outputs
             project_qc = "qc_report.%s.%s" % (project.name,
-                                              os.path.basename(
-                                                  ap.analysis_dir))
+                                              project.info.run)
             outputs.append(project_qc)
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
@@ -455,8 +490,7 @@ poll_interval = 0.5
         for project in projects:
             # Standard QC outputs
             project_qc = "qc_report.%s.%s" % (project.name,
-                                              os.path.basename(
-                                                  ap.analysis_dir))
+                                              project.info.run)
             outputs.append(project_qc)
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
@@ -511,8 +545,7 @@ poll_interval = 0.5
         for project in ap.get_analysis_projects():
             # Standard QC outputs
             project_qc = "qc_report.%s.%s" % (project.name,
-                                              os.path.basename(
-                                                  ap.analysis_dir))
+                                              project.info.run)
             outputs.append(project_qc)
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
@@ -574,8 +607,7 @@ poll_interval = 0.5
         for project in ap.get_analysis_projects():
             # Standard QC outputs
             project_qc = "qc_report.%s.%s" % (project.name,
-                                              os.path.basename(
-                                                  ap.analysis_dir))
+                                              project.info.run)
             outputs.append(project_qc)
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
@@ -734,8 +766,7 @@ poll_interval = 0.5
         for project in ap.get_analysis_projects():
             # Standard QC outputs
             project_qc = "qc_report.%s.%s" % (project.name,
-                                              os.path.basename(
-                                                  ap.analysis_dir))
+                                              project.info.run)
             outputs.append(project_qc)
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
@@ -791,8 +822,7 @@ poll_interval = 0.5
         for project in ap.get_analysis_projects():
             # Standard QC outputs
             project_qc = "qc_report.%s.%s" % (project.name,
-                                              os.path.basename(
-                                                  ap.analysis_dir))
+                                              project.info.run)
             outputs.append(project_qc)
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
@@ -859,8 +889,7 @@ poll_interval = 0.5
         for project in ap.get_analysis_projects():
             # Standard QC outputs
             project_qc = "qc_report.%s.%s" % (project.name,
-                                              os.path.basename(
-                                                  ap.analysis_dir))
+                                              project.info.run)
             outputs.append(project_qc)
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
@@ -909,8 +938,7 @@ poll_interval = 0.5
         for project in ap.get_analysis_projects():
             # Standard QC outputs
             project_qc = "qc_report.%s.%s" % (project.name,
-                                              os.path.basename(
-                                                  ap.analysis_dir))
+                                              project.info.run)
             outputs.append(project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
             outputs.append(os.path.join(project_qc,"qc"))
@@ -975,8 +1003,7 @@ poll_interval = 0.5
         for project in ap.get_analysis_projects():
             # Standard QC outputs
             project_qc = "qc_report.%s.%s" % (project.name,
-                                              os.path.basename(
-                                                  ap.analysis_dir))
+                                              project.info.run)
             outputs.append(project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
             outputs.append(os.path.join(project_qc,"qc"))
@@ -1087,8 +1114,7 @@ poll_interval = 0.5
         for project in ap.get_analysis_projects():
             # Standard QC outputs
             project_qc = "qc_report.%s.%s" % (project.name,
-                                              os.path.basename(
-                                                  ap.analysis_dir))
+                                              project.info.run)
             outputs.append(project_qc)
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))
@@ -1128,8 +1154,7 @@ poll_interval = 0.5
         for project in ap.get_analysis_projects():
             # Standard QC outputs
             project_qc = "qc_report.%s.%s" % (project.name,
-                                              os.path.basename(
-                                                  ap.analysis_dir))
+                                              project.info.run)
             outputs.append(project_qc)
             outputs.append("%s.zip" % project_qc)
             outputs.append(os.path.join(project_qc,"qc_report.html"))

--- a/auto_process_ngs/test/commands/test_run_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_run_qc_cmd.py
@@ -82,7 +82,7 @@ poll_interval = 0.5
         for p in ("AB","CDE","undetermined"):
             for f in ("qc",
                       "qc_report.html",
-                      "qc_report.%s.%s_analysis.zip" % (
+                      "qc_report.%s.%s.zip" % (
                           p,
                           '170901_M00879_0087_000000000-AGEW9'),
                       "multiqc_report.html"):
@@ -91,12 +91,12 @@ poll_interval = 0.5
                                 "Missing %s in project '%s'" % (f,p))
             # Check zip file has MultiQC report
             zip_file = os.path.join(mockdir.dirn,p,
-                                    "qc_report.%s.%s_analysis.zip" % (
+                                    "qc_report.%s.%s.zip" % (
                                         p,
                                         '170901_M00879_0087_000000000-AGEW9'))
             with zipfile.ZipFile(zip_file) as z:
                 multiqc = os.path.join(
-                    "qc_report.%s.%s_analysis" % (
+                    "qc_report.%s.%s" % (
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
@@ -156,7 +156,7 @@ mouse = /data/genomeIndexes/mm10/STAR
         for p in ("AB","CDE","undetermined"):
             for f in ("qc",
                       "qc_report.html",
-                      "qc_report.%s.%s_analysis.zip" % (
+                      "qc_report.%s.%s.zip" % (
                           p,
                           '170901_M00879_0087_000000000-AGEW9'),
                       "multiqc_report.html"):
@@ -165,12 +165,12 @@ mouse = /data/genomeIndexes/mm10/STAR
                                 "Missing %s in project '%s'" % (f,p))
             # Check zip file has MultiQC report
             zip_file = os.path.join(mockdir.dirn,p,
-                                    "qc_report.%s.%s_analysis.zip" % (
+                                    "qc_report.%s.%s.zip" % (
                                         p,
                                         '170901_M00879_0087_000000000-AGEW9'))
             with zipfile.ZipFile(zip_file) as z:
                 multiqc = os.path.join(
-                    "qc_report.%s.%s_analysis" % (
+                    "qc_report.%s.%s" % (
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
@@ -231,7 +231,7 @@ mouse = /data/genomeIndexes/mm10/STAR
         for p in ("AB","CDE","undetermined"):
             for f in ("qc",
                       "qc_report.html",
-                      "qc_report.%s.%s_analysis.zip" % (
+                      "qc_report.%s.%s.zip" % (
                           p,
                           '170901_M00879_0087_000000000-AGEW9'),
                       "multiqc_report.html"):
@@ -240,12 +240,12 @@ mouse = /data/genomeIndexes/mm10/STAR
                                 "Missing %s in project '%s'" % (f,p))
             # Check zip file has MultiQC report
             zip_file = os.path.join(mockdir.dirn,p,
-                                    "qc_report.%s.%s_analysis.zip" % (
+                                    "qc_report.%s.%s.zip" % (
                                         p,
                                         '170901_M00879_0087_000000000-AGEW9'))
             with zipfile.ZipFile(zip_file) as z:
                 multiqc = os.path.join(
-                    "qc_report.%s.%s_analysis" % (
+                    "qc_report.%s.%s" % (
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
@@ -307,7 +307,7 @@ mouse = /data/genomeIndexes/mm10/STAR
         for p in ("AB","CDE","undetermined"):
             for f in ("qc",
                       "qc_report.html",
-                      "qc_report.%s.%s_analysis.zip" % (
+                      "qc_report.%s.%s.zip" % (
                           p,
                           '170901_M00879_0087_000000000-AGEW9'),
                       "multiqc_report.html"):
@@ -316,12 +316,12 @@ mouse = /data/genomeIndexes/mm10/STAR
                                 "Missing %s in project '%s'" % (f,p))
             # Check zip file has MultiQC report
             zip_file = os.path.join(mockdir.dirn,p,
-                                    "qc_report.%s.%s_analysis.zip" % (
+                                    "qc_report.%s.%s.zip" % (
                                         p,
                                         '170901_M00879_0087_000000000-AGEW9'))
             with zipfile.ZipFile(zip_file) as z:
                 multiqc = os.path.join(
-                    "qc_report.%s.%s_analysis" % (
+                    "qc_report.%s.%s" % (
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
@@ -397,7 +397,7 @@ mouse = /data/cellranger/transcriptomes/mm10
         for p in ("AB","CDE","undetermined"):
             for f in ("qc",
                       "qc_report.html",
-                      "qc_report.%s.%s_analysis.zip" % (
+                      "qc_report.%s.%s.zip" % (
                           p,
                           '170901_M00879_0087_000000000-AGEW9'),
                       "multiqc_report.html"):
@@ -406,12 +406,12 @@ mouse = /data/cellranger/transcriptomes/mm10
                                 "Missing %s in project '%s'" % (f,p))
             # Check zip file has MultiQC report
             zip_file = os.path.join(mockdir.dirn,p,
-                                    "qc_report.%s.%s_analysis.zip" % (
+                                    "qc_report.%s.%s.zip" % (
                                         p,
                                         '170901_M00879_0087_000000000-AGEW9'))
             with zipfile.ZipFile(zip_file) as z:
                 multiqc = os.path.join(
-                    "qc_report.%s.%s_analysis" % (
+                    "qc_report.%s.%s" % (
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
@@ -488,7 +488,7 @@ mouse = /data/cellranger/transcriptomes/mm10_pre_mrna
         for p in ("AB","CDE","undetermined"):
             for f in ("qc",
                       "qc_report.html",
-                      "qc_report.%s.%s_analysis.zip" % (
+                      "qc_report.%s.%s.zip" % (
                           p,
                           '170901_M00879_0087_000000000-AGEW9'),
                       "multiqc_report.html"):
@@ -497,12 +497,12 @@ mouse = /data/cellranger/transcriptomes/mm10_pre_mrna
                                 "Missing %s in project '%s'" % (f,p))
             # Check zip file has MultiQC report
             zip_file = os.path.join(mockdir.dirn,p,
-                                    "qc_report.%s.%s_analysis.zip" % (
+                                    "qc_report.%s.%s.zip" % (
                                         p,
                                         '170901_M00879_0087_000000000-AGEW9'))
             with zipfile.ZipFile(zip_file) as z:
                 multiqc = os.path.join(
-                    "qc_report.%s.%s_analysis" % (
+                    "qc_report.%s.%s" % (
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
@@ -579,7 +579,7 @@ mouse = /data/cellranger/atac_references/mm10
         for p in ("AB","CDE","undetermined"):
             for f in ("qc",
                       "qc_report.html",
-                      "qc_report.%s.%s_analysis.zip" % (
+                      "qc_report.%s.%s.zip" % (
                           p,
                           '170901_M00879_0087_000000000-AGEW9'),
                       "multiqc_report.html"):
@@ -588,12 +588,12 @@ mouse = /data/cellranger/atac_references/mm10
                                 "Missing %s in project '%s'" % (f,p))
             # Check zip file has MultiQC report
             zip_file = os.path.join(mockdir.dirn,p,
-                                    "qc_report.%s.%s_analysis.zip" % (
+                                    "qc_report.%s.%s.zip" % (
                                         p,
                                         '170901_M00879_0087_000000000-AGEW9'))
             with zipfile.ZipFile(zip_file) as z:
                 multiqc = os.path.join(
-                    "qc_report.%s.%s_analysis" % (
+                    "qc_report.%s.%s" % (
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -72,7 +72,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertEqual(status,0)
         for f in ("qc",
                   "qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "multiqc_report.html"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
@@ -109,7 +109,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertEqual(status,0)
         for f in ("qc",
                   "qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "multiqc_report.html"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
@@ -148,7 +148,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(self.wd,"PJB","qc")),
                         "Missing 'qc'")
         for f in ("qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "multiqc_report.html"):
             self.assertFalse(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
@@ -180,7 +180,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertEqual(status,0)
         for f in ("qc",
                   "qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd)):
+                  "qc_report.PJB.zip"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
                             "Missing %s" % f)
@@ -217,7 +217,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(self.wd,"PJB","qc")),
                         "Missing 'qc'")
         for f in ("qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "multiqc_report.html"):
             self.assertFalse(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
@@ -251,7 +251,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(self.wd,"PJB","qc")),
                         "Missing 'qc'")
         for f in ("qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "multiqc_report.html"):
             self.assertFalse(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
@@ -283,7 +283,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertEqual(status,1)
         for f in ("qc",
                   "qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd)):
+                  "qc_report.PJB.zip"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
                             "Missing %s" % f)
@@ -320,7 +320,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertEqual(status,0)
         for f in ("qc",
                   "qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "multiqc_report.html"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
@@ -358,8 +358,7 @@ class TestQCPipeline(unittest.TestCase):
                                                    "qc.non_default")),
                          "'qc' directory doesn't exist, but should")
         for f in ("qc.non_default_report.html",
-                  "qc.non_default_report.PJB.%s.zip" %
-                  os.path.basename(self.wd),
+                  "qc.non_default_report.PJB.zip",
                   "multiqc.non_default_report.html"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
@@ -390,7 +389,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertEqual(status,0)
         for f in ("qc",
                   "qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "multiqc_report.html"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
@@ -430,7 +429,7 @@ class TestQCPipeline(unittest.TestCase):
         for p in ("AB","CD"):
             for f in ("qc",
                       "qc_report.html",
-                      "qc_report.%s.%s.zip" % (p,os.path.basename(self.wd)),
+                      "qc_report.%s.zip" % p,
                       "multiqc_report.html"):
                 self.assertTrue(os.path.exists(os.path.join(self.wd,p,f)),
                                 "Missing %s" % f)
@@ -464,7 +463,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertEqual(status,0)
         for f in ("qc",
                   "qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "multiqc_report.html"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
@@ -498,7 +497,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertEqual(status,0)
         for f in ("qc",
                   "qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "multiqc_report.html"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
@@ -535,7 +534,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(self.wd,"PJB","qc")),
                         "Missing 'qc'")
         for f in ("qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "multiqc_report.html"):
             self.assertFalse(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
@@ -574,8 +573,7 @@ class TestQCPipeline(unittest.TestCase):
                                                    "qc")),
                          "'qc' directory doesn't exist, but should")
         for f in ("qc_report.html",
-                  "qc_report.PJB.%s.zip" %
-                  os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "multiqc_report.html"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
@@ -621,7 +619,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertEqual(status,0)
         for f in ("qc",
                   "qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "qc/cellranger_count",
                   "qc/cellranger_count/PJB1/_cmdline",
                   "qc/cellranger_count/PJB1/outs/web_summary.html",
@@ -678,7 +676,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertEqual(status,0)
         for f in ("qc",
                   "qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "qc/cellranger_count",
                   "qc/cellranger_count/PJB1/_cmdline",
                   "qc/cellranger_count/PJB1/outs/web_summary.html",
@@ -737,7 +735,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertEqual(status,0)
         for f in ("qc",
                   "qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "qc/cellranger_count",
                   "qc/cellranger_count/PJB1/_cmdline",
                   "qc/cellranger_count/PJB1/outs/web_summary.html",
@@ -795,7 +793,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertEqual(status,0)
         for f in ("qc",
                   "qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "qc/cellranger_count",
                   "qc/cellranger_count/PJB1/_cmdline",
                   "qc/cellranger_count/PJB1/outs/web_summary.html",
@@ -850,7 +848,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertEqual(status,0)
         for f in ("qc",
                   "qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "multiqc_report.html"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
@@ -890,7 +888,7 @@ class TestQCPipeline(unittest.TestCase):
         self.assertEqual(status,0)
         for f in ("qc",
                   "qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "multiqc_report.html"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -332,7 +332,7 @@ class TestReportQCFunction(unittest.TestCase):
         self.assertEqual(report_qc(project),0)
         # Check output and reports
         for f in ("qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "multiqc_report.html"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
@@ -360,7 +360,7 @@ class TestReportQCFunction(unittest.TestCase):
         self.assertEqual(report_qc(project),1)
         # Check output and reports
         for f in ("qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "multiqc_report.html"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
@@ -381,7 +381,7 @@ class TestReportQCFunction(unittest.TestCase):
         self.assertEqual(report_qc(project),1)
         # Check output and reports
         for f in ("qc_report.html",
-                  "qc_report.PJB.%s.zip" % os.path.basename(self.wd),
+                  "qc_report.PJB.zip",
                   "multiqc_report.html"):
             self.assertFalse(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),

--- a/bin/reportqc.py
+++ b/bin/reportqc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     reportqc.py: generate report file for Illumina NGS qc runs
-#     Copyright (C) University of Manchester 2015-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2015-2020 Peter Briggs
 #
 
 #######################################################################

--- a/bin/reportqc.py
+++ b/bin/reportqc.py
@@ -90,7 +90,7 @@ def zip_report(project,report_html,qc_dir=None,qc_protocol=None):
         else:
             logging.warning("ZIP: missing file '%s'" % f)
     # MultiQC output
-    multiqc = os.path.join(project.dirn,
+    multiqc = os.path.join(report_dir,
                            "multi%s_report.html" %
                            os.path.basename(qc_dir))
     if os.path.exists(multiqc):
@@ -244,9 +244,17 @@ def main():
             print("Verification: OK")
             if args.verify:
                 continue
+        # Filename and location for report
+        if args.filename is None:
+            out_file = '%s_report.html' % qc_base
+        else:
+            out_file = args.filename
+        if not os.path.isabs(out_file):
+            out_file = os.path.join(p.dirn,out_file)
+        out_dir = os.path.dirname(out_file)
         # MultiQC report
         if args.multiqc:
-            multiqc_report = os.path.join(p.dirn,
+            multiqc_report = os.path.join(out_dir,
                                           "multi%s_report.html" %
                                           qc_base)
             # Check if we need to rerun MultiQC
@@ -278,13 +286,7 @@ def main():
                     retval += 1
             else:
                 print("MultiQC: %s (already exists)" % multiqc_report)
-        # Report generation
-        if args.filename is None:
-            out_file = '%s_report.html' % qc_base
-        else:
-            out_file = args.filename
-        if not os.path.isabs(out_file):
-            out_file = os.path.join(p.dirn,out_file)
+        # Generate report
         report_html= qc_reporter.report(qc_dir=qc_dir,
                                         qc_protocol=protocol,
                                         title=args.title,

--- a/bin/reportqc.py
+++ b/bin/reportqc.py
@@ -181,8 +181,7 @@ def main():
     retval = 0
     for d in args.dirs:
         dir_path = os.path.abspath(d)
-        project_name = os.path.basename(dir_path)
-        p = AnalysisProject(project_name,dir_path)
+        p = AnalysisProject(dir_path)
         print("Project           : %s" % p.name)
         print("Primary Fastqs dir: %s" % p.fastq_dir)
         if args.qc_dir is None:

--- a/bin/reportqc.py
+++ b/bin/reportqc.py
@@ -52,23 +52,24 @@ def zip_report(project,report_html,qc_dir=None,qc_protocol=None):
       String: path to the output ZIP file.
     """
     print("Making ZIP file:")
+    print("-- Project name        : %s" % project.name)
+    print("-- Run                 : %s" % project.info.run)
     print("-- Protocol            : %s" % qc_protocol)
     print("-- QC dir              : %s" % qc_dir)
     print("-- Single cell platform: %s" % project.info.single_cell_platform)
     # Name for ZIP file
+    report_dir = os.path.dirname(report_html)
     basename = os.path.splitext(os.path.basename(report_html))[0]
-    analysis_dir = os.path.basename(os.path.dirname(project.dirn))
+    run_name = project.info.run
+    zip_prefix = "%s.%s%s" % (basename,
+                              project.name,
+                              '.%s' % run_name if run_name else '')
+    print("-- ZIP prefix          : %s" % zip_prefix)
+    report_zip = os.path.join(report_dir,"%s.zip" % zip_prefix)
     # Create ZIP archive
-    report_zip = os.path.join(project.dirn,
-                              "%s.%s.%s.zip" %
-                              (basename,
-                               project.name,
-                               analysis_dir))
-    zip_file = ZipArchive(report_zip,relpath=project.dirn,
-                          prefix="%s.%s.%s" %
-                          (basename,
-                           project.name,
-                           analysis_dir))
+    zip_file = ZipArchive(report_zip,
+                          relpath=os.path.dirname(qc_dir),
+                          prefix=zip_prefix)
     # Get QC dir if not set
     if qc_dir is None:
         qc_dir = project.qc_dir


### PR DESCRIPTION
PR which updates the naming of the ZIP file generated as part of the reporting in the QC pipeline.

Specifically: the files are now named as `<QC_DIR>_report.<PROJECT>[.<RUN>].zip`; the `<RUN>` component is only included if it's explicitly set in the project metadata, for example.

Previously the convention was `<QC_DIR>_report.<PROJECT>.<PARENT_DIR>.zip`, but this could lead to strange names for QC run in non-auto-process projects.

The change requires changes to other parts of the system which handle projects and QC outputs (for example the `import_project` and `publish_qc` commands, and in the unit tests for running and reporting the QC). In the case of `publish_qc`, the old style naming convention is still recognised as a fallback if new style names are not found.