### PR TITLE
Implement support for 10xGenomics Visium spatial RNA-seq data

### DIFF
--- a/auto_process_ngs/barcodes/pipeline.py
+++ b/auto_process_ngs/barcodes/pipeline.py
@@ -32,7 +32,6 @@ from ..applications import Command
 from ..bcl2fastq_utils import get_nmismatches
 from ..bcl2fastq_utils import bases_mask_is_valid
 from ..bcl2fastq_utils import check_barcode_collisions
-from ..tenx_genomics_utils import has_chromium_sc_indices
 from ..pipeliner import Pipeline
 from ..pipeliner import PipelineTask
 from ..pipeliner import PipelineCommandWrapper

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -340,6 +340,7 @@ class MakeFastqs(Pipeline):
         self.add_param('_platform')
         self.add_param('_bcl2fastq_info')
         self.add_param('_cellranger_info')
+        self.add_param('_cellranger_atac_info')
         self.add_param('_missing_fastqs',type=list)
 
         # Define runners
@@ -361,6 +362,8 @@ class MakeFastqs(Pipeline):
         self.add_output('acquired_primary_data',Param())
         self.add_output('bcl2fastq_info',self.params._bcl2fastq_info)
         self.add_output('cellranger_info',self.params._cellranger_info)
+        self.add_output('cellranger_atac_info',
+                        self.params._cellranger_atac_info)
         self.add_output('stats_file',Param())
         self.add_output('stats_full',Param())
         self.add_output('per_lane_stats',Param())
@@ -1348,15 +1351,13 @@ class MakeFastqs(Pipeline):
             self.params._bcl2fastq_info.set(
                 get_bcl2fastq.output.bcl2fastq_info)
 
-        # Update outputs with cellranger information
-        for get_cellranger_task in (get_cellranger,
-                                    get_cellranger_atac,):
-            if get_cellranger_task:
-                get_cellranger = get_cellranger_task
-                break
+        # Update outputs with 10x package information
         if get_cellranger:
             self.params._cellranger_info.set(
                 get_cellranger.output.package_info)
+        if get_cellranger_atac:
+            self.params._cellranger_atac_info.set(
+                get_cellranger_atac.output.package_info)
 
         # Update outputs associated with stats
         if self._fastq_statistics:

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -437,6 +437,9 @@ def make_fastqs(ap,protocol='standard',platform=None,
             processing_software['bcl2fastq'] = outputs.bcl2fastq_info
         if outputs.cellranger_info:
             processing_software['cellranger'] = outputs.cellranger_info
+        if outputs.cellranger_atac_info:
+            processing_software['cellranger-atac'] = \
+                                                outputs.cellranger_atac_info
         ap.metadata['processing_software'] = processing_software
         # Legacy metadata items
         ap.metadata['bcl2fastq_software'] = make_fastqs.output.bcl2fastq_info

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -331,6 +331,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
         'demultiplex_icell8_atac_runner': ap.settings.runners.bcl2fastq,
         'cellranger_runner': ap.settings.runners.cellranger,
         'cellranger_atac_runner': ap.settings.runners.cellranger,
+        'spaceranger_runner': ap.settings.runners.cellranger,
         'stats_runner': ap.settings.runners.stats,
     }
     if runner is not None:
@@ -343,7 +344,8 @@ def make_fastqs(ap,protocol='standard',platform=None,
     envmodules = {}
     for name in ('bcl2fastq',
                  'cellranger_mkfastq',
-                 'cellranger_atac_mkfastq',):
+                 'cellranger_atac_mkfastq',
+                 'spaceranger_mkfastq',):
         try:
             envmodules[name] = ap.settings.modulefiles[name]
         except KeyError:
