### PR TITLE
Enable maximum cores to set when running 'make_fastqs' and 'run_qc' commands

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -1575,9 +1575,9 @@ class MakeFastqs(Pipeline):
             cellranger_maxjobs=None,cellranger_jobinterval=None,
             cellranger_localcores=None,cellranger_localmem=None,
             working_dir=None,log_dir=None,log_file=None,
-            batch_size=None,max_jobs=1,poll_interval=5,
-            runners=None,default_runner=None,envmodules=None,
-            verbose=False):
+            batch_size=None,max_jobs=1,max_slots=None,
+            poll_interval=5,runners=None,default_runner=None,
+            envmodules=None,verbose=False):
         """
         Run the tasks in the pipeline
 
@@ -1635,6 +1635,10 @@ class MakeFastqs(Pipeline):
             one command per job)
           max_jobs (int): optional maximum number of
             concurrent jobs in scheduler (defaults to 1)
+          max_slots (int): optional maximum number of 'slots'
+            (i.e. concurrent threads or maximum number of
+            CPUs) available to the scheduler (defaults to
+            no limit)
           poll_interval (float): optional polling interval
             (seconds) to set in scheduler (defaults to 5s)
           runners (dict): mapping of names to JobRunner
@@ -1752,6 +1756,7 @@ class MakeFastqs(Pipeline):
                               params=params,
                               poll_interval=poll_interval,
                               max_jobs=max_jobs,
+                              max_slots=max_slots,
                               runners=runners,
                               default_runner=default_runner,
                               envmodules=envmodules,

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -464,24 +464,17 @@ def add_make_fastqs_command(cmdparser):
                                     cellranger_localcores
     if not default_cellranger_localcores:
         default_cellranger_localcores = 1
-    cellranger = p.add_argument_group('Cellranger options (10xGenomics '
-                                      'Chromium SC 3\' and ATAC data only)')
-    cellranger.add_argument("--jobmode",
-                            dest="job_mode",
+    cellranger = p.add_argument_group('Cellranger* options (10xGenomics '
+                                      'data only)')
+    cellranger.add_argument("--10x_jobmode",
+                            dest="cellranger_jobmode",
                             default=__settings['10xgenomics'].\
                             cellranger_jobmode,
                             help="job mode to run cellranger in (default: "
                             "'%s')"
                             % __settings['10xgenomics'].cellranger_jobmode)
-    cellranger.add_argument("--mempercore",
-                            dest="mem_per_core",
-                            default=__settings['10xgenomics'].\
-                            cellranger_mempercore,
-                            help="memory assumed per core (in Gbs; default: "
-                            "%s); NB only used if jobmode is not 'local'" %
-                            __settings['10xgenomics'].cellranger_mempercore)
-    cellranger.add_argument("--localcores",
-                            dest="local_cores",
+    cellranger.add_argument("--10x_localcores",
+                            dest="cellranger_localcores",
                             default=default_cellranger_localcores,
                             help="maximum cores cellranger can request at one"
                             "time for jobmode 'local' (ignored for other "
@@ -489,8 +482,8 @@ def add_make_fastqs_command(cmdparser):
                             ("taken from job runner"
                              if not default_cellranger_localcores
                              else default_cellranger_localcores))
-    cellranger.add_argument("--localmem",
-                            dest="local_mem",
+    cellranger.add_argument("--10x_localmem",
+                            dest="cellranger_localmem",
                             default=__settings['10xgenomics'].\
                             cellranger_localmem,
                             help="maximum total memory cellranger can "
@@ -498,18 +491,27 @@ def add_make_fastqs_command(cmdparser):
                             "(ignored for other jobmodes) (in Gbs; default: "
                             "%s)" %
                             __settings['10xgenomics'].cellranger_localmem)
-    cellranger.add_argument("--maxjobs",type=int,
-                            dest="max_jobs",
+    cellranger.add_argument("--10x_maxjobs",type=int,
+                            dest="cellranger_maxjobs",
                             default=__settings.general.max_concurrent_jobs,
                             help="maxiumum number of concurrent jobs to run "
-                            "(default: %d)"
-                            % __settings.general.max_concurrent_jobs)
-    cellranger.add_argument("--jobinterval",type=int,
-                            dest="job_interval",
+                            " NB only used if jobmode is not 'local' "
+                            "(default: %d)" %
+                            __settings['10xgenomics'].cellranger_maxjobs)
+    cellranger.add_argument("--10x_mempercore",
+                            dest="cellranger_mempercore",
+                            default=__settings['10xgenomics'].\
+                            cellranger_mempercore,
+                            help="memory assumed per core (in Gbs; default: "
+                            "%s); NB only used if jobmode is not 'local'" %
+                            __settings['10xgenomics'].cellranger_mempercore)
+    cellranger.add_argument("--10x_jobinterval",type=int,
+                            dest="cellranger_jobinterval",
                             default=__settings['10xgenomics'].\
                             cellranger_jobinterval,
                             help="how often jobs are submitted (in ms; "
-                            "default: %d)" %
+                            "default: %d); only used if jobmode is not "
+                            "'local'" %
                             __settings['10xgenomics'].cellranger_jobinterval)
     cellranger.add_argument("--ignore-dual-index",
                             action="store_true",
@@ -544,6 +546,24 @@ def add_make_fastqs_command(cmdparser):
     p.add_argument('analysis_dir',metavar="ANALYSIS_DIR",nargs="?",
                    help="auto_process analysis directory (optional: defaults "
                    "to the current directory)")
+    # Job control options
+    job_control = p.add_argument_group("Job control options")
+    job_control.add_argument('-j','--maxjobs',type=int,action='store',
+                             dest="max_jobs",metavar='NJOBS',
+                             default=__settings.general.max_concurrent_jobs,
+                             help="maxiumum number of jobs to run "
+                             "concurrently (default: %s)"
+                             % (__settings.general.max_concurrent_jobs
+                                if __settings.general.max_concurrent_jobs
+                                else 'no limit'))
+    job_control.add_argument('-c','--maxcores',type=int,action='store',
+                             dest='max_cores',metavar='NCORES',
+                             default=__settings.general.max_cores,
+                             help="maximum number of cores available for "
+                             "running jobs (default: %s)"
+                             % (__settings.general.max_cores
+                                if __settings.general.max_cores
+                                else 'no limit'))
     # Advanced options
     advanced = p.add_argument_group('Advanced/debugging options')
     advanced.add_argument('--verbose',action="store_true",
@@ -1229,13 +1249,15 @@ def make_fastqs(args):
         per_lane_stats_file=args.per_lane_stats_file,
         barcode_analysis_dir=args.barcode_analysis_dir,
         create_empty_fastqs=create_empty_fastqs,
-        cellranger_jobmode=args.job_mode,
-        cellranger_mempercore=args.mem_per_core,
-        cellranger_maxjobs=args.max_jobs,
-        cellranger_jobinterval=args.job_interval,
-        cellranger_localcores=args.local_cores,
-        cellranger_localmem=args.local_mem,
+        cellranger_jobmode=args.cellranger_jobmode,
+        cellranger_mempercore=args.cellranger_mempercore,
+        cellranger_maxjobs=args.cellranger_maxjobs,
+        cellranger_jobinterval=args.cellranger_jobinterval,
+        cellranger_localcores=args.cellranger_localcores,
+        cellranger_localmem=args.cellranger_localmem,
         cellranger_ignore_dual_index=args.ignore_dual_index,
+        max_jobs=args.max_jobs,
+        max_cores=args.max_cores,
         working_dir=args.working_dir,
         verbose=args.verbose)
 

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -620,6 +620,7 @@ def add_run_qc_command(cmdparser):
     default_nthreads = __settings.qc.nprocessors
     fastq_screen_subset = __settings.qc.fastq_screen_subset
     max_concurrent_jobs = __settings.general.max_concurrent_jobs
+    max_cores = __settings.general.max_cores
     # Build parser
     p.add_argument('--projects',action='store',
                    dest='project_pattern',default=None,
@@ -678,6 +679,21 @@ def add_run_qc_command(cmdparser):
                    "<QC_DIR>_report.html)")
     add_runner_option(p)
     add_modulefiles_option(p)
+    # Job control options
+    job_control = p.add_argument_group("Job control options")
+    job_control.add_argument('-j','--maxjobs',type=int,action='store',
+                             dest="max_jobs",metavar='NJOBS',
+                             default=max_concurrent_jobs,
+                             help="maxiumum number of jobs to run "
+                             "concurrently (default: %s)"
+                             % (max_concurrent_jobs
+                                if max_concurrent_jobs else 'no limit'))
+    job_control.add_argument('-c','--maxcores',type=int,action='store',
+                             dest='max_cores',metavar='NCORES',
+                             default=max_cores,
+                             help="maximum number of cores available for "
+                             "running jobs (default: %s)"
+                             % (max_cores if max_cores else 'no limit'))
     # Advanced options
     advanced = p.add_argument_group('Advanced/debugging options')
     advanced.add_argument('--verbose',action="store_true",
@@ -1303,7 +1319,6 @@ def run_qc(args):
         runner = None
     # Do the run_qc step
     retcode = d.run_qc(projects=args.project_pattern,
-                       max_jobs=args.max_jobs,
                        ungzip_fastqs=args.ungzip_fastqs,
                        fastq_screen_subset=args.subset,
                        nthreads=args.nthreads,
@@ -1317,6 +1332,8 @@ def run_qc(args):
                        cellranger_premrna_references,
                        report_html=args.html_file,
                        runner=runner,
+                       max_jobs=args.max_jobs,
+                       max_cores=args.max_cores,
                        working_dir=args.working_dir,
                        verbose=args.verbose)
     sys.exit(retcode)

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -63,6 +63,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 cellranger_localcores=None,
                 cellranger_localmem=None,
                 cellranger_ignore_dual_index=False,
+                max_jobs=None,max_cores=None,
                 verbose=False,working_dir=None):
     """
     Create and summarise FASTQ files
