### PR TITLE
'run_qc.py': enable Cellranger executable and reference dataset to be specified on command line

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -2359,13 +2359,14 @@ class Get10xPackage(PipelineFunctionTask):
     def get_10x_package(self,require_package):
         # Look for 10xGenomics package
         package_exe = find_program(require_package)
+        package_name = os.path.basename(require_package)
         if package_exe:
             # Get information on the version etc
-            if require_package in ('cellranger',
-                                   'cellranger-atac',
-                                   'cellranger-arc',):
+            if package_name in ('cellranger',
+                                'cellranger-atac',
+                                'cellranger-arc',):
                 package_info = cellranger_info(package_exe)
-            elif require_package == 'spaceranger':
+            elif package_name == 'spaceranger':
                 package_info = spaceranger_info(package_exe)
             else:
                 raise Exception("%s: unknown 10xGenomics package" %
@@ -2373,7 +2374,7 @@ class Get10xPackage(PipelineFunctionTask):
         else:
             # Unable to locate appropriate software
             print("No appropriate %s software located" %
-                  os.path.basename(require_package))
+                  package_name)
             package_exe = None
             package_info = (None,None,None)
         # Return the information on the package

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -433,7 +433,8 @@ class QCPipeline(Pipeline):
             set_cellranger_cell_count = SetCellCountFromCellrangerCount(
                 "%s: set cell count from single library analysis" %
                 project_name,
-                project
+                project,
+                qc_dir
             )
             self.add_task(set_cellranger_cell_count,
                           requires=(run_cellranger_count,),)
@@ -1520,19 +1521,22 @@ class SetCellCountFromCellrangerCount(PipelineTask):
     Update the number of cells in the project metadata from
     'cellranger count' output
     """
-    def init(self,project):
+    def init(self,project,qc_dir=None):
         """
         Initialise the SetCellCountFromCellrangerCount task.
 
         Arguments:
-          project (AnalysisProject): project to update the number
-            of cells for
+          project (AnalysisProject): project to update the
+            number of cells for
+          qc_dir (str): directory for QC outputs (defaults
+            to subdirectory 'qc' of project directory)
         """
         pass
     def setup(self):
         # Extract and store the cell count from the cellranger
         # metric file
-        set_cell_count_for_project(self.args.project.dirn)
+        set_cell_count_for_project(self.args.project.dirn,
+                                   self.args.qc_dir)
 
 class ReportQC(PipelineTask):
     """

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1347,6 +1347,9 @@ class RunCellrangerCount(PipelineTask):
             return
         if not self.args.cellranger_exe:
             raise Exception("No cellranger executable provided")
+        if not (self.args.out_dir or self.args.qc_dir):
+            raise Exception("Need to provide at least one of "
+                            "output directory and QC directory")
         # Top-level working directory
         self._working_dir = self.args.working_dir
         # Cellranger details

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -385,12 +385,13 @@ class QCPipeline(Pipeline):
                 check_cellranger_count_requires.append(
                     make_cellranger_libraries)
 
-            # Check outputs for cellranger count
+            # Check QC outputs for cellranger count
             check_cellranger_count = CheckCellrangerCountOutputs(
                 "%s: check single library analysis (cellranger)" %
                 project_name,
                 project,
                 fastq_dir=fastq_dir,
+                qc_dir=qc_dir,
                 qc_protocol=qc_protocol,
                 verbose=self.params.VERBOSE
             )
@@ -1201,8 +1202,8 @@ class CheckCellrangerCountOutputs(PipelineFunctionTask):
     """
     Check the outputs from cellranger(-atac) count
     """