@@ -440,6 +442,8 @@ def make_fastqs(ap,protocol='standard',platform=None,
         if outputs.cellranger_atac_info:
             processing_software['cellranger-atac'] = \
                                                 outputs.cellranger_atac_info
+        if outputs.spaceranger_info:
+            processing_software['spaceranger'] = outputs.spaceranger_info
         ap.metadata['processing_software'] = processing_software
         # Legacy metadata items
         ap.metadata['bcl2fastq_software'] = make_fastqs.output.bcl2fastq_info

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -13,6 +13,7 @@ import os
 import time
 import shutil
 import gzip
+import ast
 import logging
 from ..bcl2fastq.pipeline import PROTOCOLS
 from ..bcl2fastq.pipeline import MakeFastqs
@@ -423,7 +424,21 @@ def make_fastqs(ap,protocol='standard',platform=None,
 
     # Update the metadata
     if status == 0:
+        # Platform
         ap.metadata['platform'] = make_fastqs.output.platform
+        # Software used for processing
+        try:
+            processing_software = ast.literal_eval(
+                ap.metadata.processing_software)
+        except ValueError:
+            processing_software = dict()
+        outputs = make_fastqs.output
+        if outputs.bcl2fastq_info:
+            processing_software['bcl2fastq'] = outputs.bcl2fastq_info
+        if outputs.cellranger_info:
+            processing_software['cellranger'] = outputs.cellranger_info
+        ap.metadata['processing_software'] = processing_software
+        # Legacy metadata items
         ap.metadata['bcl2fastq_software'] = make_fastqs.output.bcl2fastq_info
         ap.metadata['cellranger_software'] = make_fastqs.output.cellranger_info
 

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -226,16 +226,18 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
     if not barcodes_files:
         print("...no barcode analysis found")
     # Collect 10xGenomics cellranger QC summaries
-    print("Checking for 10xGenomics cellranger QC summaries")
+    print("Checking for 10xGenomics mkfastq QC summaries")
     cellranger_qc_html = []
     for filen in os.listdir(ap.analysis_dir):
-        if filen.startswith("cellranger_qc_summary") and \
-           filen.endswith(".html"):
-            print("...found %s" % filen)
-            cellranger_qc_html.append(
-                os.path.join(ap.analysis_dir,filen))
+        for pkg in ("cellranger",
+                    "cellranger-atac",):
+            if filen.startswith("%s_qc_summary" % pkg) and \
+               filen.endswith(".html"):
+                print("...found %s" % filen)
+                cellranger_qc_html.append(
+                    os.path.join(ap.analysis_dir,filen))
     if not cellranger_qc_html:
-        print("...no cellranger QC summaries found")
+        print("...no 10xGenomics mkfastq QC summaries found")
     # Collect QC for project directories
     print("Checking project directories")
     projects = ap.get_analysis_projects(pattern=project_pattern)

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -434,10 +434,10 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
             package_info = processing_software[pkg]
         except KeyError:
             package_info = None
-        params_tbl.add_row(param=pkg.title(),
-                           value=('unspecified' if not package_info else
-                                  "%s %s" % (package_info[1],
-                                             package_info[2])))
+        if package_info:
+            params_tbl.add_row(param=pkg.title(),
+                               value="%s %s" % (package_info[1],
+                                                package_info[2]))
     params_tbl.add_row(param="Reference",
                        value=ap.run_reference_id)
     general_info.add(params_tbl)

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -410,20 +410,37 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
     params_tbl.add_row(param="Endedness",
                        value=('Paired end' if ap.paired_end
                               else 'Single end'))
+    # Software information
     try:
-        bcl2fastq_software = ast.literal_eval(
-            ap.metadata.bcl2fastq_software)
+        processing_software = ast.literal_eval(
+            ap.metadata.processing_software)
     except ValueError:
-        bcl2fastq_software = None
+        processing_software = None
+    if processing_software:
+        try:
+            bcl2fastq_software = processing_software['bcl2fastq']
+        except KeyError:
+            bcl2fastq_software = None
+        try:
+            cellranger_software = processing_software['cellranger']
+        except KeyError:
+            cellranger_software = None
+    else:
+        # Fallback to legacy metadata items
+        try:
+            bcl2fastq_software = ast.literal_eval(
+                ap.metadata.bcl2fastq_software)
+        except ValueError:
+            bcl2fastq_software = None
+        try:
+            cellranger_software = ast.literal_eval(
+                ap.metadata.cellranger_software)
+        except ValueError:
+            cellranger_software = None
     params_tbl.add_row(param="Bcl2fastq",
                        value=('unspecified' if not bcl2fastq_software else
                               "%s %s" % (bcl2fastq_software[1],
                                          bcl2fastq_software[2])))
-    try:
-        cellranger_software = ast.literal_eval(
-            ap.metadata.cellranger_software)
-    except ValueError:
-        cellranger_software = None
     params_tbl.add_row(param="Cellranger",
                        value=('unspecified' if not cellranger_software else
                               "%s %s" % (cellranger_software[1],

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -230,7 +230,8 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
     cellranger_qc_html = []
     for filen in os.listdir(ap.analysis_dir):
         for pkg in ("cellranger",
-                    "cellranger-atac",):
+                    "cellranger-atac",
+                    "spaceranger",):
             if filen.startswith("%s_qc_summary" % pkg) and \
                filen.endswith(".html"):
                 print("...found %s" % filen)
@@ -428,7 +429,7 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                 ap.metadata.cellranger_software)
         except ValueError:
             pass
-    for pkg in ("bcl2fastq","cellranger","cellranger-atac"):
+    for pkg in ("bcl2fastq","cellranger","cellranger-atac","spaceranger"):
         try:
             package_info = processing_software[pkg]
         except KeyError:
@@ -468,10 +469,10 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
         fileops.mkdir(barcodes_dirn)
         for filen in barcodes_files:
             fileops.copy(filen,barcodes_dirn)
-    # 10xGenomics cellranger QC summaries
+    # 10xGenomics mkfastq QC summaries
     if cellranger_qc_html:
         cellranger_qc = index_page.add_section(
-            "QC summary: cellranger mkfastq")
+            "QC summary: 10xGenomics mkfastq")
         for qc_html in cellranger_qc_html:
             # Check for optional lane list at tail of QC summary
             # e.g. cellranger_qc_summary_45.html

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -410,41 +410,33 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
     params_tbl.add_row(param="Endedness",
                        value=('Paired end' if ap.paired_end
                               else 'Single end'))
-    # Software information
+    # Processing software information
     try:
         processing_software = ast.literal_eval(
             ap.metadata.processing_software)
     except ValueError:
-        processing_software = None
-    if processing_software:
+        processing_software = dict()
+    if not processing_software:
+        # Fallback to using legacy metadata items
         try:
-            bcl2fastq_software = processing_software['bcl2fastq']
-        except KeyError:
-            bcl2fastq_software = None
-        try:
-            cellranger_software = processing_software['cellranger']
-        except KeyError:
-            cellranger_software = None
-    else:
-        # Fallback to legacy metadata items
-        try:
-            bcl2fastq_software = ast.literal_eval(
+            processing_software['bcl2fastq_software'] = ast.literal_eval(
                 ap.metadata.bcl2fastq_software)
         except ValueError:
-            bcl2fastq_software = None
+            pass
         try:
-            cellranger_software = ast.literal_eval(
+            processing_software['cellranger_software'] = ast.literal_eval(
                 ap.metadata.cellranger_software)
         except ValueError:
-            cellranger_software = None
-    params_tbl.add_row(param="Bcl2fastq",
-                       value=('unspecified' if not bcl2fastq_software else
-                              "%s %s" % (bcl2fastq_software[1],
-                                         bcl2fastq_software[2])))
-    params_tbl.add_row(param="Cellranger",
-                       value=('unspecified' if not cellranger_software else
-                              "%s %s" % (cellranger_software[1],
-                                         cellranger_software[2])))
+            pass
+    for pkg in ("bcl2fastq","cellranger","cellranger-atac"):
+        try:
+            package_info = processing_software[pkg]
+        except KeyError:
+            package_info = None
+        params_tbl.add_row(param=pkg.title(),
+                           value=('unspecified' if not package_info else
+                                  "%s %s" % (package_info[1],
+                                             package_info[2])))
     params_tbl.add_row(param="Reference",
                        value=ap.run_reference_id)
     general_info.add(params_tbl)

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -483,10 +483,11 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
             else:
                 lanes = None
             fileops.copy(qc_html,dirn)
-            cellranger_qc.add(Link("QC summary for %s" %
-                                   ("all lanes" if lanes is None
-                                    else "lanes %s" % lanes),
-                                   os.path.basename(qc_html)))
+            cellranger_qc.add(Link("%s: QC summary for %s" %
+                                   (os.path.basename(qc_html).split('_')[0].title(),
+                                    ("all lanes" if lanes is None
+                                     else "lanes %s" % lanes)),
+                                    os.path.basename(qc_html)))
     if projects:
         # Table of projects
         projects_summary = index_page.add_section("QC Reports")

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -288,17 +288,35 @@ def report_summary(ap):
         platform = 'unknown'
     if ap.metadata.run_number is not None:
         run_number = ap.metadata.run_number
+    # Software information
+    try:
+        processing_software = ast.literal_eval(
+            ap.metadata.processing_software)
+    except ValueError:
+        processing_software = None
+    if processing_software:
+        bcl2fastq_software = processing_software['bcl2fastq']
+        cellranger_software = processing_software['cellranger']
+    else:
+        # Fallback to legacy metadata items
+        try:
+            bcl2fastq_software = ast.literal_eval(
+                ap.metadata.bcl2fastq_software)
+        except ValueError:
+            bcl2fastq_software = None
+        try:
+            cellranger_software = ast.literal_eval(
+                ap.metadata.cellranger_software)
+        except ValueError:
+            cellranger_software = None
     try:
         bcl2fastq_software = ast.literal_eval(
             ap.metadata.bcl2fastq_software)
     except ValueError:
         bcl2fastq_software = None
-    try:
-        cellranger_software = ast.literal_eval(
-            ap.metadata.cellranger_software)
+    if cellranger_software:
         report_items.append('Cellranger')
-    except ValueError:
-        cellranger_software = None
+    # Assay/kit information
     if ap.metadata.assay is not None:
         assay = ap.metadata.assay
         report_items.append('Assay')

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -288,34 +288,27 @@ def report_summary(ap):
         platform = 'unknown'
     if ap.metadata.run_number is not None:
         run_number = ap.metadata.run_number
-    # Software information
+    # Processing software information
     try:
         processing_software = ast.literal_eval(
             ap.metadata.processing_software)
     except ValueError:
-        processing_software = None
-    if processing_software:
-        bcl2fastq_software = processing_software['bcl2fastq']
-        cellranger_software = processing_software['cellranger']
-    else:
+        processing_software = dict()
+    if not processing_software:
         # Fallback to legacy metadata items
         try:
-            bcl2fastq_software = ast.literal_eval(
+            processing_software['bcl2fastq'] = ast.literal_eval(
                 ap.metadata.bcl2fastq_software)
         except ValueError:
-            bcl2fastq_software = None
+            pass
         try:
-            cellranger_software = ast.literal_eval(
+            processing_software['cellranger'] = ast.literal_eval(
                 ap.metadata.cellranger_software)
         except ValueError:
-            cellranger_software = None
-    try:
-        bcl2fastq_software = ast.literal_eval(
-            ap.metadata.bcl2fastq_software)
-    except ValueError:
-        bcl2fastq_software = None
-    if cellranger_software:
-        report_items.append('Cellranger')
+            pass
+    for pkg in ('cellranger','cellranger-atac'):
+        if pkg in processing_software:
+            report_items.append(pkg.title())
     # Assay/kit information
     if ap.metadata.assay is not None:
         assay = ap.metadata.assay
@@ -350,13 +343,23 @@ def report_summary(ap):
             value = ('Paired end' if analysis_dir.paired_end else
                      'Single end')
         elif item == 'Bcl2fastq':
-            value = ('Unknown' if not bcl2fastq_software else
-                     "%s %s" % (bcl2fastq_software[1],
-                                bcl2fastq_software[2]))
+            if 'bcl2fastq' in processing_software:
+                value = "%s %s" % (processing_software['bcl2fastq'][1],
+                                   processing_software['bcl2fastq'][2])
+            else:
+                value = 'Unknown'
         elif item == 'Cellranger':
-            value = ('Unknown' if not cellranger_software else
-                     "%s %s" % (cellranger_software[1],
-                                cellranger_software[2]))
+            if 'cellranger' in processing_software:
+                value = "%s %s" % (processing_software['cellranger'][1],
+                                   processing_software['cellranger'][2])
+            else:
+                value = 'Unknown'
+        elif item == 'Cellranger-atac':
+            if 'cellranger-atac' in processing_software:
+                value = "%s %s" % (processing_software['cellranger-atac'][1],
+                                   processing_software['cellranger-atac'][2])
+            else:
+                value = 'Unknown'
         elif item == 'Assay':
             value = assay
         else:

--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -105,6 +105,7 @@ def setup_analysis_dirs(ap,
                                    '10xGenomics Chromium 3\'v2',
                                    '10xGenomics Chromium 3\'v3',
                                    '10xGenomics Single Cell ATAC',
+                                   '10xGenomics Visium',
                                    'ICELL8',
                                    'ICELL8 ATAC'):
                 logger.error("Unknown single cell platform for '%s': "

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -317,9 +317,12 @@ class AnalysisDirMetadata(MetadataDict):
     source: source of the data (e.g. local facility)
     platform: sequencing platform e.g. 'miseq'
     assay: the 'assay' from the IEM SampleSheet e.g. 'Nextera XT'
+    processing_software: dictionary of software packages used in
+      in the processing
     bcl2fastq_software: info on the Bcl conversion software used
+      (deprecated)
     cellranger_software: info on the 10xGenomics cellranger software
-      used
+      used (deprecated)
     instrument_name: name/i.d. for the sequencing instrument
     instrument_datestamp: datestamp from the sequencing instrument
     instrument_run_number: the run number from the sequencing
@@ -344,6 +347,7 @@ class AnalysisDirMetadata(MetadataDict):
                                   'source': 'source',
                                   'platform':'platform',
                                   'assay': 'assay',
+                                  'processing_software': 'processing_software',
                                   'bcl2fastq_software': 'bcl2fastq_software',
                                   'cellranger_software': 'cellranger_software',
                                   'instrument_name': 'instrument_name',

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1596,11 +1596,11 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
             # Outs
             outs_dir = os.path.join(top_dir,"outs")
             os.mkdir(outs_dir)
-            if cellranger_exe == "cellranger":
+            if self._package_name == "cellranger":
                 metrics_file = os.path.join(outs_dir,"metrics_summary.csv")
                 with open(metrics_file,'w') as fp:
                     fp.write(mock10xdata.METRICS_SUMMARY)
-            elif cellranger_exe == "cellranger-atac":
+            elif self._package_name == "cellranger-atac":
                 summary_file = os.path.join(outs_dir,"summary.csv")
                 with open(summary_file,'w') as fp:
                     fp.write(mock10xdata.ATAC_SUMMARY)

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -478,6 +478,7 @@ class UpdateAnalysisDir(DirectoryUpdater):
 
     - add_processing_report
     - add_barcode_analysis
+    - add_10x_mkfastq_qc_output
     - add_cellranger_qc_output
 
     Example usage:
@@ -523,6 +524,22 @@ class UpdateAnalysisDir(DirectoryUpdater):
                   "barcodes.html"):
             self.add_file(os.path.join(barcode_analysis_dir,f))
 
+    def add_10x_mkfastq_qc_output(self,pkg,lanes=None):
+        """
+        Add mock 10xGenomics mkfastq QC report
+
+        Arguments:
+          pkg (str): 10xGenomics package (e.g. 'cellranger',
+            'cellranger-atac' etc)
+          lanes (str): optional, specify lane numbers for
+            the report
+        """
+        self.add_file("%s_qc_summary%s.html"
+                      % (pkg,
+                         "_%s" % lanes
+                         if lanes is not None
+                         else ""))
+
     def add_cellranger_qc_output(self,lanes=None):
         """
         Add mock cellranger QC report
@@ -531,10 +548,8 @@ class UpdateAnalysisDir(DirectoryUpdater):
           lanes (str): optional, specify lane numbers for
             the report
         """
-        self.add_file("cellranger_qc_summary%s.html"
-                      % ("_%s" % lanes
-                         if lanes is not None
-                         else ""))
+        self.add_10x_mkfastq_qc_output(pkg="cellranger",
+                                       lanes=lanes)
 
 class UpdateAnalysisProject(DirectoryUpdater):
     """

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1012,7 +1012,7 @@ sys.exit(MockBcl2fastq2Exe(exit_code=%s,
                            assert_mask_short_adapter_reads=%s,
                            assert_adapter=%s,
                            assert_adapter2=%s,
-                           version='%s').main(sys.argv[1:]))
+                           version=%s).main(sys.argv[1:]))
             """ % (exit_code,
                    missing_fastqs,
                    ("\"%s\"" % platform
@@ -1031,7 +1031,9 @@ sys.exit(MockBcl2fastq2Exe(exit_code=%s,
                    ("\"%s\"" % assert_adapter2
                     if assert_adapter2 is not None
                     else None),
-                   version))
+                   ("\"%s\"" % version
+                    if version is not None
+                    else None)))
             os.chmod(path,0o775)
         with open(path,'r') as fp:
             print("bcl2fastq:")

--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     qc/outputs: utilities to predict and check QC pipeline outputs
-#     Copyright (C) University of Manchester 2019 Peter Briggs
+#     Copyright (C) University of Manchester 2019-2020 Peter Briggs
 #
 """
 Provides utility functions for QC outputs.
@@ -213,7 +213,8 @@ def check_illumina_qc_outputs(project,qc_dir,qc_protocol=None):
         # Fastq_screen
         if qc_protocol in ('singlecell',
                            '10x_scRNAseq',
-                           '10x_snRNAseq',):
+                           '10x_snRNAseq',
+                           '10x_Visium',):
             if project.fastq_attrs(fastq).read_number == 1:
                 # No screens for R1 for single cell
                 continue
@@ -276,7 +277,8 @@ def check_fastq_strand_outputs(project,qc_dir,fastq_strand_conf,
             fq_pair = (fq_group[0],fq_group[2])
         elif qc_protocol in ('singlecell',
                              '10x_scRNAseq',
-                             '10x_snRNAseq',):
+                             '10x_snRNAseq',
+                             '10x_Visium',):
             # Strand stats output based on R2
             fq_pair = (fq_group[1],)
         else:
@@ -397,9 +399,10 @@ def expected_outputs(project,qc_dir,fastq_strand_conf=None,
         # Fastq_screen
         if (qc_protocol in ('singlecell',
                             '10x_scRNAseq',
-                            '10x_snRNAseq',)) \
+                            '10x_snRNAseq',
+                            '10x_Visium',)) \
             and project.fastq_attrs(fastq).read_number == 1:
-            # No screens for R1 for single cell
+            # No screens for R1 for single cell or Visium
             continue
         for screen in FASTQ_SCREENS:
             for output in [os.path.join(qc_dir,f)
@@ -413,7 +416,8 @@ def expected_outputs(project,qc_dir,fastq_strand_conf=None,
             # Strand stats output
             if qc_protocol in ('singlecell',
                                '10x_scRNAseq',
-                               '10x_snRNAseq',):
+                               '10x_snRNAseq',
+                               '10x_Visium',):
                 # Strand stats output based on R2
                 output = os.path.join(qc_dir,
                                       fastq_strand_output(fq_group[1]))

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -734,7 +734,8 @@ class RunIlluminaQC(PipelineTask):
             # No screens for R1 reads for single cell
             if self.args.qc_protocol in ('singlecell',
                                          '10x_scRNAseq',
-                                         '10x_snRNAseq') \
+                                         '10x_snRNAseq',
+                                         '10x_Visium',) \
                 and self.args.fastq_attrs(fastq).read_number == 1:
                 cmd.add_args('--no-screens')
             # Add the command

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -896,6 +896,27 @@ class QCReport(Document):
             'fastq_screen': 'FastqScreen',
             'fastq_strand': 'FastqStrand',
         }
+        # Collect processing software metadata
+        try:
+            processing_software = ast.literal_eval(
+                self.run_metadata.processing_software)
+        except ValueError:
+            processing_software = dict()
+        if not processing_software:
+            # Fallback to legacy metadata items
+            try:
+                bcl2fastq_software = ast.literal_eval(
+                    self.run_metadata.bcl2fastq_software)
+            except ValueError:
+                bcl2fastq_software = None
+            processing_software['bcl2fastq'] = bcl2fastq_software
+            try:
+                cellranger_software = ast.literal_eval(
+                    self.run_metadata.cellranger_software)
+            except ValueError:
+                cellranger_software = None
+            processing_software['cellranger'] = cellranger_software
+        # Report software packages
         for pkg in software_packages:
             # Acquire the value
             try:
@@ -905,28 +926,18 @@ class QCReport(Document):
                     # No value set, skip this item
                     continue
             except KeyError:
-                if pkg == 'bcl2fastq':
-                    try:
-                        bcl2fastq = ast.literal_eval(
-                            self.run_metadata.bcl2fastq_software)
-                        value = bcl2fastq[2]
-                    except ValueError:
-                        continue
-                elif pkg == 'cellranger':
-                    try:
-                        cellranger = ast.literal_eval(
-                            self.run_metadata.cellranger_software)
-                        software_names['cellranger'] = cellranger[1].title()
-                        value = cellranger[2]
-                    except ValueError:
-                        continue
-                elif pkg not in software_names:
-                    # Unrecognised package name
-                    raise Exception("Unrecognised software package "
-                                    "item to report: '%s'" % pkg)
-                else:
-                    # No value set, skip this item
+                try:
+                    value = processing_software[pkg][2]
+                except KeyError:
+                    # Not processing software
                     continue
+                except TypeError:
+                    # Not valid data
+                    continue
+            if pkg not in software_names:
+                # Unrecognised package name
+                raise Exception("Unrecognised software package "
+                                    "item to report: '%s'" % pkg)
             # Add to the metadata table
             self.software_table.add_row(
                 program=software_names[pkg],

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -886,12 +886,14 @@ class QCReport(Document):
         """
         software_packages = ['bcl2fastq',
                              'cellranger',
+                             'cellranger-atac',
                              'fastqc',
                              'fastq_screen',
                              'fastq_strand',]
         software_names = {
             'bcl2fastq': 'Bcl2fastq',
             'cellranger': 'Cellranger',
+            'cellranger-atac': 'Cellranger-atac',
             'fastqc': 'FastQC',
             'fastq_screen': 'FastqScreen',
             'fastq_strand': 'FastqStrand',
@@ -905,17 +907,15 @@ class QCReport(Document):
         if not processing_software:
             # Fallback to legacy metadata items
             try:
-                bcl2fastq_software = ast.literal_eval(
+                processing_software['bcl2fastq'] = ast.literal_eval(
                     self.run_metadata.bcl2fastq_software)
             except ValueError:
-                bcl2fastq_software = None
-            processing_software['bcl2fastq'] = bcl2fastq_software
+                pass
             try:
-                cellranger_software = ast.literal_eval(
+                processing_software['cellranger'] = ast.literal_eval(
                     self.run_metadata.cellranger_software)
             except ValueError:
-                cellranger_software = None
-            processing_software['cellranger'] = cellranger_software
+                pass
         # Report software packages
         for pkg in software_packages:
             # Acquire the value

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -887,6 +887,7 @@ class QCReport(Document):
         software_packages = ['bcl2fastq',
                              'cellranger',
                              'cellranger-atac',
+                             'spaceranger',
                              'fastqc',
                              'fastq_screen',
                              'fastq_strand',]
@@ -894,6 +895,7 @@ class QCReport(Document):
             'bcl2fastq': 'Bcl2fastq',
             'cellranger': 'Cellranger',
             'cellranger-atac': 'Cellranger-atac',
+            'spaceranger': 'Spaceranger',
             'fastqc': 'FastQC',
             'fastq_screen': 'FastqScreen',
             'fastq_strand': 'FastqStrand',
@@ -934,7 +936,7 @@ class QCReport(Document):
                 except TypeError:
                     # Not valid data
                     continue
-            if pkg not in software_names:
+            if pkg not in software_packages:
                 # Unrecognised package name
                 raise Exception("Unrecognised software package "
                                     "item to report: '%s'" % pkg)

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     utils: utility classes and functions for QC
-#     Copyright (C) University of Manchester 2018-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2020 Peter Briggs
 #
 """
 Provides utility classes and functions for analysis project QC.
@@ -67,6 +67,10 @@ def determine_qc_protocol(project):
             elif single_cell_platform == "ICELL8":
                 # ICELL8 scATAC-seq
                 protocol = "ICELL8_scATAC"
+    # Spatial RNA-seq
+    if project.info.single_cell_platform == "10xGenomics Visium":
+        # 10xGenomics Visium spatial transcriptomics
+        protocol = "10x_Visium"
     return protocol
 
 def verify_qc(project,qc_dir=None,fastq_dir=None,qc_protocol=None,

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -132,6 +132,8 @@ class Settings(object):
                                                     'cellranger_mkfastq')
         self.modulefiles['cellranger_atac_mkfastq'] = config.get('modulefiles',
                                                     'cellranger_atac_mkfastq')
+        self.modulefiles['spaceranger_mkfastq'] = config.get('modulefiles',
+                                                    'spaceranger_mkfastq')
         self.modulefiles['run_qc'] = config.get('modulefiles','run_qc')
         self.modulefiles['publish_qc'] = config.get('modulefiles','publish_qc')
         self.modulefiles['process_icell8'] = config.get('modulefiles','process_icell8')

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -547,10 +547,69 @@ def cellranger_info(path=None,name=None):
                                    (line,ex))
     else:
         # No package supplied or located
-        logger.warning("Unable to identify cellranger package "
-                       "from '%s'" % cellranger_path)
+        logger.warning("Unable to identify %s package from '%s'" %
+                       (name,cellranger_path))
     # Return what we found
     return (cellranger_path,package_name,package_version)
+
+def spaceranger_info(path=None,name=None):
+    """
+    Retrieve information on the spaceranger software
+
+    If called without any arguments this will locate the first
+    spaceranger executable that is available on the user's PATH,
+    and attempts to extract the version.
+
+    Alternatively if the path to an executable is supplied then
+    the version will be determined from that instead.
+
+    If no version is identified then the script path is still
+    returned, but without any version info.
+
+    If a 'path' is supplied then the package name will be taken
+    from the basename; otherwise the package name can be supplied
+    via the 'name' argument. If neither are supplied then the
+    package name defaults to 'cellranger'.
+
+    Returns:
+      Tuple: tuple consisting of (PATH,PACKAGE,VERSION) where PATH
+        is the full path for the spaceranger program, PACKAGE is
+        'spaceranger', and VERSION is the package version. If any
+        value can't be determined then it will be returned as an
+        empty string.
+    """
+    # Initialise
+    spaceranger_path = ''
+    if name is None:
+        if path:
+            name = os.path.basename(path)
+        else:
+            name = 'spaceranger'
+    package_name = name
+    package_version = ''
+    # Locate the core script
+    if not path:
+        spaceranger_path = find_program(package_name)
+    else:
+        spaceranger_path = os.path.abspath(path)
+    # Identify the version
+    if os.path.basename(spaceranger_path) == package_name:
+        # Run the program to get the version
+        version_cmd = Command(spaceranger_path,'--version')
+        output = version_cmd.subprocess_check_output()[1]
+        # Extract version from line of the from
+        # spaceranger 1.1.0
+        try:
+            package_version = output.split()[-1]
+        except Exception as ex:
+            logger.warning("Unable to get version from '%s': %s" %
+                           (line,ex))
+    else:
+        # No package supplied or located
+        logger.warning("Unable to identify spaceranger package "
+                       "from '%s'" % spaceranger_path)
+    # Return what we found
+    return (spaceranger_path,package_name,package_version)
 
 def run_cellranger_mkfastq(sample_sheet,
                            primary_data_dir,

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -16,6 +16,7 @@ Chromium SC 3'v2 system:
 - has_10x_indices
 - has_chromium_sc_indices
 - cellranger_info
+- spaceranger_info
 - make_qc_summary_html
 - build_fastq_path_dir
 - run_cellranger_mkfastq

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -13,6 +13,7 @@ Chromium SC 3'v2 system:
 - MetricSummary
 - AtacSummary
 - flow_cell_id
+- has_10x_indices
 - has_chromium_sc_indices
 - cellranger_info
 - make_qc_summary_html
@@ -223,25 +224,28 @@ def flow_cell_id(run_name):
     ds,inst,run,prefix,flow_cell_id = split_run_name_full(run_name)
     return flow_cell_id
 
-def has_chromium_sc_indices(sample_sheet):
+def has_10x_indices(sample_sheet):
     """
-    Check if a sample sheet contains Chromium SC indices
-
-    The Chromium SC indices can be obtained from:
-
-    https://support.10xgenomics.com/permalink/27rGqWvNYYuqkgeS66sksm
+    Check if a sample sheet contains 10xGenomics-format indices
 
     The Chromium SC 3'v2 indices are of the form:
 
     SI-GA-[A-H][1-12]
 
-    e.g. 'SI-GA-B11'
+    e.g. 'SI-GA-B11' (see
+    https://support.10xgenomics.com/permalink/27rGqWvNYYuqkgeS66sksm)
 
-    For scATAC-seq the indices are of the form:
+    For scATAC-seq the indices are assumed to be of the form:
 
     SI-NA-[A-H][1-12]
 
     e.g. 'SI-NA-G9'
+
+    For Visium data the indices are assumed to be of the form:
+
+    SI-TT-[A-H][1-12]
+
+    e.g. 'SI-TT-B1'
 
     Arguments:
       sample_sheet (str): path to the sample sheet CSV
@@ -249,9 +253,9 @@ def has_chromium_sc_indices(sample_sheet):
 
     Returns:
       Boolean: True if the sample sheet contains at least
-        one Chromium SC index, False if not.
+        one 10xGenomics-style index, False if not.
     """
-    index_pattern = re.compile(r"SI-(GA|NA)-[A-H](1[0-2]|[1-9])$")
+    index_pattern = re.compile(r"SI-(GA|NA|TT)-[A-H](1[0-2]|[1-9])$")
     s = SampleSheet(sample_sheet)
     for line in s:
         try:
@@ -260,6 +264,14 @@ def has_chromium_sc_indices(sample_sheet):
         except KeyError:
             pass
     return False
+
+def has_chromium_sc_indices(sample_sheet):
+    """
+    Wrapper for 'has_10x_indices'.
+
+    Maintained for backwards compatibility
+    """
+    return has_10x_indices(sample_sheet)
 
 def get_bases_mask_10x_atac(runinfo_xml):
     """

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -1714,7 +1714,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(p.output.cellranger_info,
                          (os.path.join(self.bin,"cellranger"),
                           "cellranger",
-                          "2.2.0"))
+                          "3.1.0"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))
@@ -1789,8 +1789,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         MockCellrangerExe.create(os.path.join(self.bin,
                                               "cellranger"))
         MockCellrangerExe.create(os.path.join(self.bin,
-                                              "cellranger-atac"),
-                                 reads=('R1','R2','R3','I1',))
+                                              "cellranger-atac"))
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Set up mock outputs in analysis directory to mimic
@@ -1852,7 +1851,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(p.output.cellranger_info,
                          (os.path.join(self.bin,"cellranger"),
                           "cellranger",
-                          "2.2.0"))
+                          "3.1.0"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))
@@ -1939,8 +1938,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         MockCellrangerExe.create(os.path.join(self.bin,
                                               "cellranger"))
         MockCellrangerExe.create(os.path.join(self.bin,
-                                              "cellranger-atac"),
-                                 reads=('R1','R2','R3','I1',))
+                                              "cellranger-atac"))
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Set up mock outputs in analysis directory to mimic
@@ -1999,7 +1997,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(p.output.cellranger_info,
                          (os.path.join(self.bin,"cellranger"),
                           "cellranger",
-                          "2.2.0"))
+                          "3.1.0"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))
@@ -2841,7 +2839,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.cellranger_info,
                          (os.path.join(self.bin,"cellranger"),
                           "cellranger",
-                          "2.2.0"))
+                          "3.1.0"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))
@@ -2938,7 +2936,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.cellranger_info,
                          (os.path.join(self.bin,"cellranger"),
                           "cellranger",
-                          "2.2.0"))
+                          "3.1.0"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))
@@ -3056,7 +3054,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.cellranger_info,
                          (os.path.join(self.bin,"cellranger"),
                           "cellranger",
-                          "2.2.0"))
+                          "3.1.0"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))
@@ -3130,8 +3128,7 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
         MockBcl2fastq2Exe.create(os.path.join(self.bin,
                                               "bcl2fastq"))
         MockCellrangerExe.create(os.path.join(self.bin,
-                                              "cellranger-atac"),
-                                 reads=('R1','R2','R3','I1',))
+                                              "cellranger-atac"))
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         analysis_dir = os.path.join(self.wd,"analysis")
@@ -3153,7 +3150,7 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
         self.assertEqual(p.output.cellranger_atac_info,
                          (os.path.join(self.bin,"cellranger-atac"),
                           "cellranger-atac",
-                          "2.2.0"))
+                          "1.2.0"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))
@@ -3227,8 +3224,7 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
         MockBcl2fastq2Exe.create(os.path.join(self.bin,
                                               "bcl2fastq"))
         MockCellrangerExe.create(os.path.join(self.bin,
-                                              "cellranger-atac"),
-                                 reads=('R1','R2','R3','I1',))
+                                              "cellranger-atac"))
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Set up mock outputs in analysis directory to mimic
@@ -3272,7 +3268,7 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
         self.assertEqual(p.output.cellranger_atac_info,
                          (os.path.join(self.bin,"cellranger-atac"),
                           "cellranger-atac",
-                          "2.2.0"))
+                          "1.2.0"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -1745,7 +1745,8 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
-                      "processing_qc.html"):
+                      "processing_qc.html",
+                      "cellranger_qc_summary_12.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
@@ -1819,7 +1820,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                   "statistics.info",
                   "per_lane_statistics.info",
                   "per_lane_sample_stats.info",
