### PR TITLE
Update 'process_icell8.py' to work with latest 'pipeliner' changes

### DIFF
--- a/auto_process_ngs/icell8/pipeline.py
+++ b/auto_process_ngs/icell8/pipeline.py
@@ -1954,8 +1954,7 @@ class UpdateProjectData(PipelineTask):
     def setup(self):
         # Load the project data
         project_dir = os.path.abspath(self.args.project_dir)
-        project = AnalysisProject(project_dir,
-                                  os.path.basename(project_dir))
+        project = AnalysisProject(project_dir)
         # Set the primary fastq set
         project.set_primary_fastq_dir(self.args.primary_fastq_dir)
         # Set the number of cells

--- a/auto_process_ngs/icell8/pipeline.py
+++ b/auto_process_ngs/icell8/pipeline.py
@@ -1092,7 +1092,7 @@ class GetICell8Stats(PipelineTask):
             (default: taken from job runner)
 
         Outputs:
-          stats_file (st): path to the output stats file
+          stats_file (str): path to the output stats file
         """
         self.add_output('stats_file',stats_file)
     def setup(self):

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -200,8 +200,8 @@ class Settings(object):
                                                         'mammalian_conf_file')
         self.icell8['contaminants_conf_file'] = config.get('icell8',
                                                            'contaminants_conf_file')
-        self.icell8['nprocessors_contaminant_filter'] = config.getint('icell8','nprocessors_contaminant_filter',1)
-        self.icell8['nprocessors_statistics'] = config.getint('icell8','nprocessors_statistics',1)
+        self.icell8['nprocessors_contaminant_filter'] = config.getint('icell8','nprocessors_contaminant_filter',None)
+        self.icell8['nprocessors_statistics'] = config.getint('icell8','nprocessors_statistics',None)
         # 10xgenomics
         self.add_section('10xgenomics')
         self['10xgenomics']['cellranger_jobmode'] = config.get('10xgenomics',

--- a/bin/process_icell8.py
+++ b/bin/process_icell8.py
@@ -243,7 +243,7 @@ if __name__ == "__main__":
     try:
         default_nprocessors = nprocessors['default']
     except KeyError:
-        default_nprocessors = 1
+        default_nprocessors = None
     for stage in stages:
         stage_nprocessors = default_nprocessors
         if stage not in nprocessors:

--- a/bin/process_icell8.py
+++ b/bin/process_icell8.py
@@ -321,10 +321,11 @@ if __name__ == "__main__":
     print("Stage specific settings :")
     for stage in stages:
         nprocs = nprocessors[stage]
+        runner = runners[stage]
         print("-- %s: %s (nprocs=%s)" % (stage,
-                                         runners[stage],
+                                         runner,
                                          nprocs if nprocs
-                                         else '<from runner>'))
+                                         else runner.nslots))
     if modulefiles is not None:
         print("Environment modules:")
         for modulefile in modulefiles.split(','):

--- a/bin/process_icell8.py
+++ b/bin/process_icell8.py
@@ -231,6 +231,8 @@ if __name__ == "__main__":
         if stage not in stages:
             logger.fatal("Bad stage for --nprocessors option: %s" % stage)
             sys.exit(1)
+        if n is not None:
+            n = int(n)
         nprocessors[stage] = int(n)
     if args.threads is not None:
         for stage in ('contaminant_filter','statistics'):
@@ -318,9 +320,11 @@ if __name__ == "__main__":
     print("Maximum concurrent jobs : %s" % max_jobs)
     print("Stage specific settings :")
     for stage in stages:
-        print("-- %s: %s (nprocs=%d)" % (stage,
+        nprocs = nprocessors[stage]
+        print("-- %s: %s (nprocs=%s)" % (stage,
                                          runners[stage],
-                                         nprocessors[stage]))
+                                         nprocs if nprocs
+                                         else '<from runner>'))
     if modulefiles is not None:
         print("Environment modules:")
         for modulefile in modulefiles.split(','):


### PR DESCRIPTION
PR which updates the `process_icell8.py` utility to work with the latest updates to `pipeliner`, specifically:

* Fix a bug with handling and reporting the number of processors for different pipeline stages on startup
* Update tasks to get the default number of available CPUs from the job runners, where appropriate