### PR TITLE
Update 'make_fastq' and 'run_qc' for cellranger 5.0.1

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -2612,6 +2612,8 @@ class Run10xMkfastq(PipelineTask):
         self.add_output('missing_fastqs',list())
     def setup(self):
         # 10xGenomics software package
+        if not self.args.pkg_exe:
+            raise Exception("No 10xGenomics executable provided")
         self.pkg = os.path.basename(self.args.pkg_exe)
         # Check if mkfastq should be skipped
         if self.args.skip_mkfastq:

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1274,6 +1274,7 @@ class Mock10xPackageExe(object):
     @staticmethod
     def create(path,exit_code=0,missing_fastqs=None,
                platform=None,assert_bases_mask=None,
+               assert_include_introns=None,
                reads=None,multiome_data=None,
                version=None):
         """
@@ -1295,6 +1296,10 @@ class Mock10xPackageExe(object):
           assert_bases_mask (str): if set then
             check that the supplied bases mask
             matches this value (not implemented)
+          assert_include_introns (bool): if set
+            to True/False then check that the
+            '--include-introns' option was/n't
+            set (ignored if set to None)
           reads (list): list of 'reads' that
             will be created
           multiome_data (str): either 'GEX' or
@@ -1314,6 +1319,7 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
                            exit_code=%s,
                            platform=%s,
                            assert_bases_mask=%s,
+                           assert_include_introns=%s,
                            reads=%s,
                            multiome_data=%s,
                            version=%s).main(sys.argv[1:]))
@@ -1324,6 +1330,7 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
                    ("\"%s\"" % assert_bases_mask
                     if assert_bases_mask is not None
                     else None),
+                   assert_include_introns,
                    reads,
                    ("\"%s\"" % multiome_data
                     if multiome_data is not None
@@ -1341,6 +1348,7 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
                  exit_code=0,
                  platform=None,
                  assert_bases_mask=None,
+                 assert_include_introns=None,
                  reads=None,
                  multiome_data=None,
                  version=None):
@@ -1363,6 +1371,7 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
         self._exit_code = exit_code
         self._platform = platform
         self._assert_bases_mask = assert_bases_mask
+        self._assert_include_introns = assert_include_introns
         self._multiome_data = str(multiome_data).upper()
         if self._package_name == 'cellranger-arc':
             assert self._multiome_data is not None
@@ -1489,19 +1498,23 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
         """
         # Store command line
         cmdline = "%s" % ' '.join(args)
+        # Split version
+        version = tuple([int(x) for x in self._version.split('.')])
         # Build generic header
         try:
             cmd = " %s" % args[0]
         except IndexError:
             cmd = ''
         # Construct header
-        if self._package_name in ('cellranger','cellranger-atac'):
+        if (self._package_name == 'cellranger' and version[0] <= 3) or \
+           self._package_name == 'cellranger-atac':
             header = """%s
 %s%s (%s)
 Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
 -------------------------------------------------------------------------------
 """ % (self._path,self._package_name,cmd,self._version)
-        elif self._package_name in ('cellranger-arc',):
+        elif self._package_name in ('cellranger',
+                                    'cellranger-arc',):
             header = "%s %s-%s" % (self._package_name,self._package_name,
                                    self._version)
         elif self._package_name in ('spaceranger,'):
@@ -1539,6 +1552,11 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
         if self._package_name == "cellranger":
             count.add_argument("--transcriptome",action="store")
             count.add_argument("--chemistry",action="store")
+            if version[0] >= 5:
+                count.add_argument("--include-introns",
+                                   action="store_true")
+                count.add_argument("--r1-length",action="store")
+                count.add_argument("--r2-length",action="store")
         elif self._package_name == "cellranger-atac":
             count.add_argument("--reference",action="store")
         elif self._package_name == "cellranger-arc":
@@ -1552,6 +1570,15 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
         count.add_argument("--jobinterval",action="store")
         # Process command line
         args = p.parse_args()
+        # Check bases mask
+        if self._assert_bases_mask:
+            print("Checking bases mask: %s" % args.use_bases_mask)
+            assert(args.use_bases_mask == self._assert_bases_mask)
+        # Check --include-introns
+        if self._assert_include_introns is not None:
+            print("Checking --include-introns: %s" % args.include_introns)
+            assert(args.include_introns == self._assert_include_introns)
+        # Handle commands
         if args.command == "mkfastq":
             ##################
             # mkfastq command

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1359,7 +1359,7 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
         self._package_name = os.path.basename(self._path)
         if version is None:
             if self._package_name == 'cellranger':
