### PR TITLE
bcl2fastq/pipeline: test that 'MakeFastqs' pipeline raises exception for unrecognised protocol

### DIFF
--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -3791,6 +3791,30 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_makefastqs_exception_for_invalid_protocol(self):
+        """
+        MakeFastqs: raise exception for invalid protocol
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Supplying an unrecognised protocol should raise
+        # an exception
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet,
+                          protocol="not_unimplemented")
+
+    #@unittest.skip("Skipped")
     def test_makefastqs_exception_for_invalid_barcodes(self):
         """
         MakeFastqs: raise exception for invalid barcodes


### PR DESCRIPTION
PR that adds a unit test for the `MakeFastqs` pipeline (in `bcl2fastq/pipeline`) to check that an exception is raised when an unrecognised protocol is specified.