-                  "processing_qc.html",):
+                  "processing_qc.html",
+                  "cellranger_qc_summary_7.html",
+                  "cellranger-atac_qc_summary_8.html",):
             with open(os.path.join(analysis_dir,f),'wt') as fp:
                 fp.write("")
         # Do the test
@@ -1891,7 +1894,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
-                      "processing_qc.html"):
+                      "processing_qc.html",
+                      "cellranger_qc_summary_7.html",
+                      "cellranger-atac_qc_summary_8.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
@@ -1962,7 +1967,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                   "statistics.info",
                   "per_lane_statistics.info",
                   "per_lane_sample_stats.info",
-                  "processing_qc.html",):
+                  "processing_qc.html",
+                  "cellranger_qc_summary_7.html",
+                  "cellranger-atac_qc_summary_8.html",):
             with open(os.path.join(analysis_dir,f),'wt') as fp:
                 fp.write("")
         # Do the test
@@ -2030,7 +2037,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
-                      "processing_qc.html"):
+                      "processing_qc.html",
+                      "cellranger_qc_summary_7.html",
+                      "cellranger-atac_qc_summary_8.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
@@ -2862,7 +2871,8 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
-                      "processing_qc.html"):
+                      "processing_qc.html",
+                      "cellranger_qc_summary.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
@@ -2958,7 +2968,8 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
-                      "processing_qc.html"):
+                      "processing_qc.html",
+                      "cellranger_qc_summary.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
@@ -3022,7 +3033,8 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                   "statistics.info",
                   "per_lane_statistics.info",
                   "per_lane_sample_stats.info",
