### PR TITLE
run_qc.py: stop if QC directory already exists unless --update option used

### DIFF
--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -130,6 +130,11 @@ if __name__ == "__main__":
     reporting.add_argument('-f','--filename',action='store',
                            help="file name for output QC report (default: "
                            "<OUT_DIR>/<QC_DIR_NAME>_report.html)")
+    reporting.add_argument('-u','--update',action='store_true',
+                           help="force QC pipeline to run even if output "
+                           "QC directory already exists in <OUT_DIR> "
+                           "(default: stop if output QC directory already "
+                           "exists)")
     # Project metadata
     metadata = p.add_argument_group('Metadata')
     metadata.add_argument('--organism',metavar='ORGANISM',
@@ -536,6 +541,14 @@ if __name__ == "__main__":
         qc_dir = 'qc'
     qc_dir = os.path.join(out_dir,qc_dir)
     print("QC directory    : %s" % qc_dir)
+
+    # Check if QC directory already exists
+    if os.path.exists(qc_dir):
+        if not args.update:
+            logger.fatal("QC directory already exists (use --update to "
+                         "run QC anyway)")
+            sys.exit(1)
+        print("Output QC directory already exists, updating")
 
     # Output file name
     if args.filename is None:

--- a/docs/source/using/run_qc_standalone.rst
+++ b/docs/source/using/run_qc_standalone.rst
@@ -79,6 +79,14 @@ The following options can be used to override the defaults:
 * ``--name``: sets the name for the project (used in the
   QC report title)
 
+Updating existing QC outputs
+----------------------------
+
+If the output directory for the QC already exists then by
+default ``run_qc.py`` will stop without running the pipeline;
+to override this behaviour and update an existing QC output
+directory, specify the ``-u`` or ``--update`` option.
+
 Running 10xGenomics single library analyses
 -------------------------------------------
 


### PR DESCRIPTION
PR which updates `run_qc.py` so that it will stop if an existing QC directory is detected (issue #617). A new option `--update` can be used to override this behaviour.