### PR TITLE
Remove 'ResourceWarnings' from Travis CI tests

### DIFF
--- a/auto_process_ngs/applications.py
+++ b/auto_process_ngs/applications.py
@@ -199,6 +199,11 @@ class Command(object):
             logging.warning("KeyboardInterrupt: stopping command subprocess")
             p.kill()
             returncode = -1
+        # Close files before finishing
+        if log:
+            fpout.close()
+        if err:
+            fperr.close()
         return returncode
 
     def subprocess_check_output(self,include_err=True,working_dir=None):

--- a/auto_process_ngs/fastq_utils.py
+++ b/auto_process_ngs/fastq_utils.py
@@ -36,6 +36,7 @@ import gzip
 import subprocess
 import logging
 from bcftbx.FASTQFile import FastqIterator
+from bcftbx.FASTQFile import get_fastq_file_handle
 from bcftbx.FASTQFile import nreads
 from bcftbx.qc.report import strip_ngs_extensions
 
@@ -468,9 +469,10 @@ def get_read_number(fastq):
     Returns:
       Integer: read number (1 or 2) extracted from the first read.
     """
-    for r in FastqIterator(fastq):
-        seq_id = r.seqid
-        break
+    with get_fastq_file_handle(fastq) as fp:
+        for r in FastqIterator(fp=fp):
+            seq_id = r.seqid
+            break
     return int(seq_id.pair_id)
 
 def get_read_count(fastqs):
@@ -514,9 +516,10 @@ def pair_fastqs(fastqs):
     for fq in [os.path.abspath(fq) for fq in fastqs]:
         # Get header from first read
         seq_id = None
-        for r in FastqIterator(fq):
-            seq_id = r.seqid
-            break
+        with get_fastq_file_handle(fq) as fp:
+            for r in FastqIterator(fp=fp):
+                seq_id = r.seqid
+                break
         if seq_id is None:
             logging.debug("'Bad' file: %s" % fq)
             bad_files.append(fq)

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -294,52 +294,55 @@ class MockAnalysisDir(MockIlluminaData):
         # Add top-level logs directory
         os.mkdir(os.path.join(self.dirn,'logs'))
         # Add project dirs
-        projects_info = open(os.path.join(self.dirn,'projects.info'),'w')
-        projects_info.write('#%s\n' % '\t'.join(('Project',
-                                                 'Samples',
-                                                 'User',
-                                                 'Library',
-                                                 'Organism',
-                                                 'PI',
-                                                 'Comments')))
-        for project in self.projects:
-            if project.startswith("Undetermined"):
-                project_name = 'undetermined'
-            else:
-                project_name = project
-            project_metadata = { 'Run': self.run_name,
-                                 'Platform': self.platform }
-            try:
-                for item in self.project_metadata[project_name]:
-                    project_metadata[item] = \
-                                self.project_metadata[project_name][item]
-            except KeyError:
-                pass
-            project_dir = MockAnalysisProject(project_name,
-                                              metadata=project_metadata)
-            sample_names = []
-            for sample in self.samples_in_project(project):
-                sample_names.append(sample)
-                for fq in self.fastqs_in_sample(project,sample):
-                    project_dir.add_fastq(fq)
-            # Add line to projects.info
-            if project_name != 'undetermined':
-                projects_info.write('%s\n' % '\t'.join((project,
-                                                        ','.join(sample_names),
-                                                        '.',
-                                                        '.',
-                                                        '.',
-                                                        '.',
-                                                        '.')))
-                # Add lines to custom_SampleSheet
-                with open(os.path.join(self.dirn,'custom_SampleSheet.csv'),
-                          'a') as fp:
-                    for sample in self.samples_in_project(project):
-                        fp.write('%s,,,,,,%s,\n' % (sample,
-                                                    project_name))
-            # Write the project directory to disk
-            if not no_project_dirs:
-                project_dir.create(top_dir=self.dirn)
+        with open(os.path.join(self.dirn,'projects.info'),
+                  'wt') as projects_info:
+            projects_info.write('#%s\n' % '\t'.join(('Project',
+                                                     'Samples',
+                                                     'User',
+                                                     'Library',
+                                                     'Organism',
+                                                     'PI',
+                                                     'Comments')))
+            for project in self.projects:
+                if project.startswith("Undetermined"):
+                    project_name = 'undetermined'
+                else:
+                    project_name = project
+                project_metadata = { 'Run': self.run_name,
+                                     'Platform': self.platform }
+                try:
+                    for item in self.project_metadata[project_name]:
+                        project_metadata[item] = \
+                            self.project_metadata[project_name][item]
+                except KeyError:
+                    pass
+                project_dir = MockAnalysisProject(project_name,
+                                                  metadata=project_metadata)
+                sample_names = []
+                for sample in self.samples_in_project(project):
+                    sample_names.append(sample)
+                    for fq in self.fastqs_in_sample(project,sample):
+                        project_dir.add_fastq(fq)
+                # Add line to projects.info
+                if project_name != 'undetermined':
+                    projects_info.write('%s\n' % '\t'.join(
+                        (project,
+                         ','.join(sample_names),
+                         '.',
+                         '.',
+                         '.',
+                         '.',
+                         '.')))
+                    # Add lines to custom_SampleSheet
+                    with open(os.path.join(self.dirn,
+                                           'custom_SampleSheet.csv'),
+                              'a') as fp:
+                        for sample in self.samples_in_project(project):
+                            fp.write('%s,,,,,,%s,\n' % (sample,
+                                                        project_name))
+                # Write the project directory to disk
+                if not no_project_dirs:
+                    project_dir.create(top_dir=self.dirn)
         # Finished
         return self.dirn
 

--- a/auto_process_ngs/test/commands/test_import_project.py
+++ b/auto_process_ngs/test/commands/test_import_project.py
@@ -32,9 +32,11 @@ class TestAutoProcessImportProject(unittest.TestCase):
         os.mkdir(project_dir)
         os.mkdir(os.path.join(project_dir,'fastqs'))
         for fq in ('NP01_S1_R1_001.fastq.gz','NP01_S1_R1_001.fastq.gz'):
-            open(os.path.join(project_dir,'fastqs',fq),'w').write('')
-        open(os.path.join(project_dir,'README.info'),'w').write(
-            """Run\t160622_NB5001234_0011_ABCDE5AFXX
+            with open(os.path.join(project_dir,'fastqs',fq),'wt') as fp:
+                fp.write('')
+        with open(os.path.join(project_dir,'README.info'),'wt') as fp:
+            fp.write(
+                """Run\t160622_NB5001234_0011_ABCDE5AFXX
 Platform\tnextseq
 User\tPeter Briggs
 PI\tAnne Cleaves

--- a/auto_process_ngs/test/commands/test_merge_fastq_dirs_cmd.py
+++ b/auto_process_ngs/test/commands/test_merge_fastq_dirs_cmd.py
@@ -238,7 +238,8 @@ poll_interval = 0.5
         # Check projects.info files
         self._assert_file_exists(os.path.join(analysis_dir,'save.projects.info'))
         self._assert_file_exists(os.path.join(analysis_dir,'projects.info'))
-        projects_info = open(os.path.join(analysis_dir,'projects.info'),'r').read()
+        with open(os.path.join(analysis_dir,'projects.info'),'rt') as fp:
+            projects_info = fp.read()
         expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Comments
 AB	AB1,AB2	.	.	.	.	.	.
 CDE	CDE3,CDE4	.	.	.	.	.	.
@@ -290,7 +291,8 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         # Check projects.info files
         self._assert_file_exists(os.path.join(analysis_dir,'save.projects.info'))
         self._assert_file_exists(os.path.join(analysis_dir,'projects.info'))
-        projects_info = open(os.path.join(analysis_dir,'projects.info'),'r').read()
+        with open(os.path.join(analysis_dir,'projects.info'),'rt') as fp:
+            projects_info = fp.read()
         expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Comments
 AB	AB1,AB2	.	.	.	.	.	.
 CDE	CDE3,CDE4	.	.	.	.	.	.
@@ -341,7 +343,8 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         # Check projects.info files
         self._assert_file_exists(os.path.join(analysis_dir,'save.projects.info'))
         self._assert_file_exists(os.path.join(analysis_dir,'projects.info'))
-        projects_info = open(os.path.join(analysis_dir,'projects.info'),'r').read()
+        with open(os.path.join(analysis_dir,'projects.info'),'rt') as fp:
+            projects_info = fp.read()
         expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Comments
 AB	AB1,AB2	.	.	.	.	.	.
 CDE	CDE3,CDE4	.	.	.	.	.	.
@@ -391,7 +394,8 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         # Check projects.info files
         self._assert_file_exists(os.path.join(analysis_dir,'save.projects.info'))
         self._assert_file_exists(os.path.join(analysis_dir,'projects.info'))
-        projects_info = open(os.path.join(analysis_dir,'projects.info'),'r').read()
+        with open(os.path.join(analysis_dir,'projects.info'),'rt') as fp:
+            projects_info = fp.read()
         expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Comments
 AB	AB1,AB2	.	.	.	.	.	.
 CDE	CDE3,CDE4	.	.	.	.	.	.
@@ -440,7 +444,8 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         # Check projects.info files
         self._assert_file_exists(os.path.join(analysis_dir,'save.projects.info'))
         self._assert_file_exists(os.path.join(analysis_dir,'projects.info'))
-        projects_info = open(os.path.join(analysis_dir,'projects.info'),'r').read()
+        with open(os.path.join(analysis_dir,'projects.info'),'rt') as fp:
+            projects_info = fp.read()
         expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Comments
 AB	AB1,AB2	.	.	.	.	.	.
 CDE	CDE3,CDE4	.	.	.	.	.	.
@@ -489,7 +494,8 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         # Check projects.info files
         self._assert_file_exists(os.path.join(analysis_dir,'save.projects.info'))
         self._assert_file_exists(os.path.join(analysis_dir,'projects.info'))
-        projects_info = open(os.path.join(analysis_dir,'projects.info'),'r').read()
+        with open(os.path.join(analysis_dir,'projects.info'),'rt') as fp:
+            projects_info = fp.read()
         expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Comments
 AB	AB1,AB2	.	.	.	.	.	.
 CDE	CDE3,CDE4	.	.	.	.	.	.
@@ -629,7 +635,8 @@ CDE	CDE3,CDE4	.	.	.	.	.	.
         # Check projects.info files
         self._assert_file_exists(os.path.join(analysis_dir,'save.projects.info'))
         self._assert_file_exists(os.path.join(analysis_dir,'projects.info'))
-        projects_info = open(os.path.join(analysis_dir,'projects.info'),'r').read()
+        with open(os.path.join(analysis_dir,'projects.info'),'rt') as fp:
+            projects_info = fp.read()
         expected = """#Project	Samples	User	Library	SC_Platform	Organism	PI	Comments
 AB	AB1,AB2	.	.	.	.	.	.
 CDE	CDE3,CDE4	.	.	.	.	.	.

--- a/auto_process_ngs/test/commands/test_setup_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_cmd.py
@@ -785,8 +785,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                             "Missing file: %s" % filen)
         # Check contents of projects.info
         projects_info = os.path.join(analysis_dir,"projects.info")
