### PR TITLE
reportqc.py: move ZIP archive creation to 'qc/reporting'

### DIFF
--- a/auto_process_ngs/test/qc/test_reporting.py
+++ b/auto_process_ngs/test/qc/test_reporting.py
@@ -6,6 +6,7 @@ import unittest
 import os
 import tempfile
 import shutil
+import zipfile
 from auto_process_ngs.mock import MockAnalysisProject
 from auto_process_ngs.mockqc import MockQCOutputs
 from auto_process_ngs.analysis import AnalysisProject
@@ -144,6 +145,45 @@ class TestQCReporter(unittest.TestCase):
         reporter.report(filename=os.path.join(self.wd,'report.non_canonical.html'))
         self.assertTrue(os.path.exists(
             os.path.join(self.wd,'report.non_canonical.html')))
+    def test_qcreporter_single_end_make_zip_file(self):
+        """QCReporter: single-end data: make ZIP file
+        """
+        analysis_dir = self._make_analysis_project(paired_end=False)
+        project = AnalysisProject('PJB',analysis_dir)
+        reporter = QCReporter(project)
+        self.assertEqual(reporter.name,'PJB')
+        self.assertFalse(reporter.paired_end)
+        self.assertTrue(reporter.verify())
+        reporter.report(filename=os.path.join(self.wd,
+                                              'PJB',
+                                              'report.SE.html'),
+                        make_zip=True)
+        self.assertTrue(os.path.exists(
+            os.path.join(self.wd,'PJB','report.SE.html')))
+        self.assertTrue(os.path.exists(
+            os.path.join(self.wd,'PJB','report.SE.PJB.zip')))
+        contents = zipfile.ZipFile(
+            os.path.join(self.wd,'PJB',
+                         'report.SE.PJB.zip')).namelist()
+        print(contents)
+        expected = (
+            'report.SE.PJB/report.SE.html',
+            'report.SE.PJB/qc/PJB1_S1_R1_001_fastqc.html',
+            'report.SE.PJB/qc/PJB1_S1_R1_001_model_organisms_screen.png',
+            'report.SE.PJB/qc/PJB1_S1_R1_001_model_organisms_screen.txt',
+            'report.SE.PJB/qc/PJB1_S1_R1_001_other_organisms_screen.png',
+            'report.SE.PJB/qc/PJB1_S1_R1_001_other_organisms_screen.txt',
+            'report.SE.PJB/qc/PJB1_S1_R1_001_rRNA_screen.png',
+            'report.SE.PJB/qc/PJB1_S1_R1_001_rRNA_screen.txt',
+            'report.SE.PJB/qc/PJB2_S2_R1_001_fastqc.html',
+            'report.SE.PJB/qc/PJB2_S2_R1_001_model_organisms_screen.png',
+            'report.SE.PJB/qc/PJB2_S2_R1_001_model_organisms_screen.txt',
+            'report.SE.PJB/qc/PJB2_S2_R1_001_other_organisms_screen.png',
+            'report.SE.PJB/qc/PJB2_S2_R1_001_other_organisms_screen.txt',
+            'report.SE.PJB/qc/PJB2_S2_R1_001_rRNA_screen.png',
+            'report.SE.PJB/qc/PJB2_S2_R1_001_rRNA_screen.txt')
+        for f in expected:
+            self.assertTrue(f in contents,"%s is missing from ZIP file" % f)
 
 class TestFastqSet(unittest.TestCase):
     def test_fastqset_PE(self):


### PR DESCRIPTION
PR which removes the `zip_report` function from the `reportqc.py` utility and replaces it with new functionality added to the `QCReporter.report()` method in the `qc/reporting` module.

The principal reason for doing this is to address inconsistencies between links in the HTML report and what is included in the ZIP archive: the HTML report links to all outputs that are detected regardless of the QC protocol (i.e. it is intended to be "protocol agnostic") but the ZIP file was only including outputs that were expected for a specific protocol. In special cases (for example, `cellranger* count` outputs are present in the QC directory after being manually generated), outputs could be linked from the HTML report but the target files would be missing from the ZIP file (resulting in broken links).

The PR addresses this by explicitly collecting and storing the output files in the `QCReport._detect_outputs` method, and using this list in the new ZIP archive generation in `QCReporter` so that all detected outputs are included regardless of protocol.