### PR TITLE
Improve handling of projects.info file

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -276,7 +276,7 @@ class AnalysisDir(object):
                 else:
                     # Check against projects.info, if possible
                     try:
-                        if not self.projects_metadata.lookup('Project',dirn):
+                        if dirn not in self.projects_metadata:
                             logger.debug("- %s: not in projects.info" % dirn)
                             self._extra_dirs.append(dirn)
                             continue

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -484,22 +484,24 @@ class AutoProcess(object):
         """
         if project_metadata_file is not None:
             self.params['project_metadata'] = project_metadata_file
-        print("Project metadata file: %s" % self.params.project_metadata)
+        logging.debug("Project metadata file: %s" %
+                      self.params.project_metadata)
         filen = os.path.join(self.analysis_dir,
                              self.params.project_metadata)
         if unaligned_dir is not None:
             self.params['unaligned_dir'] = unaligned_dir
-        print("Unaligned_dir: %s" % self.params.unaligned_dir)
+        logging.debug("Unaligned_dir: %s" % self.params.unaligned_dir)
         illumina_data = IlluminaData.IlluminaData(
             self.analysis_dir,
             unaligned_dir=self.params.unaligned_dir)
         if os.path.exists(filen):
             # Load data from existing file
-            print("Loading project metadata from existing file: %s" % filen)
+            logging.debug("Loading project metadata from existing file: %s" %
+                          filen)
             project_metadata = ProjectMetadataFile(filen)
         else:
             # New (empty) metadata file
-            print("Creating new project metadata file: %s" % filen)
+            logging.debug("Creating new project metadata file: %s" % filen)
             project_metadata = ProjectMetadataFile()
         # Get projects and samples
         projects = {}
@@ -531,6 +533,8 @@ class AutoProcess(object):
                                                 sample_names=sample_names)
         # Save
         project_metadata.save(filen)
+        print("Updated project metadata file '%s'" %
+              self.params.project_metadata)
 
     def detect_unaligned_dir(self):
         # Attempt to detect an existing 'bcl2fastq' or 'Unaligned' directory

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -838,6 +838,9 @@ class AutoProcess(object):
         # Get matching projects from metadata file
         for line in project_metadata:
             name = line['Project']
+            if name.startswith('#'):
+                # Ignore commented project
+                continue
             if not bcf_utils.name_matches(name,pattern):
                 # Name failed to match, ignore
                 continue

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -733,7 +733,7 @@ class AutoProcess(object):
           Boolean: True if run is paired end, False if single end,
             None if endedness cannot be determined
         """
-        projects = self.get_analysis_projects_from_dirs()
+        projects = self.get_analysis_projects()
         if projects:
             return reduce(lambda x,y: x and y.info.paired_end,
                           projects,True)

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -405,19 +405,36 @@ class AutoProcess(object):
             relative paths are created under the analysis directory
             (default: 'projects.info')
         """
-        # Generate a project metadata file based on the fastq
-        # files and directory structure
-        project_metadata = self.load_project_metadata(
-            project_metadata_file=project_metadata_file,
-            update=True)
+        # Check metadata file doesn't already exist
+        filen = os.path.join(self.params.analysis_dir,
+                             project_metadata_file)
+        if os.path.exists(filen):
+            raise Exception("%s: file already exists" % filen)
+        # Populate project metadata file from bcl2fastq output dir
+        project_metadata = ProjectMetadataFile()
+        try:
+            # Load data from bcl2fastq output dir
+            illumina_data = self.load_illumina_data()
+            # Populate the metadata file with projects
+            for project in illumina_data.projects:
+                project_name = project.name
+                sample_names = set()
+                for sample in project.samples:
+                    sample_name = sample.name
+                    for fastq in sample.fastq:
+                        sample_names.add(sample_name)
+                sample_names = sorted(list(sample_names))
+                project_metadata.add_project(project_name,sample_names)
+        except IlluminaData.IlluminaDataError as ex:
+            logging.warning("Unable to get project data from bcl2fastq "
+                            "output : %s" % ex)
         # Save to file
-        filen = os.path.join(self.params.analysis_dir,project_metadata_file)
         project_metadata.save(filen)
         self.params['project_metadata'] = project_metadata_file
-        print("Saving project metadata to %s" % self.params.project_metadata)
+        print("Created new project metadata file '%s'" %
+              self.params.project_metadata)
 
-    def load_project_metadata(self,project_metadata_file='projects.info',
-                              check=True,update=False):
+    def load_project_metadata(self,project_metadata_file=None):
         """
         Load data from projects metadata file
 
@@ -430,96 +447,20 @@ class AutoProcess(object):
           project_metadata_file (str): name of the metadata file
             relative to the analysis directory (default:
             'projects.info')