-                self._version = '3.1.0'
+                self._version = '5.0.1'
             elif self._package_name == 'cellranger-atac':
                 self._version = '1.2.0'
             elif self._package_name == 'cellranger-arc':

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -25,6 +25,11 @@ Pipeline task classes:
 - RunCellrangerCount
 - SetCellCountFromCellrangerCount
 - ReportQC
+
+Also imports the following pipeline tasks:
+
+- Get10xPackage
+
 """
 
 ######################################################################
@@ -41,6 +46,7 @@ from bcftbx.utils import mkdirs
 from bcftbx.utils import find_program
 from ..analysis import copy_analysis_project
 from ..applications import Command
+from ..bcl2fastq.pipeline import Get10xPackage
 from ..fastq_utils import pair_fastqs_by_name
 from ..fastq_utils import remove_index_fastqs
 from ..pipeliner import Pipeline
@@ -321,6 +327,22 @@ class QCPipeline(Pipeline):
             # Tasks 'check_cellranger_count' depends on
             check_cellranger_count_requires = []
 
+            # Locate cellranger
+            if qc_protocol in ("10x_scRNAseq",
+                               "10x_snRNAseq",):
+                require_cellranger_exe = "cellranger"
+            elif qc_protocol in ("10x_scATAC",):
+                require_cellranger_exe = "cellranger-atac"
+            elif qc_protocol in ("10x_Multiome_ATAC",
+                                 "10x_Multiome_GEX",):
+                require_cellranger_exe = "cellranger-arc"
+
+            get_cellranger = Get10xPackage(
+                "%s: get information on cellranger" % project_name,
+                require_package=require_cellranger_exe)
+            self.add_task(get_cellranger,
+                          envmodules=self.envmodules['cellranger'])
+
             # Get reference data for cellranger
             get_cellranger_reference_data = GetCellrangerReferenceData(
                 "%s: get 'cellranger count' reference data" %
@@ -331,9 +353,12 @@ class QCPipeline(Pipeline):
                 premrna_references=self.params.cellranger_premrna_references,
                 atac_references=self.params.cellranger_atac_references,
                 multiome_references=self.params.cellranger_arc_references,
+                cellranger_exe=get_cellranger.output.package_exe,
+                cellranger_version=get_cellranger.output.package_version,
                 qc_protocol=qc_protocol
             )
             self.add_task(get_cellranger_reference_data,
+                          requires=(get_cellranger,),
                           runner=self.runners['verify_runner'],
                           log_dir=log_dir)
             update_qc_metadata_requires.append(get_cellranger_reference_data)
@@ -379,6 +404,8 @@ class QCPipeline(Pipeline):
                 project.dirn,
                 qc_dir=qc_dir,
                 working_dir=self.params.WORKING_DIR,
+                cellranger_exe=get_cellranger.output.package_exe,
+                cellranger_version=get_cellranger.output.package_version,
                 chemistry=self.params.cellranger_chemistry,
                 cellranger_jobmode=self.params.cellranger_jobmode,
                 cellranger_maxjobs=self.params.cellranger_maxjobs,
@@ -389,7 +416,8 @@ class QCPipeline(Pipeline):
                 qc_protocol=qc_protocol
             )
             self.add_task(run_cellranger_count,
-                          requires=(get_cellranger_reference_data,
+                          requires=(get_cellranger,
+                                    get_cellranger_reference_data,
                                     check_cellranger_count,),
                           runner=self.runners['cellranger_runner'],
                           envmodules=self.envmodules['cellranger'],
@@ -965,7 +993,8 @@ class GetCellrangerReferenceData(PipelineFunctionTask):
     """
     def init(self,project,organism=None,transcriptomes=None,
              premrna_references=None,atac_references=None,
-             multiome_references=None,qc_protocol=None):
+             multiome_references=None,qc_protocol=None,
+             cellranger_exe=None,cellranger_version=None):
         """
         Initialise the GetCellrangerReferenceData task
 
@@ -985,6 +1014,11 @@ class GetCellrangerReferenceData(PipelineFunctionTask):
             to reference genome data for cellranger-atac
           multiome_references (mapping): mapping of organism
             names to reference datasets for cellranger-arc
+          cellranger_exe (str): the path to the Cellranger
+            software package to use (e.g. 'cellranger',
+            'cellranger-atac', 'spaceranger')
+          cellranger_version (str): the version string for the
+            Cellranger package
           qc_protocol (str): QC protocol to use
 
         Outputs:
@@ -995,20 +1029,32 @@ class GetCellrangerReferenceData(PipelineFunctionTask):
         """
         self.add_output('reference_data_path',Param(type=str))
     def setup(self):
