### PR TITLE
Store sequencer model in analysis directory metadata

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -380,6 +380,7 @@ class AnalysisProject(object):
     comments    : additional comments, either None or else string of text
     paired_end  : True if data is paired end, False if not
     primary_fastq_dir: subdirectory holding the 'primary' fastq set
+    sequencer_model: model of sequencer used to generate the data
 
     It is possible for a project to have multiple sets of associated
     fastq files, held within separate subdirectories of the project
@@ -400,8 +401,8 @@ class AnalysisProject(object):
     """
     def __init__(self,name,dirn=None,user=None,PI=None,library_type=None,
                  single_cell_platform=None,organism=None,run=None,
-                 comments=None,platform=None,fastq_attrs=None,
-                 fastq_dir=None):
+                 comments=None,platform=None,sequencer_model=None,
+                 fastq_attrs=None,fastq_dir=None):
         """Create a new AnalysisProject instance
 
         Arguments:
@@ -474,6 +475,8 @@ class AnalysisProject(object):
             self.info['organism'] = organism
         if platform is not None:
             self.info['platform'] = platform
+        if sequencer_model is not None:
+            self.info['sequencer_model'] = sequencer_model
         if comments is not None:
             self.info['comments'] = comments
 
@@ -1311,6 +1314,7 @@ def copy_analysis_project(project,fastq_dir=None):
                            run=project.info.run,
                            comments=project.info.comments,
                            platform=project.info.platform,
+                           sequencer_model=project.info.sequencer_model,
                            fastq_dir=fastq_dir,
                            fastq_attrs=
                            project.fastq_attrs)

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -335,6 +335,18 @@ class AutoProcess(object):
                 print("Setting 'platform' metadata item to %s" %
                       platform)
                 self.metadata['platform'] = platform
+        # Sequencer model
+        if self.metadata.sequencer_model is None:
+            instrument_name = self.metadata.instrument_name
+            if instrument_name:
+                try:
+                    self.metadata.sequencer_model = \
+                        self.settings.sequencers[instrument_name].model
+                    print("Setting 'sequencer_model' metadata item to "
+                          "'%s'" % self.metadata.sequencer_model)
+                except KeyError:
+                    print("Unable to get sequencer model for "
+                          "instrument '%s'" % instrument_name)
 
     def edit_samplesheet(self):
         """

--- a/auto_process_ngs/bcl2fastq_utils.py
+++ b/auto_process_ngs/bcl2fastq_utils.py
@@ -93,7 +93,7 @@ def get_sequencer_platform(dirn,instrument=None,settings=None):
     if instrument and settings:
         print("Identifying platform from instrument name")
         try:
-            return settings.sequencers[instrument]
+            return settings.sequencers[instrument].platform
         except KeyError:
             # Instrument not listed in the settings
             logger.warning("Instrument name '%s' not found in "

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -402,6 +402,9 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                        value=ap.metadata.run_number)
     params_tbl.add_row(param="Platform",
                        value=ap.metadata.platform)
+    if ap.metadata.sequencer_model:
+        params_tbl.add_row(param="Sequencer",
+                           value=ap.metadata.sequencer_model)
     params_tbl.add_row(param="Endedness",
                        value=('Paired end' if ap.paired_end
                               else 'Single end'))

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -242,6 +242,7 @@ def report_summary(ap):
     - Platform
     - Run name
     - Run reference id
+    - Sequencer model
     - Processing software
     - Assay (i.e. sequencing kit)
 
@@ -266,6 +267,7 @@ def report_summary(ap):
     report_items = ['Run name',
                     'Reference',
                     'Platform',
+                    'Sequencer',
                     'Directory',
                     'Endedness',
                     'Bcl2fastq',]
@@ -323,6 +325,8 @@ def report_summary(ap):
             value = ap.run_reference_id
         elif item == 'Platform':
             value = platform
+        elif item == 'Sequencer':
+            value = ap.metadata.sequencer_model
         elif item == 'Directory':
             value = ap.params.analysis_dir
         elif item == 'Endedness':
@@ -540,6 +544,9 @@ def fetch_value(ap,project,field):
     elif field == 'sequencer_platform' or field == 'platform':
         return ('' if not ap.metadata.platform
                 else str(ap.metadata.platform).upper())
+    elif field == 'sequencer_model':
+        return ('' if not ap.metadata.sequencer_model
+                else ap.metadata.sequencer_model)
     elif field == 'no_of_samples' or field == '#samples':
         return str(len(project.samples))
     elif field == 'no_of_cells' or field == '#cells':

--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -137,7 +137,8 @@ def setup_analysis_dirs(ap,
             single_cell_platform=single_cell_platform,
             run=run_name,
             comments=comments,
-            platform=ap.metadata.platform)
+            platform=ap.metadata.platform,
+            sequencer_model=ap.metadata.sequencer_model)
         if project.exists:
             logging.warning("Project '%s' already exists, skipping" %
                             project.name)

--- a/auto_process_ngs/commands/setup_cmd.py
+++ b/auto_process_ngs/commands/setup_cmd.py
@@ -122,6 +122,15 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
                                           instrument=instrument,
                                           settings=ap.settings)
     print("Platform identified as '%s'" % platform)
+    # Sequencer model
+    model = ap.metadata.sequencer_model
+    if model is None:
+        try:
+            model = ap.settings.sequencers[instrument]['model']
+        except KeyError:
+            pass
+    if model:
+        print("Sequencer model identified as '%s'" % model)
     # Log dir
     ap.set_log_dir(ap.get_log_subdir('setup'))
     # Attempt to acquire sample sheet
@@ -301,6 +310,7 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
     ap.metadata['instrument_datestamp'] = datestamp
     ap.metadata['instrument_run_number'] = run_number
     ap.metadata['instrument_flow_cell_id'] = flow_cell
+    ap.metadata['sequencer_model'] = model
     ap.metadata['assay'] = assay
     ap.metadata['source'] = data_source
     # Make a 'projects.info' metadata file

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -326,6 +326,7 @@ class AnalysisDirMetadata(MetadataDict):
       instrument
     instrument_flow_cell_id: the flow cell ID from the sequencing
       instrument
+    sequencer_model: the model of the sequencing instrument
 
     """
     def __init__(self,filen=None):