-        self.assertEqual(open(projects_info,'r').read(),
-                         """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+        with open(projects_info,'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
 AB\tAB1,AB2\t.\t.\t.\t.\t.\t.
 CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
 """)
@@ -864,8 +865,9 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
                             "Missing file: %s" % filen)
         # Check contents of projects.info
         projects_info = os.path.join(analysis_dir,"projects.info")
-        self.assertEqual(open(projects_info,'r').read(),
-                         """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+        with open(projects_info,'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
 AB\tAB1,AB2\t.\t.\t.\t.\t.\t.
 CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
 """)

--- a/auto_process_ngs/test/icell8/test_atac.py
+++ b/auto_process_ngs/test/icell8/test_atac.py
@@ -320,8 +320,9 @@ class TestSplitFastqFunction(unittest.TestCase):
                                  os.path.join(self.wd,"test_B001.fastq"),
                                  os.path.join(self.wd,"test_B002.fastq")])
         # Check the contents
-        self.assertEqual(open(os.path.join(self.wd,"test_B000.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 1:N:0:1
+        with open(os.path.join(self.wd,"test_B000.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 1:N:0:1
 TAAACATTCTGGGGGTTGGGGTGAGGTNTNNNNNNNNA
 +
 AA/AAEEEEEEEEEEEAEEEEAEAEEE#E########E
@@ -342,8 +343,9 @@ AAATATGGCGAGGAAAACTGAAAAAGGNGNNNNNNNNA
 +
 AAAAAEEEEEEEEEEEEEEEEEEEEEA#/########E
 """)
-        self.assertEqual(open(os.path.join(self.wd,"test_B001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:12850:1056 1:N:0:1
+        with open(os.path.join(self.wd,"test_B001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:12850:1056 1:N:0:1
 CTCCTTCTCTGATTGATCAGATAGCTCNTGNNNNNN
 +
 AAAAAEEEEEEEEEEEEEEEEEEEEEE#EE######
@@ -364,8 +366,9 @@ ACAAAAAATTGCTCCCCTATCAATTNTNANNNNNNNNT
 +
 AAAAAEEEEEEEEEEEEEEEEE/EE#E#E########E
 """)
-        self.assertEqual(open(os.path.join(self.wd,"test_B002.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:12602:1058 1:N:0:1
+        with open(os.path.join(self.wd,"test_B002.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:12602:1058 1:N:0:1
 CAGCTAAGAGCATCGAGGGGGCGCCGAGAGNNNNNNGG
 +
 AAAAAEEEEEEEEEEEEEEEEEEEEEEEEE######EE
@@ -441,10 +444,11 @@ class TestAssignReadsFunction(unittest.TestCase):
                                       "B002",
                                       "unassigned_barcodes.txt"))
         # Check the output files
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "1_S1_R1_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:9835:1054 1:N:0:1
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "1_S1_R1_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:9835:1054 1:N:0:1
 TTTCTGTAGTGTGGCGTGTTGGTGTNGNCNNNNNNNNA
 +
 AAAAAEEEEEEEEEEEEEEEEEEEE#A#E########E
@@ -457,10 +461,11 @@ CTCCTTCTCTGATTGATCAGATAGCTCNTGNNNNNN
 +
 AAAAAEEEEEEEEEEEEEEEEEEEEEE#EE######
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "1_S1_R2_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:9835:1054 2:N:0:1
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "1_S1_R2_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:9835:1054 2:N:0:1
 AACGTGCTCCTTCTATCCGGGCAACACCAACACGCCA
 +
 AAAAAEEEEEEEEEAEEEEEEEEEEEEEEEEEEEEEA
@@ -473,10 +478,11 @@ CTGAAGGGACTTGGGCCATGATAGAAAGTGAGAATTTA
 +
 AAAAAEEEEEEEEEEEEEEEEEAEEEEEEEEEEEEEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "1_S1_I1_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:9835:1054 1:N:0:1
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "1_S1_I1_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:9835:1054 1:N:0:1
 TAAGGCGA
 +
 AAAAAEEE
@@ -489,10 +495,11 @@ CATCCTGT
 +
 AAAAAEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "1_S1_I2_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:9835:1054 2:N:0:1
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "1_S1_I2_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:9835:1054 2:N:0:1
 CTTGGTTA
 +
 AAAAAEEE
@@ -505,10 +512,11 @@ TGTAGATT
 +
 AAAAAEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "2_S2_R1_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:24409:1053 1:N:0:1
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "2_S2_R1_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:24409:1053 1:N:0:1
 ACTCTCTTCTAATGGAGGACTGTGTNANANNNNNNNNT
 +
 AAAAAEEEEEEEEEEEEEEEEEEEE#E#E########E
@@ -521,10 +529,11 @@ GACATACTAGGAGACCCAGACAACTACATACCNGCTAA
 +
 AAAAAEEEEEEE/EEAEEAEAEEAEEEEEAE/#/EEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "2_S2_R2_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:24409:1053 2:N:0:1
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "2_S2_R2_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:24409:1053 2:N:0:1
 ACCCTATTGTGTAATGTGCATGACATATGGCATACTAA
 +
 AAAAAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE
@@ -537,10 +546,11 @@ GTGTTTAGTGGATTAGCTGGTATGTAGTTGTCTGGGT
 +
 AAAAAEAEEEEEEEEE/EE6EEEEEEEEEEEEEEEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "2_S2_I1_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:24409:1053 1:N:0:1
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "2_S2_I1_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:24409:1053 1:N:0:1
 CGAGGCTG
 +
 AAAAAEEE
@@ -553,10 +563,11 @@ TTCCATAT
 +
 AAAAAEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "2_S2_I2_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:24409:1053 2:N:0:1
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "2_S2_I2_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:24409:1053 2:N:0:1
 CCCTATCG
 +
 AAAAAEEE
@@ -569,10 +580,11 @@ CCCTATCG
 +
 AAAAAEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "3_S3_R1_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:21842:1053 1:N:0:1
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "3_S3_R1_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:21842:1053 1:N:0:1
 ACAAAAAATTGCTCCCCTATCAATTNTNANNNNNNNNT
 +
 AAAAAEEEEEEEEEEEEEEEEE/EE#E#E########E
@@ -585,10 +597,11 @@ AGATATAGCATTCCCACGAATAAATAATATNANNTNTT
 +
 AAAAA6EE/A/A///AEEAEEAEEEEEEEE#/##E#AE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "3_S3_R2_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:21842:1053 2:N:0:1
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "3_S3_R2_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:21842:1053 2:N:0:1
 ATTGCTAATATTCATCCTATGTGGGCAATTGATGAATA
 +
 AAAAAEEEE<EEEEEEEEEEEEEEEEEEEEAEEEEEE/
@@ -601,10 +614,11 @@ CTATTGATGATGCTAGTAGAAGGAGAAATGATGGTGGT
 +
 6AAAAE/AE/A<AAE//EEAEE/EEEEEEEEEE/EEE/
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "3_S3_I1_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:21842:1053 1:N:0:1
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "3_S3_I1_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:21842:1053 1:N:0:1
 AAGAGGCA
 +
 AAAAAEEE
@@ -617,10 +631,11 @@ AAGAGGCA
 +
 AA6A66AA
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "3_S3_I2_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:21842:1053 2:N:0:1
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "3_S3_I2_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:21842:1053 2:N:0:1
 TACTCCTT
 +
 AAAAAEEE
@@ -633,10 +648,11 @@ TACTCCTT
 +
 AA/AAEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "10_S4_R1_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 1:N:0:1
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "10_S4_R1_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 1:N:0:1
 TAAACATTCTGGGGGTTGGGGTGAGGTNTNNNNNNNNA
 +
 AA/AAEEEEEEEEEEEAEEEEAEAEEE#E########E
@@ -649,10 +665,11 @@ CAGCTGTTCTCATCATGATCTTTATAATTTNNNNNNC
 +
 AAAAAEEEEEEEEEEEEEEEEEEEEEEEEE######E
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "10_S4_R2_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 2:N:0:1
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "10_S4_R2_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 2:N:0:1
 TTTCCACCCAGAAGGATGGGAGCAGATGTTAATAAC
 +
 AAAAAAEEEEEEAEEEEEAAEEEEE/EEEAEEAAEE
@@ -665,10 +682,11 @@ ATATGGTGGAGGGCAGCCATGAAGTCATTCTAAATTTG
 +
 AAAAAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "10_S4_I1_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 1:N:0:1
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "10_S4_I1_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 1:N:0:1
 AGTAGATT
 +
 AAAAAEEE
@@ -681,10 +699,11 @@ AGTAGATT
 +
 AAAAAEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "10_S4_I2_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 2:N:0:1
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "10_S4_I2_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 2:N:0:1
 GCCACGTC
 +
 AAA/AEEE
@@ -725,10 +744,11 @@ AAAAAEEE
                                       "B002",
                                       "unassigned_barcodes.txt"))
         # Check the output files
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "1_S1_R1_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:9835:1054 1:N:0:TAACCAAG+TAAGGCGA
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "1_S1_R1_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:9835:1054 1:N:0:TAACCAAG+TAAGGCGA
 TTTCTGTAGTGTGGCGTGTTGGTGTNGNCNNNNNNNNA
 +
 AAAAAEEEEEEEEEEEEEEEEEEEE#A#E########E
@@ -741,10 +761,11 @@ CTCCTTCTCTGATTGATCAGATAGCTCNTGNNNNNN
 +
 AAAAAEEEEEEEEEEEEEEEEEEEEEE#EE######
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "1_S1_R2_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:9835:1054 2:N:0:TAACCAAG+TAAGGCGA
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "1_S1_R2_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:9835:1054 2:N:0:TAACCAAG+TAAGGCGA
 AACGTGCTCCTTCTATCCGGGCAACACCAACACGCCA
 +
 AAAAAEEEEEEEEEAEEEEEEEEEEEEEEEEEEEEEA
@@ -757,10 +778,11 @@ CTGAAGGGACTTGGGCCATGATAGAAAGTGAGAATTTA
 +
 AAAAAEEEEEEEEEEEEEEEEEAEEEEEEEEEEEEEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "1_S1_I1_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:9835:1054 1:N:0:TAACCAAG+TAAGGCGA
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "1_S1_I1_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:9835:1054 1:N:0:TAACCAAG+TAAGGCGA
 TAAGGCGA
 +
 AAAAAEEE
@@ -773,10 +795,11 @@ CATCCTGT
 +
 AAAAAEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "1_S1_I2_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:9835:1054 2:N:0:TAACCAAG+TAAGGCGA
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "1_S1_I2_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:9835:1054 2:N:0:TAACCAAG+TAAGGCGA
 CTTGGTTA
 +
 AAAAAEEE
@@ -789,10 +812,11 @@ TGTAGATT
 +
 AAAAAEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "2_S2_R1_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:24409:1053 1:N:0:CGATAGGG+CGAGGCTG
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "2_S2_R1_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:24409:1053 1:N:0:CGATAGGG+CGAGGCTG
 ACTCTCTTCTAATGGAGGACTGTGTNANANNNNNNNNT
 +
 AAAAAEEEEEEEEEEEEEEEEEEEE#E#E########E
@@ -805,10 +829,11 @@ GACATACTAGGAGACCCAGACAACTACATACCNGCTAA
 +
 AAAAAEEEEEEE/EEAEEAEAEEAEEEEEAE/#/EEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "2_S2_R2_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:24409:1053 2:N:0:CGATAGGG+CGAGGCTG
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "2_S2_R2_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:24409:1053 2:N:0:CGATAGGG+CGAGGCTG
 ACCCTATTGTGTAATGTGCATGACATATGGCATACTAA
 +
 AAAAAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE
@@ -821,10 +846,11 @@ GTGTTTAGTGGATTAGCTGGTATGTAGTTGTCTGGGT
 +
 AAAAAEAEEEEEEEEE/EE6EEEEEEEEEEEEEEEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "2_S2_I1_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:24409:1053 1:N:0:CGATAGGG+CGAGGCTG
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "2_S2_I1_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:24409:1053 1:N:0:CGATAGGG+CGAGGCTG
 CGAGGCTG
 +
 AAAAAEEE
@@ -837,10 +863,11 @@ TTCCATAT
 +
 AAAAAEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "2_S2_I2_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:24409:1053 2:N:0:CGATAGGG+CGAGGCTG
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "2_S2_I2_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:24409:1053 2:N:0:CGATAGGG+CGAGGCTG
 CCCTATCG
 +
 AAAAAEEE
@@ -853,10 +880,11 @@ CCCTATCG
 +
 AAAAAEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "3_S3_R1_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:21842:1053 1:N:0:AAGGAGTA+AAGAGGCA
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "3_S3_R1_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:21842:1053 1:N:0:AAGGAGTA+AAGAGGCA
 ACAAAAAATTGCTCCCCTATCAATTNTNANNNNNNNNT
 +
 AAAAAEEEEEEEEEEEEEEEEE/EE#E#E########E
@@ -869,10 +897,11 @@ AGATATAGCATTCCCACGAATAAATAATATNANNTNTT
 +
 AAAAA6EE/A/A///AEEAEEAEEEEEEEE#/##E#AE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "3_S3_R2_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:21842:1053 2:N:0:AAGGAGTA+AAGAGGCA
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "3_S3_R2_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:21842:1053 2:N:0:AAGGAGTA+AAGAGGCA
 ATTGCTAATATTCATCCTATGTGGGCAATTGATGAATA
 +
 AAAAAEEEE<EEEEEEEEEEEEEEEEEEEEAEEEEEE/
@@ -885,10 +914,11 @@ CTATTGATGATGCTAGTAGAAGGAGAAATGATGGTGGT
 +
 6AAAAE/AE/A<AAE//EEAEE/EEEEEEEEEE/EEE/
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "3_S3_I1_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:21842:1053 1:N:0:AAGGAGTA+AAGAGGCA
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "3_S3_I1_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:21842:1053 1:N:0:AAGGAGTA+AAGAGGCA
 AAGAGGCA
 +
 AAAAAEEE
@@ -901,10 +931,11 @@ AAGAGGCA
 +
 AA6A66AA
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "3_S3_I2_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:21842:1053 2:N:0:AAGGAGTA+AAGAGGCA
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "3_S3_I2_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:21842:1053 2:N:0:AAGGAGTA+AAGAGGCA
 TACTCCTT
 +
 AAAAAEEE
@@ -917,10 +948,11 @@ TACTCCTT
 +
 AA/AAEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "10_S4_R1_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 1:N:0:GACGTGGC+AGTAGATT
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "10_S4_R1_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 1:N:0:GACGTGGC+AGTAGATT
 TAAACATTCTGGGGGTTGGGGTGAGGTNTNNNNNNNNA
 +
 AA/AAEEEEEEEEEEEAEEEEAEAEEE#E########E
@@ -933,10 +965,11 @@ CAGCTGTTCTCATCATGATCTTTATAATTTNNNNNNC
 +
 AAAAAEEEEEEEEEEEEEEEEEEEEEEEEE######E
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "10_S4_R2_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 2:N:0:GACGTGGC+AGTAGATT
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "10_S4_R2_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 2:N:0:GACGTGGC+AGTAGATT
 TTTCCACCCAGAAGGATGGGAGCAGATGTTAATAAC
 +
 AAAAAAEEEEEEAEEEEEAAEEEEE/EEEAEEAAEE
@@ -949,10 +982,11 @@ ATATGGTGGAGGGCAGCCATGAAGTCATTCTAAATTTG
 +
 AAAAAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "10_S4_I1_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 1:N:0:GACGTGGC+AGTAGATT
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "10_S4_I1_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 1:N:0:GACGTGGC+AGTAGATT
 AGTAGATT
 +
 AAAAAEEE
@@ -965,10 +999,11 @@ AGTAGATT
 +
 AAAAAEEE
 """)
-        self.assertEqual(open(os.path.join(self.wd,
-                                           "B002",
-                                           "10_S4_I2_001.fastq")).read(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 2:N:0:GACGTGGC+AGTAGATT
+        with open(os.path.join(self.wd,
+                               "B002",
+                               "10_S4_I2_001.fastq"),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 2:N:0:GACGTGGC+AGTAGATT
 GCCACGTC
 +
 AAA/AEEE
@@ -1094,8 +1129,9 @@ class TestConcatFastqsFunction(unittest.TestCase):
         self.assertEqual(fastq,
                          os.path.join(self.final_dir,
                                       "PJB1_S1_R1_001.fastq.gz"))
-        self.assertEqual(gzip.open(fastq).read().decode(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 1:N:0:1
+        with gzip.open(fastq) as fp:
+            self.assertEqual(fp.read().decode(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 1:N:0:1
 TAAACATTCTGGGGGTTGGGGTGAGGTNTNNNNNNNNA
 +
 AA/AAEEEEEEEEEEEAEEEEAEAEEE#E########E
@@ -1152,8 +1188,9 @@ AAAAAEEEEEEEEEEEEEEEEEEEEEE#EE######
         self.assertEqual(fastq,
                          os.path.join(self.final_dir,
                                       "PJB1_S1_TTCGTGCA+GATCCAAA_R1_001.fastq.gz"))
-        self.assertEqual(gzip.open(fastq).read().decode(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 1:N:0:1
+        with gzip.open(fastq) as fp:
+            self.assertEqual(fp.read().decode(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 1:N:0:1
 TAAACATTCTGGGGGTTGGGGTGAGGTNTNNNNNNNNA
 +
 AA/AAEEEEEEEEEEEAEEEEAEAEEE#E########E
@@ -1211,8 +1248,9 @@ AAAAAEEEEEEEEEEEEEEEEEEEEEE#EE######
         self.assertEqual(fastq,
                          os.path.join(self.final_dir,
                                       "PJB1_S1_L001_R1_001.fastq.gz"))
-        self.assertEqual(gzip.open(fastq).read().decode(),
-                         """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 1:N:0:1
+        with gzip.open(fastq) as fp:
+            self.assertEqual(fp.read().decode(),
+                             """@NB500968:115:HWJNYBGX9:1:11101:4820:1056 1:N:0:1
 TAAACATTCTGGGGGTTGGGGTGAGGTNTNNNNNNNNA
 +
 AA/AAEEEEEEEEEEEAEEEEAEAEEE#E########E

--- a/auto_process_ngs/test/test_applications.py
+++ b/auto_process_ngs/test/test_applications.py
@@ -33,12 +33,12 @@ class TestCommand(unittest.TestCase):
     def test_command_handles_forward_slash(self):
         """Check forward slash is handled correctly
         """
-        cmd = Command('find','-name','"*"','-exec','grep','"hello"','{}','\;')
+        cmd = Command('find','-name','"*"','-exec','grep','"hello"','{}','\\;')
         self.assertEqual(cmd.command,'find')
-        self.assertEqual(cmd.args,['-name','"*"','-exec','grep','"hello"','{}','\;'])
+        self.assertEqual(cmd.args,['-name','"*"','-exec','grep','"hello"','{}','\\;'])
         self.assertEqual(cmd.command_line,['find','-name','"*"','-exec',
-                                           'grep','"hello"','{}','\;'])
-        self.assertEqual(str(cmd),'find -name "*" -exec grep "hello" {} \;')
+                                           'grep','"hello"','{}','\\;'])
+        self.assertEqual(str(cmd),'find -name "*" -exec grep "hello" {} \\;')
 
     def test_run_subprocess(self):
         """Run command using subprocess

--- a/auto_process_ngs/test/test_bcl2fastq.py
+++ b/auto_process_ngs/test/test_bcl2fastq.py
@@ -722,8 +722,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 4,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
 """
         self.assertTrue(os.path.exists(sample_sheet_out))
-        self.assertEqual(open(sample_sheet_out,'r').read(),
-                         expected)
+        with open(sample_sheet_out,'r') as fp:
+            self.assertEqual(fp.read(),expected)
+
     def test_make_custom_sample_sheet_adapter(self):
         """
         make_custom_sample_sheet: update adapter sequence
@@ -760,8 +761,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 4,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
 """
         self.assertTrue(os.path.exists(sample_sheet_out))
-        self.assertEqual(open(sample_sheet_out,'r').read(),
-                         expected)
+        with open(sample_sheet_out,'r') as fp:
+            self.assertEqual(fp.read(),expected)
+
     def test_make_custom_sample_sheet_adapter_read2(self):
         """
         make_custom_sample_sheet: update adapter sequence (read2)
@@ -799,8 +801,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 4,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
 """
         self.assertTrue(os.path.exists(sample_sheet_out))
-        self.assertEqual(open(sample_sheet_out,'r').read(),
-                         expected)
+        with open(sample_sheet_out,'r') as fp:
+            self.assertEqual(fp.read(),expected)
+
     def test_make_custom_sample_sheet_no_adapters(self):
         """
         make_custom_sample_sheet: remove adapter sequences
@@ -836,8 +839,8 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
 4,PJB2-1580,PJB2-1580,,,N702,TGACCAAT,N502,TCTTTCCC,PeterBriggs,
 """
         self.assertTrue(os.path.exists(sample_sheet_out))
-        self.assertEqual(open(sample_sheet_out,'r').read(),
-                         expected)
+        with open(sample_sheet_out,'rt') as fp:
+            self.assertEqual(fp.read(),expected)
 
 class TestBasesMaskIsValid(unittest.TestCase):
     """Tests for the bases_mask_is_valid function

--- a/auto_process_ngs/test/test_fastq_utils.py
+++ b/auto_process_ngs/test/test_fastq_utils.py
@@ -587,7 +587,8 @@ class TestAssignBarcodesSingleEnd(unittest.TestCase):
         self.wd = tempfile.mkdtemp(suffix='.test_assign_barcodes_single_end')
         # Test file
         self.fastq_in = os.path.join(self.wd,'test.fq')
-        open(self.fastq_in,'w').write(fastq_r1)
+        with open(self.fastq_in,'wt') as fp:
+            fp.write(fastq_r1)
         # Output file
         self.fastq_out = os.path.join(self.wd,'out.fq')
     def tearDown(self):
@@ -600,8 +601,8 @@ class TestAssignBarcodesSingleEnd(unittest.TestCase):
         nreads = assign_barcodes_single_end(self.fastq_in,
                                             self.fastq_out)
         self.assertEqual(nreads,5)
-        self.assertEqual(open(self.fastq_out,'r').read(),
-                         fastq_r1_out)
+        with open(self.fastq_out,'r') as fp:
+            self.assertEqual(fp.read(),fastq_r1_out)
 
 # pair_fastqs
 fastq1_r1 = """@MISEQ:34:000000000-A7PHP:1:1101:12552:1774 1:N:0:TAAGGCGA

--- a/auto_process_ngs/test/test_fileops.py
+++ b/auto_process_ngs/test/test_fileops.py
@@ -146,8 +146,8 @@ class TestCopyFunction(FileopsTestCase):
         status = copy(src_file,tgt_file)
         self.assertEqual(status,0)
         self.assertTrue(os.path.isfile(tgt_file))
-        self.assertEqual(open(tgt_file).read(),
-                         "This is a test file")
+        with open(tgt_file,'rt') as fp:
+            self.assertEqual(fp.read(),"This is a test file")
 
     def test_local_copy_as_link(self):
         """fileops.copy: copy a local file as a link
@@ -161,8 +161,8 @@ class TestCopyFunction(FileopsTestCase):
         status = copy(src_file,tgt_file,link=True)
         self.assertEqual(status,0)
         self.assertTrue(os.path.isfile(tgt_file))
-        self.assertEqual(open(tgt_file).read(),
-                         "This is a test file")
+        with open(tgt_file,'rt') as fp:
+            self.assertEqual(fp.read(),"This is a test file")
         # Convoluted way to check if one file is hard-linked
         # to another (see https://stackoverflow.com/a/41942022)
         stat_src = os.stat(src_file)
@@ -191,10 +191,10 @@ class TestCopytreeFunction(FileopsTestCase):
         self.assertEqual(status,0)
         self.assertTrue(os.path.isdir(tgt_dir))
         self.assertTrue(os.path.isdir(os.path.join(tgt_dir,'subdir')))
-        self.assertEqual(open(os.path.join(tgt_dir,'test1.txt')).read(),
-                         "This is test file 1")
-        self.assertEqual(open(os.path.join(tgt_dir,'subdir','test2.txt')).read(),
-                         "This is test file 2")
+        with open(os.path.join(tgt_dir,'test1.txt'),'rt') as fp:
+            self.assertEqual(fp.read(),"This is test file 1")
+        with open(os.path.join(tgt_dir,'subdir','test2.txt'),'rt') as fp:
+            self.assertEqual(fp.read(),"This is test file 2")
 
 class TestSetGroupFunction(FileopsTestCase):
     """Tests for the 'set_group' function
@@ -264,8 +264,8 @@ class TestUnzip(FileopsTestCase):
         self.assertTrue(os.path.isdir(out_dir))
         out_file = os.path.join(out_dir,'test.txt')
         self.assertTrue(os.path.isfile(out_file))
-        self.assertEqual(open(out_file).read(),
-                         "This is a test file")
+        with open(out_file,'rt') as fp:
+            self.assertEqual(fp.read(),"This is a test file")
 
 class TestRename(FileopsTestCase):
     """Tests for the 'rename' function

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -86,7 +86,7 @@ class TestMetadataDict(unittest.TestCase):
                                             'chat': 'Chit chat'},
                                 order=('salutation','chat','valediction'))
         metadata.save(self.metadata_file)
-        fp = open(self.metadata_file,'rU')
+        fp = open(self.metadata_file,'rt')
         for line,expected_key in zip(fp,expected_keys):
             self.assertEqual(line.split('\t')[0],expected_key)
 
@@ -101,7 +101,7 @@ class TestMetadataDict(unittest.TestCase):
                          'Salutation',
                          'Valediction',)
         metadata.save(self.metadata_file)
-        fp = open(self.metadata_file,'rU')
+        fp = open(self.metadata_file,'rt')
         for line,expected_key in zip(fp,expected_keys):
             self.assertEqual(line.split('\t')[0],expected_key)
 

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -86,9 +86,9 @@ class TestMetadataDict(unittest.TestCase):
                                             'chat': 'Chit chat'},
                                 order=('salutation','chat','valediction'))
         metadata.save(self.metadata_file)
-        fp = open(self.metadata_file,'rt')
-        for line,expected_key in zip(fp,expected_keys):
-            self.assertEqual(line.split('\t')[0],expected_key)
+        with open(self.metadata_file,'rt') as fp:
+            for line,expected_key in zip(fp,expected_keys):
+                self.assertEqual(line.split('\t')[0],expected_key)
 
     def test_implicit_key_order(self):
         """Check that keys are implicitly ordered on output
@@ -101,9 +101,9 @@ class TestMetadataDict(unittest.TestCase):
                          'Salutation',
                          'Valediction',)
         metadata.save(self.metadata_file)
-        fp = open(self.metadata_file,'rt')
-        for line,expected_key in zip(fp,expected_keys):
-            self.assertEqual(line.split('\t')[0],expected_key)
+        with open(self.metadata_file,'rt') as fp:
+            for line,expected_key in zip(fp,expected_keys):
+                self.assertEqual(line.split('\t')[0],expected_key)
 
     def test_get_null_items(self):
         """Check fetching of items with null values
@@ -299,7 +299,8 @@ class TestProjectMetadataFile(unittest.TestCase):
             self.fail()
         # Save to an actual file and check its contents
         metadata.save(self.metadata_file)
-        self.assertEqual(open(self.metadata_file,'r').read(),contents)
+        with open(self.metadata_file,'rt') as fp:
+            self.assertEqual(fp.read(),contents)
 
     def test_create_new_project_metadata_file(self):
         """Create and save ProjectMetadataFile with content
@@ -321,7 +322,8 @@ class TestProjectMetadataFile(unittest.TestCase):
         self.assertEqual(len(metadata),2)
         # Save to an actual file and check its contents
         metadata.save(self.metadata_file)
-        self.assertEqual(open(self.metadata_file,'r').read(),contents)
+        with open(self.metadata_file,'rt') as fp:
+            self.assertEqual(fp.read(),contents)
 
     def test_read_existing_project_metadata_file(self):
         """Read contents from existing ProjectMetadataFile
@@ -345,7 +347,8 @@ class TestProjectMetadataFile(unittest.TestCase):
                          PI="Harley",
                          Comments="Squeak!"))
         contents = "#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments\nCharlie\tC1-2\tCharlie P\tRNA-seq\t.\tYeast\tMarley\t.\nFarley\tF3-4\tFarley G\tChIP-seq\t.\tMouse\tHarley\tSqueak!\n"