-        # Set the references we're going to use
-        if self.args.qc_protocol == "10x_scRNAseq":
+        # Report inputs
+        print("Cellranger : %s" % self.args.cellranger_exe)
+        print("Version    : %s" % self.args.cellranger_version)
+        print("QC protocol: %s" % self.args.qc_protocol)
+        # Check that a cellranger exe was supplied
+        if self.args.cellranger_exe is None:
+            print("No cellranger package supplied")
+            return
+        # Set the class of references we're going to use,
+        # based on cellranger package and QC protocol (where
+        # appropriate)
+        cellranger_pkg = os.path.basename(self.args.cellranger_exe)
+        if cellranger_pkg == "cellranger":
             references = self.args.transcriptomes
-        elif self.args.qc_protocol == "10x_snRNAseq":
-            references = self.args.premrna_references
-        elif self.args.qc_protocol == "10x_scATAC":
+            if self.args.qc_protocol == "10x_snRNAseq" and \
+               int(self.args.cellranger_version.split('.')[0]) < 5:
+                references = self.args.premrna_references
+        elif cellranger_pkg == "cellranger-atac":
             references = self.args.atac_references
-        elif self.args.qc_protocol in ("10x_Multiome_ATAC",
-                                       "10x_Multiome_GEX",):
+        elif cellranger_pkg == "cellranger-arc":
             references = self.args.multiome_references
         else:
             self.fail(message="Don't know which reference "
-                      "dataset to use for protocol '%s'" %
-                      self.args.qc_protocol)
+                      "dataset to use for '%s' and protocol '%s'" %
+                      (self.args.cellranger_exe,
+                       self.args.qc_protocol))
             return
         if references is None:
             references = {}
@@ -1027,6 +1073,7 @@ class GetCellrangerReferenceData(PipelineFunctionTask):
         try:
             self.output.reference_data_path.set(
                 references[organisms[0]])
+            print("Reference dataset: %s" % references[organisms[0]])
         except KeyError:
             # No reference data available
             print("No reference data available for '%s'" % organism)
