### PR TITLE
Store library prep kit in 'projects.info' and project metadata

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -372,6 +372,7 @@ class AnalysisProject(object):
     user        : user name
     PI          : PI name
     library_type: library type, either None or e.g. 'RNA-seq' etc
+    kit         : library prep kit, either None or e.g. 'TruSeq Stranded mRNA'
     single_cell_platform: single cell prep platform, either None or 'ICell8' etc
     number of cells: number of cells in single cell projects
     ICELL8 well list: well list file for ICELL8 single cell projects
@@ -400,7 +401,7 @@ class AnalysisProject(object):
     'set_primary_fastq_dir' method.
     """
     def __init__(self,name,dirn=None,user=None,PI=None,library_type=None,
-                 single_cell_platform=None,organism=None,run=None,
+                 kit=None,single_cell_platform=None,organism=None,run=None,
                  comments=None,platform=None,sequencer_model=None,
                  fastq_attrs=None,fastq_dir=None):
         """Create a new AnalysisProject instance
@@ -414,6 +415,8 @@ class AnalysisProject(object):
           PI: optional, specify name of the principal investigator
           library_type: optional, specify library type e.g. 'RNA-seq',
             'miRNA' etc
+          kit: optional, specify library prep kit e.g.
+            'TruSeq Stranded mRNA' etc
           single_cell_platform: optional, specify single cell
             preparation platform e.g. 'Icell8', '10xGenomics' etc
           organism: optional, specify organism e.g. 'Human', 'Mouse'
@@ -469,6 +472,8 @@ class AnalysisProject(object):
             self.info['PI'] = PI
         if library_type is not None:
             self.info['library_type'] = library_type
+        if kit is not None:
+            self.info['kit'] = kit
         if single_cell_platform is not None:
             self.info['single_cell_platform'] = single_cell_platform
         if organism is not None:

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -424,7 +424,9 @@ class AutoProcess(object):
                     for fastq in sample.fastq:
                         sample_names.add(sample_name)
                 sample_names = sorted(list(sample_names))
-                project_metadata.add_project(project_name,sample_names)
+                project_metadata.add_project(project_name,
+                                             sample_names,
+                                             kit=self.metadata.assay)
         except IlluminaData.IlluminaDataError as ex:
             logging.warning("Unable to get project data from bcl2fastq "
                             "output : %s" % ex)
@@ -527,7 +529,9 @@ class AutoProcess(object):
         for project_name in projects:
             sample_names = projects[project_name]
             if project_name not in project_metadata:
-                project_metadata.add_project(project_name,sample_names)
+                project_metadata.add_project(project_name,
+                                             sample_names,
+                                             kit=self.metadata.kit)
             else:
                 project_metadata.update_project(project_name,
                                                 sample_names=sample_names)

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -531,7 +531,7 @@ class AutoProcess(object):
             if project_name not in project_metadata:
                 project_metadata.add_project(project_name,
                                              sample_names,
-                                             kit=self.metadata.kit)
+                                             kit=self.metadata.assay)
             else:
                 project_metadata.update_project(project_name,
                                                 sample_names=sample_names)

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     report_cmd.py: implement auto process 'report' command
-#     Copyright (C) University of Manchester 2018-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2020 Peter Briggs
 #
 #########################################################################
 

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -152,6 +152,7 @@ def report_info(ap):
         report.append("  User    : %s" % info.user)
         report.append("  PI      : %s" % info.PI)
         report.append("  Library : %s" % info.library_type)
+        report.append("  Kit     : %s" % info.kit)
         report.append("  SC Plat.: %s" % info.single_cell_platform)
         report.append("  Organism: %s" % info.organism)
         report.append("  Dir     : %s" % os.path.basename(project.dirn))
@@ -360,7 +361,8 @@ def report_summary(ap):
                       'library_type',
                       'single_cell_platform',
                       'number_of_cells',
-                      'organism')
+                      'organism',
+                      'kit')
         for project in analysis_dir.projects:
             project_data = dict(project=project.name)
             for item in data_items:
@@ -381,7 +383,8 @@ def report_summary(ap):
                          project_data['organism'],
                          library,
                          samples,
-                         "(PI %s)" % project_data['PI']))
+                         "(PI %s)" % project_data['PI'],
+                         "(%s)" % project_data['kit']))
             if project.info.comments:
                 comments[project.name] = project.info.comments
         report.append(utils.pretty_print_rows(rows))
@@ -535,6 +538,8 @@ def fetch_value(ap,project,field):
     elif field == 'application' or field == 'library_type':
         return ('' if not info.library_type
                 else info.library_type)
+    elif field == 'kit' or field == 'library_prep_kit':
+        return ('' if not info.kit else info.kit)
     elif field == 'single_cell_platform':
         return ('' if not info.single_cell_platform
                 else info.single_cell_platform)

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -121,6 +121,7 @@ def report_info(ap):
     report.append("Run reference: %s" % ap.run_reference_id)
     report.append("Directory    : %s" % ap.analysis_dir)
     report.append("Platform     : %s" % ap.metadata.platform)
+    report.append("Sequencer    : %s" % ap.metadata.sequencer_model)
     report.append("Unaligned dir: %s" % ap.params.unaligned_dir)
     if ap.readme_file:
         report.append("README.txt found: %s" % ap.readme_file)
@@ -269,8 +270,7 @@ def report_summary(ap):
                     'Platform',
                     'Sequencer',
                     'Directory',
-                    'Endedness',
-                    'Bcl2fastq',]
+                    'Endedness',]
     # Gather information
     analysis_dir = analysis.AnalysisDir(ap.analysis_dir)
     datestamp = None
@@ -297,7 +297,6 @@ def report_summary(ap):
     try:
         cellranger_software = ast.literal_eval(
             ap.metadata.cellranger_software)
-        report_items.append('Cellranger')
     except ValueError:
         cellranger_software = None
     if ap.metadata.assay is not None:

--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -121,6 +121,7 @@ def setup_analysis_dirs(ap,
         PI = line['PI']
         organism = line['Organism']
         library_type = line['Library']
+        kit = line['Kit']
         single_cell_platform = line['SC_Platform']
         comments = line['Comments']
         # Check it's in the list
@@ -136,6 +137,7 @@ def setup_analysis_dirs(ap,
             PI=PI,
             organism=organism,
             library_type=library_type,
+            kit=kit,
             single_cell_platform=single_cell_platform,
             run=run_name,
             comments=comments,

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -441,6 +441,8 @@ class ProjectMetadataFile(TabFile.TabFile):
     Single cell platform: single-cell preparation platform (e.g. 'ICELL8')
     Organism: name(s) of the organism(s)
     PI: name(s) of the associated principal investigator(s)
+    Kit: the assay/kit used to prepare the samples
+    Spike in: any spike-in used when the samples were run
     Comments: free text containing additional information
               about the project
 
@@ -464,6 +466,8 @@ class ProjectMetadataFile(TabFile.TabFile):
                                 'SC_Platform',
                                 'Organism',
                                 'PI',
+                                'Kit',
+                                'Spike_in',
                                 'Comments')
         # Map keywords to column names
         self._kwmap = { 'Project': 'project_name',
@@ -473,20 +477,19 @@ class ProjectMetadataFile(TabFile.TabFile):
                         'SC_Platform': 'sc_platform',
                         'Organism': 'organism',
                         'PI' : 'PI',
+                        'Kit': 'kit',
+                        'Spike_in': 'spike_in',
                         'Comments': 'comments', }
-        # List of default values
-        self._default_values = { }
+        # Set up fields
         # Optional file to read from
         self.__filen = filen
-        if self.__filen is None:
-            # No existing file so set the default
-            # fields to write to the file
-            self._fields = self._default_fields
-        else:
+        if self.__filen:
             # Get columns from existing file
-            with open(self.__filen,'r') as fp:
+            with open(self.__filen,'rt') as fp:
                 header = fp.readline()
                 self._fields = header.rstrip('\n').lstrip('#').split('\t')
+        else:
+            self._fields = list(self._default_fields)
         # Open the file
         TabFile.TabFile.__init__(self,filen=self.__filen,
                                  column_names=self._fields,
@@ -496,7 +499,7 @@ class ProjectMetadataFile(TabFile.TabFile):
         # Add any missing columns
         for field in self._default_fields:
             if field not in self._fields:
-                self.appendColumn(field)
+                self.appendColumn(field,'.')
 
     def add_project(self,project_name,sample_names,**kws):
         """Add information about a project into the file

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -442,7 +442,6 @@ class ProjectMetadataFile(TabFile.TabFile):
     Organism: name(s) of the organism(s)
     PI: name(s) of the associated principal investigator(s)
     Kit: the assay/kit used to prepare the samples
-    Spike in: any spike-in used when the samples were run
     Comments: free text containing additional information
               about the project
 
@@ -467,7 +466,6 @@ class ProjectMetadataFile(TabFile.TabFile):
                                 'Organism',
                                 'PI',
                                 'Kit',
-                                'Spike_in',
                                 'Comments')
         # Map keywords to column names
         self._kwmap = { 'Project': 'project_name',
@@ -478,7 +476,6 @@ class ProjectMetadataFile(TabFile.TabFile):
                         'Organism': 'organism',
                         'PI' : 'PI',
                         'Kit': 'kit',
-                        'Spike_in': 'spike_in',
                         'Comments': 'comments', }
         # Set up fields
         # Optional file to read from

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -377,6 +377,7 @@ class AnalysisProjectInfo(MetadataDict):
     single_cell_platform: the single cell preparation platform
     number of cells: number of cells in single cell projects
     ICELL8 well list: well list file for ICELL8 single cell projects
+    kit: assay/kit used for preparing the samples
     paired_end: True if the data is paired end, False if not
     primary_fastq_dir: the primary subdir with FASTQ files
     samples: textual description of the samples in the project
@@ -401,6 +402,7 @@ class AnalysisProjectInfo(MetadataDict):
                                   'PI':'PI',
                                   'organism':'Organism',
                                   'library_type':'Library type',
+                                  'kit':'Library prep kit',
                                   'single_cell_platform':'Single cell platform',
                                   'number_of_cells':'Number of cells',
                                   'icell8_well_list':'ICELL8 well list',
@@ -417,6 +419,7 @@ class AnalysisProjectInfo(MetadataDict):
                                   'PI',
                                   'organism',
                                   'library_type',
+                                  'kit',
                                   'single_cell_platform',
                                   'number_of_cells',
                                   'icell8_well_list',

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -615,9 +615,15 @@ class QCReport(Document):
                                        css_classes=("info",))
         comments_list = List()
         try:
-            if self.project.info.comments:
-                for comment in self.project.info.comments.split(';'):
-                    comments_list.add_item(comment.strip())
+            if self.project.info.comments or self.project.info.kit:
+                # Add comments split by semi-colon
+                if self.project.info.comments:
+                    for comment in self.project.info.comments.split(';'):
+                        comments_list.add_item(comment.strip())
+                # Append the library prep kit
+                if self.project.info.kit:
+                    comments_list.add_item("Library prep: %s" %
+                                           self.project.info.kit)
             else:
                 # Drop out with exception
                 raise AttributeError
@@ -794,6 +800,7 @@ class QCReport(Document):
                           'user',
                           'PI',
                           'library_type',
+                          'kit',
                           'single_cell_platform',
                           'number_of_cells',
                           'organism',
@@ -812,6 +819,7 @@ class QCReport(Document):
             'user': 'User',
             'PI': 'PI',
             'library_type': 'Library type',
+            'kit': 'Library prep kit',
             'sequencer_model': 'Sequencer model',
             'single_cell_platform': 'Single cell preparation platform',
             'number_of_cells': 'Number of cells',

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     reporting: report QC from analysis projects
-#     Copyright (C) University of Manchester 2018-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2020 Peter Briggs
 #
 
 #######################################################################

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -421,8 +421,8 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,ICELL8_ATAC,
         # Check the samples listed in the projects.info file
         with open(os.path.join(analysis_dir,'projects.info'),'rt') as fp:
             self.assertEqual(fp.read(),
-                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
-ICELL8_ATAC\tUnassigned-Sample1,Unassigned-Sample2\t.\t.\t.\t.\t.\t.
+                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments
+ICELL8_ATAC\tUnassigned-Sample1,Unassigned-Sample2\t.\t.\t.\t.\t.\t.\t.
 """)
 
     #@unittest.skip("Skipped")

--- a/auto_process_ngs/test/commands/test_merge_fastq_dirs_cmd.py
+++ b/auto_process_ngs/test/commands/test_merge_fastq_dirs_cmd.py
@@ -240,9 +240,9 @@ poll_interval = 0.5
         self._assert_file_exists(os.path.join(analysis_dir,'projects.info'))
         with open(os.path.join(analysis_dir,'projects.info'),'rt') as fp:
             projects_info = fp.read()
-        expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Comments
-AB	AB1,AB2	.	.	.	.	.	.
-CDE	CDE3,CDE4	.	.	.	.	.	.
+        expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Kit	Comments
+AB	AB1,AB2	.	.	.	.	.	.	.
+CDE	CDE3,CDE4	.	.	.	.	.	.	.
 """
         self.assertEqual(projects_info,expected)
 
@@ -293,9 +293,9 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         self._assert_file_exists(os.path.join(analysis_dir,'projects.info'))
         with open(os.path.join(analysis_dir,'projects.info'),'rt') as fp:
             projects_info = fp.read()
-        expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Comments
-AB	AB1,AB2	.	.	.	.	.	.
-CDE	CDE3,CDE4	.	.	.	.	.	.
+        expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Kit	Comments
+AB	AB1,AB2	.	.	.	.	.	.	.
+CDE	CDE3,CDE4	.	.	.	.	.	.	.
 """
         self.assertEqual(projects_info,expected)
 
@@ -345,9 +345,9 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         self._assert_file_exists(os.path.join(analysis_dir,'projects.info'))
         with open(os.path.join(analysis_dir,'projects.info'),'rt') as fp:
             projects_info = fp.read()
-        expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Comments
-AB	AB1,AB2	.	.	.	.	.	.
-CDE	CDE3,CDE4	.	.	.	.	.	.
+        expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Kit	Comments
+AB	AB1,AB2	.	.	.	.	.	.	.
+CDE	CDE3,CDE4	.	.	.	.	.	.	.
 """
         self.assertEqual(projects_info,expected)
 
@@ -396,9 +396,9 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         self._assert_file_exists(os.path.join(analysis_dir,'projects.info'))
         with open(os.path.join(analysis_dir,'projects.info'),'rt') as fp:
             projects_info = fp.read()
-        expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Comments
-AB	AB1,AB2	.	.	.	.	.	.
-CDE	CDE3,CDE4	.	.	.	.	.	.
+        expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Kit	Comments
+AB	AB1,AB2	.	.	.	.	.	.	.
+CDE	CDE3,CDE4	.	.	.	.	.	.	.
 """
         self.assertEqual(projects_info,expected)
 
@@ -446,9 +446,9 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         self._assert_file_exists(os.path.join(analysis_dir,'projects.info'))
         with open(os.path.join(analysis_dir,'projects.info'),'rt') as fp:
             projects_info = fp.read()
-        expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Comments
-AB	AB1,AB2	.	.	.	.	.	.
-CDE	CDE3,CDE4	.	.	.	.	.	.
+        expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Kit	Comments
+AB	AB1,AB2	.	.	.	.	.	.	.
+CDE	CDE3,CDE4	.	.	.	.	.	.	.
 """
         self.assertEqual(projects_info,expected)
 
@@ -496,9 +496,9 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         self._assert_file_exists(os.path.join(analysis_dir,'projects.info'))
         with open(os.path.join(analysis_dir,'projects.info'),'rt') as fp:
             projects_info = fp.read()
-        expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Comments
-AB	AB1,AB2	.	.	.	.	.	.
-CDE	CDE3,CDE4	.	.	.	.	.	.
+        expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Kit	Comments
+AB	AB1,AB2	.	.	.	.	.	.	.
+CDE	CDE3,CDE4	.	.	.	.	.	.	.
 """
         self.assertEqual(projects_info,expected)
 
@@ -637,10 +637,8 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         self._assert_file_exists(os.path.join(analysis_dir,'projects.info'))
         with open(os.path.join(analysis_dir,'projects.info'),'rt') as fp:
             projects_info = fp.read()
-        expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Comments
-AB	AB1,AB2	.	.	.	.	.	.
-CDE	CDE3,CDE4	.	.	.	.	.	.
+        expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Kit	Comments
+AB	AB1,AB2	.	.	.	.	.	.	.
+CDE	CDE3,CDE4	.	.	.	.	.	.	.
 """
         self.assertEqual(projects_info,expected)
-        
-        

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -53,14 +53,17 @@ class TestReportInfo(unittest.TestCase):
             'miseq',
             metadata={ "source": "testing",
                        "run_number": 87,
+                       "sequencer_model": "MiSeq",
                        "assay": "Nextera" },
             project_metadata={
                 "AB": { "User": "Alison Bell",
                         "Library type": "RNA-seq",
+                        "Library prep kit": "Nextera",
                         "Organism": "Human",
                         "PI": "Audrey Bower" },
                 "CDE": { "User": "Charles David Edwards",
                          "Library type": "ChIP-seq",
+                         "Library prep kit": "TruSeq Stranded mRNA",
                          "Organism": "Mouse",
                          "PI": "Colin Delaney Eccleston" }
             },
@@ -72,6 +75,7 @@ class TestReportInfo(unittest.TestCase):
         expected = """Run reference: MISEQ_170901#87
 Directory    : %s
 Platform     : miseq
+Sequencer    : MiSeq
 Unaligned dir: bcl2fastq
 
 Summary of data in 'bcl2fastq' dir:
@@ -86,6 +90,7 @@ Summary of data in 'bcl2fastq' dir:
   User    : Alison Bell
   PI      : Audrey Bower
   Library : RNA-seq
+  Kit     : Nextera
   SC Plat.: None
   Organism: Human
   Dir     : AB
@@ -100,6 +105,7 @@ Summary of data in 'bcl2fastq' dir:
   User    : Charles David Edwards
   PI      : Colin Delaney Eccleston
   Library : ChIP-seq
+  Kit     : TruSeq Stranded mRNA
   SC Plat.: None
   Organism: Mouse
   Dir     : CDE
@@ -114,6 +120,7 @@ Summary of data in 'bcl2fastq' dir:
   User    : None
   PI      : None
   Library : None
+  Kit     : None
   SC Plat.: None
   Organism: None
   Dir     : undetermined
@@ -135,10 +142,12 @@ Summary of data in 'bcl2fastq' dir:
             'miseq',
             metadata={ "source": "testing",
                        "run_number": 87,
+                       "sequencer_model": "MiSeq",
                        "assay": "Nextera" },
             project_metadata={
                 "AB": { "User": "Alison Bell",
                         "Library type": "scRNA-seq",
+                        "Library prep kit": "Nextera",
                         "Organism": "Human",
                         "PI": "Audrey Bower",
                         "Single cell platform": "ICELL8",
@@ -146,6 +155,7 @@ Summary of data in 'bcl2fastq' dir:
                         },
                 "CDE": { "User": "Charles David Edwards",
                          "Library type": "ChIP-seq",
+                         "Library prep kit": "TruSeq Stranded mRNA",
                          "Organism": "Mouse",
                          "PI": "Colin Delaney Eccleston" }
             },
@@ -157,6 +167,7 @@ Summary of data in 'bcl2fastq' dir:
         expected = """Run reference: MISEQ_170901#87
 Directory    : %s
 Platform     : miseq
+Sequencer    : MiSeq
 Unaligned dir: bcl2fastq
 
 Summary of data in 'bcl2fastq' dir:
@@ -171,6 +182,7 @@ Summary of data in 'bcl2fastq' dir:
   User    : Alison Bell
   PI      : Audrey Bower
   Library : scRNA-seq
+  Kit     : Nextera
   SC Plat.: ICELL8
   Organism: Human
   Dir     : AB
@@ -185,6 +197,7 @@ Summary of data in 'bcl2fastq' dir:
   User    : Charles David Edwards
   PI      : Colin Delaney Eccleston
   Library : ChIP-seq
+  Kit     : TruSeq Stranded mRNA
   SC Plat.: None
   Organism: Mouse
   Dir     : CDE
@@ -199,6 +212,7 @@ Summary of data in 'bcl2fastq' dir:
   User    : None
   PI      : None
   Library : None
+  Kit     : None
   SC Plat.: None
   Organism: None
   Dir     : undetermined
@@ -220,6 +234,7 @@ Summary of data in 'bcl2fastq' dir:
             'miseq',
             metadata={ "source": "testing",
                        "run_number": 87,
+                       "sequencer_model": "MiSeq",
                        "assay": "Nextera" },
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
@@ -229,6 +244,7 @@ Summary of data in 'bcl2fastq' dir:
         expected = """Run reference: MISEQ_170901#87
 Directory    : %s
 Platform     : miseq
+Sequencer    : MiSeq
 Unaligned dir: bcl2fastq
 
 Summary of data in 'bcl2fastq' dir:
@@ -377,16 +393,18 @@ class TestReportSummary(unittest.TestCase):
             'miseq',
             metadata={ "source": "testing",
                        "run_number": 87,
-                       "assay": "Nextera",
-                       "sequencer_model": "MiSeq" },
+                       "sequencer_model": "MiSeq",
+                       "assay": "Nextera" },
             project_metadata={
                 "AB": { "User": "Alison Bell",
                         "Library type": "RNA-seq",
+                        "Library prep kit": "Nextera",
                         "Organism": "Human",
                         "PI": "Audrey Bower",
                         "Sequencer model": "MiSeq" },
                 "CDE": { "User": "Charles David Edwards",
                          "Library type": "ChIP-seq",
+                         "Library prep kit": "TruSeq Stranded mRNA",
                          "Organism": "Mouse",
                          "PI": "Colin Delaney Eccleston",
                          "Sequencer model": "MiSeq",
@@ -405,12 +423,11 @@ Platform : MISEQ
 Sequencer: MiSeq
 Directory: %s
 Endedness: Paired end
-Bcl2fastq: Unknown
 Assay    : Nextera
 
 2 projects:
-- 'AB':  Alison Bell           Human RNA-seq  2 samples (PI Audrey Bower)           
-- 'CDE': Charles David Edwards Mouse ChIP-seq 2 samples (PI Colin Delaney Eccleston)
+- 'AB':  Alison Bell           Human RNA-seq  2 samples (PI Audrey Bower)            (Nextera)             
+- 'CDE': Charles David Edwards Mouse ChIP-seq 2 samples (PI Colin Delaney Eccleston) (TruSeq Stranded mRNA)
 
 Additional notes/comments:
 - CDE: Repeat of previous run
@@ -437,12 +454,14 @@ Additional notes/comments:
             project_metadata={
                 "AB": { "User": "Alison Bell",
                         "Library type": "scRNA-seq",
+                        "Library prep kit": "Nextera",
                         "Organism": "Human",
                         "PI": "Audrey Bower",
                         "Single cell platform": "ICELL8",
                         "Number of cells": 1311 },
                 "CDE": { "User": "Charles David Edwards",
                          "Library type": "ChIP-seq",
+                         "Library prep kit": "TruSeq Stranded mRNA",
                          "Organism": "Mouse",
                          "PI": "Colin Delaney Eccleston",
                          "Comments": "Repeat of previous run" }
@@ -454,19 +473,17 @@ Additional notes/comments:
         # Generate summary report
         expected = """MISEQ run #87 datestamped 170901
 ================================
-Run name  : 170901_M00879_0087_000000000-AGEW9
-Reference : MISEQ_170901#87
-Platform  : MISEQ
-Sequencer : MiSeq
-Directory : %s
-Endedness : Paired end
-Bcl2fastq : bcl2fastq 2.17.1.14
-Cellranger: cellranger 3.0.1
-Assay     : Nextera
+Run name : 170901_M00879_0087_000000000-AGEW9
+Reference: MISEQ_170901#87
+Platform : MISEQ
+Sequencer: MiSeq
+Directory: %s
+Endedness: Paired end
+Assay    : Nextera
 
 2 projects:
-- 'AB':  Alison Bell           Human scRNA-seq (ICELL8) 2 samples/1311 cells (PI Audrey Bower)           
-- 'CDE': Charles David Edwards Mouse ChIP-seq           2 samples            (PI Colin Delaney Eccleston)
+- 'AB':  Alison Bell           Human scRNA-seq (ICELL8) 2 samples/1311 cells (PI Audrey Bower)            (Nextera)             
+- 'CDE': Charles David Edwards Mouse ChIP-seq           2 samples            (PI Colin Delaney Eccleston) (TruSeq Stranded mRNA)
 
 Additional notes/comments:
 - CDE: Repeat of previous run
@@ -497,15 +514,13 @@ Additional notes/comments:
         # Generate summary report
         expected = """MISEQ run #87 datestamped 170901
 ================================
-Run name  : 170901_M00879_0087_000000000-AGEW9
-Reference : MISEQ_170901#87
-Platform  : MISEQ
-Sequencer : MiSeq
-Directory : %s
-Endedness : Paired end
-Bcl2fastq : bcl2fastq 2.17.1.14
-Cellranger: cellranger 3.0.1
-Assay     : Nextera
+Run name : 170901_M00879_0087_000000000-AGEW9
+Reference: MISEQ_170901#87
+Platform : MISEQ
+Sequencer: MiSeq
+Directory: %s
+Endedness: Paired end
+Assay    : Nextera
 
 No projects found; 'bcl2fastq' directory contains the following data:
 
@@ -775,6 +790,7 @@ class TestFetchValueFunction(unittest.TestCase):
             project_metadata={
                 "AB": { "User": "Alison Bell",
                         "Library type": "scRNA-seq",
+                        "Library prep kit": "Nextera",
                         "Organism": "Human",
                         "PI": "Audrey Bower",
                         "Single cell platform": "ICELL8",
@@ -782,6 +798,7 @@ class TestFetchValueFunction(unittest.TestCase):
                         "Sequencer model": "MiSeq" },
                 "CDE": { "User": "Charles David Edwards",
                          "Library type": "ChIP-seq",
+                         "Library prep kit": "TruSeq Stranded mRNA",
                          "Organism": "Mouse",
                          "PI": "Colin Delaney Eccleston",
                          "Sequencer model": "MiSeq" }
@@ -808,6 +825,8 @@ class TestFetchValueFunction(unittest.TestCase):
         self.assertEqual(fetch_value(ap,project,'pi'),'Audrey Bower')
         self.assertEqual(fetch_value(ap,project,'application'),'scRNA-seq')
         self.assertEqual(fetch_value(ap,project,'library_type'),'scRNA-seq')
+        self.assertEqual(fetch_value(ap,project,'kit'),'Nextera')
+        self.assertEqual(fetch_value(ap,project,'library_prep_kit'),'Nextera')
         self.assertEqual(fetch_value(ap,project,'organism'),'Human')
         self.assertEqual(fetch_value(ap,project,'sequencer_model'),'MiSeq')
         self.assertEqual(fetch_value(ap,project,'sequencer_platform'),'MISEQ')

--- a/auto_process_ngs/test/commands/test_setup_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_cmd.py
@@ -787,9 +787,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         projects_info = os.path.join(analysis_dir,"projects.info")
         with open(projects_info,'rt') as fp:
             self.assertEqual(fp.read(),
-                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
-AB\tAB1,AB2\t.\t.\t.\t.\t.\t.
-CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
+                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments
+AB\tAB1,AB2\t.\t.\t.\t.\t.\t.\t.
+CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.\t.
 """)
         # Check subdirs have been created
         for subdirn in ('ScriptCode',
@@ -867,9 +867,9 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
         projects_info = os.path.join(analysis_dir,"projects.info")
         with open(projects_info,'rt') as fp:
             self.assertEqual(fp.read(),
-                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
-AB\tAB1,AB2\t.\t.\t.\t.\t.\t.
-CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
+                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments
+AB\tAB1,AB2\t.\t.\t.\t.\t.\t.\t.
+CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.\t.
 """)
         # Check subdirs have been created
         for subdirn in ('ScriptCode',

--- a/auto_process_ngs/test/test_auto_processor.py
+++ b/auto_process_ngs/test/test_auto_processor.py
@@ -161,9 +161,9 @@ class TestAutoProcessMakeProjectMetadataFile(unittest.TestCase):
             os.path.join(mockdir.dirn,"projects.info")))
         with open(os.path.join(mockdir.dirn,"projects.info"),'rt') as fp:
             self.assertEqual(fp.read(),
-                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
-AB\tAB1,AB2\t.\t.\t.\t.\t.\t.
-CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
+                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments
+AB\tAB1,AB2\t.\t.\t.\t.\t.\t.\t.
+CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.\t.
 """)
 
     def test_make_project_metadata_file_no_bcl2fastq_output(self):
@@ -188,7 +188,7 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
             os.path.join(mockdir.dirn,"projects.info")))
         with open(os.path.join(mockdir.dirn,"projects.info"),'rt') as fp:
             self.assertEqual(fp.read(),
-                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments
 """)
 
     def test_make_project_metadata_file_exception_if_file_exists(self):
@@ -239,15 +239,15 @@ class TestAutoProcessUpdateProjectMetadataFile(unittest.TestCase):
         mockdir.create(no_project_dirs=True)
         # Create empty projects.info file
         with open(os.path.join(mockdir.dirn,"projects.info"),'wt') as fp:
-            fp.write("#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments\n")
+            fp.write("#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments\n")
         # Update the projects.info file
         AutoProcess(mockdir.dirn).update_project_metadata_file()
         # Check output
         with open(os.path.join(mockdir.dirn,"projects.info"),'rt') as fp:
             self.assertEqual(fp.read(),
-                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
-AB\tAB1,AB2\t.\t.\t.\t.\t.\t.
-CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
+                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments
+AB\tAB1,AB2\t.\t.\t.\t.\t.\t.\t.
+CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.\t.
 """)
 
     def test_update_project_metadata_file_partial_from_bcl2fastq_output(self):
@@ -264,15 +264,15 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
         mockdir.create(no_project_dirs=True)
         # Create projects.info file with one project already listed
         with open(os.path.join(mockdir.dirn,"projects.info"),'wt') as fp:
-            fp.write("#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments\nCDE\tCDE3,CDE4\t.\t.\t.\t.\t.\tKeep me")
+            fp.write("#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments\nCDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.\tKeep me")
         # Update the projects.info file
         AutoProcess(mockdir.dirn).update_project_metadata_file()
         # Check output
         with open(os.path.join(mockdir.dirn,"projects.info"),'rt') as fp:
             self.assertEqual(fp.read(),
-                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
-AB\tAB1,AB2\t.\t.\t.\t.\t.\t.
-CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\tKeep me
+                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments
+AB\tAB1,AB2\t.\t.\t.\t.\t.\t.\t.
+CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.\tKeep me
 """)
 
     def test_update_project_metadata_file_missing_from_bcl2fastq_output(self):
@@ -294,9 +294,9 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\tKeep me
         # Check output
         with open(os.path.join(mockdir.dirn,"projects.info"),'rt') as fp:
             self.assertEqual(fp.read(),
-                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
-AB\tAB1,AB2\t.\t.\t.\t.\t.\t.
-CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
+                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments
+AB\tAB1,AB2\t.\t.\t.\t.\t.\t.\t.
+CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.\t.
 """)
 
     def test_update_project_metadata_file_comment_out_missing_project(self):
@@ -313,7 +313,7 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
         mockdir.create(no_project_dirs=True)
         # Create projects.info file with one project already listed
         with open(os.path.join(mockdir.dirn,"projects.info"),'wt') as fp:
-            fp.write("#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments\nFG\tFG5,FG6\t.\t.\t.\t.\t.\tKeep me")
+            fp.write("#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments\nFG\tFG5,FG6\t.\t.\t.\t.\t.\t.\tKeep me")
         # Update the projects.info file
         AutoProcess(mockdir.dirn).update_project_metadata_file()
         # Check output - missing project kept but commented out
@@ -321,10 +321,10 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
             print(fp.read())
         with open(os.path.join(mockdir.dirn,"projects.info"),'rt') as fp:
             self.assertEqual(fp.read(),
-                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
-AB\tAB1,AB2\t.\t.\t.\t.\t.\t.
-CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
-#FG\tFG5,FG6\t.\t.\t.\t.\t.\tKeep me
+                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments
+AB\tAB1,AB2\t.\t.\t.\t.\t.\t.\t.
+CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.\t.
+#FG\tFG5,FG6\t.\t.\t.\t.\t.\t.\tKeep me
 """)
 
     def test_update_project_metadata_file_uncomment_existing_project(self):
@@ -341,15 +341,15 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
         mockdir.create(no_project_dirs=True)
         # Create projects.info file with one project already listed
         with open(os.path.join(mockdir.dirn,"projects.info"),'wt') as fp:
-            fp.write("#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments\n#CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\tKeep me")
+            fp.write("#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments\n#CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.\tKeep me")
         # Update the projects.info file
         AutoProcess(mockdir.dirn).update_project_metadata_file()
         # Check output - missing project kept but commented out
         with open(os.path.join(mockdir.dirn,"projects.info"),'rt') as fp:
             self.assertEqual(fp.read(),
-                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
-AB\tAB1,AB2\t.\t.\t.\t.\t.\t.
-CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\tKeep me
+                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments
+AB\tAB1,AB2\t.\t.\t.\t.\t.\t.\t.
+CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.\tKeep me
 """)
 
     def test_update_project_metadata_file_dont_comment_missing_project_when_dir_is_present(self):
@@ -366,7 +366,7 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\tKeep me
         mockdir.create(no_project_dirs=True)
         # Create projects.info file with one project already listed
         with open(os.path.join(mockdir.dirn,"projects.info"),'wt') as fp:
-            fp.write("#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments\nFG\tFG5,FG6\t.\t.\t.\t.\t.\tKeep me")
+            fp.write("#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments\nFG\tFG5,FG6\t.\t.\t.\t.\t.\t.\tKeep me")
         # Create the corresponding project
         project = MockAnalysisProject('FG',('FG5_S1_R1_001.fastq.gz',
                                             'FG6_S1_R1_001.fastq.gz'))
@@ -378,10 +378,10 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\tKeep me
             print(fp.read())
         with open(os.path.join(mockdir.dirn,"projects.info"),'rt') as fp:
             self.assertEqual(fp.read(),
-                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
-AB\tAB1,AB2\t.\t.\t.\t.\t.\t.
-CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
-FG\tFG5,FG6\t.\t.\t.\t.\t.\tKeep me
+                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments
+AB\tAB1,AB2\t.\t.\t.\t.\t.\t.\t.
+CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.\t.
+FG\tFG5,FG6\t.\t.\t.\t.\t.\t.\tKeep me
 """)
 
     def test_update_project_metadata_file_dont_uncomment_missing_project_when_dir_is_present(self):
@@ -398,7 +398,7 @@ FG\tFG5,FG6\t.\t.\t.\t.\t.\tKeep me
         mockdir.create(no_project_dirs=True)
         # Create projects.info file with one project already listed
         with open(os.path.join(mockdir.dirn,"projects.info"),'wt') as fp:
-            fp.write("#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments\n#FG\tFG5,FG6\t.\t.\t.\t.\t.\tKeep me")
+            fp.write("#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments\n#FG\tFG5,FG6\t.\t.\t.\t.\t.\t.\tKeep me")
         # Create the corresponding project
         project = MockAnalysisProject('FG',('FG5_S1_R1_001.fastq.gz',
                                             'FG6_S1_R1_001.fastq.gz'))
@@ -410,10 +410,10 @@ FG\tFG5,FG6\t.\t.\t.\t.\t.\tKeep me
             print(fp.read())
         with open(os.path.join(mockdir.dirn,"projects.info"),'rt') as fp:
             self.assertEqual(fp.read(),
-                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
-AB\tAB1,AB2\t.\t.\t.\t.\t.\t.
-CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
-#FG\tFG5,FG6\t.\t.\t.\t.\t.\tKeep me
+                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments
+AB\tAB1,AB2\t.\t.\t.\t.\t.\t.\t.
+CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.\t.
+#FG\tFG5,FG6\t.\t.\t.\t.\t.\t.\tKeep me
 """)
 
 class TestAutoProcessGetAnalysisProjectsMethod(unittest.TestCase):
@@ -528,9 +528,9 @@ class TestAutoProcessGetAnalysisProjectsMethod(unittest.TestCase):
         projects_info = os.path.join(mockdir.dirn,"projects.info")
         with open(projects_info,"w") as fp:
             fp.write(
-"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
-#AB\tAB1,AB2\tAlan Brown\tRNA-seq\t.\tHuman\tAudrey Benson\t1% PhiX
-CDE\tCDE3,CDE4\tClive David Edwards\tChIP-seq\t.\tMouse\tClaudia Divine Eccleston\t1% PhiX
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments
+#AB\tAB1,AB2\tAlan Brown\tRNA-seq\t.\tHuman\tAudrey Benson\tNextera XT\t1% PhiX
+CDE\tCDE3,CDE4\tClive David Edwards\tChIP-seq\t.\tMouse\tClaudia Divine Eccleston\tNextera XT\t1% PhiX
 """)
         # List the projects
         projects = AutoProcess(mockdir.dirn).get_analysis_projects()

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -691,6 +691,7 @@ class TestAnalysisProjectInfo(unittest.TestCase):
         self.assertEqual(info.single_cell_platform,None)
         self.assertEqual(info.number_of_cells,None)
         self.assertEqual(info.icell8_well_list,None)
+        self.assertEqual(info.kit,None)
         self.assertEqual(info.paired_end,None)
         self.assertEqual(info.primary_fastq_dir,None)
         self.assertEqual(info.samples,None)

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -657,18 +657,20 @@ class TestProjectMetadataFile(unittest.TestCase):
         """Output is sorted into project order
         """
         sorted_contents = \
-"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments\nCharlie\tC1,C2\tCharlie P\tRNA-seq\t.\tYeast\tMarley\t.\nXavier\tX3,X4\tXavier C\tChIP-seq\t.\tFly\tLensher\t.\n"""
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments\nCharlie\tC1,C2\tCharlie P\tRNA-seq\t.\tYeast\tMarley\tNextera XT\t.\nXavier\tX3,X4\tXavier C\tChIP-seq\t.\tFly\tLensher\tNextera XT\t.\n"""
         metadata = ProjectMetadataFile()
         metadata.add_project('Xavier',['X3','X4'],
                              user="Xavier C",
                              library_type="ChIP-seq",
                              organism="Fly",
-                             PI="Lensher")
+                             PI="Lensher",
+                             kit="Nextera XT")
         metadata.add_project('Charlie',['C1','C2'],
                              user="Charlie P",
                              library_type="RNA-seq",
                              organism="Yeast",
-                             PI="Marley")
+                             PI="Marley",
+                             kit="Nextera XT")
         metadata.save(self.metadata_file)
         with open(self.metadata_file,'rt') as fp:
             self.assertEqual(fp.read(),sorted_contents)

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -293,7 +293,7 @@ class TestProjectMetadataFile(unittest.TestCase):
         """
         # Make an empty 'file'
         metadata = ProjectMetadataFile()
-        contents = "#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tSpike_in\tComments\n"
+        contents = "#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments\n"
         self.assertEqual(len(metadata),0)
         for project in metadata:
             self.fail()
@@ -318,9 +318,8 @@ class TestProjectMetadataFile(unittest.TestCase):
                              library_type="ChIP-seq",
                              organism="Mouse",
                              PI="Harley",
-                             spike_in="1% PhiX",
                              comments="Squeak!")
-        contents = "#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tSpike_in\tComments\nCharlie\tC1,C2\tCharlie P\tRNA-seq\t.\tYeast\tMarley\tNextera XT\t.\t.\nFarley\tF3,F4\tFarley G\tChIP-seq\t.\tMouse\tHarley\t.\t1% PhiX\tSqueak!\n"
+        contents = "#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments\nCharlie\tC1,C2\tCharlie P\tRNA-seq\t.\tYeast\tMarley\tNextera XT\t.\nFarley\tF3,F4\tFarley G\tChIP-seq\t.\tMouse\tHarley\t.\tSqueak!\n"
         self.assertEqual(len(metadata),2)
         # Save to an actual file and check its contents
         metadata.save(self.metadata_file)
@@ -340,7 +339,6 @@ class TestProjectMetadataFile(unittest.TestCase):
                          Organism="Yeast",
                          PI="Marley",
                          Kit=".",
-                         Spike_in=".",
                          Comments="."))
         data.append(dict(Project="Farley",
                          Samples="F3-4",
@@ -350,16 +348,15 @@ class TestProjectMetadataFile(unittest.TestCase):
                          Organism="Mouse",
                          PI="Harley",
                          Kit=".",
-                         Spike_in=".",
                          Comments="Squeak!"))