-        open(self.metadata_file,'w').write(contents)
+        with open(self.metadata_file,'wt') as fp:
+            fp.write(contents)
         # Load and check contents
         metadata = ProjectMetadataFile(self.metadata_file)
         self.assertEqual(len(metadata),2)

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -105,8 +105,8 @@ class TestPipeline(unittest.TestCase):
         self.assertEqual(exit_status,0)
         out_file = os.path.join(self.working_dir,"out.txt")
         self.assertTrue(os.path.exists(out_file))
-        self.assertEqual(open(out_file,'r').read(),
-                         "item1\nitem2\n")
+        with open(out_file,'rt') as fp:
+            self.assertEqual(fp.read(),"item1\nitem2\n")
 
     def test_pipeline_with_multiple_commands(self):
         """
@@ -142,8 +142,8 @@ class TestPipeline(unittest.TestCase):
                      for f in ("out1.txt","out2.txt")]
         for out_file in out_files:
             self.assertTrue(os.path.exists(out_file))
-            self.assertEqual(open(out_file,'r').read(),
-                             "item\n")
+            with open(out_file,'rt') as fp:
+                self.assertEqual(fp.read(),"item\n")
 
     def test_pipeline_with_batched_commands(self):
         """
@@ -180,8 +180,8 @@ class TestPipeline(unittest.TestCase):
                      for f in ("out1.txt","out2.txt")]
         for out_file in out_files:
             self.assertTrue(os.path.exists(out_file))