-                  "processing_qc.html",):
+                  "processing_qc.html",
+                  "cellranger_qc_summary.html",):
             with open(os.path.join(analysis_dir,f),'wt') as fp:
                 fp.write("")
         # Do the test
@@ -3074,7 +3086,8 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
-                      "processing_qc.html"):
+                      "processing_qc.html",
+                      "cellranger_qc_summary.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
@@ -3170,7 +3183,8 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
-                      "processing_qc.html"):
+                      "processing_qc.html",
+                      "cellranger-atac_qc_summary.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
@@ -3237,7 +3251,8 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                   "statistics.info",
                   "per_lane_statistics.info",
                   "per_lane_sample_stats.info",
-                  "processing_qc.html",):
+                  "processing_qc.html",
+                  "cellranger-atac_qc_summary.html",):
             with open(os.path.join(analysis_dir,f),'wt') as fp:
                 fp.write("")
         # Do the test
@@ -3287,7 +3302,8 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
-                      "processing_qc.html"):
+                      "processing_qc.html",
+                      "cellranger-atac_qc_summary.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -3150,7 +3150,7 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                          (os.path.join(self.bin,"bcl2fastq"),
                           "bcl2fastq",
                           "2.20.0.422"))
-        self.assertEqual(p.output.cellranger_info,
+        self.assertEqual(p.output.cellranger_atac_info,
                          (os.path.join(self.bin,"cellranger-atac"),
                           "cellranger-atac",
                           "2.2.0"))
@@ -3269,7 +3269,7 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                          (os.path.join(self.bin,"bcl2fastq"),
                           "bcl2fastq",
                           "2.20.0.422"))