-          check (bool): if True then check existing metadata for
-            consistency with fastq files
-          update (bool): if True then update inconsistent metadata
-            (i.e. add missing projects and remove ones that are
-            inconsistent); implies 'check=True'
         """
-        if project_metadata_file is not None:
-            filen = os.path.join(self.params.analysis_dir,
-                                 project_metadata_file)
-        else:
-            filen = None
+        if project_metadata_file is None:
+            project_metadata_file='projects.info'
+        filen = os.path.join(self.params.analysis_dir,
+                             project_metadata_file)
         logging.debug("Project metadata file: %s" % filen)
-        try:
-            illumina_data = self.load_illumina_data()
-        except IlluminaData.IlluminaDataError as ex:
-            logging.warning("Failed to load data from bcl2fastq output "
-                            "(ignored): %s" % ex)
-            illumina_data = None
-        projects_from_dirs = [p for p in
-                              self.get_analysis_projects_from_dirs()
-                              if (p.is_analysis_dir and
-                                  p.name != "undetermined")]
-        if filen is not None and os.path.exists(filen):
+        if os.path.exists(filen):
             # Load existing file and check for consistency
             logging.debug("Loading project metadata from existing file")
             project_metadata = ProjectMetadataFile(filen)
         else:
             # First try to populate basic metadata from existing projects
-            logging.debug("Metadata file not found, guessing basic data")
+            logging.debug("Metadata file not found")
             project_metadata = ProjectMetadataFile()
-            projects = projects_from_dirs
-            if not projects:
-                # Get information from fastq files
-                logging.warning("No existing project directories detected")
-                logging.debug("Use fastq data from 'unaligned' directory")
-                if illumina_data is None:
-                    # Can't even get fastq files
-                    logging.warning("Failed to load fastq data from '%s'" %
-                                    self.params.unaligned_dir)
-                else:
-                    projects = illumina_data.projects
-            # Populate the metadata file list of projects
-            logging.debug("Project\tSample\tFastq")
-            for project in projects:
-                project_name = project.name
-                sample_names = []
-                for sample in project.samples:
-                    sample_name = sample.name
-                    for fastq in sample.fastq:
-                        logging.debug("%s\t%s\t%s" % (project_name,sample_name,fastq))
-                    sample_names.append(sample_name)
-                project_metadata.add_project(project_name,sample_names)
-            # Turn off redundant checking/updating
-            check = False
-            update = False
-        # Perform consistency check or update
-        if check or update:
-            # Check that each project listed actually exists
-            bad_projects = []
-            for line in project_metadata:
-                pname = line['Project']
-                test_project = AnalysisProject(
-                    pname,os.path.join(self.analysis_dir,pname))
-                if not test_project.is_analysis_dir:
-                    # Project doesn't exist
-                    logging.warning("Project '%s' listed in metadata file doesn't exist" \
-                                    % pname)
-                    bad_projects.append(line)
-            # Remove bad projects
-            if update:
-                logging.debug("Removing non-existent projects")
-                for bad_project in bad_projects:
-                    del(bad_project)
-            # Check that all actual projects are listed
-            for project in projects_from_dirs:
-                if len(project_metadata.lookup('Project',project.name)) == 0:
-                    # Project not listed
-                    if project.name != 'undetermined':
-                        logging.warning("Project '%s' not listed in metadata file" %
-                                        project.name)
-                    if update:
-                        # Add line for unlisted project
-                        logging.debug("Adding basic data for project '%s'" % project.name)
-                        sample_names = []
-                        for sample in project.samples:
-                            sample_name = sample.name
-                            for fastq in sample.fastq:
-                                logging.debug("%s\t%s\t%s" % (project.name,sample_name,fastq))
-                            sample_names.append(sample_name)
-                        project_metadata.add_project(project.name,sample_names)
         # Return the metadata object
         return project_metadata
 
@@ -560,10 +501,29 @@ class AutoProcess(object):
             # New (empty) metadata file
             print("Creating new project metadata file: %s" % filen)
             project_metadata = ProjectMetadataFile()
-        # Populate/update
+        # Get projects and samples
+        projects = {}
         for project in illumina_data.projects:
-            project_name = project.name
-            sample_names = [s.name for s in project.samples]
+            projects[project.name] = sorted([s.name for s in project.samples])
+        # Add data from metadata file
+        for line in project_metadata:
+            project_name = line['Project']
+            project_is_commented = project_name.startswith('#')
+            # Uncomment project line for now
+            project_name = project_name.lstrip('#')
+            # Add to the list if not found
+            if project_name not in projects:
+                if project_is_commented or \
+                   not os.path.exists(os.path.join(self.analysis_dir,
+                                                   project_name)):
+                    # Comment out project not in latest list
+                    # if already commented or if project directory
+                    # doesn't exist
+                    project_name = "#%s" % project_name
+                projects[project_name] = line['Samples'].split(',')
+        # Populate/update
+        for project_name in projects:
+            sample_names = projects[project_name]
             if project_name not in project_metadata:
                 project_metadata.add_project(project_name,sample_names)
             else:

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -396,6 +396,26 @@ class AutoProcess(object):
         return IlluminaData.IlluminaData(self.analysis_dir,
                                          unaligned_dir=unaligned_dir)
 
+    def make_project_metadata_file(self,project_metadata_file='projects.info'):
+        """
+        Create a new project metadata file
+
+        Arguments:
+          project_metadata_file (str): name of the metadata file;
+            relative paths are created under the analysis directory
+            (default: 'projects.info')
+        """
+        # Generate a project metadata file based on the fastq
+        # files and directory structure
+        project_metadata = self.load_project_metadata(
+            project_metadata_file=project_metadata_file,
+            update=True)
+        # Save to file
+        filen = os.path.join(self.params.analysis_dir,project_metadata_file)
+        project_metadata.save(filen)
+        self.params['project_metadata'] = project_metadata_file
+        print("Saving project metadata to %s" % self.params.project_metadata)
+
     def load_project_metadata(self,project_metadata_file='projects.info',
                               check=True,update=False):
         """