@@ -1141,7 +1188,8 @@ class RunCellrangerCount(PipelineTask):
     Run 'cellranger count'
     """
     def init(self,samples,fastq_dir,reference_data_path,out_dir,
-             qc_dir=None,chemistry='auto',cellranger_jobmode='local',
+             qc_dir=None,cellranger_exe=None,cellranger_version=None,
+             chemistry='auto',cellranger_jobmode='local',
              cellranger_maxjobs=None,cellranger_mempercore=None,
              cellranger_jobinterval=None,cellranger_localcores=None,
              cellranger_localmem=None,qc_protocol=None,
@@ -1164,6 +1212,11 @@ class RunCellrangerCount(PipelineTask):
             'count' QC ouputs (e.g. metrics CSV and summary
             HTML files) into. Outputs won't be copied if
             no value is supplied
+          cellranger_exe (str): the path to the Cellranger
+            software package to use (e.g. 'cellranger',
+            'cellranger-atac', 'spaceranger')
+          cellranger_version (str): the version string for the
+            Cellranger package
           chemistry (str): assay configuration (set to
             'auto' to let cellranger determine this
             automatically; ignored if not scRNA-seq)
@@ -1195,16 +1248,13 @@ class RunCellrangerCount(PipelineTask):
         if not self.args.reference_data_path:
             print("No reference data available: nothing to do")
             return
+        if not self.args.cellranger_exe:
+            raise Exception("No cellranger executable provided")
         # Top-level working directory
         self._working_dir = self.args.working_dir
-        # Determine the cellranger executable to use
-        if self.args.qc_protocol == '10x_scATAC':
-            cellranger_exe = "cellranger-atac"
-        elif self.args.qc_protocol in ('10x_Multiome_ATAC',
-                                       '10x_Multiome_GEX',):
-            cellranger_exe = "cellranger-arc"
-        else:
-            cellranger_exe = "cellranger"
+        # Cellranger details
+        cellranger_exe = os.path.basename(self.args.cellranger_exe)
+        cellranger_version = self.args.cellranger_version
         # Run cellranger for each sample
         for sample in self.args.samples:
             work_dir = os.path.join(self._working_dir,
@@ -1218,20 +1268,38 @@ class RunCellrangerCount(PipelineTask):
                 cellranger_exe,
                 "count",
                 "--id",sample)
+            # Add package-specific options
             if cellranger_exe == "cellranger":
+                # Cellranger (gene expression data)
                 cmd.add_args("--fastqs",self.args.fastq_dir,
                              "--sample",sample,
-                             "--transcriptome",self.args.reference_data_path,
+                             "--transcriptome",
+                             self.args.reference_data_path,
                              "--chemistry",self.args.chemistry)
+                # Additional options for cellranger 5.0+
+                cellranger_major_version = \
+                    int(cellranger_version.split('.')[0])
+                if cellranger_major_version >= 5:
+                    # Hard-trim the input R1 sequence to 26bp
+                    cmd.add_args("--r1-length=26")
+                    if self.args.qc_protocol == "10x_snRNAseq":
+                    # For single nuclei RNA-seq specify the
+                    # --include-introns for cellranger 5.0+
+                        cmd.add_args("--include-introns")
             elif cellranger_exe == "cellranger-atac":
+                # Cellranger-ATAC
                 cmd.add_args("--fastqs",self.args.fastq_dir,
                              "--sample",sample,
-                             "--reference",self.args.reference_data_path)
+                             "--reference",
+                             self.args.reference_data_path)
             elif cellranger_exe == "cellranger-arc":
-                cmd.add_args("--reference",self.args.reference_data_path,
-                             "--libraries",os.path.join(self.args.qc_dir,
-                                                        "libraries.%s.csv"
-                                                        % sample))
+                # Cellranger-ARC (multiome GEX + ATAC data)
+                cmd.add_args("--reference",
+                             self.args.reference_data_path,
+                             "--libraries",
+                             os.path.join(self.args.qc_dir,
+                                          "libraries.%s.csv"
+                                          % sample))
             # Set number of local cores
             if self.args.cellranger_localcores:
                 localcores = self.args.cellranger_localcores

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1033,6 +1033,7 @@ class GetCellrangerReferenceData(PipelineFunctionTask):
         print("Cellranger : %s" % self.args.cellranger_exe)
         print("Version    : %s" % self.args.cellranger_version)
         print("QC protocol: %s" % self.args.qc_protocol)
+        print("Organism(s): %s" % self.args.organism)
         # Check that a cellranger exe was supplied
         if self.args.cellranger_exe is None:
             print("No cellranger package supplied")

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -753,14 +753,23 @@ def cellranger_info(path=None,name=None):
         for line in output.split('\n'):
             if package_name in ('cellranger',
                                 'cellranger-atac',):
-                if line.startswith(package_name):
-                    # Extract version from line of the form
-                    # cellranger  (2.0.1)
-                    try:
+                try:
+                    if line.startswith("%s %s-" % (package_name,
+                                                   package_name)):
+                        # Extract version from line of the form
+                        # cellranger cellranger-5.0.1
+                        package_version = line.split('-')[-1]
+                    elif line.startswith("%s " % package_name) and \
+                         line.endswith(")"):
+                        # Extract version from line of the form
+                        # cellranger ... (2.0.1)
                         package_version = line.split('(')[-1].strip(')')
-                    except Exception as ex:
-                        logger.warning("Unable to get version from '%s': "
-                                       "%s" % (line,ex))
+                    else:
+                        # Raise an exception
+                        raise("unrecognised version format")
+                except Exception as ex:
+                    logger.warning("Unable to get version from '%s': "
+                                   "%s" % (line,ex))
             elif package_name == 'cellranger-arc':
                 # Extract version from line of the form
                 # cellranger-arc cellranger-arc-1.0.0

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -1715,7 +1715,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(p.output.cellranger_info,
                          (os.path.join(self.bin,"cellranger"),
                           "cellranger",
-                          "3.1.0"))
+                          "5.0.1"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))
@@ -1852,7 +1852,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(p.output.cellranger_info,
                          (os.path.join(self.bin,"cellranger"),
                           "cellranger",
-                          "3.1.0"))
+                          "5.0.1"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))
@@ -1998,7 +1998,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(p.output.cellranger_info,
                          (os.path.join(self.bin,"cellranger"),
                           "cellranger",
-                          "3.1.0"))
+                          "5.0.1"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))
@@ -2840,7 +2840,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.cellranger_info,
                          (os.path.join(self.bin,"cellranger"),
                           "cellranger",
-                          "3.1.0"))
+                          "5.0.1"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))
@@ -2937,7 +2937,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.cellranger_info,
                          (os.path.join(self.bin,"cellranger"),
                           "cellranger",
-                          "3.1.0"))
+                          "5.0.1"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))
@@ -3055,7 +3055,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.cellranger_info,
                          (os.path.join(self.bin,"cellranger"),
                           "cellranger",
-                          "3.1.0"))
+                          "5.0.1"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))

--- a/auto_process_ngs/test/commands/test_run_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_run_qc_cmd.py
@@ -416,15 +416,16 @@ mouse = /data/cellranger/transcriptomes/mm10
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
 
-    def test_run_qc_10x_snRNAseq(self):
-        """run_qc: 10x snRNA-seq with strandedness and single library analysis
+    def test_run_qc_10x_snRNAseq_310(self):
+        """run_qc: 10x snRNA-seq with strandedness and single library analysis (cellranger 3.1.0)
         """
         # Make mock illumina_qc.sh and multiqc
         MockIlluminaQcSh.create(os.path.join(self.bin,
                                              "illumina_qc.sh"))
         MockFastqStrandPy.create(os.path.join(self.bin,
                                               "fastq_strand.py"))