@@ -349,6 +350,7 @@ class AnalysisDirMetadata(MetadataDict):
                                   'instrument_datestamp': 'instrument_datestamp',
                                   'instrument_flow_cell_id': 'instrument_flow_cell_id',
                                   'instrument_run_number': 'instrument_run_number',
+                                  'sequencer_model': 'sequencer_model',
                               },
                               order=('run_name',
                                      'platform',

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -369,6 +369,7 @@ class AnalysisProjectInfo(MetadataDict):
     name: the project name
     run: the name of the sequencing run
     platform: the sequencing platform name e.g. 'miseq'
+    sequencer_model: the sequencer model e.g. 'MiSeq'
     user: the user associated with the project
     PI: the principal investigator associated with the project
     organism: the organism associated with the project
@@ -395,6 +396,7 @@ class AnalysisProjectInfo(MetadataDict):
                                   'name':'Project name',
                                   'run':'Run',
                                   'platform':'Platform',
+                                  'sequencer_model':'Sequencer model',
                                   'user':'User',
                                   'PI':'PI',
                                   'organism':'Organism',
@@ -421,6 +423,7 @@ class AnalysisProjectInfo(MetadataDict):
                                   'paired_end',
                                   'primary_fastq_dir',
                                   'samples',
+                                  'sequencer_model',
                                   'comments',
                               ),
                               filen=filen)

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -790,6 +790,7 @@ class QCReport(Document):
         """
         metadata_items = ['run',
                           'run_id',
+                          'sequencer_model',
                           'user',
                           'PI',
                           'library_type',
@@ -811,6 +812,7 @@ class QCReport(Document):
             'user': 'User',
             'PI': 'PI',
             'library_type': 'Library type',
+            'sequencer_model': 'Sequencer model',
             'single_cell_platform': 'Single cell preparation platform',
             'number_of_cells': 'Number of cells',
             'organism': 'Organism',

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -509,13 +509,18 @@ class Settings(object):
             logging.warning("No settings file found, reporting built-in "
                             "defaults")
         for section in self._sections:
+            if section == 'sequencers':
+                display_name = 'sequencer'
+            else:
+                display_name = section
             if self.has_subsections(section):
                 for subsection in getattr(self,section):
                     text.append(
-                        show_dictionary('%s:%s' % (section,subsection),
+                        show_dictionary('%s:%s' % (display_name,subsection),
                                         getattr(self,section)[subsection]))
             else:
-                text.append(show_dictionary(section,getattr(self,section)))
+                text.append(show_dictionary(display_name,
+                                            getattr(self,section)))
         return '\n'.join(text)
 
 #######################################################################

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -161,11 +161,25 @@ class Settings(object):
             logging.debug("No strand stats conf files defined")
         # Sequencers
         self.add_section('sequencers')
+        for section in filter(lambda x: x.startswith('sequencer:'),
+                              config.sections()):
+            instrument = section.split(':')[1]
+            self.sequencers[instrument] = self.get_sequencer_config(
+                section,config)
+        # Add any settings legacy 'sequencers' section
         try:
             for instrument,platform in config.items('sequencers'):
-                self['sequencers'][instrument] = platform
+                if instrument not in self.sequencers:
+                    self['sequencers'][instrument] = \
+                        AttributeDictionary(platform=None,
+                                            model=None)
+                self['sequencers'][instrument]['platform'] = platform
+            logging.warning("Added sequencer information from "
+                            "deprecated 'sequencers' section (use "
+                            "'seqencer:INSTRUMENT' sections "
+                            "instead)")
         except NoSectionError:
-            logging.debug("No sequencers defined")
+            pass
         # Sequencing platform-specific defaults
         self.add_section('platform')
         for section in filter(lambda x: x.startswith('platform:'),
@@ -363,6 +377,40 @@ class Settings(object):
         values['include_qc_report'] = config.getboolean(
             section,'include_qc_report',False)
         values['hard_links'] = config.getboolean(section,'hard_links',False)
+        return values
+
+    def get_sequencer_config(self,section,config):
+        """
+        Retrieve 'sequencer' configuration options from .ini file
+
+        Given the name of a section (e.g. 'sequencer:SN7001250'),
+        fetch the data associated with the sequencer instrument
+        and return in an AttributeDictionary object.
+
+        The items that can be extracted are:
+
+        - platform (compulsory, str)
+        - model (str, default 'None')
+
+        Arguments:
+          section (str): name of the section to retrieve the
+            settings from
+          config (Config): Config object with settings loaded
+
+        Returns:
+          AttributeDictionary: dictionary of option:value pairs.
+        """
+        values = AttributeDictionary()
+        values['platform'] = config.get(section,'platform',None)
+        values['model'] = config.get(section,'model',None)
+        if values['platform'] is None:
+            raise Exception("%s: missing required 'platform'" % section)
+        if values['model']:
+            # Strip quotes
+            model = values['model']
+            while model[0] in ('"','\'',) and model[-1] in ('"','\'',):
+                model = model[1:-1]
+            values['model'] = model
         return values
 
     def set(self,param,value):

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -176,7 +176,7 @@ class Settings(object):
                 self['sequencers'][instrument]['platform'] = platform
             logging.warning("Added sequencer information from "
                             "deprecated 'sequencers' section (use "
-                            "'seqencer:INSTRUMENT' sections "
+                            "'sequencer:INSTRUMENT' sections "
                             "instead)")
         except NoSectionError:
             pass

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -274,16 +274,19 @@ class TestReportConcise(unittest.TestCase):
             'miseq',
             metadata={ "source": "testing",
                        "run_number": 87,
-                       "assay": "Nextera" },
+                       "assay": "Nextera",
+                       "sequencer_model": "MiSeq" },
             project_metadata={
                 "AB": { "User": "Alison Bell",
                         "Library type": "RNA-seq",
                         "Organism": "Human",
-                        "PI": "Audrey Bower" },
+                        "PI": "Audrey Bower",
+                        "Sequencer model": "MiSeq" },
                 "CDE": { "User": "Charles David Edwards",
                          "Library type": "ChIP-seq",
                          "Organism": "Mouse",
-                         "PI": "Colin Delaney Eccleston" }
+                         "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "MiSeq" }
             },
             top_dir=self.dirn)
         mockdir.create()
@@ -374,16 +377,19 @@ class TestReportSummary(unittest.TestCase):
             'miseq',
             metadata={ "source": "testing",
                        "run_number": 87,
-                       "assay": "Nextera" },
+                       "assay": "Nextera",
+                       "sequencer_model": "MiSeq" },
             project_metadata={
                 "AB": { "User": "Alison Bell",
                         "Library type": "RNA-seq",
                         "Organism": "Human",
-                        "PI": "Audrey Bower" },
+                        "PI": "Audrey Bower",
+                        "Sequencer model": "MiSeq" },
                 "CDE": { "User": "Charles David Edwards",
                          "Library type": "ChIP-seq",
                          "Organism": "Mouse",
                          "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "MiSeq",
                          "Comments": "Repeat of previous run" }
             },
             top_dir=self.dirn)
@@ -396,6 +402,7 @@ class TestReportSummary(unittest.TestCase):
 Run name : 170901_M00879_0087_000000000-AGEW9
 Reference: MISEQ_170901#87
 Platform : MISEQ
+Sequencer: MiSeq
 Directory: %s
 Endedness: Paired end
 Bcl2fastq: Unknown
@@ -425,7 +432,8 @@ Additional notes/comments:
                        "('/usr/bin/bcl2fastq', 'bcl2fastq', '2.17.1.14')",
                        "cellranger_software":
                        "('/usr/bin/cellranger', 'cellranger', '3.0.1')",
-                       "assay": "Nextera" },
+                       "assay": "Nextera",
+                       "sequencer_model": "MiSeq" },
             project_metadata={
                 "AB": { "User": "Alison Bell",
                         "Library type": "scRNA-seq",
@@ -449,6 +457,7 @@ Additional notes/comments:
 Run name  : 170901_M00879_0087_000000000-AGEW9
 Reference : MISEQ_170901#87
 Platform  : MISEQ
+Sequencer : MiSeq
 Directory : %s
 Endedness : Paired end
 Bcl2fastq : bcl2fastq 2.17.1.14
@@ -479,7 +488,8 @@ Additional notes/comments:
                        "('/usr/bin/bcl2fastq', 'bcl2fastq', '2.17.1.14')",
                        "cellranger_software":
                        "('/usr/bin/cellranger', 'cellranger', '3.0.1')",
-                       "assay": "Nextera" },
+                       "assay": "Nextera",
+                       "sequencer_model": "MiSeq" },
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
         # Make autoprocess instance
@@ -490,6 +500,7 @@ Additional notes/comments:
 Run name  : 170901_M00879_0087_000000000-AGEW9
 Reference : MISEQ_170901#87
 Platform  : MISEQ
+Sequencer : MiSeq
 Directory : %s
 Endedness : Paired end
 Bcl2fastq : bcl2fastq 2.17.1.14
@@ -540,16 +551,19 @@ class TestReportProjects(unittest.TestCase):
             'miseq',
             metadata={ "source": "testing",
                        "run_number": 87,
-                       "assay": "Nextera" },
+                       "assay": "Nextera",
+                       "sequencer_model": "MiSeq" },
             project_metadata={
                 "AB": { "User": "Alison Bell",
                         "Library type": "RNA-seq",
                         "Organism": "Human",
-                        "PI": "Audrey Bower" },
+                        "PI": "Audrey Bower",
+                        "Sequencer model": "MiSeq" },
                 "CDE": { "User": "Charles David Edwards",
                          "Library type": "ChIP-seq",
                          "Organism": "Mouse",
-                         "PI": "Colin Delaney Eccleston" }
+                         "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "MiSeq" }
             },
             top_dir=self.dirn)
         mockdir.create()
@@ -572,26 +586,29 @@ MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\t
             'miseq',
             metadata={ "source": "testing",
                        "run_number": 87,
-                       "assay": "Nextera" },
+                       "assay": "Nextera",
+                       "sequencer_model": "MiSeq" },
             project_metadata={
                 "AB": { "User": "Alison Bell",
                         "Library type": "RNA-seq",
                         "Organism": "Human",
-                        "PI": "Audrey Bower" },
+                        "PI": "Audrey Bower",
+                        "Sequencer model": "MiSeq" },
                 "CDE": { "User": "Charles David Edwards",
                          "Library type": "ChIP-seq",
                          "Organism": "Mouse",
-                         "PI": "Colin Delaney Eccleston" }
+                         "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "MiSeq" }
             },
             top_dir=self.dirn)
         mockdir.create()
         # Make autoprocess instance and set required metadata
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Generate projects report
-        expected = """170901\tMISEQ_170901#87\t87\ttesting\t\tAB\tAlison Bell\tAudrey Bower\tRNA-seq\t\tHuman\tMISEQ\t2\t\tyes\tAB1-2\t%s
-170901\tMISEQ_170901#87\t87\ttesting\t\tCDE\tCharles David Edwards\tColin Delaney Eccleston\tChIP-seq\t\tMouse\tMISEQ\t2\t\tyes\tCDE3-4\t%s
+        expected = """170901\tMISEQ_170901#87\t87\ttesting\t\tAB\tAlison Bell\tAudrey Bower\tRNA-seq\t\tHuman\tMISEQ\tMiSeq\t2\t\tyes\tAB1-2\t%s
+170901\tMISEQ_170901#87\t87\ttesting\t\tCDE\tCharles David Edwards\tColin Delaney Eccleston\tChIP-seq\t\tMouse\tMISEQ\tMiSeq\t2\t\tyes\tCDE3-4\t%s
 """ % (ap.params.analysis_dir,ap.params.analysis_dir)
