### PR TITLE
'run_qc.py': standardise setting default output directory

### DIFF
--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -188,9 +188,8 @@ if __name__ == "__main__":
     reporting.add_argument('-n','--name',action='store',
                            help="name for the project")
     reporting.add_argument('-o','--out_dir',action='store',
-                           help="directory to write outputs to (default: "
-                           "project directory (if directory was supplied "
-                           "and is a project; otherwise, use current "
+                           help="top-level directory for reports and "
+                           "QC output subdirectory (default: current "
                            "working directory)")
     reporting.add_argument('--qc_dir',
                            help="explicitly specify QC output directory. "
@@ -341,12 +340,6 @@ if __name__ == "__main__":
             sys.exit(1)
         # Look for project metadata
         info_file = find_info_file(dir_path)
-        if info_file:
-            # Presence of info file indicates Fastqs are in
-            # a subdirectory of a project directory, so set
-            # it as the default output directory
-            if not out_dir:
-                out_dir = os.path.dirname(info_file)
     else:
         # Look for a metadata file based on Fastqs
         for fq in inputs:

--- a/docs/source/using/run_qc_standalone.rst
+++ b/docs/source/using/run_qc_standalone.rst
@@ -53,11 +53,8 @@ determine which metrics are run:
 Specifying the outputs
 ----------------------
 
-If a list of Fastqs is supplied then by default the QC reports
-will be written to the current directory, with the QC outputs
-written to a ``qc`` subdirectory. If a directory is supplied as
-input then the reports and ``qc`` subdirectory will be written
-to that directory.
+By default the QC reports are written to the current directory,
+with the QC outputs written to a ``qc`` subdirectory.
 
 The following options can be used to override the defaults:
 


### PR DESCRIPTION
PR which addresses issue #618 by always setting the default output directory to the current directory, regardless of where the input Fastqs are located.