### PR TITLE
run_qc.py: enable running on arbitrary lists of Fastqs

### DIFF
--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -569,6 +569,7 @@ if __name__ == "__main__":
         logger.critical("QC failed (see warnings above)")
 
     # Update the QC metadata
+    announce("Updating QC metadata")
     qc_info = AnalysisProjectQCDirInfo(filen=os.path.join(qc_dir,
                                                           "qc.info"))
     if qc_info.fastq_dir:
@@ -583,5 +584,11 @@ if __name__ == "__main__":
                                                if qc_info.fastq_dir
                                                else '<not set>'))
 
+    # Report locations of final outputs
+    announce("QC pipeline completed")
+    print("Output directory   : %s" % out_dir)
+    print("HTML report        : %s" % out_file)
+    print("QC output directory: %s" % qc_dir)
+    print("Exit status        : %s" % status)
     # Finish and return exit code from pipeline
     sys.exit(status)

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -22,10 +22,16 @@ import os
 import argparse
 import psutil
 import math
+import glob
+import tempfile
+import shutil
+import atexit
 import logging
 from bcftbx.JobRunner import fetch_runner
 from bcftbx.JobRunner import SimpleJobRunner
 from auto_process_ngs.analysis import AnalysisProject
+from auto_process_ngs.metadata import AnalysisProjectInfo
+from auto_process_ngs.metadata import AnalysisProjectQCDirInfo
 import auto_process_ngs
 import auto_process_ngs.settings
 import auto_process_ngs.envmod as envmod
@@ -74,6 +80,18 @@ def announce(title):
     print(title)
     print("="*len_title)
 
+def cleanup_atexit(tmp_project_dir):
+    """
+    Perform clean up actions on exit
+
+    Removes the temporary project directory
+    created for running the QC
+    """
+    if os.path.isdir(tmp_project_dir):
+        print("Removing temporary project directory: %s"
+              % tmp_project_dir)
+        shutil.rmtree(tmp_project_dir)
+
 #######################################################################
 # Main program
 #######################################################################
@@ -88,8 +106,9 @@ if __name__ == "__main__":
     # Build parser
     p.add_argument('--version', action='version',
                    version=("%%(prog)s %s" % __version__))