-        custom_fields = ['datestamp','run_id','run_number','source','null','project','user','PI','library_type','single_cell_platform','organism','platform','#samples','#cells','paired_end','samples','path']
+        custom_fields = ['datestamp','run_id','run_number','source','null','project','user','PI','library_type','single_cell_platform','organism','platform','sequencer_model','#samples','#cells','paired_end','samples','path']
         for o,e in zip(report_projects(ap,fields=custom_fields).split('\n'),
                        expected.split('\n')):
             self.assertEqual(o,e)
@@ -605,18 +622,21 @@ MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\t
             'miseq',
             metadata={ "source": "testing",
                        "run_number": 87,
-                       "assay": "Nextera" },
+                       "assay": "Nextera",
+                       "sequencer_model": "MiSeq" },
             project_metadata={
                 "AB": { "User": "Alison Bell",
                         "Library type": "scRNA-seq",
                         "Organism": "Human",
                         "PI": "Audrey Bower",
                         "Single cell platform": "ICELL8",
-                        "Number of cells": 1311 },
+                        "Number of cells": 1311,
+                        "Sequencer model": "MiSeq" },
                 "CDE": { "User": "Charles David Edwards",
                          "Library type": "ChIP-seq",
                          "Organism": "Mouse",
-                         "PI": "Colin Delaney Eccleston" }
+                         "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "MiSeq" }
             },
             top_dir=self.dirn)
         mockdir.create()