-        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="3.1.0")
         MockMultiQC.create(os.path.join(self.bin,"multiqc"))
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
@@ -457,6 +458,98 @@ mouse = /data/genomeIndexes/mm10/STAR
 [10xgenomics_premrna_references]
 human = /data/cellranger/transcriptomes/hg38_pre_mrna
 mouse = /data/cellranger/transcriptomes/mm10_pre_mrna
+""")
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=Settings(settings_ini))
+        # Run the QC
+        status = run_qc(ap,
+                        run_multiqc=True,
+                        max_jobs=1)
+        self.assertEqual(status,0)
+        # Check the fastq_strand_conf files were created
+        for p in ("AB","CDE"):
+            self.assertTrue(os.path.exists(
+                os.path.join(mockdir.dirn,p,"qc","fastq_strand.conf")))
+        # Check fastq_strand outputs are present
+        for p in ("AB","CDE"):
+            fastq_strand_outputs = list(
+                filter(lambda f:
+                       f.endswith("fastq_strand.txt"),
+                       os.listdir(os.path.join(
+                           mockdir.dirn,p,"qc"))))
+            self.assertTrue(len(fastq_strand_outputs) > 0)
+        # Check cellranger count outputs are present
+        for p in ("AB","CDE"):
+            self.assertTrue(os.path.exists(os.path.join(mockdir.dirn,
+                                                        p,
+                                                        "qc",
+                                                        "cellranger_count")))
+        # Check output and reports
+        for p in ("AB","CDE","undetermined"):
+            for f in ("qc",
+                      "qc_report.html",
+                      "qc_report.%s.%s.zip" % (
+                          p,
+                          '170901_M00879_0087_000000000-AGEW9'),
+                      "multiqc_report.html"):
+                self.assertTrue(os.path.exists(os.path.join(mockdir.dirn,
+                                                            p,f)),
+                                "Missing %s in project '%s'" % (f,p))
+            # Check zip file has MultiQC report
+            zip_file = os.path.join(mockdir.dirn,p,
+                                    "qc_report.%s.%s.zip" % (
+                                        p,
+                                        '170901_M00879_0087_000000000-AGEW9'))
+            with zipfile.ZipFile(zip_file) as z:
+                multiqc = os.path.join(
+                    "qc_report.%s.%s" % (
+                        p,'170901_M00879_0087_000000000-AGEW9'),
+                    "multiqc_report.html")
+                self.assertTrue(multiqc in z.namelist())
+
+    def test_run_qc_10x_snRNAseq_501(self):
+        """run_qc: 10x snRNA-seq with strandedness and single library analysis (cellranger 5.0.1)
+        """
+        # Make mock illumina_qc.sh and multiqc
+        MockIlluminaQcSh.create(os.path.join(self.bin,
+                                             "illumina_qc.sh"))
+        MockFastqStrandPy.create(os.path.join(self.bin,
+                                              "fastq_strand.py"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="5.0.1")
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901" },
+            project_metadata={ "AB": { "Organism": "human",
+                                       "Single cell platform":
+                                       "10xGenomics Chromium 3'v3",
+                                       "Library type": "snRNA-seq", },
+                               "CDE": { "Organism": "mouse",
+                                        "Single cell platform":
+                                        "10xGenomics Chromium 3'v3",
+                                        "Library type": "snRNA-seq", } },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Settings file with fastq_strand indexes and
+        # polling interval
+        settings_ini = os.path.join(self.dirn,"auto_process.ini")
+        with open(settings_ini,'w') as s:
+            s.write("""[general]
+poll_interval = 1.0
+
+[fastq_strand_indexes]
+human = /data/genomeIndexes/hg38/STAR
+mouse = /data/genomeIndexes/mm10/STAR
+
+[10xgenomics_transcriptomes]
+human = /data/cellranger/transcriptomes/hg38
+mouse = /data/cellranger/transcriptomes/mm10
 """)
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn,

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -582,15 +582,16 @@ class TestQCPipeline(unittest.TestCase):
         self.assertTrue(os.path.exists(log_dir),
                         "Log dir '%s' not found" % log_dir)
 
-    def test_qcpipeline_with_cellranger_count_scRNA_seq(self):
-        """QCPipeline: single cell RNA-seq QC run with 'cellranger count'
+    def test_qcpipeline_with_cellranger_count_scRNA_seq_310(self):
+        """QCPipeline: single cell RNA-seq QC run with 'cellranger count' (v3.1.0)
         """
         # Make mock illumina_qc.sh and multiqc
         MockIlluminaQcSh.create(os.path.join(self.bin,
                                              "illumina_qc.sh"))
         MockMultiQC.create(os.path.join(self.bin,"multiqc"))
         MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
