### PR TITLE
'report' command: fix broken '--summary' option when cellranger-atac was used

### DIFF
--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -354,7 +354,7 @@ def report_summary(ap):
                                    processing_software['cellranger'][2])
             else:
                 value = 'Unknown'
-        elif item == 'Cellranger-atac':
+        elif item == 'Cellranger-Atac':
             if 'cellranger-atac' in processing_software:
                 value = "%s %s" % (processing_software['cellranger-atac'][1],
                                    processing_software['cellranger-atac'][2])


### PR DESCRIPTION
PR which fixes a bug in the `report` command which complained about missing item `Cellranger-Atac`, for 10x single cell ATAC data.