-    def init(self,project,fastq_dir=None,qc_protocol=None,
-             verbose=False):
+    def init(self,project,fastq_dir=None,qc_dir=None,
+             qc_protocol=None,verbose=False):
         """
         Initialise the CheckCellrangerCountOutputs task.
 
@@ -1211,6 +1212,9 @@ class CheckCellrangerCountOutputs(PipelineFunctionTask):
             QC for
           fastq_dir (str): directory holding Fastq files
             (defaults to current fastq_dir in project)
+          qc_dir (str): top-level QC directory to look
+            for 'count' QC outputs (e.g. metrics CSV and
+            summary HTML files)
           qc_protocol (str): QC protocol to use
           verbose (bool): if True then print additional
             information from the task
@@ -1236,7 +1240,8 @@ class CheckCellrangerCountOutputs(PipelineFunctionTask):
         self.add_call("Check cellranger count outputs for %s"
                       % self.args.project.name,
                       check_outputs,
-                      self.args.project)
+                      self.args.project,
+                      self.args.qc_dir)
     def finish(self):
         # Collect the sample names with missing outputs
         for result in self.result():

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -467,7 +467,8 @@ class QCPipeline(Pipeline):
             cellranger_arc_references=None,cellranger_jobmode='local',
             cellranger_maxjobs=None,cellranger_mempercore=None,
             cellranger_jobinterval=None,cellranger_localcores=None,
-            cellranger_localmem=None,working_dir=None,log_file=None,
+            cellranger_localmem=None,cellranger_exe=None,
+            working_dir=None,log_file=None,
             batch_size=None,max_jobs=1,max_slots=None,poll_interval=5,
             runners=None,default_runner=None,envmodules=None,
             verbose=False):
@@ -514,6 +515,10 @@ class QCPipeline(Pipeline):
             (default: None)
           cellranger_localmem (int): maximum memory cellranger
             can request in jobmode 'local' (default: None)
+          cellranger_exe (str): optional, explicitly specify
+            the cellrange executable to use for single
+            library analysis (default: cellranger executable
+            is determined automatically)
           working_dir (str): optional path to a working
             directory (defaults to temporary directory in
             the current directory)
@@ -589,7 +594,8 @@ class QCPipeline(Pipeline):
                                   'cellranger_mempercore': cellranger_mempercore,
                                   'cellranger_jobinterval': cellranger_jobinterval,
                                   'cellranger_localcores': cellranger_localcores,
-                                  'cellranger_localmem': cellranger_localmem
+                                  'cellranger_localmem': cellranger_localmem,
+                                  'cellranger_exe': cellranger_exe,
                               },
                               poll_interval=poll_interval,
                               max_jobs=max_jobs,

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1499,7 +1499,7 @@ class RunCellrangerCount(PipelineTask):
                     mkdirs(count_dir)
                 shutil.move(top_dir,count_dir)
         # Also copy outputs to QC directory
-        if self.args.qc_dir:
+        if self.args.qc_dir and self.args.samples:
             print("Copying outputs to QC directory")
             # Top level output directory
             count_dir = os.path.abspath(

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -699,6 +699,70 @@ class TestQCPipeline(unittest.TestCase):
                                                         "PJB",f)),
                             "Missing %s" % f)
 
+    def test_qcpipeline_with_cellranger_count_specify_exe(self):
+        """QCPipeline: single cell RNA-seq QC run with 'cellranger count' (specify cellranger exe)
+        """
+        # Make mock illumina_qc.sh and multiqc
+        MockIlluminaQcSh.create(os.path.join(self.bin,
+                                             "illumina_qc.sh"))
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock cellranger not on PATH
+        cellranger_bin = os.path.join(self.wd,"cellranger")
+        os.mkdir(cellranger_bin)
+        MockCellrangerExe.create(os.path.join(cellranger_bin,
+                                              "cellranger"),
+                                 version="5.0.1")
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v2',
+                                           'Library type': 'scRNA-seq' })
+        p.create(top_dir=self.wd)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject("PJB",
+                                          os.path.join(self.wd,"PJB")),
+                          multiqc=True)
+        status = runqc.run(fastq_strand_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           cellranger_transcriptomes=
+                           { 'human': '/data/hg38/cellranger' },
+                           cellranger_exe=os.path.join(cellranger_bin,
+                                                       "cellranger"),
+                           poll_interval=0.5,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        # Check output and reports
+        self.assertEqual(status,0)
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/PJB1/_cmdline",
+                  "qc/cellranger_count/PJB1/outs/web_summary.html",
+                  "qc/cellranger_count/PJB1/outs/metrics_summary.csv",
+                  "qc/cellranger_count/PJB2/_cmdline",
+                  "qc/cellranger_count/PJB2/outs/web_summary.html",
+                  "qc/cellranger_count/PJB2/outs/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/PJB1/_cmdline",
+                  "cellranger_count/PJB1/outs/web_summary.html",
+                  "cellranger_count/PJB1/outs/metrics_summary.csv",
+                  "cellranger_count/PJB2/_cmdline",
+                  "cellranger_count/PJB2/outs/web_summary.html",
+                  "cellranger_count/PJB2/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
     def test_qcpipeline_with_cellranger_count_snRNA_seq_310(self):
         """QCPipeline: single nuclei RNA-seq QC run with 'cellranger count' (v3.1.0)
         """

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -607,6 +607,7 @@ if __name__ == "__main__":
                        cellranger_exe=args.cellranger_exe,
                        cellranger_reference_dataset=\
                        cellranger_reference_dataset,
+                       cellranger_out_dir=out_dir,
                        max_jobs=max_jobs,
                        max_slots=max_cores,
                        batch_size=args.batch_size,

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -161,6 +161,12 @@ if __name__ == "__main__":
                                                else default_nthreads,))
     # Cellranger options
     cellranger = p.add_argument_group('Cellranger/10xGenomics options')
+    cellranger.add_argument('--cellranger',action='store',
+                            metavar='CELLRANGER_EXE',
+                            dest='cellranger_exe',
+                            help="explicitly specify path to Cellranger "
+                            "executable to use for single library "
+                            "analysis")
     cellranger.add_argument('--10x_transcriptome',action='append',
                             metavar='ORGANISM=REFERENCE',
                             dest='cellranger_transcriptomes',
@@ -579,6 +585,7 @@ if __name__ == "__main__":
                        cellranger_jobinterval=cellranger_jobinterval,
                        cellranger_localcores=cellranger_localcores,
                        cellranger_localmem=cellranger_localmem,
+                       cellranger_exe=args.cellranger_exe,
                        max_jobs=max_jobs,
                        max_slots=max_cores,
                        batch_size=args.batch_size,

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -113,15 +113,11 @@ if __name__ == "__main__":
                    nargs="+",
                    help="directory or list of Fastq files to run the "
                    "QC on")
-    p.add_argument('-n','--name',action='store',
-                   help="name for the project (used in report title)")
-    p.add_argument('--organism',metavar='ORGANISM',
-                   action='store',dest='organism',default=None,
-                   help="explicitly specify organism (e.g. 'human', "
-                   "'mouse'). Multiple organisms should be separated "
-                   "by commas (e.g. 'human,mouse')")
     # Reporting options
     reporting = p.add_argument_group('Output and reporting')
+    reporting.add_argument('-n','--name',action='store',
+                           help="name for the project (used in report "
+                           "title)")
     reporting.add_argument('-o','--out_dir',action='store',
                            help="top-level directory for reports and "
                            "QC output subdirectory (default: current "
@@ -134,6 +130,14 @@ if __name__ == "__main__":
     reporting.add_argument('-f','--filename',action='store',
                            help="file name for output QC report (default: "
                            "<OUT_DIR>/<QC_DIR_NAME>_report.html)")
+    # Project metadata
+    metadata = p.add_argument_group('Metadata')
+    metadata.add_argument('--organism',metavar='ORGANISM',
+                          action='store',dest='organism',default=None,
+                          help="explicitly specify organism (e.g. "
+                          "'human', 'mouse'). Multiple organisms "
+                          "should be separated by commas (e.g. "
+                          "'human,mouse')")
     # QC pipeline options
     qc_options = p.add_argument_group('QC options')
     qc_options.add_argument('-p','--protocol',metavar='PROTOCOL',

--- a/docs/source/using/run_qc_standalone.rst
+++ b/docs/source/using/run_qc_standalone.rst
@@ -53,8 +53,6 @@ determine which metrics are run:
 * ``--protocol``: specify the QC protocol (see :doc:`run_qc`
   for a complete list)
 * ``--organism``: specify the organism(s)
-* ``--name``: sets the name for the project (used in the
-  QC report title)
 
 .. note::
 
@@ -78,6 +76,32 @@ The following options can be used to override the defaults:
   written; if this is a relative path then it will be a
   subdirectory of the top-level output directory
 * ``--filename``: name for the HTML report from the QC
+* ``--name``: sets the name for the project (used in the
+  QC report title)
+
+Running 10xGenomics single library analyses
+-------------------------------------------
+
+When running the QC pipeline on 10xGenomics data using an
+:doc:`appropriate protocol <run_qc>`, additional options are
+available for controlling the single library analyses that
+are run using the `count` command of the appropriate
+10xGenomics software package.
+
+The following options can be used to override the defaults
+defined in the configuration:
+
+* ``--cellranger``: explicitly sets the path to the ``cellranger``
+  (or other appropriate 10xGenomics package)
+* ``--cellranger-reference``: sets the path to the reference
+  dataset to use for single library analysis
+
+.. note::
+
+   The full outputs from the single library analyses are
+   copied to the ``cellranger_count`` subdirectory of the
+   top-level output directory, in addition to the metrics
+   and HTML summary files written to the QC directory.
 
 Running on different platforms: ``--local``
 -------------------------------------------


### PR DESCRIPTION
PR which updates the `run_qc.py` utility to address issue #637 and allow the `cellranger` executable and reference dataset paths to be specified on the command line, for use with the 10xGenomics single library analyses.

The updates include changes to the QC pipleine (in `qc/pipeline.py`) to enable the `cellranger` executable and reference dataset paths to be supplied to the pipeline's `run` method, and for these values to override the automatic detection mechanisms within the pipeline.

The values can be set by the user when running `run_qc.py` via two new options:

* `--cellranger` (sets the path to the `cellranger` executable to use)
* `--cellranger-reference` (sets the path to the reference dataset)

The update also deprecates the existing `--10x_transcriptome` and `--10x_premrna_reference` options, which are replaced by the new `--cellranger-reference` option.

Additionally some minor bugs are addressed when the pipeline is run from `run_qc.py`, including:

* ensuring that the `cellranger count` outputs are captured and written to the output directory;
* ensuring that the correct location is checked for pre-existing QC outputs for `cellranger count` when determining which samples need single library analysis running on them;
* fixing an issue with setting the cell counts. 