-        contents = "#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tSpike_in\tComments\nCharlie\tC1-2\tCharlie P\tRNA-seq\t.\tYeast\tMarley\t.\t.\t.\nFarley\tF3-4\tFarley G\tChIP-seq\t.\tMouse\tHarley\t.\t.\tSqueak!\n"
+        contents = "#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tKit\tComments\nCharlie\tC1-2\tCharlie P\tRNA-seq\t.\tYeast\tMarley\t.\t.\nFarley\tF3-4\tFarley G\tChIP-seq\t.\tMouse\tHarley\t.\tSqueak!\n"
         with open(self.metadata_file,'wt') as fp:
             fp.write(contents)
         # Load and check contents
         metadata = ProjectMetadataFile(self.metadata_file)
         self.assertEqual(len(metadata),2)
         for x,y in zip(data,metadata):
-            for attr in ('Project','User','Library','Organism','PI','Kit','Spike_in','Comments'):
+            for attr in ('Project','User','Library','Organism','PI','Kit','Comments'):
                 self.assertEqual(x[attr],y[attr])
 
     def test_read_existing_legacy_project_metadata_file(self):
@@ -375,7 +372,6 @@ class TestProjectMetadataFile(unittest.TestCase):
                          Organism="Yeast",
                          PI="Marley",
                          Kit=".",