@@ -826,18 +846,6 @@ class AutoProcess(object):
         else:
             print("No metadata file found")
         self.print_values(self.metadata)
-
-    def make_project_metadata_file(self,project_metadata_file='projects.info'):
-        # Generate a project metadata file based on the fastq
-        # files and directory structure
-        project_metadata = self.load_project_metadata(
-            project_metadata_file=project_metadata_file,
-            update=True)
-        # Save to file
-        filen = os.path.join(self.params.analysis_dir,project_metadata_file)
-        project_metadata.save(filen)
-        self.params['project_metadata'] = project_metadata_file
-        print("Saving project metadata to %s" % self.params.project_metadata)
 
     def get_analysis_projects(self,pattern=None):
         """

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -441,10 +441,10 @@ def make_fastqs(ap,protocol='standard',platform=None,
         raise Exception("Fastq generation failed")
 
     # Make or update 'projects.info' metadata file
-    if lanes:
-        ap.update_project_metadata_file()
-    else:
+    if not ap.params.project_metadata:
         ap.make_project_metadata_file()
+    else:
+        ap.update_project_metadata_file()
 
     # Finish
     return status

--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -78,8 +78,10 @@ def setup_analysis_dirs(ap,
         logger.warning("Update '%s' and rerun" % project_metadata_file)
         return 1
     project_metadata = ap.load_project_metadata(
-        project_metadata_file=project_metadata_file,
-        check=True)
+        project_metadata_file=project_metadata_file)
+    # Filter out the commented projects
+    project_metadata = [p for p in project_metadata
+                        if not p['Project'].startswith('#')]
     # Sanity check that the project data file has been populated
     got_project_data = True
     for line in project_metadata:

--- a/auto_process_ngs/commands/setup_cmd.py
+++ b/auto_process_ngs/commands/setup_cmd.py
@@ -314,8 +314,9 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
     ap.metadata['assay'] = assay
     ap.metadata['source'] = data_source
     # Make a 'projects.info' metadata file
-    if unaligned_dir is not None:
-        ap.make_project_metadata_file()
+    if not ap.params.project_metadata:
+        if unaligned_dir is not None:
+            ap.make_project_metadata_file()
     # Set flags to allow parameters etc to be saved back
     ap._save_params = True
     ap._save_metadata = True

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -595,6 +595,9 @@ class ProjectMetadataFile(TabFile.TabFile):
             defaults to the same file as data was read in from)
 
         """
+        # Sort into project name order
+        self.sort(lambda line: str(line['Project']).rstrip('#'))
+        # Write to file
         if filen is not None:
             self.__filen = filen
         self.write(filen=self.__filen,include_header=True)

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -526,7 +526,7 @@ class ProjectMetadataFile(TabFile.TabFile):
             try:
                 kw = self._kwmap[field]
             except KeyError as ex:
-                raise ex
+                raise KeyError("Unrecognised field: '%s'" % field)
             # Look up the assigned value
             try:
                 value = kws[kw]
@@ -569,7 +569,7 @@ class ProjectMetadataFile(TabFile.TabFile):
             try:
                 kw = self._kwmap[field]
             except KeyError as ex:
-                raise ex
+                raise KeyError("Unrecognised field: '%s'" % field)
             # Assign the new values
             if kw not in kws:
                 continue

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -598,6 +598,7 @@ class ProjectMetadataFile(TabFile.TabFile):
 
     def __contains__(self,name):
         """
+        Internal: check if field 'name' exists
         """
         return (name in [p[self._fields[0]] for p in self])
 

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -581,12 +581,6 @@ class ProjectMetadataFile(TabFile.TabFile):
             else:
                 project[field] = value
 