-    p.add_argument("project_dir",metavar="DIR",
-                   help="directory with Fastq files to run the "
+    p.add_argument("inputs",metavar="DIR | FASTQ [ FASTQ ... ]",
+                   nargs="+",
+                   help="directory or list of Fastq files to run the "
                    "QC on")
     p.add_argument('-p','--protocol',metavar='PROTOCOL',
                    action='store',dest='qc_protocol',default=None,
@@ -129,16 +148,21 @@ if __name__ == "__main__":
                    "settings)")
     # Reporting options
     reporting = p.add_argument_group('Output and reporting')
-    reporting.add_argument('--qc_dir',metavar='QC_DIR',
-                           action='store',dest='qc_dir',default=None,
+    reporting.add_argument('-n','--name',action='store',
+                           help="name for the project")
+    reporting.add_argument('-o','--out_dir',action='store',
+                           help="directory to write outputs to (default: "
+                           "project directory (if directory was supplied "
+                           "and is a project; otherwise, use current "
+                           "working directory)")
+    reporting.add_argument('--qc_dir',
                            help="explicitly specify QC output directory. "
                            "NB if a relative path is supplied then it's "
-                           "assumed to be a subdirectory of DIR (default: "
-                           "<DIR>/qc)")
-    reporting.add_argument('-f','--filename',metavar='NAME',action='store',
-                           dest='filename',default=None,
+                           "assumed to be a subdirectory of OUT_DIR "
+                           "(default: <OUT_DIR>/qc)")
+    reporting.add_argument('-f','--filename',action='store',
                            help="file name for output QC report (default: "
-                           "<DIR>/<QC_DIR>_report.html)")
+                           "<OUT_DIR>/<QC_DIR_NAME>_report.html)")
     reporting.add_argument('--multiqc',action='store_true',
                            dest='run_multiqc', default=False,
                            help="also generate MultiQC report")
@@ -210,6 +234,91 @@ if __name__ == "__main__":
 
     # Parse the command line
     args = p.parse_args()
+
+    # Initialise
+    project_metadata = AnalysisProjectInfo()
+    dir_path = os.getcwd()
+    out_dir = args.out_dir
+    qc_dir = args.qc_dir
+    master_fastq_dir = None
+
+    # Deal with inputs
+    #
+    # Possibilities are:
+    # - subdirectory in a project
+    # - project directory
+    # - non-project directory with Fastqs
+    # - list of Fastqs
+    announce("Locating inputs")
+    inputs = []
+    for f in args.inputs:
+        for ff in glob.glob(os.path.abspath(f)):
+            if not os.path.exists(ff):
+                # Input not found
+                logger.fatal("%s: input not found" % ff)
+                sys.exit(1)
+            elif os.path.isdir(ff) and len(args.inputs) > 1:
+                # Can only be a single directory
+                logger.fatal("Input must be a single directory, or a list of "
+                             "Fastqs")
+                sys.exit(1)
+            else:
+                inputs.append(ff)
+    # Get list of Fastqs from directory
+    if len(inputs) == 1 and os.path.isdir(inputs[0]):
+        dir_path = inputs[0]
+        if args.fastq_dir:
+            # Fastqs subdir was specified
+            dir_path = os.path.join(dir_path,args.fastq_dir)
+        if not os.path.isdir(dir_path):
+            logger.fatal("%s: directory not found" % dir_path)
+            sys.exit(1)
+        # See if directory contains Fastqs
+        inputs = [os.path.join(dir_path,f)
+                  for f in os.listdir(inputs[0])
+                  if (f.endswith('.fastq') or
+                      f.endswith('.fq') or
+                      f.endswith('.fastq.gz'))]
+        if not inputs:
+            # No Fastqs, try loading as a project
+            inputs = list(AnalysisProject(dir_path).fastqs)
+            master_fastq_dir = AnalysisProject(dir_path).fastq_dir
+        else:
+            # Store the source directory for Fastqs
+            master_fastq_dir = dir_path
+        # Check we have some Fastqs
+        if not inputs:
+            logger.fatal("%s: no Fastqs found" % dir_path)
+            sys.exit(1)
+        # Look for project metadata
+        d = dir_path
+        while True:
+            info_file = os.path.join(d,"README.info")
+            if os.path.exists(info_file):
+                try:
+                    # Try to load metadata
+                    project_metadata.load(info_file,
+                                          fail_on_error=True)
+                    print("Located project metadata in %s" % info_file)
+                    # Fastqs are in a subdirectory of a project directory,
+                    # set it as the default output directory
+                    if not out_dir:
+                        out_dir = d
+                    break
+                except Exception:
+                    # Failed to load valid metadata file
+                    pass
+            # Try next level up
+            d = os.path.dirname(d)
+            if d == os.path.sep:
+                # Run out of directories
+                print("Unable to locate project metadata")
+                break
+    print("Located %s Fastq%s" % (len(inputs),
+                                  's' if len(inputs) != 1 else ''))
+    if not inputs:
+        logger.fatal("No Fastqs found")
+        sys.exit(1)
 
     # Set up environment
     envmodules = dict()
@@ -352,28 +461,68 @@ if __name__ == "__main__":
                 'report_runner': default_runner,
             }
 
-    # Load the project
-    announce("Loading project data")
-    project_dir = os.path.abspath(args.project_dir)
-    project_name = os.path.basename(project_dir)
-    project = AnalysisProject(project_name,project_dir)
+    # Output directory
+    announce("Setting up output destinations")
+    if not out_dir:
+        out_dir = os.getcwd()
+    out_dir = os.path.abspath(out_dir)
+    print("Output directory: %s" % out_dir)
+    if not os.path.exists(out_dir):
+        os.mkdir(out_dir)
+
+    # QC directory
+    if not qc_dir:
+        qc_dir = 'qc'
+    qc_dir = os.path.join(out_dir,qc_dir)
+    print("QC directory    : %s" % qc_dir)
 
     # Output file name
     if args.filename is None:
-        out_file = None
+        out_file = "%s_report.html" % os.path.basename(qc_dir)
     else:
         out_file = args.filename
-        if not os.path.isabs(out_file):
-            out_file = os.path.join(project.dirn,out_file)
+    if not os.path.isabs(out_file):
+        out_file = os.path.join(out_dir,out_file)
+    print("Output report: %s" % out_file)
+
+    # Build and populate a temporary project directory
+    announce("Building temporary project directory")
+    project_dir = tempfile.mkdtemp(suffix=".run_qc",dir=os.getcwd())
+    print("Building temporary project directory '%s'" % project_dir)
+    fastq_dir = os.path.join(project_dir,"fastqs")
+    os.mkdir(fastq_dir)
+    print("Populating %s" % fastq_dir)
+    for fq in inputs:
+        # Make symlinks to the Fastq files
+        os.symlink(fq,os.path.join(fastq_dir,os.path.basename(fq)))
+
+    # Set up metadata
+    info_file = os.path.join(project_dir,"README.info")
+    if args.name:
+        # Set project name to user-supplied value
+        project_metadata['name'] = args.name
+    elif project_metadata.name is None:
+        # Set to output directory name if not already set
+        project_metadata['name'] = os.path.basename(out_dir)
+    if args.organism:
+        project_metadata['organism'] = args.organism
+    print("Writing metadata to %s" % info_file)
+    project_metadata.save(info_file)
+
+    # Remove the temporary directory on exit
+    atexit.register(cleanup_atexit,project_dir)
+
+    # Load the project
+    project = AnalysisProject(project_dir)
+    print("Loaded project '%s'" % project.name)
 
     # Set up and run the QC pipeline
     announce("Running QC pipeline")
     runqc = QCPipeline()
     runqc.add_project(project,
-                      qc_dir=args.qc_dir,
-                      fastq_dir=args.fastq_dir,
-                      organism=args.organism,
+                      qc_dir=qc_dir,
                       qc_protocol=args.qc_protocol,
+                      report_html=out_file,
                       multiqc=args.run_multiqc)
     status = runqc.run(nthreads=nthreads,
                        fastq_subset=args.fastq_screen_subset,
@@ -401,4 +550,21 @@ if __name__ == "__main__":
                        verbose=args.verbose)
     if status:
         logger.critical("QC failed (see warnings above)")
+
+    # Update the QC metadata
+    qc_info = AnalysisProjectQCDirInfo(filen=os.path.join(qc_dir,
+                                                          "qc.info"))
+    if qc_info.fastq_dir:
+        if master_fastq_dir:
+            print("Updating stored Fastq directory for QC: %s" %
+                  master_fastq_dir)
+        else:
+            print("Unsetting stored Fastq directory for QC")
+        qc_info['fastq_dir'] = master_fastq_dir
+        qc_info.save()
+        print("Updated Fastq directory: %s" % (qc_info.fastq_dir
+                                               if qc_info.fastq_dir
+                                               else '<not set>'))
+
+    # Finish and return exit code from pipeline
     sys.exit(status)

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -528,6 +528,11 @@ if __name__ == "__main__":
     project = AnalysisProject(project_dir)
     print("Loaded project '%s'" % project.name)
 
+    # Set working directory for pipeline
+    working_dir = args.working_dir
+    if not working_dir:
+        working_dir = os.path.join(project_dir,'__run_qc')
+
     # Set up and run the QC pipeline
     announce("Running QC pipeline")
     runqc = QCPipeline()
@@ -558,7 +563,7 @@ if __name__ == "__main__":
                        runners=runners,
                        default_runner=default_runner,
                        envmodules=envmodules,
