### PR TITLE
'qc/outputs': fix unit tests for 'cellranger-atac count' outputs

### DIFF
--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -753,13 +753,17 @@ class UpdateAnalysisProject(DirectoryUpdater):
         zip_file.close()
         self._reload_project()
 
-    def add_cellranger_count_outputs(self,qc_dir=None,legacy=False):
+    def add_cellranger_count_outputs(self,qc_dir=None,cellranger='cellranger',
+                                     legacy=False):
         """
         Add mock 'cellranger count' outputs to project
 
         Arguments:
           qc_dir (str): specify non-default QC output
             directory
+          cellranger (str): specify the 10xGenomics software
+            package to add outputs for (defaults to
+            'cellranger'; alternatives are 'cellranger-atac')
           legacy (bool): if True then generate 'legacy'
             style cellranger outputs
         """
@@ -776,6 +780,12 @@ class UpdateAnalysisProject(DirectoryUpdater):
                 self.add_subdir(self._project.qc_dir)
             self.add_subdir(os.path.join(self._project.qc_dir,
                                          "cellranger_count"))
+        if cellranger == 'cellranger':
+            cellranger_output_files = ("web_summary.html",
+                                       "metrics_summary.csv")
+        elif cellranger == 'cellranger-atac':
+            cellranger_output_files = ("web_summary.html",
+                                       "summary.csv")
         for sample in self._project.samples:
             if legacy:
                 sample_dir = os.path.join(self._project.dirn,
@@ -787,7 +797,7 @@ class UpdateAnalysisProject(DirectoryUpdater):
                                           sample.name)
             self.add_subdir(sample_dir)
             self.add_subdir(os.path.join(sample_dir,"outs"))
-            for f in ("web_summary.html","metrics_summary.csv"):
+            for f in cellranger_output_files:
                 self.add_file(os.path.join(sample_dir,"outs",f))
             for f in ("_cmdline",):
                 self.add_file(os.path.join(sample_dir,f))

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -645,7 +645,7 @@ class TestCheckCellrangerAtacCountOutputs(unittest.TestCase):
             include_fastq_strand=False,
             include_multiqc=False)
         # Check the outputs
-        self.assertEqual(check_cellranger_count_outputs(project),["PJB1",])
+        self.assertEqual(check_cellranger_atac_count_outputs(project),["PJB1",])
 
     def test_check_cellranger_atac_count_outputs_10x_scATAC_present(self):
         """
@@ -663,9 +663,10 @@ class TestCheckCellrangerAtacCountOutputs(unittest.TestCase):
             protocol="10x_scATAC",
             include_fastq_strand=False,
             include_multiqc=False)
-        UpdateAnalysisProject(project).add_cellranger_count_outputs()
+        UpdateAnalysisProject(project).add_cellranger_count_outputs(
+            cellranger="cellranger-atac")
         # Check the outputs
-        self.assertEqual(check_cellranger_count_outputs(project),[])
+        self.assertEqual(check_cellranger_atac_count_outputs(project),[])
 
 class TestExpectedOutputs(unittest.TestCase):
     """

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -97,7 +97,7 @@ class TestCellrangerCountOutputFunction(unittest.TestCase):
                           'cellranger_count/PJB2/outs/metrics_summary.csv',
                           'cellranger_count/PJB2/outs/web_summary.html'))
 
-    def test_cellranger_count_output(self):
+    def test_cellranger_count_output_with_sample(self):
         """cellranger_count_output: check for project and sample
         """
         project = AnalysisProject("PJB",os.path.join(self.wd,"PJB"))
@@ -135,7 +135,7 @@ class TestCellrangerAtacCountOutputFunction(unittest.TestCase):
                           'cellranger_count/PJB2/outs/summary.csv',
                           'cellranger_count/PJB2/outs/web_summary.html'))
 
-    def test_cellranger_atac_count_output(self):
+    def test_cellranger_atac_count_output_with_sample(self):
         """cellranger_atac_count_output: check for project and sample
         """
         project = AnalysisProject("PJB",os.path.join(self.wd,"PJB"))


### PR DESCRIPTION
PR that updates code in the `mock` module and unit tests for the `qc/outputs` module, to correctly test functions for handling outputs from `cellranger-atac count`.

Also renames a couple of test cases with duplicated names, to prevent them being hidden.