### PR TITLE
AutoProcess: reimplement & simplify internals of 'undetermined' method

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -932,16 +932,12 @@ class AutoProcess(object):
     def undetermined(self):
         # Return analysis project directory for undetermined indices
         # or None if not found
-        dirs = bcf_utils.list_dirs(self.analysis_dir,matches='undetermined')
-        if len(dirs) == 0:
+        undetermined_dir = os.path.join(self.analysis_dir,'undetermined')
+        if os.path.isdir(undetermined_dir):
+            return AnalysisProject(undetermined_dir)
+        else:
             logging.debug("No undetermined analysis directory found")
             return None
-        elif len(dirs) > 1:
-            raise Exception("Found multiple undetermined analysis "
-                            "directories: %s" % ' '.join(dirs))
-        # Attempt to load the analysis project data
-        undetermined_dir = os.path.join(self.analysis_dir,dirs[0])
-        return AnalysisProject(dirs[0],undetermined_dir)
 
     def log_analysis(self):
         # Add a record of the analysis to the logging file

--- a/auto_process_ngs/test/test_auto_processor.py
+++ b/auto_process_ngs/test/test_auto_processor.py
@@ -789,3 +789,55 @@ class TestAutoProcessPairedEndMethod(unittest.TestCase):
                 fp.write('')
         # Check that paired_end is true
         self.assertTrue(AutoProcess(mockdir.dirn).paired_end)
+
+class TestAutoProcessUndeterminedMethod(unittest.TestCase):
+    """
+    Tests for the 'undetermined' method
+    """
+    def setUp(self):
+        # Create a temp working dir
+        self.dirn = tempfile.mkdtemp(suffix='TestAutoProcess')
+        # Store original location
+        self.pwd = os.getcwd()
+        # Move to working directory
+        os.chdir(self.dirn)
+
+    def tearDown(self):
+        # Return to original dir
+        os.chdir(self.pwd)
+        # Remove the temporary test directory
+        shutil.rmtree(self.dirn)
+
+    def test_undetermined(self):
+        """AutoProcess.undetermined: 'undetermined' exists
+        """
+        # Make an auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '160621_K00879_0087_000000000-AGEW9',
+            'hiseq',
+            metadata={ "run_number": 87,
+                       "source": "local" },
+            paired_end=True,
+            top_dir=self.dirn)
+        mockdir.create()
+        # Check that undetermined is returned
+        undetermined = AutoProcess(mockdir.dirn).undetermined()
+        self.assertTrue(isinstance(undetermined,AnalysisProject))
+
+    def test_undetermined_missing(self):
+        """AutoProcess.undetermined: 'undetermined' missing
+        """
+        # Make an auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '160621_K00879_0087_000000000-AGEW9',
+            'hiseq',
+            metadata={ "run_number": 87,
+                       "source": "local" },
+            paired_end=True,
+            top_dir=self.dirn)
+        mockdir.create()
+        # Remove undetermined
+        shutil.rmtree(os.path.join(mockdir.dirn,'undetermined'))
+        # Check that undetermined is returned
+        undetermined = AutoProcess(mockdir.dirn).undetermined()
+        self.assertEqual(undetermined,None)


### PR DESCRIPTION
PR which refactors and simplifies the internals of the `undetermined` method of the `AutoProcess` class (in the `auto_processor` module). The behaviour of the method is unchanged.

The PR also adds new unit tests for the method.