-    def project(self,name):
-        """Return AttributeDictionary for a project
-
-        """
-        raise NotImplementedError
-
     def save(self,filen=None):
         """Save the data back to file
 

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -490,8 +490,9 @@ class ProjectMetadataFile(TabFile.TabFile):
         # Open the file
         TabFile.TabFile.__init__(self,filen=self.__filen,
                                  column_names=self._fields,
-                                 first_line_is_header=True,
-                                 convert=False)
+                                 skip_first_line=True,
+                                 convert=False,
+                                 keep_commented_lines=True)
         # Add any missing columns
         for field in self._default_fields:
             if field not in self._fields:

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -936,3 +936,67 @@ smpl2,smpl2,,,A005,CTTAGGAC,10xGenomics,
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_make_fastqs_existing_projects_info_file(self):
+        """make_fastqs: handle existing projects.info file
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,"bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        ap = AutoProcess(settings=self.settings)
+        ap.setup(os.path.join(self.wd,
+                              "171020_M00879_00002_AHGXXXX"))
+        # Make a projects.info file
+        with open(os.path.join(ap.analysis_dir,'projects.info'),"wt") as fp:
+            fp.write(
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+Proj1\tPR1,PR2\t.\t.\t.\t.\t.\t.
+""")
+        ap.params['project_metadata'] = 'projects.info'
+        # Do the test
+        self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
+        self.assertTrue(ap.params.project_metadata is not None)
+        make_fastqs(ap,protocol="standard")
+        # Check parameters
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(self.wd,
+                                      "171020_M00879_00002_AHGXXXX_analysis",
+                                      "primary_data"))
+        self.assertTrue(ap.params.acquired_primary_data)
+        self.assertEqual(ap.params.unaligned_dir,"bcl2fastq")
+        self.assertEqual(ap.params.barcode_analysis_dir,"barcode_analysis")
+        self.assertEqual(ap.params.stats_file,"statistics.info")
+        # Check outputs
+        analysis_dir = os.path.join(
+            self.wd,
+            "171020_M00879_00002_AHGXXXX_analysis")
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       os.path.join("logs",
+                                    "002_make_fastqs"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "projects.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)

--- a/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
@@ -91,6 +91,61 @@ CDE\tCDE3,CDE4\tClive David Edwards\tChIP-seq\t.\tMouse\tClaudia Divine Ecclesto
                 fastq = os.path.join(fastqs_dir,fq)
                 self.assertTrue(os.path.exists(fastq))
 
+    def test_setup_analysis_dirs_ignore_commented_projects(self):
+        """
+        setup_analysis_dirs: ignore commented line in 'projects.info'
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901" },
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        # Check project dirs don't exist
+        for project in ("AB","CDE"):
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertFalse(os.path.exists(project_dir_path))
+        # Add required metadata to 'projects.info'
+        projects_info = os.path.join(mockdir.dirn,"projects.info")
+        with open(projects_info,"w") as fp:
+            fp.write(
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+#AB\tAB1,AB2\tAlan Brown\tRNA-seq\t.\tHuman\tAudrey Benson\t1% PhiX
+CDE\tCDE3,CDE4\tClive David Edwards\tChIP-seq\t.\tMouse\tClaudia Divine Eccleston\t1% PhiX
+""")
+        # Expected data
+        projects = {
+            "CDE": ["CDE3_S3_R1_001.fastq.gz",
+                    "CDE3_S3_R2_001.fastq.gz",
+                    "CDE4_S4_R1_001.fastq.gz",
+                    "CDE4_S4_R2_001.fastq.gz"],
+            "undetermined": ["Undetermined_S0_R1_001.fastq.gz",
+                             "Undetermined_S0_R1_001.fastq.gz"]
+        }
+        # Setup the project dirs
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        setup_analysis_dirs(ap)
+        # Check project dirs and contents
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertTrue(os.path.exists(project_dir_path))
+            # Check README.info file
+            readme_file = os.path.join(project_dir_path,
+                                       "README.info")
+            self.assertTrue(os.path.exists(readme_file))
+            # Check Fastqs
+            fastqs_dir = os.path.join(project_dir_path,
+                                      "fastqs")
+            self.assertTrue(os.path.exists(fastqs_dir))
+            for fq in projects[project]:
+                fastq = os.path.join(fastqs_dir,fq)
+                self.assertTrue(os.path.exists(fastq))
+        # Check that 'AB' and '#AB' projects weren't created
+        for project in ('AB','#AB'):
+            self.assertFalse(os.path.exists(
+                os.path.join(mockdir.dirn,project)))
+
     def test_setup_analysis_dirs_icell8_atac(self):
         """
         setup_analysis_dirs: test create new analysis dir for ICELL8 ATAC

--- a/auto_process_ngs/test/test_auto_processor.py
+++ b/auto_process_ngs/test/test_auto_processor.py
@@ -747,3 +747,45 @@ class TestAutoProcessPairedEndMethod(unittest.TestCase):
         # Remove the unaligned dir
         shutil.rmtree(os.path.join(mockdir.dirn,"bcl2fastq"))
         self.assertEqual(AutoProcess(mockdir.dirn).paired_end,None)
+
+    def test_single_end_extra_dir(self):
+        """AutoProcess.paired_end: check for single-ended data (extra dir)
+        """
+        # Make an auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '160621_K00879_0087_000000000-AGEW9',
+            'hiseq',
+            metadata={ "run_number": 87,
+                       "source": "local" },
+            paired_end=False,
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add an extra project-like directory with Fastq pairs
+        extra_dir = os.path.join(mockdir.dirn,'extra_project')
+        os.mkdir(extra_dir)
+        for fq in ('extra_R1.fastq','extra_R2.fastq,'):
+            with open(os.path.join(extra_dir,fq),'wt') as fp:
+                fp.write('')
+        # Check that paired_end is false
+        self.assertFalse(AutoProcess(mockdir.dirn).paired_end)
+
+    def test_paired_end_extra_dir(self):
+        """AutoProcess.paired_end: check for paired-ended data (extra dir)
+        """
+        # Make an auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '160621_K00879_0087_000000000-AGEW9',
+            'hiseq',
+            metadata={ "run_number": 87,
+                       "source": "local" },
+            paired_end=True,
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add an extra project-like directory with Fastqs
+        extra_dir = os.path.join(mockdir.dirn,'extra_project')
+        os.mkdir(extra_dir)
+        for fq in ('extra1_R1.fastq','extra2_R1.fastq,'):
+            with open(os.path.join(extra_dir,fq),'wt') as fp:
+                fp.write('')
+        # Check that paired_end is true
+        self.assertTrue(AutoProcess(mockdir.dirn).paired_end)

--- a/auto_process_ngs/test/test_auto_processor.py
+++ b/auto_process_ngs/test/test_auto_processor.py
@@ -513,6 +513,36 @@ class TestAutoProcessGetAnalysisProjectsMethod(unittest.TestCase):
             matched_projects = [x for x in projects if x.name == p]
             self.assertEqual(len(matched_projects),1)
 
+    def test_ignore_commented_projects(self):
+        """AutoProcess.get_analysis_projects: ignore commented projects
+        """
+        # Make an auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '160621_K00879_0087_000000000-AGEW9',
+            'hiseq',
+            metadata={ "run_number": 87,
+                       "source": "local" },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Update the projects.info file
+        projects_info = os.path.join(mockdir.dirn,"projects.info")
+        with open(projects_info,"w") as fp:
+            fp.write(
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+#AB\tAB1,AB2\tAlan Brown\tRNA-seq\t.\tHuman\tAudrey Benson\t1% PhiX
+CDE\tCDE3,CDE4\tClive David Edwards\tChIP-seq\t.\tMouse\tClaudia Divine Eccleston\t1% PhiX
+""")
+        # List the projects
+        projects = AutoProcess(mockdir.dirn).get_analysis_projects()
+        expected = ('CDE','undetermined')
+        self.assertEqual(len(projects),len(expected))
+        for p in projects:
+            self.assertTrue(isinstance(p,AnalysisProject))
+            self.assertTrue(p.name in expected)
+        for p in expected:
+            matched_projects = [x for x in projects if x.name == p]
+            self.assertEqual(len(matched_projects),1)
+
     def test_with_project_dirs_select_subset(self):
         """AutoProcess.get_analysis_projects: select subset of projects
         """

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -371,6 +371,36 @@ class TestProjectMetadataFile(unittest.TestCase):
         self.assertEqual(metadata[0]['Project'],"1234")
         self.assertEqual(metadata[1]['Project'],"56.78")
 
+    def test_handle_commented_project(self):
+        """Handle commented project lines
+        """
+        # Create metadata file independently
+        data = list()
+        data.append(dict(Project="Charlie",
+                         Samples="C1-2",
+                         User="Charlie P",
+                         Library="RNA-seq",
+                         SC_Platform=".",
+                         Organism="Yeast",
+                         PI="Marley",
+                         Comments="."))
+        data.append(dict(Project="#Farley",
+                         Samples="F3-4",
+                         User="Farley G",
+                         Library="ChIP-seq",
+                         SC_Platform=".",
+                         Organism="Mouse",
+                         PI="Harley",
+                         Comments="Squeak!"))
+        contents = "#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments\nCharlie\tC1-2\tCharlie P\tRNA-seq\t.\tYeast\tMarley\t.\n#Farley\tF3-4\tFarley G\tChIP-seq\t.\tMouse\tHarley\tSqueak!\n"
+        open(self.metadata_file,'w').write(contents)
+        # Load and check contents
+        metadata = ProjectMetadataFile(self.metadata_file)
+        self.assertEqual(len(metadata),2)
+        for x,y in zip(data,metadata):
+            for attr in ('Project','User','Library','Organism','PI','Comments'):
+                self.assertEqual(x[attr],y[attr])
+
     def test_refuse_to_add_duplicate_projects(self):
         """Refuse to add duplicated project names
         """

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -476,6 +476,26 @@ class TestProjectMetadataFile(unittest.TestCase):
         self.assertEqual(project[5],"Yeast")
         self.assertEqual(project[6],"Marley")
 
+    def test_output_is_sorted(self):
+        """Output is sorted into project order
+        """
+        sorted_contents = \
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments\nCharlie\tC1,C2\tCharlie P\tRNA-seq\t.\tYeast\tMarley\t.\nXavier\tX3,X4\tXavier C\tChIP-seq\t.\tFly\tLensher\t.\n"""
+        metadata = ProjectMetadataFile()
+        metadata.add_project('Xavier',['X3','X4'],
+                             user="Xavier C",
+                             library_type="ChIP-seq",
+                             organism="Fly",
+                             PI="Lensher")
+        metadata.add_project('Charlie',['C1','C2'],
+                             user="Charlie P",
+                             library_type="RNA-seq",
+                             organism="Yeast",
+                             PI="Marley")
+        metadata.save(self.metadata_file)
+        with open(self.metadata_file,'rt') as fp:
+            self.assertEqual(fp.read(),sorted_contents)
+
 class TestAnalysisProjectInfo(unittest.TestCase):
     """Tests for the AnalysisDirMetadata class
     """

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -427,10 +427,100 @@ class TestProjectMetadataFile(unittest.TestCase):
                              PI="Marley")
         # Check for existing project
         self.assertTrue("Charlie" in metadata)
+        self.assertTrue("#Charlie" in metadata)
         # Check for non-existent project
         self.assertFalse("Marley" in metadata)
+        self.assertFalse("#Marley" in metadata)
 
-    def test_update_exisiting_project(self):
+    def test_check_if_commented_project_in_metadata(self):
+        """Check if project appears in metadata when commented
+        """
+        # Make new 'file' and add projects
+        metadata = ProjectMetadataFile()
+        metadata.add_project('#Charlie',['C1','C2'],
+                             user="Charlie P",
+                             library_type="RNA-seq",
+                             organism="Yeast",
+                             PI="Marley")
+        # Check for existing project
+        self.assertTrue("Charlie" in metadata)
+        self.assertTrue("#Charlie" in metadata)
+        # Check for non-existent project
+        self.assertFalse("Marley" in metadata)
+        self.assertFalse("#Marley" in metadata)
+
+    def test_lookup_project(self):
+        """Check that lookup returns specified project
+        """
+        # Make new 'file' and add projects
+        metadata = ProjectMetadataFile()
+        metadata.add_project('Charlie',['C1','C2'],
+                             user="Charlie P",
+                             library_type="RNA-seq",
+                             organism="Yeast",
+                             PI="Marley")
+        # Fetch data
+        project = metadata.lookup("Charlie")
+        self.assertEqual(project[0],"Charlie")
+        self.assertEqual(project[1],"C1,C2")
+        self.assertEqual(project[2],"Charlie P")
+        self.assertEqual(project[3],"RNA-seq")
+        self.assertEqual(project[4],".")
+        self.assertEqual(project[5],"Yeast")
+        self.assertEqual(project[6],"Marley")
+        # Fetch data for commented name
+        project = metadata.lookup("#Charlie")
+        self.assertEqual(project[0],"Charlie")
+        self.assertEqual(project[1],"C1,C2")
+        self.assertEqual(project[2],"Charlie P")
+        self.assertEqual(project[3],"RNA-seq")
+        self.assertEqual(project[4],".")
+        self.assertEqual(project[5],"Yeast")
+        self.assertEqual(project[6],"Marley")
+
+    def test_lookup_commented_project(self):
+        """Check that lookup returns specified (commented) project
+        """
+        # Make new 'file' and add projects
+        metadata = ProjectMetadataFile()
+        metadata.add_project('#Charlie',['C1','C2'],
+                             user="Charlie P",
+                             library_type="RNA-seq",
+                             organism="Yeast",
+                             PI="Marley")
+        # Fetch data
+        project = metadata.lookup("Charlie")
+        self.assertEqual(project[0],"#Charlie")
+        self.assertEqual(project[1],"C1,C2")
+        self.assertEqual(project[2],"Charlie P")
+        self.assertEqual(project[3],"RNA-seq")
+        self.assertEqual(project[4],".")
+        self.assertEqual(project[5],"Yeast")
+        self.assertEqual(project[6],"Marley")
+        # Fetch data for commented name
+        project = metadata.lookup("#Charlie")
+        self.assertEqual(project[0],"#Charlie")
+        self.assertEqual(project[1],"C1,C2")
+        self.assertEqual(project[2],"Charlie P")
+        self.assertEqual(project[3],"RNA-seq")
+        self.assertEqual(project[4],".")
+        self.assertEqual(project[5],"Yeast")
+        self.assertEqual(project[6],"Marley")
+
+    def test_lookup_missing_project_raises_exception(self):
+        """Check that lookup raises KeyError if specified project is missing
+        """
+        # Make new 'file'
+        metadata = ProjectMetadataFile()
+        # Check for exceptions
+        self.assertRaises(KeyError,
+                          metadata.lookup,
+                          "Charlie")
+        self.assertRaises(KeyError,
+                          metadata.lookup,
+                          "#Charlie")
+
+    def test_update_existing_project(self):
         """Update the data for an existing project
         """
         # Make new 'file' and add project
@@ -442,7 +532,7 @@ class TestProjectMetadataFile(unittest.TestCase):
                              PI="Marley")
         # Check initial data is correct
         self.assertTrue("Charlie" in metadata)
-        project = metadata.lookup("Project","Charlie")[0]
+        project = metadata.lookup("Charlie")
         self.assertEqual(project[1],"C1,C2")
         self.assertEqual(project[2],"Charlie P")
         self.assertEqual(project[3],"scRNA-seq")
@@ -456,7 +546,7 @@ class TestProjectMetadataFile(unittest.TestCase):
                                 sc_platform="ICell8")
         # Check the data has been updated
         self.assertTrue("Charlie" in metadata)