-        self.assertEqual(p.output.cellranger_info,
+        self.assertEqual(p.output.cellranger_atac_info,
                          (os.path.join(self.bin,"cellranger-atac"),
                           "cellranger-atac",
                           "2.2.0"))

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -11,6 +11,7 @@ from bcftbx.mock import SampleSheets
 from bcftbx.IlluminaData import IlluminaData
 from auto_process_ngs.mock import MockBcl2fastq2Exe
 from auto_process_ngs.mock import MockCellrangerExe
+from auto_process_ngs.mock import Mock10xPackageExe
 from auto_process_ngs.mock import make_mock_bcl2fastq2_output
 from auto_process_ngs.pipeliner import PipelineParam
 from auto_process_ngs.bcl2fastq.pipeline import MakeFastqs
@@ -3300,6 +3301,101 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                       "per_lane_sample_stats.info",
                       "processing_qc.html",
                       "cellranger-atac_qc_summary.html",):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_10x_visium_protocol(self):
+        """
+        MakeFastqs: '10x_visium' protocol
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics Chromium SC indices
+        samplesheet_visium_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+smpl1,smpl1,,,SI-TT-A1,SI-TT-A1,SI-TT-A1,SI-TT-A1,10xGenomics,
+smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_visium_indices)
+        # Create mock bcl2fastq and spaceranger
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        Mock10xPackageExe.create(os.path.join(self.bin,
+                                              "spaceranger"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="10x_visium")
+        status = p.run(analysis_dir,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.spaceranger_info,
+                         (os.path.join(self.bin,"spaceranger"),
+                          "spaceranger",
+                          "1.1.0"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertFalse(os.path.exists(
+            os.path.join(analysis_dir,"barcode_analysis")),
+                         "Found subdir: barcode_analysis")
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html",
+                      "spaceranger_qc_summary.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)

--- a/auto_process_ngs/test/commands/test_publish_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_publish_qc_cmd.py
@@ -776,6 +776,43 @@ poll_interval = 0.5
                              item)
             self.assertTrue(os.path.exists(f),"Missing %s" % f)
 
+    def test_publish_qc_with_multiple_10x_mkfastq_qc(self):
+        """publish_qc: publish 10xGenomics mkfastq QC output (multiple packages)
+        """
+        # Make an auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '160621_K00879_0087_000000000-AGEW9',
+            'hiseq',
+            metadata={ "run_number": 87,
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
+        # Add processing and cellranger QC reports
+        UpdateAnalysisDir(ap).add_processing_report()
+        UpdateAnalysisDir(ap).add_10x_mkfastq_qc_output("cellranger-atac",
+                                                        lanes="45")
+        UpdateAnalysisDir(ap).add_10x_mkfastq_qc_output("cellranger",
+                                                        lanes="78")
+        # Make a mock publication area
+        publication_dir = os.path.join(self.dirn,'QC')
+        os.mkdir(publication_dir)
+        # Publish
+        publish_qc(ap,location=publication_dir)
+        # Check outputs
+        outputs = ["index.html",
+                   "processing_qc.html",
+                   "cellranger-atac_qc_summary_45.html",
+                   "cellranger_qc_summary_78.html"]
+        # Do checks
+        for item in outputs:
+            f = os.path.join(publication_dir,
+                             "160621_K00879_0087_000000000-AGEW9_analysis",
+                             item)
+            self.assertTrue(os.path.exists(f),"Missing %s" % f)
+
     def test_publish_qc_with_cellranger_count(self):
         """publish_qc: project with cellranger count output
         """

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -484,6 +484,8 @@ Additional notes/comments:
             'miseq',
             metadata={ "source": "testing",
                        "run_number": 87,
+                       "processing_software":
+                       "{ 'bcl2fastq': ('/usr/bin/bcl2fastq', 'bcl2fastq', '2.17.1.14'), 'cellranger': ('/usr/bin/cellranger', 'cellranger', '3.0.1') }",
                        "bcl2fastq_software":
                        "('/usr/bin/bcl2fastq', 'bcl2fastq', '2.17.1.14')",
                        "cellranger_software":

--- a/auto_process_ngs/test/commands/test_run_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_run_qc_cmd.py
@@ -599,14 +599,13 @@ mouse = /data/cellranger/atac_references/mm10
                 self.assertTrue(multiqc in z.namelist())
 
     def test_run_qc_10x_visium(self):
-        """run_qc: 10x Visium spatial RNA-seq with strandedness and single library analysis
+        """run_qc: 10x Visium spatial RNA-seq with strandedness
         """
         # Make mock illumina_qc.sh and multiqc
         MockIlluminaQcSh.create(os.path.join(self.bin,
                                              "illumina_qc.sh"))
         MockFastqStrandPy.create(os.path.join(self.bin,
                                               "fastq_strand.py"))