-            self.assertEqual(open(out_file,'r').read(),
-                             "item\n")
+            with open(out_file,'rt') as fp:
+                self.assertEqual(fp.read(),"item\n")
 
     def test_pipeline_sets_pipelineparam_as_task_input(self):
         """
@@ -214,7 +214,8 @@ class TestPipeline(unittest.TestCase):
         self.assertEqual(exit_status,0)
         out_file = os.path.join(self.working_dir,"out.txt")
         self.assertTrue(os.path.exists(out_file))
-        self.assertEqual(open(out_file,'r').read(),"goodbye\n")
+        with open(out_file,'rt') as fp:
+            self.assertEqual(fp.read(),"goodbye\n")
 
     def test_pipeline_with_external_scheduler(self):
         """
@@ -246,8 +247,8 @@ class TestPipeline(unittest.TestCase):
         self.assertEqual(exit_status,0)
         out_file = os.path.join(self.working_dir,"out.txt")
         self.assertTrue(os.path.exists(out_file))
-        self.assertEqual(open(out_file,'r').read(),
-                         "item1\nitem2\n")
+        with open(out_file,'rt') as fp:
+            self.assertEqual(fp.read(),"item1\nitem2\n")
 
     def test_pipeline_working_dir_is_respected(self):
         """
@@ -283,8 +284,8 @@ class TestPipeline(unittest.TestCase):
         self.assertEqual(exit_status,0)
         out_file = os.path.join(self.working_dir,"out.txt")
         self.assertTrue(os.path.exists(out_file))
-        self.assertEqual(open(out_file,'r').read(),
-                         "item1\nitem2\n")
+        with open(out_file,'rt') as fp:
+            self.assertEqual(fp.read(),"item1\nitem2\n")
 
     def test_pipeline_stops_on_task_failure(self):
         """
