### PR TITLE
'analysis': updates to 'AnalysisDir', new run and project locator functions

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -249,7 +249,7 @@ class AnalysisDir(object):
             self.projects_metadata = None
         # Run name
         try:
-            self.run_name = self.metadata.run
+            self.run_name = self.metadata.run_name
         except AttributeError:
             self.run_name = self._analysis_dir[0:-len('_analysis')]
         self.run_name = os.path.basename(self.run_name)

--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -188,6 +188,22 @@ class AnalysisDir(object):
     It is also possible to have one or more subdirectories containing
     outputs from the CASAVA or bclToFastq processing software.
 
+    Properties:
+
+    analysis_dir: full path to the directory
+    run_name: the name of the parent sequencing run
+    metadata: metadata items associated with the run
+    projects: list of AnalysisProject objects
+    undetermined: AnalysisProject object for 'undetermined'
+    sequencing_data: list of IlluminaData objects
+    projects_metadata: metadata from the 'projects.info' file
+    datestamp: datestamp extracted from run name
+    instrument_name: instrument name extracted from run name
+    instrument_run_number: run number extracted from run name
+    n_projects: number of projects
+    n_sequencing_data: number of sequencing data directories
+    paired_end: whether data are paired ended
+
     """
     def __init__(self,analysis_dir):
         """Create a new AnalysisDir instance for a specified directory

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -256,6 +256,9 @@ class MetadataDict(bcf_utils.AttributeDictionary):
                 null_items.append(key)
         return null_items
 
+    def __len__(self):
+        return len([k for k in self.__key_order if self[k] is not None])
+
 class AnalysisDirParameters(MetadataDict):
     """Class for storing parameters in an analysis directory
 

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -238,6 +238,24 @@ class TestMetadataDict(unittest.TestCase):
                           strict=False,
                           fail_on_error=True)
 
+    def test_len(self):
+        """
+        Metadata: check 'len' functionality
+        """
+        # Empty metadata class
+        metadata = MetadataDict(
+            attributes={
+                'salutation':'salutation',
+                'valediction':'valediction'
+            })
+        self.assertEqual(len(metadata),0)
+        # Set one item
+        metadata['salutation'] = "hello"
+        self.assertEqual(len(metadata),1)
+        # Set two items
+        metadata['valediction'] = "goodbye"
+        self.assertEqual(len(metadata),2)
+
 class TestAnalysisDirParameters(unittest.TestCase):
     """Tests for the AnalysisDirParameters class
     """


### PR DESCRIPTION
PR that updates the `analysis` module:

* Updates the startup of the `AnalysisDir` class to make the loading of metadata less verbose (requires implementation of the `__len__` built-in for the `MetadataDict` class in the `metadata` module, also part of this PR)
* Fixes a bug with setting the `run_name` property in the `AnalysisDir` class
* Implements new functions to reference and locate runs and projects:
  - `split_sample_name`: extracts components from a sample reference of the form `[RUN][:PROJECT][/SAMPLE]`
  - `locate_run` and `locate_project`: searches for analysis directories and projects respectively, based on various name formats
  - `match_run_id`: checks if an analysis directory matches a run ID, based on various name formats