### PR TITLE
run_qc.py: fix failure when running on existing project directory

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -643,7 +643,7 @@ class AnalysisProject(object):
                             "for project '%s': directory doesn't exist"
                             % (new_primary_fastq_dir,self.name))
 
-    def use_fastq_dir(self,fastq_dir=None):
+    def use_fastq_dir(self,fastq_dir=None,strict=True):
         """
         Switch fastq directory and repopulate
 
@@ -652,6 +652,17 @@ class AnalysisProject(object):
 
         Relative paths are assumed to be subdirectories
         of the project directory.
+
+        Arguments:
+          fastq_dir (str): path to the fastq dir to switch
+            to; must be a subdirectory of the project,
+            otherwise an exception is raised unless 'strict'
+            is set to False
+          strict (bool): if True (the default) then
+            'fastq_dir' must resolve to a subdirectory of
+            the project; otherwise an exception is raised.
+            Setting 'strict' to False allows the fastq dir
+            to be outside of the project
         """
         if fastq_dir is None:
             fastq_dir = self.info.primary_fastq_dir
@@ -669,9 +680,12 @@ class AnalysisProject(object):
         full_fastq_dir = os.path.normpath(full_fastq_dir)
         if full_fastq_dir not in [os.path.normpath(os.path.join(self.dirn,d))
                                   for d in self.fastq_dirs]:
-            raise Exception("Fastq dir '%s' not found in "
-                            "project '%s' (%s)" %
-                            (fastq_dir,self.name,self.dirn))
+            msg = "Fastq dir '%s' not found in project '%s' (%s)" % \
+                  (fastq_dir,self.name,self.dirn)
+            if strict:
+                raise Exception(msg)
+            else:
+                logger.warning(msg)
         self.populate(fastq_dir=fastq_dir)
 
     def setup_qc_dir(self,qc_dir=None,fastq_dir=None):

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -833,6 +833,43 @@ class TestAnalysisProject(unittest.TestCase):
         self.assertRaises(Exception,
                           project.use_fastq_dir,'fastqs.non_existant')
 
+    def test_analysis_project_switch_to_fastq_dir_outside_project_strict(self):
+        """Check AnalysisProject fails when switching to fastqs dir outside the project
+        """
+        self.make_mock_project_dir(
+            'PJB',
+            ('PJB1-A_ACAGTG_L001_R1_001.fastq.gz',
+             'PJB1-B_ACAGTG_L002_R1_001.fastq.gz',))
+        dirn = os.path.join(self.dirn,'PJB')
+        external_fastqs_dir = os.path.join(self.dirn,"external_fastqs")
+        os.mkdir(external_fastqs_dir)
+        for fq in ('PJB2-A_ACAGTG_L001_R1_001.fastq.gz',
+                   'PJB2-B_ACAGTG_L002_R1_001.fastq.gz',):
+            with open(os.path.join(external_fastqs_dir,fq),'wt') as fp:
+                fp.write("")
+        project = AnalysisProject('PJB',dirn)
+        self.assertRaises(Exception,
+                          project.use_fastq_dir,external_fastqs_dir)
+
+    def test_analysis_project_switch_to_fastq_dir_outside_project_not_strict(self):
+        """Check AnalysisProject ok when switching to fastqs dir outside the project when 'strict' is off
+        """
+        self.make_mock_project_dir(
+            'PJB',
+            ('PJB1-A_ACAGTG_L001_R1_001.fastq.gz',
+             'PJB1-B_ACAGTG_L002_R1_001.fastq.gz',))
+        dirn = os.path.join(self.dirn,'PJB')
+        external_fastqs_dir = os.path.join(self.dirn,"external_fastqs")
+        os.mkdir(external_fastqs_dir)
+        for fq in ('PJB2-A_ACAGTG_L001_R1_001.fastq.gz',
+                   'PJB2-B_ACAGTG_L002_R1_001.fastq.gz',):
+            with open(os.path.join(external_fastqs_dir,fq),'wt') as fp:
+                fp.write("")
+        project = AnalysisProject('PJB',dirn)
+        project.use_fastq_dir(external_fastqs_dir,strict=False)
+        self.assertEqual(project.fastq_dir,
+                         os.path.join(external_fastqs_dir))
+
     def test_analysis_project_switch_fastq_dir_preserves_qc_dir(self):
         """Check AnalysisProject switch fastqs dirs preserves QC dir
         """

--- a/bin/reportqc.py
+++ b/bin/reportqc.py
@@ -187,7 +187,7 @@ def main():
                                     "(%s != %s)" % (fastq_dir,
                                                     qc_info.fastq_dir))
         print("...using Fastqs dir: %s" % p.fastq_dir)
-        p.use_fastq_dir(fastq_dir)
+        p.use_fastq_dir(fastq_dir,strict=False)
         projects.append(p)
 
     # Verify QC for projects

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -325,6 +325,7 @@ if __name__ == "__main__":
             else:
                 inputs.append(ff)
     # Get list of Fastqs from directory
+    dir_path = None
     if len(inputs) == 1 and os.path.isdir(inputs[0]):
         dir_path = inputs[0]
         if not os.path.isdir(dir_path):
@@ -525,7 +526,10 @@ if __name__ == "__main__":
     # Output directory
     announce("Setting up output destinations")
     if not out_dir:
-        out_dir = os.getcwd()
+        if dir_path:
+            out_dir = dir_path
+        else:
+            out_dir = os.getcwd()
     out_dir = os.path.abspath(out_dir)
     print("Output directory: %s" % out_dir)
     if not os.path.exists(out_dir):


### PR DESCRIPTION
PR that attempts to address the bug reported in issue #647, whereby the reporting fails when `run_qc.py` is run on an existing project directory using a command line of the form:

    run_qc.py PROJECT

`reportqc.py` invoked within the pipeline fails as it expects the source Fastq directory to be a subdir of PROJECT, but `run_qc.py` invokes the pipeline using a temporary project directory elsewhere with its own Fastq directory.

The fix relaxes this subdirectory requirement in `reportqc.py`, and requires an update to the `use_fastq_dir` method of `AnalysisProject` which introduces a new flag that can turn the checking off.