@@ -488,8 +489,8 @@ class TestPipeline(unittest.TestCase):
         # Check the outputs
         self.assertEqual(exit_status,0)
         self.assertTrue(os.path.exists(out_file))
-        self.assertEqual(open(out_file,'r').read(),
-                         "item1\nitem2\n")
+        with open(out_file,'rt') as fp:
+            self.assertEqual(fp.read(),"item1\nitem2\n")
 
     def test_pipeline_add_runner(self):
         """
@@ -556,7 +557,8 @@ class TestPipeline(unittest.TestCase):
         # Check the outputs
         self.assertEqual(exit_status,0)
         self.assertTrue(os.path.exists(out_file))
-        self.assertEqual(open(out_file,'r').read(),"item1\n")
+        with open(out_file,'r') as fp:
+            self.assertEqual(fp.read(),"item1\n")
 
     def test_pipeline_runner_set_default_runner_at_runtime(self):
         """
@@ -605,7 +607,8 @@ class TestPipeline(unittest.TestCase):
         # Check the outputs
         self.assertEqual(exit_status,0)
         self.assertTrue(os.path.exists(out_file))
-        self.assertEqual(open(out_file,'r').read(),"item1\nitem2\n")
+        with open(out_file,'rt') as fp:
+            self.assertEqual(fp.read(),"item1\nitem2\n")
 
     @unittest.skipIf(not envmod.__ENVMODULES__,
                      "Environment modules not available")
