### PR TITLE
'make_fastqs': handle non standard run names for 10xGenomics data

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -86,7 +86,6 @@ from ..pipeliner import PipelineParam as Param
 from ..pipeliner import resolve_parameter
 from ..tenx_genomics_utils import add_cellranger_args
 from ..tenx_genomics_utils import cellranger_info
-from ..tenx_genomics_utils import flow_cell_id
 from ..tenx_genomics_utils import get_bases_mask_10x_atac
 from ..tenx_genomics_utils import make_qc_summary_html
 from .reporting import ProcessingQCReport
@@ -2429,7 +2428,7 @@ class RunCellrangerMkfastq(PipelineTask):
             lanes_suffix = "_%s" % ''.join([str(l) for l in self.lanes])
         else:
             lanes_suffix = ""
-        self.cellranger_out_dir = "%s%s" % (flow_cell_id(self.args.run_dir),
+        self.cellranger_out_dir = "%s%s" % (illumina_run.runinfo.flowcell,
                                             lanes_suffix)
         self.mro_file = "__%s.mro" % self.cellranger_out_dir
         # Set bases mask

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1521,7 +1521,13 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
                 lanes_ext = "_%s" % ''.join([str(l) for l in lanes])
             else:
                 lanes_ext = ''
-            flow_cell_dir = flow_cell_id(run) + lanes_ext
+            try:
+                # Try to get the flow cell from RunInfo.xml
+                run_info = IlluminaRunInfo(os.path.join(run,"RunInfo.xml"))
+                flow_cell_dir = run_info.flowcell + lanes_ext
+            except Exception:
+                # Fallback to extracting from the name
+                flow_cell_dir = flow_cell_id(run) + lanes_ext
             os.mkdir(flow_cell_dir)
             outs_dir = os.path.join(flow_cell_dir,"outs")
             os.mkdir(outs_dir)


### PR DESCRIPTION
PR to fix bug #493 in the `make_fastqs` command, when processing 10xGenomics runs where the run directory name is not a standard Illumina sequencer formatted name. The fix is to fetch the flowcell ID from the run's `RunInfo.xml` file rather than trying to extract it from the run name.

~NB this needs PR https://github.com/fls-bioinformatics-core/genomics/pull/177 for the tests to complete.~