-        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"))
         MockMultiQC.create(os.path.join(self.bin,"multiqc"))
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])

--- a/auto_process_ngs/test/commands/test_run_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_run_qc_cmd.py
@@ -597,3 +597,84 @@ mouse = /data/cellranger/atac_references/mm10
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
+
+    def test_run_qc_10x_visium(self):
+        """run_qc: 10x Visium spatial RNA-seq with strandedness and single library analysis
+        """
+        # Make mock illumina_qc.sh and multiqc
+        MockIlluminaQcSh.create(os.path.join(self.bin,
+                                             "illumina_qc.sh"))
+        MockFastqStrandPy.create(os.path.join(self.bin,
+                                              "fastq_strand.py"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"))
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901" },
+            project_metadata={ "AB": { "Organism": "human",
+                                       "Single cell platform":
+                                       "10xGenomics Visium",
+                                       "Library type": "RNA-seq", },
+                               "CDE": { "Organism": "mouse",
+                                        "Single cell platform":
+                                        "10xGenomics Visium",
+                                        "Library type": "RNA-seq", } },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Settings file with fastq_strand indexes and
+        # polling interval
+        settings_ini = os.path.join(self.dirn,"auto_process.ini")
+        with open(settings_ini,'w') as s:
+            s.write("""[general]
+poll_interval = 1.0
+
+[fastq_strand_indexes]
+human = /data/genomeIndexes/hg38/STAR
+mouse = /data/genomeIndexes/mm10/STAR
+""")
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=Settings(settings_ini))
+        # Run the QC
+        status = run_qc(ap,
+                        run_multiqc=True,
+                        max_jobs=1)
+        self.assertEqual(status,0)
+        # Check the fastq_strand_conf files were created
+        for p in ("AB","CDE"):
+            self.assertTrue(os.path.exists(
+                os.path.join(mockdir.dirn,p,"qc","fastq_strand.conf")))
+        # Check fastq_strand outputs are present
+        for p in ("AB","CDE"):
+            fastq_strand_outputs = list(
+                filter(lambda f:
+                       f.endswith("fastq_strand.txt"),
+                       os.listdir(os.path.join(
+                           mockdir.dirn,p,"qc"))))
+            self.assertTrue(len(fastq_strand_outputs) > 0)
+        # Check output and reports
+        for p in ("AB","CDE","undetermined"):
+            for f in ("qc",
+                      "qc_report.html",
+                      "qc_report.%s.%s.zip" % (
+                          p,
+                          '170901_M00879_0087_000000000-AGEW9'),
+                      "multiqc_report.html"):
+                self.assertTrue(os.path.exists(os.path.join(mockdir.dirn,
+                                                            p,f)),
+                                "Missing %s in project '%s'" % (f,p))
+            # Check zip file has MultiQC report
+            zip_file = os.path.join(mockdir.dirn,p,
+                                    "qc_report.%s.%s.zip" % (
+                                        p,
+                                        '170901_M00879_0087_000000000-AGEW9'))
+            with zipfile.ZipFile(zip_file) as z:
+                multiqc = os.path.join(
+                    "qc_report.%s.%s" % (
+                        p,'170901_M00879_0087_000000000-AGEW9'),
+                    "multiqc_report.html")
+                self.assertTrue(multiqc in z.namelist())

--- a/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
@@ -209,6 +209,62 @@ AB\tAB1,AB2\tAlan Brown\tscATAC-seq\tICELL8 ATAC\tHuman\tAudrey Benson\t1% PhiX
                                         "icell8_atac_stats.xlsx")
         self.assertTrue(os.path.exists(icell8_atac_xlsx))
 
+    def test_setup_analysis_dirs_10x_visium(self):
+        """
+        setup_analysis_dirs: test create new analysis dir for 10x Visium
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901" },
+            reads=('R1','R2','R3','I1'),
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq")))
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq","AB")))
+        # Add required metadata to 'projects.info'
+        projects_info = os.path.join(mockdir.dirn,"projects.info")
+        with open(projects_info,"w") as fp:
+            fp.write(
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+AB\tAB1,AB2\tAlan Brown\tscATAC-seq\t10xGenomics Visium\tHuman\tAudrey Benson\t1% PhiX
+""")
+        # Expected data
+        projects = {
+            "AB": ["AB1_S1_R1_001.fastq.gz",
+                   "AB1_S1_R2_001.fastq.gz",
+                   "AB1_S1_R3_001.fastq.gz",
+                   "AB1_S1_I1_001.fastq.gz",
+                   "AB2_S2_R1_001.fastq.gz",
+                   "AB2_S2_R2_001.fastq.gz",
+                   "AB2_S2_R3_001.fastq.gz",
+                   "AB2_S2_I1_001.fastq.gz"],
+            "undetermined": ["Undetermined_S0_R1_001.fastq.gz",]
+        }
+        # Check project dirs don't exist
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertFalse(os.path.exists(project_dir_path))
+        # Setup the project dirs
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        setup_analysis_dirs(ap)
+        # Check project dirs and contents
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertTrue(os.path.exists(project_dir_path))
+            # Check README.info file
+            readme_file = os.path.join(project_dir_path,
+                                       "README.info")
+            self.assertTrue(os.path.exists(readme_file))
+            # Check Fastqs
+            fastqs_dir = os.path.join(project_dir_path,
+                                      "fastqs")
+            self.assertTrue(os.path.exists(fastqs_dir))
+            for fq in projects[project]:
+                fastq = os.path.join(fastqs_dir,fq)
+                self.assertTrue(os.path.exists(fastq))
+
     def test_setup_analysis_dirs_missing_metadata(self):
         """
         setup_analysis_dirs: raise exception if metadata not set

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -1074,3 +1074,49 @@ class TestExpectedOutputs(unittest.TestCase):
         for r in reference_outputs:
             self.assertTrue(os.path.join(self.wd,p.name,r) in expected,
                             "%s not found in expected" % r)
+
+    def test_expected_outputs_10x_visium(self):
+        """
+        expected_outputs: 10xGenomics Visium
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           "10xGenomics Visium" })
+        p.create(top_dir=self.wd)
+        # Make mock fastq_strand
+        mock_fastq_strand_conf = os.path.join(self.wd,
+                                              p.name,
+                                              "fastq_strand.conf")
+        with open(mock_fastq_strand_conf,'w') as fp:
+            fp.write("")
+        reference_outputs = ("qc/PJB1_S1_R1_001_fastqc",
+                             "qc/PJB1_S1_R1_001_fastqc.html",
+                             "qc/PJB1_S1_R1_001_fastqc.zip",
+                             "qc/PJB1_S1_R2_001_fastqc",
+                             "qc/PJB1_S1_R2_001_fastqc.html",
+                             "qc/PJB1_S1_R2_001_fastqc.zip",
+                             "qc/PJB1_S1_R2_001_model_organisms_screen.png",
+                             "qc/PJB1_S1_R2_001_model_organisms_screen.txt",
+                             "qc/PJB1_S1_R2_001_other_organisms_screen.png",
+                             "qc/PJB1_S1_R2_001_other_organisms_screen.txt",
+                             "qc/PJB1_S1_R2_001_rRNA_screen.png",
+                             "qc/PJB1_S1_R2_001_rRNA_screen.txt",
+                             "qc/PJB1_S1_R2_001_fastq_strand.txt",)
+        expected = expected_outputs(AnalysisProject(p.name,
+                                                    os.path.join(self.wd,
+                                                                 p.name)),
+                                    "qc",
+                                    fastq_strand_conf=mock_fastq_strand_conf,
+                                    cellranger_refdata=None,
+                                    qc_protocol="10x_Visium")
+        for e in expected:
+            print(e)
+            self.assertTrue(e in [os.path.join(self.wd,p.name,r)
+                                  for r in reference_outputs],
+                            "%s not found in reference" % e)
+        for r in reference_outputs:
+            self.assertTrue(os.path.join(self.wd,p.name,r) in expected,
+                            "%s not found in expected" % r)

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -212,6 +212,24 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
         self.assertEqual(determine_qc_protocol(project),
                          "ICELL8_scATAC")
 
