### PR TITLE
Fix bug setting sequencer model in 'AutoProcess.update_metadata()'

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -340,7 +340,7 @@ class AutoProcess(object):
             instrument_name = self.metadata.instrument_name
             if instrument_name:
                 try:
-                    self.metadata.sequencer_model = \
+                    self.metadata['sequencer_model'] = \
                         self.settings.sequencers[instrument_name].model
                     print("Setting 'sequencer_model' metadata item to "
                           "'%s'" % self.metadata.sequencer_model)


### PR DESCRIPTION
PR which fixes a bug in the `metadata --update` command (implemented in the `AutoProcess.update_metadata()` method) for setting the sequencer model (new value was incorrectly assigned and wasn't getting written back out to file).