-        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="3.1.0")
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Make mock analysis project
@@ -639,15 +640,75 @@ class TestQCPipeline(unittest.TestCase):
                                                         "PJB",f)),
                             "Missing %s" % f)
 
-    def test_qcpipeline_with_cellranger_count_snRNA_seq(self):
-        """QCPipeline: single nuclei RNA-seq QC run with 'cellranger count'
+    def test_qcpipeline_with_cellranger_count_scRNA_seq_501(self):
+        """QCPipeline: single cell RNA-seq QC run with 'cellranger count' (v5.0.1)
         """
         # Make mock illumina_qc.sh and multiqc
         MockIlluminaQcSh.create(os.path.join(self.bin,
                                              "illumina_qc.sh"))
         MockMultiQC.create(os.path.join(self.bin,"multiqc"))
         MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
-        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="5.0.1",
+                                 assert_include_introns=False)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v2',
+                                           'Library type': 'scRNA-seq' })
+        p.create(top_dir=self.wd)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject("PJB",
+                                          os.path.join(self.wd,"PJB")),
+                          multiqc=True)
+        status = runqc.run(fastq_strand_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           cellranger_transcriptomes=
+                           { 'human': '/data/hg38/cellranger' },
+                           poll_interval=0.5,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        # Check output and reports
+        self.assertEqual(status,0)
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/PJB1/_cmdline",
+                  "qc/cellranger_count/PJB1/outs/web_summary.html",
+                  "qc/cellranger_count/PJB1/outs/metrics_summary.csv",
+                  "qc/cellranger_count/PJB2/_cmdline",
+                  "qc/cellranger_count/PJB2/outs/web_summary.html",
+                  "qc/cellranger_count/PJB2/outs/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/PJB1/_cmdline",
+                  "cellranger_count/PJB1/outs/web_summary.html",
+                  "cellranger_count/PJB1/outs/metrics_summary.csv",
+                  "cellranger_count/PJB2/_cmdline",
+                  "cellranger_count/PJB2/outs/web_summary.html",
+                  "cellranger_count/PJB2/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    def test_qcpipeline_with_cellranger_count_snRNA_seq_310(self):
+        """QCPipeline: single nuclei RNA-seq QC run with 'cellranger count' (v3.1.0)
+        """
+        # Make mock illumina_qc.sh and multiqc
+        MockIlluminaQcSh.create(os.path.join(self.bin,
+                                             "illumina_qc.sh"))
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="3.1.0")
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Make mock analysis project
@@ -668,6 +729,66 @@ class TestQCPipeline(unittest.TestCase):
         status = runqc.run(fastq_strand_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_premrna_references=
+                           { 'human': '/data/hg38/cellranger' },
+                           poll_interval=0.5,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        # Check output and reports
+        self.assertEqual(status,0)
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/PJB1/_cmdline",
+                  "qc/cellranger_count/PJB1/outs/web_summary.html",
+                  "qc/cellranger_count/PJB1/outs/metrics_summary.csv",
+                  "qc/cellranger_count/PJB2/_cmdline",
+                  "qc/cellranger_count/PJB2/outs/web_summary.html",
+                  "qc/cellranger_count/PJB2/outs/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/PJB1/_cmdline",
+                  "cellranger_count/PJB1/outs/web_summary.html",
+                  "cellranger_count/PJB1/outs/metrics_summary.csv",
+                  "cellranger_count/PJB2/_cmdline",
+                  "cellranger_count/PJB2/outs/web_summary.html",
+                  "cellranger_count/PJB2/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    def test_qcpipeline_with_cellranger_count_snRNA_seq_501(self):
+        """QCPipeline: single nuclei RNA-seq QC run with 'cellranger count' (v5.0.1)
+        """
+        # Make mock illumina_qc.sh and multiqc
+        MockIlluminaQcSh.create(os.path.join(self.bin,
+                                             "illumina_qc.sh"))
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        # Mock cellranger 5.0.1 with check on --include-introns
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="5.0.1",
+                                 assert_include_introns=True)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v2',
+                                           'Library type': 'snRNA-seq' })
+        p.create(top_dir=self.wd)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject("PJB",
+                                          os.path.join(self.wd,"PJB")),
+                          multiqc=True)
+        status = runqc.run(fastq_strand_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           cellranger_transcriptomes=
                            { 'human': '/data/hg38/cellranger' },
                            poll_interval=0.5,
                            max_jobs=1,

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -305,6 +305,13 @@ class TestCellrangerInfo(unittest.TestCase):
             fp.write("#!/bin/bash\ncat <<EOF\ncellranger $1  (2.0.1)\nCopyright (c) 2017 10x Genomics, Inc.  All rights reserved.\n-------------------------------------------------------------------------------\n\nUsage:\n    cellranger mkfastq\n\n    cellranger count\n    cellranger aggr\n    cellranger reanalyze\n    cellranger mkloupe\n    cellranger mat2csv\n\n    cellranger mkgtf\n    cellranger mkref\n\n    cellranger vdj\n\n    cellranger mkvdjref\n\n    cellranger testrun\n    cellranger upload\n    cellranger sitecheckEOF")
         os.chmod(cellranger_201,0o775)
         return cellranger_201
+    def _make_mock_cellranger_501(self):
+        # Make a fake cellranger 5.0.1 executable
+        cellranger_501 = os.path.join(self.wd,"cellranger")
+        with open(cellranger_501,'w') as fp:
+            fp.write("#!/bin/bash\necho -n cellranger cellranger-5.0.1")
+        os.chmod(cellranger_501,0o775)
+        return cellranger_501
     def _make_mock_cellranger_atac_101(self):
         # Make a fake cellranger-atac 1.0.1 executable
         cellranger_atac_101 = os.path.join(self.wd,"cellranger-atac")
@@ -336,6 +343,13 @@ class TestCellrangerInfo(unittest.TestCase):
         cellranger = self._make_mock_cellranger_201()
         self.assertEqual(cellranger_info(name='cellranger'),
                          (cellranger,'cellranger','2.0.1'))
+
+    def test_cellranger_501(self):
+        """cellranger_info: collect info for cellranger 5.0.1
+        """
+        cellranger = self._make_mock_cellranger_501()
+        self.assertEqual(cellranger_info(path=cellranger),
+                         (cellranger,'cellranger','5.0.1'))
 
     def test_cellranger_atac_101(self):
         """cellranger_info: collect info for cellranger-atac 1.0.1


### PR DESCRIPTION
PR which addresses issue #635 and updates the processing and QC pipelines ('make_fastqs' and 'run_qc' commands respectively) to accommodate `cellranger` version 5.0.1.

The updates try to preserve backwards-compatibility with `cellranger` 3.1.0 (compatibility with older versions isn't guaranteed).