+    def test_determine_qc_protocol_10x_visium(self):
+        """determine_qc_protocol: spatial RNA-seq run (10xGenomics Visium)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={'Single cell platform':
+                                          "10xGenomics Visium",
+                                          'Library type':
+                                          "scATAC-seq"})
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        self.assertEqual(determine_qc_protocol(project),
+                         "10x_Visium")
+
 class TestVerifyQCFunction(unittest.TestCase):
     """
     Tests for verify_qc function

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -267,6 +267,7 @@ class TestAnalysisDirMetadata(unittest.TestCase):
         self.assertEqual(metadata.platform,None)
         self.assertEqual(metadata.source,None)
         self.assertEqual(metadata.assay,None)
+        self.assertEqual(metadata.processing_software,None)
         self.assertEqual(metadata.bcl2fastq_software,None)
         self.assertEqual(metadata.cellranger_software,None)
         self.assertEqual(metadata.instrument_name,None)

--- a/auto_process_ngs/test/test_settings.py
+++ b/auto_process_ngs/test/test_settings.py
@@ -44,6 +44,7 @@ class TestSettings(unittest.TestCase):
         self.assertEqual(s.modulefiles.bcl2fastq,None)
         self.assertEqual(s.modulefiles.cellranger_mkfastq,None)
         self.assertEqual(s.modulefiles.cellranger_atac_mkfastq,None)
+        self.assertEqual(s.modulefiles.spaceranger_mkfastq,None)
         self.assertEqual(s.modulefiles.illumina_qc,None)
         self.assertEqual(s.modulefiles.fastq_strand,None)
         self.assertEqual(s.modulefiles.cellranger,None)
@@ -93,6 +94,7 @@ nprocessors = 8
         self.assertEqual(s.modulefiles.bcl2fastq,None)
         self.assertEqual(s.modulefiles.cellranger_mkfastq,None)
         self.assertEqual(s.modulefiles.cellranger_atac_mkfastq,None)
+        self.assertEqual(s.modulefiles.spaceranger_mkfastq,None)
         self.assertEqual(s.modulefiles.run_qc,None)
         # Fastq_stats
         self.assertEqual(s.fastq_stats.nprocessors,8)

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -344,6 +344,46 @@ class TestCellrangerInfo(unittest.TestCase):
         self.assertEqual(cellranger_info(name='cellranger-atac'),
                          (cellranger_atac,'cellranger-atac','1.0.1'))
 
+class TestSpacerangerInfo(unittest.TestCase):
+    """
+    Tests for the spaceranger_info function
+    """
+    def setUp(self):
+        # Make temporary working dir
+        self.wd = tempfile.mkdtemp(suffix="TestSpacerangerInfo")
+        # Store the original state of PATH env var
+        self.original_path = os.environ['PATH']
+    def tearDown(self):
+        # Restore the PATH env var
+        os.environ['PATH'] = self.original_path
+        # Remove temp dir
+        if REMOVE_TEST_OUTPUTS:
+            shutil.rmtree(self.wd)
+    def _make_mock_spaceranger_110(self):
+        # Make a fake spaceranger 1.0.1 executable
+        spaceranger_110 = os.path.join(self.wd,"spaceranger")
+        with open(spaceranger_110,'w') as fp:
+            fp.write("#!/bin/bash\necho -n spaceranger 1.1.0")
+        os.chmod(spaceranger_110,0o775)
+        return spaceranger_110
+
+    def test_spaceranger_110(self):
+        """spaceranger_info: collect info for spaceranger 1.1.0
+        """
+        spaceranger = self._make_mock_spaceranger_110()
+        self.assertEqual(spaceranger_info(path=spaceranger),
+                         (spaceranger,'spaceranger','1.1.0'))
+
+    def test_spaceranger_110_on_path(self):
+        """spaceranger_info: collect info for spaceranger 1.1.0 from PATH
+        """
+        os.environ['PATH'] = "%s%s%s" % (os.environ['PATH'],
+                                         os.pathsep,
+                                         self.wd)
+        spaceranger = self._make_mock_spaceranger_110()
+        self.assertEqual(spaceranger_info(name='spaceranger'),
+                         (spaceranger,'spaceranger','1.1.0'))
+
 class TestMetricsSummary(unittest.TestCase):
     """
     Tests for the 'MetricsSummary' class

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -31,9 +31,9 @@ class TestFlowCellId(unittest.TestCase):
         self.assertEqual(flow_cell_id("170426_K00311_0033_AHJCY7BBXX"),
                          "HJCY7BBXX")
 
-class TestHasChromiumSCIndices(unittest.TestCase):
+class TestHas10xindices(unittest.TestCase):
     """
-    Tests for the 'has_chromium_sc_indices' function
+    Tests for the 'has_10x_indices' function
     """
     def setUp(self):
         # Sample sheet contents
@@ -87,6 +87,22 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
 2,smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
 3,smpl3,smpl3,,,A006,SI-NA-C1,10xGenomics,
 4,smpl4,smpl4,,,A007,SI-NA-D1,10xGenomics,
+"""
+        self.sample_sheet_with_visium_indices = """[Header]
+IEMFileVersion,4
+
+[Reads]
+76
+76
+
+[Settings]
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index,index2,Sample_Project,Description
+1,smpl1,smpl1,,,A001,SI-TT-A1,,SI-TT-A1,,10xGenomics,
+2,smpl2,smpl2,,,A005,SI-TT-B1,,SI-TT-B1,,10xGenomics,
 """
         self.sample_sheet_standard_indices = """[Header]
 IEMFileVersion,4
@@ -157,46 +173,53 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,Sample_Project,Description
         return sample_sheet_csv
     def test_sample_sheet_all_chromium_sc_3_v2_indices(self):
         """
-        has_chromium_indices: sample sheet with Chromium SC 3'v2 indices only
+        has_10x_indices: sample sheet with Chromium SC 3'v2 indices only
         """
         s = self._make_sample_sheet(
             self.sample_sheet_with_chromium_indices)
-        self.assertTrue(has_chromium_sc_indices(s))
+        self.assertTrue(has_10x_indices(s))
     def test_sample_sheet_with_star10_chromium_sc_3_v2_index(self):
         """
-        has_chromium_indices: sample sheet with '*10' Chromium SC 3'v2 index
+        has_10x_indices: sample sheet with '*10' Chromium SC 3'v2 index
         """
         s = self._make_sample_sheet(
             self.sample_sheet_with_chromium_indices_A10)
-        self.assertTrue(has_chromium_sc_indices(s))
+        self.assertTrue(has_10x_indices(s))
     def test_sample_sheet_all_sc_atac_indices(self):
         """
-        has_chromium_indices: sample sheet with 10x scATAC-seq indices only
+        has_10x_indices: sample sheet with 10x scATAC-seq indices only
         """
         s = self._make_sample_sheet(
             self.sample_sheet_with_atac_indices)
-        self.assertTrue(has_chromium_sc_indices(s))
+        self.assertTrue(has_10x_indices(s))
+    def test_sample_sheet_all_sc_atac_indices(self):
+        """
+        has_10x_indices: sample sheet with 10x Visium indices only
+        """
+        s = self._make_sample_sheet(
+            self.sample_sheet_with_visium_indices)
+        self.assertTrue(has_10x_indices(s))
     def test_sample_sheet_no_chromium_indices(self):
         """
-        has_chromium_indices: sample sheet with no Chromium SC indices
+        has_10x_indices: sample sheet with no Chromium SC indices
         """
         s = self._make_sample_sheet(
             self.sample_sheet_standard_indices)
-        self.assertFalse(has_chromium_sc_indices(s))
+        self.assertFalse(has_10x_indices(s))
     def test_sample_sheet_no_indices(self):
         """