-                       working_dir=args.working_dir,
+                       working_dir=working_dir,
                        verbose=args.verbose)
     if status:
         logger.critical("QC failed (see warnings above)")

--- a/docs/source/using/run_qc_standalone.rst
+++ b/docs/source/using/run_qc_standalone.rst
@@ -8,20 +8,57 @@ The general invocation is:
 
 ::
 
-   run_qc.py DIR [ DIR ... ]
+   run_qc.py DIR | FASTQ [ FASTQ ... ]
 
-where ``DIR`` is a directory with the Fastq files to run the QC
-on (or which has a ``fastqs`` subdirectory with the Fastqs; use
-the ``--fastq_dir`` option to specify a different subdirectory).
+If ``DIR`` is supplied then it should be a directory containing
+the Fastq files to run the QC on, or which has a ``fastqs``
+subdirectory with the Fastqs (use the ``--fastq_dir`` option to
+specify a different subdirectory), for example:
 
-Some of the most commonly used options are:
+::
 
-* ``--protocol``: specify the QC protocol
+   run_qc.py /mnt/data/project --fastq_dir=fastqs.trimmed
+
+Alternatively a list of Fastq files can be supplied directly,
+for example:
+
+::
+
+   run_qc.py /mnt/data/project/fastqs.trimmed/*.fastq
+
+Specifying the QC metadata
+--------------------------
+
+The following options specify metadata for the QC which will
+determine which metrics are run:
+
+* ``--protocol``: specify the QC protocol (see :doc:`run_qc`
+  for a complete list)
 * ``--organism``: specify the organism(s)
-* ``--multiqc``: turns on generation of MultiQC reports
+* ``--name``: sets the name for the project (used in the
+  QC report title)
 
 (See the documentation in the :ref:`utilities_run_qc` section
 for the full range of options.)
+
+Specifying the outputs
+----------------------
+
+If a list of Fastqs is supplied then by default the QC reports
+will be written to the current directory, with the QC outputs
+written to a ``qc`` subdirectory. If a directory is supplied as
+input then the reports and ``qc`` subdirectory will be written
+to that directory.
+
+The following options can be used to override the defaults:
+
+* ``-o``/``--out_dir``: sets the top-level directory where
+  the QC reports and outputs are written
+* ``--qc_dir``: sets the location where the QC outputs are
+  written; if this is a relative path then it will be a
+  subdirectory of the top-level output directory
+* ``--filename``: name for the HTML report from the QC
+* ``--multiqc``: turns on generation of MultiQC reports
 
 Running on different platforms: ``--local``
 -------------------------------------------
@@ -56,8 +93,8 @@ CPUs and memory. However the following options can be used with
   being run. If this isn't set explicitly then the pipeline will
   attempt to determine the available memory automatically.
 
-For example: submitting a QC run as a single job on a Grid
-Engine compute cluster might look like:
+Explicitly specifying these parameters for a QC run submitted as
+a single job on a Grid Engine compute cluster might look like:
 
 ::
 

--- a/docs/source/using/run_qc_standalone.rst
+++ b/docs/source/using/run_qc_standalone.rst
@@ -26,6 +26,10 @@ for example:
 
    run_qc.py /mnt/data/project/fastqs.trimmed/*.fastq
 
+Various options are available to control the QC; the following
+sections outline the most useful - see the documentation in the
+:ref:`utilities_run_qc` section for the full set of options.
+
 Specifying the QC metadata
 --------------------------
 
@@ -37,9 +41,6 @@ determine which metrics are run:
 * ``--organism``: specify the organism(s)
 * ``--name``: sets the name for the project (used in the
   QC report title)
-
-(See the documentation in the :ref:`utilities_run_qc` section
-for the full range of options.)
 
 Specifying the outputs
 ----------------------


### PR DESCRIPTION
PR which addresses issue #358 and allows the `run_qc.py` utility to operate on a list of arbitrary Fastq files supplied on the command line, as well as on (project) directories as before.

The PR also adds new options to allow the top-level output directory (`--out_dir`) and project name (`--name`) to be set.