-        project = metadata.lookup("Project","Charlie")[0]
+        project = metadata.lookup("Charlie")
         self.assertEqual(project[1],"C1,C2")
         self.assertEqual(project[2],"Charlie Percival")
         self.assertEqual(project[3],"scRNA-seq")
@@ -468,11 +558,52 @@ class TestProjectMetadataFile(unittest.TestCase):
                                 sample_names=['C01','C02'])
         # Check the data has been updated
         self.assertTrue("Charlie" in metadata)
-        project = metadata.lookup("Project","Charlie")[0]
+        project = metadata.lookup("Charlie")
         self.assertEqual(project[1],"C01,C02")
         self.assertEqual(project[2],"Charlie Percival")
         self.assertEqual(project[3],"scRNA-seq")
         self.assertEqual(project[4],"ICell8")
+        self.assertEqual(project[5],"Yeast")
+        self.assertEqual(project[6],"Marley")
+
+    def test_update_project_toggles_commenting(self):
+        """Toggle the commenting for an existing project
+        """
+        # Make new 'file' and add project
+        metadata = ProjectMetadataFile()
+        metadata.add_project('Charlie',['C1','C2'],
+                             user="Charlie P",
+                             library_type="scRNA-seq",
+                             organism="Yeast",
+                             PI="Marley")
+        # Check initial data is correct
+        self.assertTrue("Charlie" in metadata)
+        project = metadata.lookup("Charlie")
+        self.assertEqual(project[0],"Charlie")
+        self.assertEqual(project[1],"C1,C2")
+        self.assertEqual(project[2],"Charlie P")
+        self.assertEqual(project[3],"scRNA-seq")
+        self.assertEqual(project[4],".")
+        self.assertEqual(project[5],"Yeast")
+        self.assertEqual(project[6],"Marley")
+        # Update and comment the project name
+        metadata.update_project('#Charlie')
+        project = metadata.lookup("Charlie")
+        self.assertEqual(project[0],"#Charlie")
+        self.assertEqual(project[1],"C1,C2")
+        self.assertEqual(project[2],"Charlie P")
+        self.assertEqual(project[3],"scRNA-seq")
+        self.assertEqual(project[4],".")
+        self.assertEqual(project[5],"Yeast")
+        self.assertEqual(project[6],"Marley")
+        # Update and uncomment the project name
+        metadata.update_project('Charlie')
+        project = metadata.lookup("Charlie")
+        self.assertEqual(project[0],"Charlie")
+        self.assertEqual(project[1],"C1,C2")
+        self.assertEqual(project[2],"Charlie P")
+        self.assertEqual(project[3],"scRNA-seq")
+        self.assertEqual(project[4],".")
         self.assertEqual(project[5],"Yeast")
         self.assertEqual(project[6],"Marley")
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -53,6 +53,14 @@ at the `University of Manchester <https://www.manchester.ac.uk/>`_.
    Managing and sharing data <using/managing_data>
    Running QC stand-alone <using/run_qc_standalone>
 