-        has_chromium_indices: sample sheet with no indices
+        has_10x_indices: sample sheet with no indices
         """
         s = self._make_sample_sheet(
             self.sample_sheet_no_indices)
-        self.assertFalse(has_chromium_sc_indices(s))
+        self.assertFalse(has_10x_indices(s))
     def test_sample_sheet_some_chromium_sc_3_v2_indices(self):
         """
-        has_chromium_indices: sample sheet with some Chromium SC 3'v2 indices
+        has_10x_indices: sample sheet with some Chromium SC 3'v2 indices
         """
         s = self._make_sample_sheet(
             self.sample_sheet_mixed_indices)
-        self.assertTrue(has_chromium_sc_indices(s))
+        self.assertTrue(has_10x_indices(s))
 
 class TestGetBasesMask10xAtac(unittest.TestCase):
     """

--- a/bin/analyse_barcodes.py
+++ b/bin/analyse_barcodes.py
@@ -29,7 +29,7 @@ from auto_process_ngs.barcodes.analysis import Reporter
 from auto_process_ngs.barcodes.analysis import report_barcodes
 from auto_process_ngs.bcl2fastq_utils import make_custom_sample_sheet
 from auto_process_ngs.bcl2fastq_utils import check_barcode_collisions
-from auto_process_ngs.tenx_genomics_utils import has_chromium_sc_indices
+from auto_process_ngs.tenx_genomics_utils import has_10x_indices
 
 from auto_process_ngs import get_version
 __version__ = get_version()
@@ -233,8 +233,8 @@ if __name__ == '__main__':
                     else:
                         s = make_custom_sample_sheet(sample_sheet,
                                                      fp.name)
-                    if has_chromium_sc_indices(fp.name):
-                        logging.warning("Lane %s has 10xGenomics Chromium "
+                    if has_10x_indices(fp.name):
+                        logging.warning("Lane %s has 10xGenomics-style "
                                         "indices in sample sheet; not "
                                         "matching against samplesheet for "
                                         "this lane" % lane)

--- a/config/auto_process.ini.sample
+++ b/config/auto_process.ini.sample
@@ -13,6 +13,7 @@ make_fastqs = None
 bcl2fastq = None
 cellranger_mkfastq = None
 cellranger_atac_mkfastq = None
+spaceranger_mkfastq = None
 run_qc = None
 illumina_qc = None
 fastq_strand = None

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -34,6 +34,7 @@ Pipeline stage      Software packages  Notes
 make_fastqs         `bcl2fastq 2.17`_  2.17+ recommended
 make_fastqs         `cellranger`_      10xGenomics Chromium single-cell RNA-seq data only
 make_fastqs         `cellranger-atac`_ 10xGenomics Chromium single-cell ATAC-seq data only
+make_fastqs         `spaceranger`_     10xGenomics Visium spatial RNA-seq data only
 run_qc              `fastqc`_
 run_qc              `fastq_screen`_
 run_qc              `bowtie`_          Required by fastq_screen
@@ -50,6 +51,7 @@ process_icell8      `bowtie2`_         Required by fastq_screen
 .. _bcl2fastq1.8.4: http://support.illumina.com/downloads/bcl2fastq_conversion_software_184.html
 .. _cellranger: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/what-is-cell-ranger
 .. _cellranger-atac: https://support.10xgenomics.com/single-cell-atac/software/pipelines/latest/what-is-cell-ranger-atac
+.. _spaceranger: https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/what-is-space-ranger
 .. _fastqc:  http://www.bioinformatics.babraham.ac.uk/projects/fastqc/
 .. _fastq_screen: http://www.bioinformatics.babraham.ac.uk/projects/fastq_screen/
 .. _bowtie: http://bowtie-bio.sourceforge.net/index.shtml

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -30,6 +30,8 @@ Protocol option          Used for
                          RNA-seq data
 ``10x_atac``             10xGenomics Chromium single-cell
                          ATAC-seq data
+``10x_visium``           10xGenomics Visium spatial RNA-seq
+                         data
 ======================== =====================================
 
 The protocols are described in the section :ref:`make_fastqs-protocols`;
@@ -83,6 +85,7 @@ the sections below:
 * :ref:`make_fastqs-icell8-atac-protocol`
 * :ref:`make_fastqs-10x_chromium_sc-protocol`
 * :ref:`make_fastqs-10x_atac-protocol`
+* :ref:`make_fastqs-10x_visium-protocol`
 
 .. _make_fastqs-standard-protocol:
 
@@ -229,6 +232,30 @@ This will generate the Fastqs in the specified output directory
    behaviour of ``cellranger-atac mkfastqs``, for example setting the
    jobmode (see :ref:`10xgenomics-additional-options`).
 
+.. _make_fastqs-10x_visium-protocol:
+
+10xGenomics spatial RNA-seq data (``--protocol=10x_visium``)
+************************************************************
+
+Fastq generation can be performed for 10xGenomics spatial RNA-seq
+ata by using the ``--protocol=10x_visium`` option:
+
+::
+
+    auto_process.py make_fastqs --protocol=10x_visium ...
+
+which fetches the data and runs ``spaceranger mkfastq``.
+
+This will generate the Fastqs in the specified output directory
+(e.g. ``bcl2fastq``) along with an HTML report derived from the
+``spaceranger`` JSON QC summary file, statistics for the Fastqs.
+
+.. note::
+
+   ``make_fastqs`` offers various options for controlling the
+   behaviour of ``spaceranger mkfastqs``, for example setting the
+   jobmode (see :ref:`10xgenomics-additional-options`).
+
 .. _make_fastqs-commonly-used-options:
 
 Commonly used options
@@ -284,12 +311,12 @@ sequences to empty strings).
 When adapter trimming is performed two additional operations are
 applied:
 
- * **Minium read length** is enforced for reads which are shorter
-   than this length after trimming, by padding them with ``N``s
-   up to the minimum length
- * **Masking of short reads** is performed for reads below a
-   masking threshold length, by masking *all* bases in the read
-   with ``N``s
+* **Minium read length** is enforced for reads which are shorter
+  than this length after trimming, by padding them with N's
+  up to the minimum length
+* **Masking of short reads** is performed for reads below a
+  masking threshold length, by masking *all* bases in the read
+  with N's
 
 Minimum read length defaults to 35 bases but can set explicitly by
 using the ``--minimum-trimmed-read-length`` option; the masking

--- a/docs/source/using/projects_info.rst
+++ b/docs/source/using/projects_info.rst
@@ -69,10 +69,15 @@ names that are used should be consistent with the configuration.
    ``d_melanogaster``)
 
 The following values are valid options for the single cell platform
-(if set; use ``.`` if the project doesn't have a single cell data):
+(if set; use ``.`` if the project doesn't have single cell data):
 
 * ``10xGenomics Chromium 3'v2``
 * ``10xGenomics Chromium 3'v3``
 * ``10xGenomics Single Cell ATAC``
 * ``ICELL8``
 * ``ICELL8 ATAC``
+
+.. note::
+
+   For 10xGenomics Visium spatial RNA-seq data, set this to
+   ``10xGenomics Visium``.

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -25,6 +25,7 @@ QC protocol       Used for
 ``10x_scATAC``    10xGenomics single cell & single nuclei ATAC-seq
 ``10x_scRNAseq``  10xGenomics single cell RNA-seq
 ``10x_snRNAseq``  10xGenomics single nuclei RNA-seq
+``10x_Visium``    10xGenomics Visium spatial RNA-seq
 ``singlecell``    ICELL8 single cell RNA-seq
 ``ICELL8_scATAC`` ICELL8 single cell ATAC-seq
 ================= ==========================
@@ -43,7 +44,8 @@ each Fastq file in the project:
    of the sequence data
 
 For the single-cell and single-nuclei RNA-seq data from ICELL8 and
-10xGenomics Chromium platforms:
+10xGenomics Chromium platforms, and for 10xGenomics Visium RNA-seq
+data:
 
  * `fastqc`_ is run for each Fastq file
  * `fastq_screen`_ and `fastq_strand`_ are run on just the R2


### PR DESCRIPTION
PR to implement support for 10xGenomics Visium spatial transcriptomics data.

Main functional changes:

* Update the `make_fastqs` command to use the `spaceranger` package (https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/what-is-space-ranger) to generate Fastqs from Visium data (using new protocol `10x_visium`)
* Update the `run_qc` command to handle QC for Visium data

Additional changes include:

* Generalising the running of 10xGenomics `mkfastq` across the `cellranger`-like set of pipelines
* Explicitly differentiating the processing QC reports for these pipelines by name (so e.g. for `cellranger-atac` the name is `cellranger-atac_qc_summary...html` etc)
* Adding a new `processing_software` metadata item for analysis directories, which supports a dictionary-style data structure for storing data on arbitrary software packages (intended to replace the `bcl2fastq_software` and `cellranger_software` metadata items, which are now deprecated)

As a side-effect the changes also include:

* Storing and reporting information on `cellranger-atac` (addressing issue #602)