-                         Spike_in=".",
                          Comments="."))
         data.append(dict(Project="Farley",
                          Samples="F3-4",
@@ -385,7 +381,6 @@ class TestProjectMetadataFile(unittest.TestCase):
                          Organism="Mouse",
                          PI="Harley",
                          Kit=".",
-                         Spike_in=".",
                          Comments="Squeak!"))
         contents = "#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments\nCharlie\tC1-2\tCharlie P\tRNA-seq\t.\tYeast\tMarley\t.\nFarley\tF3-4\tFarley G\tChIP-seq\t.\tMouse\tHarley\tSqueak!\n"
         open(self.metadata_file,'w').write(contents)
@@ -393,7 +388,7 @@ class TestProjectMetadataFile(unittest.TestCase):
         metadata = ProjectMetadataFile(self.metadata_file)
         self.assertEqual(len(metadata),2)
         for x,y in zip(data,metadata):
-            for attr in ('Project','User','Library','Organism','PI','Kit','Spike_in','Comments'):
+            for attr in ('Project','User','Library','Organism','PI','Kit','Comments'):
                 self.assertEqual(x[attr],y[attr],
                                  "Values don't match for '%s'" % attr)
 
@@ -585,14 +580,12 @@ class TestProjectMetadataFile(unittest.TestCase):
         self.assertEqual(project[6],"Marley")
         self.assertEqual(project[7],".")
         self.assertEqual(project[8],".")