@@ -639,7 +659,8 @@ MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\t
             'miseq',
             metadata={ "source": "testing",
                        "run_number": 87,
-                       "assay": "Nextera" },
+                       "assay": "Nextera",
+                       "sequencer_model": "MiSeq" },
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
         # Make autoprocess instance and set required metadata
@@ -683,16 +704,19 @@ class TestReport(unittest.TestCase):
             'miseq',
             metadata={ "source": "testing",
                        "run_number": 87,
-                       "assay": "Nextera" },
+                       "assay": "Nextera" ,
+                       "sequencer_model": "MiSeq"},
             project_metadata={
                 "AB": { "User": "Alison Bell",
                         "Library type": "RNA-seq",
                         "Organism": "Human",
-                        "PI": "Audrey Bower" },
+                        "PI": "Audrey Bower",
+                        "Sequencer model": "MiSeq" },
                 "CDE": { "User": "Charles David Edwards",
                          "Library type": "ChIP-seq",
                          "Organism": "Mouse",
-                         "PI": "Colin Delaney Eccleston" }
+                         "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "MiSeq" }
             },
             top_dir=self.dirn)
         mockdir.create()
@@ -746,18 +770,21 @@ class TestFetchValueFunction(unittest.TestCase):
             'miseq',
             metadata={ "source": "testing",
                        "run_number": 87,
-                       "assay": "Nextera" },
+                       "assay": "Nextera",
+                       "sequencer_model": "MiSeq" },
             project_metadata={
                 "AB": { "User": "Alison Bell",
                         "Library type": "scRNA-seq",
                         "Organism": "Human",
                         "PI": "Audrey Bower",
                         "Single cell platform": "ICELL8",
-                        "Number of cells": 1311 },
+                        "Number of cells": 1311,
+                        "Sequencer model": "MiSeq" },
                 "CDE": { "User": "Charles David Edwards",
                          "Library type": "ChIP-seq",
                          "Organism": "Mouse",
-                         "PI": "Colin Delaney Eccleston" }
+                         "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "MiSeq" }
             },
             top_dir=self.dirn)
         mockdir.create()
