### PR TITLE
Update 'requirements.txt' for building documentation on ReadTheDocs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/fls-bioinformatics-core/genomics.git#egg=genomics-bcftbx
+configparser
 cloudpickle
 psutil


### PR DESCRIPTION
PR which adds `configparser` to `requirements.txt` for building on ReadTheDocs (https://auto-process-ngs.readthedocs.io/en/latest/index.html).