@@ -1734,18 +1737,19 @@ class TestPipelineCommand(unittest.TestCase):
         self.assertTrue(os.path.isfile(script_file))
         self.assertEqual(os.path.dirname(script_file),
                          self.working_dir)
-        self.assertEqual(open(script_file,'r').read(),
-                         "#!/bin/bash\n"
-                         "echo \"#### COMMAND EchoCmd\"\n"
-                         "echo \"#### HOSTNAME $HOSTNAME\"\n"
-                         "echo \"#### USER $USER\"\n"
-                         "echo \"#### START $(date)\"\n"
-                         "echo \"#### CWD $(pwd)\"\n"
-                         "echo 'hello there'\n"
-                         "exit_code=$?\n"
-                         "echo \"#### END $(date)\"\n"
-                         "echo \"#### EXIT_CODE $exit_code\"\n"
-                         "exit $exit_code")
+        with open(script_file,'rt') as fp:
+            self.assertEqual(fp.read(),
+                             "#!/bin/bash\n"
+                             "echo \"#### COMMAND EchoCmd\"\n"
+                             "echo \"#### HOSTNAME $HOSTNAME\"\n"
+                             "echo \"#### USER $USER\"\n"
+                             "echo \"#### START $(date)\"\n"
+                             "echo \"#### CWD $(pwd)\"\n"
+                             "echo 'hello there'\n"
+                             "exit_code=$?\n"
+                             "echo \"#### END $(date)\"\n"
+                             "echo \"#### EXIT_CODE $exit_code\"\n"
+                             "exit $exit_code")
 
     def test_pipelinecommand_with_modules(self):
         """
@@ -1773,20 +1777,21 @@ class TestPipelineCommand(unittest.TestCase):
         self.assertTrue(os.path.isfile(script_file))
         self.assertEqual(os.path.dirname(script_file),
                          self.working_dir)
-        self.assertEqual(open(script_file,'r').read(),
-                         "#!/bin/bash --login\n"
-                         "echo \"#### COMMAND EchoCmd\"\n"
-                         "echo \"#### HOSTNAME $HOSTNAME\"\n"
-                         "echo \"#### USER $USER\"\n"
-                         "echo \"#### START $(date)\"\n"
-                         "module load apps/fastq-screen/0.13.0\n"
-                         "module load apps/fastqc/0.11.8\n"
-                         "echo \"#### CWD $(pwd)\"\n"
-                         "echo 'hello there'\n"
-                         "exit_code=$?\n"
-                         "echo \"#### END $(date)\"\n"
-                         "echo \"#### EXIT_CODE $exit_code\"\n"
-                         "exit $exit_code")
+        with open(script_file,'rt') as fp:
+            self.assertEqual(fp.read(),
+                             "#!/bin/bash --login\n"
+                             "echo \"#### COMMAND EchoCmd\"\n"
+                             "echo \"#### HOSTNAME $HOSTNAME\"\n"
+                             "echo \"#### USER $USER\"\n"
+                             "echo \"#### START $(date)\"\n"
+                             "module load apps/fastq-screen/0.13.0\n"
+                             "module load apps/fastqc/0.11.8\n"
+                             "echo \"#### CWD $(pwd)\"\n"
+                             "echo 'hello there'\n"
+                             "exit_code=$?\n"
+                             "echo \"#### END $(date)\"\n"
+                             "echo \"#### EXIT_CODE $exit_code\"\n"
+                             "exit $exit_code")
 
     def test_pipelinecommand_with_working_dir(self):
         """