@@ -782,6 +809,7 @@ class TestFetchValueFunction(unittest.TestCase):
         self.assertEqual(fetch_value(ap,project,'application'),'scRNA-seq')
         self.assertEqual(fetch_value(ap,project,'library_type'),'scRNA-seq')
         self.assertEqual(fetch_value(ap,project,'organism'),'Human')
+        self.assertEqual(fetch_value(ap,project,'sequencer_model'),'MiSeq')
         self.assertEqual(fetch_value(ap,project,'sequencer_platform'),'MISEQ')
         self.assertEqual(fetch_value(ap,project,'platform'),'MISEQ')
         self.assertEqual(fetch_value(ap,project,'no_of_samples'),'2')

--- a/auto_process_ngs/test/commands/test_setup_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_cmd.py
@@ -92,7 +92,7 @@ model = {model}
             top_dir=self.dirn)
         mock_illumina_run.create()
         # Set up autoprocessor
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings())
         setup_(ap,mock_illumina_run.dirn)
         analysis_dirn = "%s_analysis" % mock_illumina_run.name
         # Check parameters
@@ -148,7 +148,7 @@ model = {model}
             top_dir=self.dirn)
         mock_illumina_run.create()
         # Set up autoprocessor
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings())
         setup_(ap,mock_illumina_run.dirn)
         analysis_dirn = "%s_analysis" % mock_illumina_run.name
         # Check parameters
@@ -190,7 +190,7 @@ model = {model}
             top_dir=self.dirn)
         mockdir.create()
         # Do setup into existing analysis dir
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings())
         setup_(ap,mock_illumina_run.dirn)
         self.assertTrue(os.path.isdir(
             '160621_M00879_0087_000000000-AGEW9'))