+.. _control-files:
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Control files
+
+   projects.info <using/projects_info>
+
 .. _single-cell-docs:
 
 .. toctree::

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -467,8 +467,9 @@ On completion the ``make_fastqs`` command will produce:
   Fastq files
 * An HTML report on the processing QC (see the section on
   :doc:`Processing QC reports <../output/processing_qc>`)
-* A ``projects.info`` metadata file which is used for setting up
-  analysis project directories (see
+* A :doc:`projects.info <projects_info>` metadata file which
+  is used by the :doc:`setup_analysis_dirs <setup_analysis_dirs>`
+  command when setting up analysis project directories (see
   :doc:`Setting up project directories <setup_analysis_dirs>`)
 
 For standard runs there will additional outputs:

--- a/docs/source/using/projects_info.rst
+++ b/docs/source/using/projects_info.rst
@@ -1,0 +1,78 @@
+Projects metadata file: ``projects.info``
+=========================================
+
+The ``projects.info`` file is used to define the projects within
+the analysis directory, and associates metadata information with
+each project.
+
+It is initially created when the :doc:`make_fastqs <make_fastqs>`
+command completes, and acts as a control file for subsequent
+operations including:
+
+* :doc:`setup_analysis_dirs <setup_analysis_dirs>` (used to
+  populate the project directories)
+* :doc:`publish_qc <publish_qc>` (only publishes data for projects
+  that are listed in ``projects.info``)
+
+``projects.info`` is a tab delimited file with one line for each
+project, with the following fields:
+
+===============  =================================================
+Field            Data item
+===============  =================================================
+``Project``      Name of the project
+``Samples``      List of sample names associated with the project
+``User``         Name(s) of the researcher(s) directly associated
+                 with the project
+``Library``      Library or application type (e.g. ``RNA-seq``,
+                 ``ChIP-seq``)
+``SC_Platform``  Single cell platform used to prepare the samples
+``Organism``     Organism(s) that the samples in the project
+                 came from (e.g. ``Human``, ``Mouse``,
+		 ``D. Melanogaster``)
+``PI``           Name(s) of the principal investigator(s) (PIs)
+                 associated with the project
+``Comments``     Free text field for any additional comments
+===============  =================================================
+
+The project name and sample names are normally added automatically;
+the remaining fields must be populated manually by editing the
+file. The following fields are compulsory for
+``setup_analysis_dirs``:
+
+* ``User``
+* ``Library``
+* ``Organism``
+* ``PI``
+
+The following conventions are used for data item syntax:
+
+* "Null" values are represented by a full stop (i.e. ``.``)
+* Unknown values should be represented with a question mark
+  (i.e. ``?``)
+* Where there are multiple users, PIs or organisms, they should be
+  separated by comma characters (e.g. ``Human,mouse``)
+* Projects preceeded by a comment character (i.e. ``#``) are
+  ignored
+
+Currently there are no canonical lists of allowed values for libraries
+or organism names. The organism name(s) are used to look up appropriate
+reference data files for the QC pipeline in the configuration file, so
+names that are used should be consistent with the configuration.
+
+.. note::
+
+   The organism names are converted to lower case and non-alphabetic
+   characters are converted to underscores (``_``) when looking up
+   names in the configuration: for example, ``Mouse`` is converted
+   to ``mouse``, ``D. Melanogaster`` is converted to
+   ``d_melanogaster``)
+
+The following values are valid options for the single cell platform
+(if set; use ``.`` if the project doesn't have a single cell data):
+
+* ``10xGenomics Chromium 3'v2``
+* ``10xGenomics Chromium 3'v3``
+* ``10xGenomics Single Cell ATAC``
+* ``ICELL8``
+* ``ICELL8 ATAC``

--- a/docs/source/using/setup_analysis_dirs.rst
+++ b/docs/source/using/setup_analysis_dirs.rst
@@ -11,8 +11,9 @@ This is done using the ``setup_analysis_dirs`` command, for example:
 
    auto_process.py setup_analyis_dirs
 
-This reads the ``projects.info`` metadata file initially created by
-``make_fastqs`` and creates a new subdirectory for each listed project.
+This reads the :doc:`projects.info <projects_info>` metadata file
+(initially created by ``make_fastqs``) and creates a new subdirectory
+for each listed project.
 
 Before runing ``setup_analysis_dirs``, the ``projects.info`` file should
 be edited to fill in the following information for each project:
@@ -28,27 +29,8 @@ be edited to fill in the following information for each project:
 * **SC_Platform**: the single-cell platform used to prepare the samples
   (if appropriate).
 
-The final field is used for any additional comments.
-
-``projects.info`` is a tab-delimited file; "null" values are represented
-by a full stop.
-
-Where there are multiple users, PIs or organisms it is recommended that
-each name be separated by a comma character (e.g. "Human,mouse").
-
-Unknown values should be represented with a question mark i.e. '?'.
-
-Currently there are no canonical lists of allowed values for libraries or
-organism names. However the QC strandedness determination looks up
-available ``STAR`` indexes in the configuration based on the organism
-names, so these should be consistent.
-
-If set then the single-cell platform must be one of:
-
-* ``ICELL8``
-* ``10xGenomics Chromium 3'v2``
-* ``10xGenomics Chromium 3'v3``
-* ``10xGenomics Single Cell ATAC``
+See :doc:`projects_info` for more information on the format of the
+``projects.info`` file and the allowed values for each field.
 
 .. note::
 


### PR DESCRIPTION
PR implementing improvements to how the `projects.info` file is handled (see issue #598).

General updates:

* Commented lines are preserved (previously they were removed on read/save)
* Lines are sorted into project order on save
* Lookup, sorting etc operations treat commented and uncommented project names interchangeably (e.g. `PJB` and `#PJB` are considered to be the same)

In the `AutoProcess` class, the methods for creating, loading and updating the data in `projects.info` have been updated to remove the implicit "magic" updates that happened on load, and to handle commented projects.

Some commands required updates as a result of these changes:

* `setup`: bug fix to deal with running the command on an existing analysis directory that doesn't have a `params.info` file;
* `make_fastqs`: updated to handle pre-existing `projects.info` file;
* `setup_analysis_dirs`: updated to ignore commented projects in the `projects.info` file when setting up project directories.