@@ -1813,19 +1818,20 @@ class TestPipelineCommand(unittest.TestCase):
         self.assertTrue(os.path.isfile(script_file))
         self.assertEqual(os.path.dirname(script_file),
                          self.working_dir)
-        self.assertEqual(open(script_file,'r').read(),
-                         "#!/bin/bash\n"
-                         "echo \"#### COMMAND EchoCmd\"\n"
-                         "echo \"#### HOSTNAME $HOSTNAME\"\n"
-                         "echo \"#### USER $USER\"\n"
-                         "echo \"#### START $(date)\"\n"
-                         "cd /tmp/command/wd\n"
-                         "echo \"#### CWD $(pwd)\"\n"
-                         "echo 'hello there'\n"
-                         "exit_code=$?\n"
-                         "echo \"#### END $(date)\"\n"
-                         "echo \"#### EXIT_CODE $exit_code\"\n"
-                         "exit $exit_code")
+        with open(script_file,'rt') as fp:
+            self.assertEqual(fp.read(),
+                             "#!/bin/bash\n"
+                             "echo \"#### COMMAND EchoCmd\"\n"
+                             "echo \"#### HOSTNAME $HOSTNAME\"\n"
+                             "echo \"#### USER $USER\"\n"
+                             "echo \"#### START $(date)\"\n"
+                             "cd /tmp/command/wd\n"
+                             "echo \"#### CWD $(pwd)\"\n"
+                             "echo 'hello there'\n"
+                             "exit_code=$?\n"
+                             "echo \"#### END $(date)\"\n"
+                             "echo \"#### EXIT_CODE $exit_code\"\n"
+                             "exit $exit_code")
 
 class TestPipelineCommandWrapper(unittest.TestCase):
 

--- a/auto_process_ngs/test/test_samplesheet_utils.py
+++ b/auto_process_ngs/test/test_samplesheet_utils.py
@@ -273,7 +273,7 @@ a non-ASCII character here\x80
 - ABCDEFGHIJKLMNOPQRSTUVWXYZ
 - abcdefghijklmnopqrstuvwxyz
 - 01234567890
-- !"$%^&*()_-+=\|/:;'@#~`?
+- !"$%^&*()_-+=\\|/:;'@#~`?
 - {}[]
 - \t\n
 """)
@@ -285,7 +285,7 @@ a non-ASCII character here\x80
 - ABCDEFGHIJKLMNOPQRSTUVWXYZ
 - abcdefghijklmnopqrstuvwxyz
 - 01234567890
-- !"$%^&*()_-+=\|/:;'@#~`?
+- !"$%^&*()_-+=\\|/:;'@#~`?
 - {}[]
 - \t\n
 """))

--- a/auto_process_ngs/test/test_utils.py
+++ b/auto_process_ngs/test/test_utils.py
@@ -152,10 +152,11 @@ class TestOutputFiles(unittest.TestCase):
         out.write('test1','Some test text')
         out.write('test2','Some more\ntest text')
         out.close()
-        self.assertEqual(open(out.file_name('test1'),'r').read(),
-                         "Some test text\n")
-        self.assertEqual(open(out.file_name('test2'),'r').read(),
-                         "Some more\ntest text\n")
+        with open(out.file_name('test1'),'rt') as fp:
+            self.assertEqual(fp.read(),"Some test text\n")
+        with open(out.file_name('test2'),'rt') as fp:
+            self.assertEqual(open(out.file_name('test2'),'r').read(),
+                             "Some more\ntest text\n")
         # Reopen files
         out.open('test1',append=True)
         out.open('test2')
@@ -268,10 +269,10 @@ class TestBufferedOutputFiles(unittest.TestCase):
         out.write('test1','Some test text')
         out.write('test2','Some more\ntest text')
         out.close()
-        self.assertEqual(open(out.file_name('test1'),'rt').read(),
-                         "Some test text\n")
-        self.assertEqual(open(out.file_name('test2'),'rt').read(),
-                         "Some more\ntest text\n")
+        with open(out.file_name('test1'),'rt') as fp:
+            self.assertEqual(fp.read(),"Some test text\n")
+        with open(out.file_name('test2'),'rt') as fp:
+            self.assertEqual(fp.read(),"Some more\ntest text\n")
         # Reopen files
         out.open('test1',append=True)
         out.open('test2')

--- a/auto_process_ngs/test/test_utils.py
+++ b/auto_process_ngs/test/test_utils.py
@@ -106,6 +106,7 @@ class TestOutputFiles(unittest.TestCase):
         out = OutputFiles(self.wd)
         out.open('test1','test1.txt')
         out.open('test2','test2.txt')