@@ -178,6 +179,8 @@ def make_fastqs(ap,protocol='standard',platform=None,
       cellranger_ignore_dual_index (bool): (optional) on a dual-indexed
          flowcell where the second index was not used for the 10x
          sample, ignore it (10xGenomics Chromium SC data only)
+      max_jobs (int): maximum number of concurrent jobs allowed
+      max_cores (int): maximum number of cores available
       working_dir (str): path to a working directory (defaults to
          temporary directory in the current directory)
       verbose (bool): if True then report additional information for
@@ -358,8 +361,6 @@ def make_fastqs(ap,protocol='standard',platform=None,
 
     # Other pipeline settings
     poll_interval = ap.settings.general.poll_interval
-    max_jobs = ap.settings.general.max_concurrent_jobs
-    max_cores = ap.settings.general.max_cores
 
     # Construct and run pipeline
     make_fastqs = MakeFastqs(ap.params.data_dir,

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -359,6 +359,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
     # Other pipeline settings
     poll_interval = ap.settings.general.poll_interval
     max_jobs = ap.settings.general.max_concurrent_jobs
+    max_cores = ap.settings.general.max_cores
 
     # Construct and run pipeline
     make_fastqs = MakeFastqs(ap.params.data_dir,
@@ -410,6 +411,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
                              log_dir=ap.log_dir,
                              log_file=pipeline_log,
                              max_jobs=max_jobs,
+                             max_slots=max_cores,
                              poll_interval=poll_interval,
                              working_dir=working_dir,
                              verbose=verbose)

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 # Command functions
 #######################################################################
 
-def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
+def run_qc(ap,projects=None,ungzip_fastqs=False,
            fastq_screen_subset=100000,nthreads=None,
            runner=None,fastq_dir=None,qc_dir=None,
            cellranger_chemistry='auto',
@@ -32,6 +32,7 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
            cellranger_premrna_references=None,
            report_html=None,run_multiqc=True,
            working_dir=None,verbose=None,
+           max_jobs=None,max_cores=None,
            poll_interval=None):
     """Run QC pipeline script for projects
 
@@ -48,9 +49,6 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
       projects (str): specify a pattern to match one or more
         projects to run the QC for (default is to run QC for all
         projects)
-      max_jobs (int): maximum number of jobs that will be
-        scheduled to run at one time (passed to the scheduler;
-        default is 4, set to zero to remove the limit)
       ungzip_fastqs (bool): if True then run the QC script with
         the '--ungzip-fastqs' option to create decompressed
         copies of any fastq.gz inputs (default: False i.e. don't
@@ -83,6 +81,11 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
          temporary directory in the current directory)
       verbose (bool): if True then report additional information
          for pipeline diagnostics
+      max_jobs (int): maximum number of jobs that will be
+        scheduled to run at one time (passed to the scheduler;
+        default: no limit)
+      max_cores (int): maximum number of cores available to
+        the scheduler (default: no limit)
       poll_interval (float): specifies non-default polling
         interval for scheduler used for running QC
 
@@ -148,10 +151,7 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
             envmodules[name] = ap.settings.modulefiles[name]
         except KeyError:
             envmodules[name] = None
-    # Get scheduler parameters
-    if max_jobs is None:
-        max_jobs = ap.settings.general.max_concurrent_jobs
-    max_cores = ap.settings.general.max_cores
+    # Set scheduler parameters
     if poll_interval is None:
         poll_interval = ap.settings.general.poll_interval
     # Set up a master log directory and file

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -172,6 +172,7 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
     # Collect the cellranger data and parameters
     cellranger_settings = ap.settings['10xgenomics']
     cellranger_jobmode = cellranger_settings.cellranger_jobmode
+    cellranger_maxjobs = cellranger_settings.cellranger_maxjobs
     cellranger_mempercore = cellranger_settings.cellranger_mempercore
     cellranger_jobinterval = cellranger_settings.cellranger_jobinterval
     cellranger_localcores = cellranger_settings.cellranger_localcores
@@ -189,7 +190,7 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
                        cellranger_arc_references=cellranger_multiome_references,
                        cellranger_chemistry=cellranger_chemistry,
                        cellranger_jobmode=cellranger_jobmode,
-                       cellranger_maxjobs=max_jobs,
+                       cellranger_maxjobs=cellranger_maxjobs,
                        cellranger_mempercore=cellranger_mempercore,
                        cellranger_jobinterval=cellranger_jobinterval,
                        cellranger_localcores=cellranger_localcores,

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -151,6 +151,7 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
     # Get scheduler parameters
     if max_jobs is None:
         max_jobs = ap.settings.general.max_concurrent_jobs
+    max_cores = ap.settings.general.max_cores
     if poll_interval is None:
         poll_interval = ap.settings.general.poll_interval
     # Set up a master log directory and file
@@ -196,6 +197,7 @@ def run_qc(ap,projects=None,max_jobs=4,ungzip_fastqs=False,
                        log_file=log_file,
                        poll_interval=poll_interval,
                        max_jobs=max_jobs,
+                       max_slots=max_cores,
                        runners=runners,
                        default_runner=default_runner,
                        envmodules=envmodules,

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -226,6 +226,7 @@ class Settings(object):
         self['10xgenomics']['cellranger_jobmode'] = config.get('10xgenomics',
                                                                'cellranger_jobmode',
                                                                'local')
+        self['10xgenomics']['cellranger_maxjobs'] = config.getint('10xgenomics','cellranger_maxjobs',24)
         self['10xgenomics']['cellranger_mempercore'] = config.getint('10xgenomics','cellranger_mempercore',5)
         self['10xgenomics']['cellranger_jobinterval'] = config.getint('10xgenomics','cellranger_jobinterval',100)
         self['10xgenomics']['cellranger_localmem'] = config.getint('10xgenomics','cellranger_localmem',5)

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -121,6 +121,7 @@ class Settings(object):
                                                           'SimpleJobRunner')
         self.general['max_concurrent_jobs'] = config.getint('general',
                                                             'max_concurrent_jobs',12)
+        self.general['max_cores'] = config.getint('general','max_cores')
         self.general['poll_interval'] = config.getfloat('general',
                                                         'poll_interval',5)
         # modulefiles

--- a/auto_process_ngs/simple_scheduler.py
+++ b/auto_process_ngs/simple_scheduler.py
@@ -106,10 +106,11 @@ class SimpleScheduler(threading.Thread):
             runner = JobRunner.SimpleJobRunner()
         self.__runner = runner
         # Maximum number of concurrent jobs
-        self.__max_concurrent = max_concurrent
+        self.__max_concurrent = \
+            (max_concurrent if max_concurrent != 0 else None)
         # Maximum number of available slots across
         # all runners
-        self.__max_slots = max_slots
+        self.__max_slots = (max_slots if max_slots != 0 else None)
         # Length of time to wait between checking jobs
         self.__poll_interval = poll_interval
         # Length of time to wait before submitting job

--- a/auto_process_ngs/test/test_simple_scheduler.py
+++ b/auto_process_ngs/test/test_simple_scheduler.py
@@ -230,6 +230,72 @@ class TestSimpleScheduler(unittest.TestCase):
         self.assertTrue(sched.is_empty())
         sched.stop()
 
+    def test_simple_scheduler_set_max_concurrent_to_zero(self):
+        """Run several jobs with maximum concurrent jobs set to zero
+
+        """
+        sched = SimpleScheduler(runner=MockJobRunner(),poll_interval=0.01,
+                                max_concurrent=0)
+        sched.start()
+        job_1 = sched.submit(['sleep','10'])
+        job_2 = sched.submit(['sleep','20'])
+        job_3 = sched.submit(['sleep','30'])
+        # Wait for scheduler to catch up
+        time.sleep(0.1)
+        self.assertEqual(sched.n_waiting,0)
+        self.assertEqual(sched.n_running,3)
+        self.assertEqual(sched.n_finished,0)
+        self.assertFalse(sched.is_empty())
+        # Finish a job, wait for scheduler to catch up
+        job_1.terminate()
+        time.sleep(0.1)
+        self.assertEqual(sched.n_waiting,0)
+        self.assertEqual(sched.n_running,2)
+        self.assertEqual(sched.n_finished,1)
+        self.assertFalse(sched.is_empty())
+        # Finish remaining jobs, wait for scheduler to catch up
+        job_2.terminate()
+        job_3.terminate()
+        time.sleep(0.1)
+        self.assertEqual(sched.n_waiting,0)
+        self.assertEqual(sched.n_running,0)
+        self.assertEqual(sched.n_finished,3)
+        self.assertTrue(sched.is_empty())
+        sched.stop()
+
+    def test_simple_scheduler_set_max_slots_to_zero(self):
+        """Run several jobs with maximum slots set to zero
+
+        """
+        sched = SimpleScheduler(runner=MockJobRunner(),poll_interval=0.01,
+                                max_slots=0)
+        sched.start()
+        job_1 = sched.submit(['sleep','10'])
+        job_2 = sched.submit(['sleep','20'])
+        job_3 = sched.submit(['sleep','30'])
+        # Wait for scheduler to catch up
+        time.sleep(0.1)
+        self.assertEqual(sched.n_waiting,0)
+        self.assertEqual(sched.n_running,3)
+        self.assertEqual(sched.n_finished,0)
+        self.assertFalse(sched.is_empty())
+        # Finish a job, wait for scheduler to catch up
+        job_1.terminate()
+        time.sleep(0.1)
+        self.assertEqual(sched.n_waiting,0)
+        self.assertEqual(sched.n_running,2)
+        self.assertEqual(sched.n_finished,1)
+        self.assertFalse(sched.is_empty())
+        # Finish remaining jobs, wait for scheduler to catch up
+        job_2.terminate()
+        job_3.terminate()
+        time.sleep(0.1)
+        self.assertEqual(sched.n_waiting,0)
+        self.assertEqual(sched.n_running,0)
+        self.assertEqual(sched.n_finished,3)
+        self.assertTrue(sched.is_empty())
+        sched.stop()
+
     def test_simple_scheduler_run_multiple_jobs_with_max_slots(self):
         """Run several jobs with limit on maximum slots
 

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -193,8 +193,8 @@ if __name__ == "__main__":
                           dest='max_cores',type=int,
                           default=__settings.general.max_cores,
                           help="maximum number of cores available for QC "
-                          "jobs when using --local (default %s, change in
-                          in settings file)" %
+                          "jobs when using --local (default %s, change in "
+                          "in settings file)" %
                           (__settings.general.max_cores
                            if __settings.general.max_cores else 'no limit'))
     pipeline.add_argument('-m','--maxmem',metavar='M',action='store',

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -190,9 +190,13 @@ if __name__ == "__main__":
                           "any runners defined in the configuration or on "
                           "the command line)")
     pipeline.add_argument('-c','--maxcores',metavar='N',action='store',
-                          dest='max_cores',type=int,default=None,
+                          dest='max_cores',type=int,
+                          default=__settings.general.max_cores,
                           help="maximum number of cores available for QC "
-                          "jobs when using --local (default: unlimited)")
+                          "jobs when using --local (default %s, change in
+                          in settings file)" %
+                          (__settings.general.max_cores
+                           if __settings.general.max_cores else 'no limit'))
     pipeline.add_argument('-m','--maxmem',metavar='M',action='store',
                           dest='max_mem',type=int,default=None,
                           help="maximum total memory jobs can request at "
@@ -202,9 +206,11 @@ if __name__ == "__main__":
                           dest='max_jobs',type=int,
                           default=__settings.general.max_concurrent_jobs,
                           help="explicitly specify maximum number of "
-                          "concurrent QC jobs to run (default %d, change "
+                          "concurrent QC jobs to run (default %s, change "
                           "in settings file; ignored when using --local)"
-                          % __settings.general.max_concurrent_jobs)
+                          % (__settings.general.max_concurrent_jobs
+                             if __settings.general.max_concurrent_jobs
+                             else 'no limit'))
     # Advanced options
     advanced = p.add_argument_group('Advanced/debugging options')
     advanced.add_argument('--verbose',action="store_true",

--- a/config/auto_process.ini.sample
+++ b/config/auto_process.ini.sample
@@ -4,6 +4,7 @@
 [general]
 default_runner = SimpleJobRunner
 max_concurrent_jobs = 12
+max_cores = None
 poll_interval = 5
 
 # Explicitly specify modulefiles to load for each step

--- a/config/auto_process.ini.sample
+++ b/config/auto_process.ini.sample
@@ -69,10 +69,13 @@ nprocessors_statistics = 1
 # See https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/advanced/cluster-mode
 [10xgenomics]
 cellranger_jobmode = local
-# cellranger_mempercore only used if jobmode is not 'local'
+# cellranger_maxjobs and cellranger_mempercore only used if jobmode is
+# not 'local'
+cellranger_maxjobs = 24
 cellranger_mempercore = 5
 cellranger_jobinterval = 100
-# cellranger_localmem and cellranger_localcores only used if jobmode is 'local'
+# cellranger_localmem and cellranger_localcores only used if jobmode
+# is 'local'
 cellranger_localmem = 5
 cellranger_localcores = 1
 


### PR DESCRIPTION
PR to address issue #613 by updating the `make_fastqs` and `run_qc` commands to run with a maximum number of cores/slots set from the configuration (as an alternative to setting the maximum number of concurrent jobs).

The changes include:

* Adding a new `max_cores` configuration parameter in `settings` (default is `None`)
* Assigning this value to the scheduler used in the pipelines called by the `make_fastqs` and `run_qc` command

The changes also require fixing a bug in `SimpleScheduler` whereby if the maximum number of concurrent jobs or slots were supplied as zero, then the scheduler would use this as the limit (rather than assuming that zero indicates "no limits").

The command line interfaces for the `make_fastqs` and `run_qc` commands have been updated:

* `--maxjobs` (`-j`) and `--maxcores`  (`-c`) options enable the limits on jobs and cores to be set or unset
* Defaults are taken from configuration
* The `cellranger` control options in `make_fastqs` have been updated and separated from the pipeline job control options

Also `run_qc.py` has been updated to take the default maximum number of cores from the configuration.