@@ -219,21 +219,21 @@ model = {model}
             self.dirn,
             "160621_M00879_0087_000000000-AGEW9_analysis")
         # Do setup using absolute path
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings())
         setup_(ap,data_dir_abs)
         self.assertEqual(ap.params.data_dir,data_dir_abs)
         self.assertEqual(ap.analysis_dir,analysis_dir)
         del(ap)
         shutil.rmtree(analysis_dir)
         # Do setup using relative path
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings())
         setup_(ap,data_dir_rel)
         self.assertEqual(ap.params.data_dir,data_dir_abs)
         self.assertEqual(ap.analysis_dir,analysis_dir)
         del(ap)
         shutil.rmtree(analysis_dir)
         # Do setup using absolute unnormalized path
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings())
         setup_(ap,data_dir_abs_unnormalised)
         self.assertEqual(ap.params.data_dir,data_dir_abs)
         self.assertEqual(ap.analysis_dir,analysis_dir)
@@ -243,7 +243,7 @@ model = {model}
         """setup: raises exception if data directory is missing
         """
         # Set up autoprocessor
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings())
         self.assertRaises(Exception,
                           setup_,
                           ap,
@@ -265,7 +265,7 @@ model = {model}
             top_dir=self.dirn)
         mock_illumina_run.create()
         # Set up autoprocessor
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings())
         self.assertRaises(Exception,
                           setup_,
                           ap,
@@ -313,7 +313,7 @@ Sample1,Sample1,,,D701,CGTGTAGG,D501,GACCTGTA,,
 Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
 """)
         # Set up autoprocessor
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings())
         setup_(ap,mock_illumina_run.dirn,sample_sheet=sample_sheet)
         analysis_dirn = "%s_analysis" % mock_illumina_run.name
         # Check parameters
@@ -377,7 +377,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
         sample_sheet = "file://%s" % sample_sheet
         print(sample_sheet)
         # Set up autoprocessor
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings())
         setup_(ap,mock_illumina_run.dirn,sample_sheet=sample_sheet)
         analysis_dirn = "%s_analysis" % mock_illumina_run.name
         # Check parameters
@@ -441,7 +441,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
         # Make extra_file2 into a URL
         extra_file2 = "file://%s" % extra_file2
         # Set up autoprocessor
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings())
         setup_(ap,mock_illumina_run.dirn,extra_files=(extra_file1,
                                                       extra_file2))
         analysis_dirn = "%s_analysis" % mock_illumina_run.name
@@ -520,7 +520,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
         # Set up autoprocessor
         run_dir = "151125_M00879_0001_000000000-ABCDE1"
         analysis_dir = "%s_analysis" % run_dir
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings())
         setup_(ap,run_dir,unaligned_dir=casava_outputs.unaligned_dir)
         # Check parameters
         self.assertEqual(ap.analysis_dir,
@@ -599,7 +599,7 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
         # Set up autoprocessor
         run_dir = "151125_M00879_0001_000000000-ABCDE1"
         analysis_dir = "%s_analysis" % run_dir
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings())
         setup_(ap,run_dir,unaligned_dir=bcl2fastq2_outputs.unaligned_dir)
         # Check parameters
         self.assertEqual(ap.analysis_dir,
@@ -657,7 +657,7 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
         os.mkdir(unaligned_dir)
         # Set up autoprocessor
         analysis_dir = "%s_analysis" % run_dir
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings())
         self.assertRaises(Exception,
                           setup_,
                           ap,
@@ -686,7 +686,7 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
                         fq.write(fastq_r2_data.encode())
         # Set up autoprocessor
         analysis_dir = "%s_analysis" % run_dir
-        ap = AutoProcess()
+        ap = AutoProcess(settings=self.settings())
         self.assertRaises(Exception,
                           setup_,
                           ap,

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -296,8 +296,43 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertEqual(project.info.icell8_well_list,None)
         self.assertFalse(project.info.paired_end)
         self.assertEqual(project.info.platform,None)
+        self.assertEqual(project.info.sequencer_model,None)
         self.assertEqual(project.info.primary_fastq_dir,None)
         self.assertEqual(project.info.samples,None)
+        self.assertEqual(project.info.comments,None)
+        self.assertEqual(project.fastq_dirs,[])
+
+    def test_analysis_project_set_metdata(self):
+        """Create AnalysisProject instance and set metadata
+        """
+        dirn = os.path.join(self.dirn,'PJB')
+        project = AnalysisProject('PJB',
+                                  dirn,
+                                  user="Peter Briggs",
+                                  PI="Alan Dale",
+                                  library_type="scRNA-seq",
+                                  single_cell_platform="ICELL8",
+                                  organism="Mouse",
+                                  run="200911_NB700125_0020_AHXXXXX",
+                                  comments="This is a test",
+                                  platform="nextseq",
+                                  sequencer_model="NextSeq 500")
+        self.assertEqual(project.name,'PJB')
+        self.assertEqual(project.dirn,dirn)
+        self.assertEqual(project.samples,[])
+        self.assertFalse(project.multiple_fastqs)
+        self.assertEqual(project.fastq_dir,None)
+        self.assertEqual(project.info.library_type,"scRNA-seq")
+        self.assertEqual(project.info.single_cell_platform,"ICELL8")
+        self.assertEqual(project.info.organism,"Mouse")
+        self.assertEqual(project.info.number_of_cells,None)
+        self.assertEqual(project.info.icell8_well_list,None)
+        self.assertFalse(project.info.paired_end)
+        self.assertEqual(project.info.platform,"nextseq")
+        self.assertEqual(project.info.sequencer_model,"NextSeq 500")
+        self.assertEqual(project.info.primary_fastq_dir,None)
+        self.assertEqual(project.info.samples,None)
+        self.assertEqual(project.info.comments,"This is a test")
         self.assertEqual(project.fastq_dirs,[])
 
     def test_create_single_end_analysis_project(self):
@@ -1338,7 +1373,12 @@ class TestCopyAnalysisProject(unittest.TestCase):
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
                                        "PJB1_S1_R2_001.fastq.gz",),
-                                metadata={ 'Organism': 'Human' })
+                                metadata={ 'Library type': 'scRNA-seq',
+                                           'Organism': 'Human',
+                                           'Single cell platform': 'ICELL8',
+                                           'Platform': 'nextseq',
+                                           'Sequencer model': 'NextSeq 500',
+                                           'Comments': 'This is a test' })
         p.create(top_dir=self.wd)
         # Make initial project
         project = AnalysisProject("PJB",os.path.join(self.wd,"PJB"))
@@ -1350,4 +1390,14 @@ class TestCopyAnalysisProject(unittest.TestCase):
         self.assertEqual(project.fastq_dir,project2.fastq_dir)
         self.assertEqual(project.fastq_dirs,project2.fastq_dirs)
         self.assertEqual(project.fastqs,project2.fastqs)
+        self.assertEqual(project.info.user,project2.info.user)
+        self.assertEqual(project.info.PI,project2.info.PI)
+        self.assertEqual(project.info.library_type,
+                         project2.info.library_type)
+        self.assertEqual(project.info.single_cell_platform,
+                         project2.info.single_cell_platform)
         self.assertEqual(project.info.organism,project2.info.organism)
+        self.assertEqual(project.info.platform,project2.info.platform)
+        self.assertEqual(project.info.sequencer_model,
+                         project2.info.sequencer_model)
+        self.assertEqual(project.info.comments,project2.info.comments)

--- a/auto_process_ngs/test/test_bcl2fastq.py
+++ b/auto_process_ngs/test/test_bcl2fastq.py
@@ -220,6 +220,33 @@ class TestGetSequencerPlatform(unittest.TestCase):
         """
         settings_ini = os.path.join(self.dirn,"auto_process.ini")
         with open(settings_ini,'w') as s:
+            s.write("""[sequencer:SN7001251]
+platform = hiseq
+
+[sequencer:M00880]
+platform = miseq
+
+[sequencer:FS10000171]
+platform = iseq
+""")
+        settings = Settings(settings_ini)
+        print(settings.sequencers)
+        self.assertEqual(get_sequencer_platform(
+            "/mnt/data/120919_SN7001251_0035_BC133VACXX",
+            settings=settings),"hiseq")
+        self.assertEqual(get_sequencer_platform(
+            "/mnt/data/121210_M00880_0001_000000000-A2Y1L",
+            settings=settings),"miseq")
+        self.assertEqual(get_sequencer_platform(
+            "/mnt/data/20180829_FS10000171_3_BNT40323-1530",
+            settings=settings),"iseq")
+
+    def test_get_sequencer_platform_from_legacy_settings(self):
+        """
+        get_sequencer_platform: use run directory and settings (legacy)
+        """
+        settings_ini = os.path.join(self.dirn,"auto_process.ini")
+        with open(settings_ini,'w') as s:
             s.write("""[sequencers]
 SN7001251 = hiseq
 M00880 = miseq

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -467,4 +467,5 @@ class TestAnalysisProjectInfo(unittest.TestCase):
         self.assertEqual(info.paired_end,None)
         self.assertEqual(info.primary_fastq_dir,None)
         self.assertEqual(info.samples,None)
+        self.assertEqual(info.sequencer_model,None)
         self.assertEqual(info.comments,None)

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -269,6 +269,11 @@ class TestAnalysisDirMetadata(unittest.TestCase):
         self.assertEqual(metadata.assay,None)
         self.assertEqual(metadata.bcl2fastq_software,None)
         self.assertEqual(metadata.cellranger_software,None)
+        self.assertEqual(metadata.instrument_name,None)
+        self.assertEqual(metadata.instrument_datestamp,None)
+        self.assertEqual(metadata.instrument_run_number,None)
+        self.assertEqual(metadata.instrument_flow_cell_id,None)
+        self.assertEqual(metadata.sequencer_model,None)
 
 class TestProjectMetadataFile(unittest.TestCase):
     """Tests for the ProjectMetadataFile class

--- a/config/auto_process.ini.sample
+++ b/config/auto_process.ini.sample
@@ -32,10 +32,13 @@ no_lane_splitting = False
 create_empty_fastqs = True
 
 # Sequencers and platforms
-# Assign platforms to sequencer instrument names
+# Define a 'sequencer:INSTRUMENT' section for
+# each sequencing instrument name and set
+# the corresponding parameters (model, platform)
 # These values will be specific to the local site
-[sequencers]
-#SN7001250 = hiseq
+#[sequencer:SN7001250]
+#model = "HiSeq 2500"
+#platform = hiseq
 
 # QC settings
 [qc]

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -79,21 +79,47 @@ which are described in more detail in :ref:`reference_data`.
 Sequencers and platforms
 ------------------------
 
-The ``sequencers`` section of the configuration file allows
-platform names to be associated with the instrument names for the
-sequencers used at the local site.
+Information about sequencers used at the local site can be stored
+in ``sequencer`` sections of the configuration file.
 
-For example if the local facility has a HISeq 4000 instrument
+A sequencer can be defined by adding a new section of the form
+``[sequencer:INSTRUMENT_NAME]``, where ``INSTRUMENT_NAME`` is the
+ID name for the instrument. Within each section the following
+data items can then be associated with the sequencer:
+
+============= ==============================================
+``platform``  **Compulsory** sets the generic platform name
+              (one of ``hiseq``, ``hiseq4000``, ``nextseq``,
+	      ``miseq``, ``miniseq`` or ``iseq``)
+``model``     Text describing the sequencer model (e.g.
+              ``HiSeq 4000``)
+============= ==============================================
+
+For example: if the local facility has a HiSeq 4000 instrument
 with ID ``SN7001250`` then this would be defined in ``auto_process.ini``
 as follows:
 
 ::
 
-   [sequencers]
-   SN7001250 = hiseq4000
+   [sequencer:SN7001250]
+   platform = hiseq4000
+   model = "HiSeq 4000"
 
 The instrument name can be derived from the name of the directories
 produced by the sequencer (see :ref:`run_and_fastq_naming_conventions`).
+
+
+.. note::
+
+   These sections replace the old ``sequencers`` section used
+   to define the sequencer platforms, e.g.
+
+   ::
+
+      [sequencers]
+      SN7001250 = hiseq4000
+
+  This section is still supported but is now deprecated.
 
 ----------------
 Default metadata

--- a/docs/source/using/report.rst
+++ b/docs/source/using/report.rst
@@ -69,6 +69,7 @@ For example:
     Run name : 150729_M00789_0088_000000000-ABCD1
     Reference: MISEQ_150729#88
     Platform : MISEQ
+    Sequencer: MiSeq
     Directory: /runs/2015/miseq/150729_M00789_0088_000000000-ABCD1_analysis
     Endedness: Paired end
     Bcl2fastq: bcl2fastq 2.17.1.14
@@ -95,6 +96,7 @@ Field name                Associated value
 ``run_number``            Facility run number (e.g. ``88``)
 ``sequencer_platform``    Sequencer platform for the run
                           (e.g. ``MISEQ``)
+``sequencer_model``       Sequencer model (e.g. ``MiSeq``)
 ``platform``              Alias for ``sequencer_platform``
 ``datestamp``             Datestamp for the run (e.g.
                           ``150729``)


### PR DESCRIPTION
PR which updates the settings to enable a sequencer model description to be stored against an instrument name (this is done by implementing support for new `[sequencer:INSTRUMENT]` sections in the configuration file, which should be used in preference to the now deprecated `[sequencers]` sections to set `platform` and `model` data for each sequencer).

The appropriate sequencer model defined in the configuration is transferred to the metadata for an analysis directory where it is stored in a new `sequencer_model` field in the `metadata.info` file.