-        self.assertEqual(project[9],".")
         # Update some attributes
         metadata.update_project('Charlie',
                                 user="Charlie Percival",
                                 library_type="scRNA-seq",
                                 sc_platform="ICell8",
-                                kit="Nextera XT",
-                                spike_in="1% PhiX")
+                                kit="Nextera XT")
         # Check the data has been updated
         self.assertTrue("Charlie" in metadata)
         project = metadata.lookup("Charlie")
@@ -603,8 +596,7 @@ class TestProjectMetadataFile(unittest.TestCase):
         self.assertEqual(project[5],"Yeast")
         self.assertEqual(project[6],"Marley")
         self.assertEqual(project[7],"Nextera XT")
-        self.assertEqual(project[8],"1% PhiX")
-        self.assertEqual(project[9],".")
+        self.assertEqual(project[8],".")
         # Update the samples
         metadata.update_project('Charlie',
                                 sample_names=['C01','C02'])
@@ -618,8 +610,7 @@ class TestProjectMetadataFile(unittest.TestCase):
         self.assertEqual(project[5],"Yeast")
         self.assertEqual(project[6],"Marley")
         self.assertEqual(project[7],"Nextera XT")
-        self.assertEqual(project[8],"1% PhiX")
-        self.assertEqual(project[9],".")
+        self.assertEqual(project[8],".")
 
     def test_update_project_toggles_commenting(self):
         """Toggle the commenting for an existing project

--- a/docs/source/output/analysis_dirs.rst
+++ b/docs/source/output/analysis_dirs.rst
@@ -64,20 +64,26 @@ The most commonly used metadata items are listed in the table below:
 .. table::
    :widths: auto
 
-   ====================== ========================================
-   **Item**               **Description**
-   ---------------------- ----------------------------------------
-   ``run_number``         Facility-assigned identifier which
-                          can differ from the instrument run
-                          number
-   ``source``             Source of the sequencing data, for
-                          example the name of the facility,
-	                  institution or service that
-		          provided it
-   ``platform``           The sequencing platform (e.g. ``miseq``)
-   ``bcl2fastq_software`` Location and version of the package
-                          used to perform the Fastq generation
-   ====================== ========================================
+   ======================= ========================================
+   **Item**                **Description**
+   ----------------------- ----------------------------------------
+   ``run_number``          Facility-assigned identifier which
+                           can differ from the instrument run
+                           number
+   ``source``              Source of the sequencing data, for
+                           example the name of the facility,
+	                   institution or service that
+		           provided it
+   ``platform``            The sequencing platform (e.g. ``miseq``)
+   ``bcl2fastq_software``  Location and version of the package
+                           used to perform the Fastq generation
+   ``cellranger_software`` Location and version of the package
+                           for handling 10xGenomics single cell
+			   data
+   ``assay``               The library prep kit (taken from the
+                           sample sheet by default)
+   ``sequencer_model``     The model of the sequencing instrument
+   ======================= ========================================
 
 The full set of metadata items and values for can be viewed using the
 ``metadata`` command:
@@ -174,10 +180,13 @@ The most commonly used metadata items are listed in the table below:
    ------------------------ -----------------------------------------
    ``Run``                  Parent run name
    ``Platform``             Sequencing platform (e.g. ``miseq``)
+   ``Sequencer model``      The model of the sequencing instrument
    ``User``                 Name of the user(s)
    ``PI``                   Name of PI(s)
    ``Organism``             Organism name(s)
    ``Library type``         The type of experiment (e.g. ``RNA-seq``)
+   ``Library prep kit``     The kit used to prepare the libraries
+                            (e.g. ``TruSeq Stranded mRNA``)
    ``Single cell platform`` Single cell platform, if applicable
    ``Number of cells``      Number of cells (single cell only)
    ``ICELL8 well list``     Well list file (ICELL8 only)

--- a/docs/source/using/report.rst
+++ b/docs/source/using/report.rst
@@ -72,11 +72,10 @@ For example:
     Sequencer: MiSeq
     Directory: /runs/2015/miseq/150729_M00789_0088_000000000-ABCD1_analysis
     Endedness: Paired end
-    Bcl2fastq: bcl2fastq 2.17.1.14
     Assay    : TruSeq HT
 
     1 project:
-    - 'AB': Abby Brown Mouse RNA-seq 4 samples (PI Carl Dover)
+    - 'AB': Abby Brown Mouse RNA-seq 4 samples (PI Carl Dover) (Nextera)
 
     Additional notes/comments:
     - AB: 1% PhiX spike in
@@ -113,6 +112,9 @@ Field name                Associated value
 ``application``           Application associated with the
                           project (e.g. ``RNA-seq``)
 ``library_type``          Alias for ``application``
+``kit``                   Kit used for the library prep
+                          (e.g. ``Nextera``)
+``library_prep_kit``      Alias for ``kit``
 ``single_cell_platform``  Name of the single-cell platform
                           (e.g. ``ICELL8``), or empty field
 			  if not a single-cell project

--- a/docs/source/using/setup_analysis_dirs.rst
+++ b/docs/source/using/setup_analysis_dirs.rst
@@ -19,15 +19,16 @@ Before runing ``setup_analysis_dirs``, the ``projects.info`` file should
 be edited to fill in the following information for each project:
 
 * **User**: the name(s) of the user(s) associated with the project
-* **PI**: the name(s) of the principal investigator(s) (PIs) associated
-  with the project
 * **Library**: the library or application type (for example "RNA-seq",
   "ChIP-seq" etc)
+* **SC_Platform**: the single-cell platform used to prepare the samples
+  (if appropriate)
 * **Organism**: the organism(s) that the samples in the project
   originally came from (for example "Human", "Mouse", "D. Melanogaster"
   etc)
-* **SC_Platform**: the single-cell platform used to prepare the samples
-  (if appropriate).
+* **PI**: the name(s) of the principal investigator(s) (PIs) associated
+  with the project
+* **Kit**: the kit used for library prep for the samples in this project
 
 See :doc:`projects_info` for more information on the format of the
 ``projects.info`` file and the allowed values for each field.


### PR DESCRIPTION
PR which adds information on the library prep kit to the `projects.info` file generated after the `make_fastqs` command, and transfers that data to the metadata stored for each project.

~The initial value for the kit is taken from the sample sheet's `assay` data item (which is stored in the metadata for the analysis as a whole).~

**Update:** discussion with the lab manager indicates that the `assay` in the sample sheet is not to be trusted, so this shouldn't be used (in fact it should probably be dropped completely from the run metadata). Instead null values should indicate that the kit information is not known (see issue #622).

This PR addresses issue #311; it requires PR https://github.com/fls-bioinformatics-core/genomics/pull/176 to work correctly.