+        out.close()
         self.assertEqual(
             out.file_name('test1'),os.path.join(self.wd,'test1.txt'))
         self.assertEqual(
@@ -155,8 +156,7 @@ class TestOutputFiles(unittest.TestCase):
         with open(out.file_name('test1'),'rt') as fp:
             self.assertEqual(fp.read(),"Some test text\n")
         with open(out.file_name('test2'),'rt') as fp:
-            self.assertEqual(open(out.file_name('test2'),'r').read(),
-                             "Some more\ntest text\n")
+            self.assertEqual(fp.read(),"Some more\ntest text\n")
         # Reopen files
         out.open('test1',append=True)
         out.open('test2')
@@ -188,6 +188,7 @@ class TestOutputFiles(unittest.TestCase):
         self.assertEqual(len(out),0)
         out.open('test2',append=True)
         self.assertEqual(len(out),1)
+        out.close()
 
 class TestBufferedOutputFiles(unittest.TestCase):
     """

--- a/auto_process_ngs/test/test_utils.py
+++ b/auto_process_ngs/test/test_utils.py
@@ -45,7 +45,8 @@ class TestZipArchive(unittest.TestCase):
                 except OSError as ex:
                     raise OSError("Failed to make %s" % item)
             else:
-                open(item,'w').write('')
+                with open(item,'wt') as fp:
+                    fp.write('')
         # Create the zip archive
         zip_filename = os.path.join(self.dirn,'test.zip')
         self.assertFalse(os.path.exists(zip_filename))
@@ -97,10 +98,10 @@ class TestOutputFiles(unittest.TestCase):
         out.write('test1','Some test text')
         out.write('test2','Some more\ntest text')
         out.close()
-        self.assertEqual(open(out.file_name('test1'),'r').read(),
-                         "Some test text\n")
-        self.assertEqual(open(out.file_name('test2'),'r').read(),
-                         "Some more\ntest text\n")
+        with open(out.file_name('test1'),'rt') as fp:
+            self.assertEqual(fp.read(),"Some test text\n")
+        with open(out.file_name('test2'),'rt') as fp:
+            self.assertEqual(fp.read(),"Some more\ntest text\n")
     def test_outputfiles_with_basedir(self):
         out = OutputFiles(self.wd)
         out.open('test1','test1.txt')
@@ -135,10 +136,11 @@ class TestOutputFiles(unittest.TestCase):
         out.write('test1','Some test text')
         out.write('test2','Some more\ntest text')
         out.close()
-        self.assertEqual(open(out.file_name('test1'),'r').read(),
-                         "test1 already exists\nSome test text\n")
-        self.assertEqual(open(out.file_name('test2'),'r').read(),
-                         "Some more\ntest text\n")
+        with open(out.file_name('test1'),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             "test1 already exists\nSome test text\n")
+        with open(out.file_name('test2'),'rt') as fp:
+            self.assertEqual(fp.read(),"Some more\ntest text\n")
     def test_outputfiles_reopen(self):
         out = OutputFiles(base_dir=self.wd)
         out.open('test1','test1.txt')
@@ -164,10 +166,11 @@ class TestOutputFiles(unittest.TestCase):
         out.write('test1','Some extra test text')
         out.write('test2','Some different\ntest text')
         out.close()
-        self.assertEqual(open(out.file_name('test1'),'r').read(),
-                         "Some test text\nSome extra test text\n")
-        self.assertEqual(open(out.file_name('test2'),'r').read(),
-                         "Some different\ntest text\n")
+        with open(out.file_name('test1'),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             "Some test text\nSome extra test text\n")
+        with open(out.file_name('test2'),'rt') as fp:
+            self.assertEqual(fp.read(),"Some different\ntest text\n")
     def test_outputfiles_len(self):
         out = OutputFiles(base_dir=self.wd)
         self.assertEqual(len(out),0)
@@ -207,10 +210,10 @@ class TestBufferedOutputFiles(unittest.TestCase):
         out.write('test1','Some test text')
         out.write('test2','Some more\ntest text')
         out.close()
-        self.assertEqual(open(out.file_name('test1'),'rt').read(),
-                         "Some test text\n")
-        self.assertEqual(open(out.file_name('test2'),'rt').read(),
-                         "Some more\ntest text\n")
+        with open(out.file_name('test1'),'rt') as fp:
+            self.assertEqual(fp.read(),"Some test text\n")
+        with open(out.file_name('test2'),'rt') as fp:
+            self.assertEqual(fp.read(),"Some more\ntest text\n")
     def test_bufferedoutputfiles_with_gzip(self):
         out = BufferedOutputFiles()
         out.open('test1',os.path.join(self.wd,'test1.txt.gz'))
@@ -222,10 +225,10 @@ class TestBufferedOutputFiles(unittest.TestCase):
         out.write('test1','Some test text')
         out.write('test2','Some more\ntest text')
         out.close()
-        self.assertEqual(gzip.open(out.file_name('test1'),'rt').read(),
-                         "Some test text\n")
-        self.assertEqual(gzip.open(out.file_name('test2'),'rt').read(),
-                         "Some more\ntest text\n")
+        with gzip.open(out.file_name('test1'),'rt') as fp:
+            self.assertEqual(fp.read(),"Some test text\n")
+        with gzip.open(out.file_name('test2'),'rt') as fp:
+            self.assertEqual(fp.read(),"Some more\ntest text\n")
     def test_bufferedoutputfiles_with_basedir(self):
         out = BufferedOutputFiles(self.wd)
         out.open('test1','test1.txt')
@@ -249,10 +252,11 @@ class TestBufferedOutputFiles(unittest.TestCase):
         out.write('test1','Some test text')
         out.write('test2','Some more\ntest text')
         out.close()
-        self.assertEqual(open(out.file_name('test1'),'rt').read(),
-                         "test1 already exists\nSome test text\n")
-        self.assertEqual(open(out.file_name('test2'),'rt').read(),
-                         "Some more\ntest text\n")
+        with open(out.file_name('test1'),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             "test1 already exists\nSome test text\n")
+        with open(out.file_name('test2'),'rt') as fp:
+            self.assertEqual(fp.read(),"Some more\ntest text\n")
     def test_bufferedoutputfiles_reopen(self):
         out = BufferedOutputFiles(base_dir=self.wd)
         out.open('test1','test1.txt')
@@ -278,10 +282,11 @@ class TestBufferedOutputFiles(unittest.TestCase):
         out.write('test1','Some extra test text')
         out.write('test2','Some different\ntest text')
         out.close()
-        self.assertEqual(open(out.file_name('test1'),'rt').read(),
-                         "Some test text\nSome extra test text\n")
-        self.assertEqual(open(out.file_name('test2'),'rt').read(),
-                         "Some different\ntest text\n")
+        with open(out.file_name('test1'),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             "Some test text\nSome extra test text\n")
+        with open(out.file_name('test2'),'rt') as fp:
+            self.assertEqual(fp.read(),"Some different\ntest text\n")
     def test_bufferedoutputfiles_exceed_maximum_open_files(self):
         # Only allow 2 open files at once internally
         # (and with an artifically small buffer size)
@@ -309,22 +314,26 @@ class TestBufferedOutputFiles(unittest.TestCase):
         # Close everything
         out.close()
         # Check the contents for each file
-        self.assertEqual(open(out.file_name('test1'),'rt').read(),
-                         "test text\n"
-                         "and a bit more\n"
-                         "plus some final\ntext\n")
-        self.assertEqual(open(out.file_name('test2'),'rt').read(),
-                         "different\ntest text\n"
-                         "more but different\n"
-                         "and a last bit\n")
-        self.assertEqual(open(out.file_name('test3'),'rt').read(),
-                         "more test text\n"
-                         "different again\n"
-                         "plus a coda\n")
-        self.assertEqual(open(out.file_name('test4'),'rt').read(),
-                         "yet more\ntest text\n"
-                         "and even more different\ntest text\n"
-                         "et\nFIN\n")
+        with open(out.file_name('test1'),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             "test text\n"
+                             "and a bit more\n"
+                             "plus some final\ntext\n")
+        with open(out.file_name('test2'),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             "different\ntest text\n"
+                             "more but different\n"
+                             "and a last bit\n")
+        with open(out.file_name('test3'),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             "more test text\n"
+                             "different again\n"
+                             "plus a coda\n")
+        with open(out.file_name('test4'),'rt') as fp:
+            self.assertEqual(fp.read(),
+                             "yet more\ntest text\n"
+                             "and even more different\ntest text\n"
+                             "et\nFIN\n")
 
 class TestShowProgressChecker(unittest.TestCase):
     """
@@ -778,8 +787,8 @@ class TestWriteScriptFile(unittest.TestCase):
         self.assertFalse(os.path.exists(script_file))
         write_script_file(script_file,"sleep 50\n#")
         self.assertTrue(os.path.exists(script_file))
-        self.assertEqual(open(script_file).read(),
-                         "sleep 50\n#\n")
+        with open(script_file,'rt') as fp:
+            self.assertEqual(fp.read(),"sleep 50\n#\n")
 
     def test_write_script_file_with_shell(self):
         """write_script_file creates new script file with shell
@@ -788,8 +797,8 @@ class TestWriteScriptFile(unittest.TestCase):
         self.assertFalse(os.path.exists(script_file))
         write_script_file(script_file,"sleep 50\n#",shell='/bin/sh')
         self.assertTrue(os.path.exists(script_file))
-        self.assertEqual(open(script_file).read(),
-                         "#!/bin/sh\nsleep 50\n#\n")
+        with open(script_file,'rt') as fp:
+            self.assertEqual(fp.read(),"#!/bin/sh\nsleep 50\n#\n")
 
     def test_write_script_file_append(self):
         """write_script_file appends to an existing file
@@ -799,5 +808,6 @@ class TestWriteScriptFile(unittest.TestCase):
             fp.write("#\necho Going to sleep\n")
         write_script_file(script_file,"sleep 50\n#",append=True)
         self.assertTrue(os.path.exists(script_file))
-        self.assertEqual(open(script_file).read(),
-                         "#\necho Going to sleep\nsleep 50\n#\n")
+        with open(script_file,'rt') as fp:
+            self.assertEqual(fp.read(),
+                             "#\necho Going to sleep\nsleep 50\n#\n")


### PR DESCRIPTION
PR that refactors code to remove the majority of `ResourceWarning` messages from the unit tests when running under Travis CI, due to files being opened for read or write and then not being closed before the tests finish.

The fixes are to ensure that the files are closed, either explicitly in the case of:

* `MockAnalysisDir.create()` method in the `mock` module
* `Command.run_subprocess()` method in the `applications` module
* `get_read_number()` and `pair_fastqs()` functions in the `fastq_utils` module

or by using the `with open(...) as ...` idiom (just about every other instance of the warning).

(There are also some updates to address warnings about unknown escape sequences, which seemed to be due to unescaped `\`s.)

Most of the changes are to unit test code rather than application code.