### PR TITLE
Move 'bcl2fastq utils.py' to 'bcl2fastq/utils.py'

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -36,7 +36,7 @@ from .metadata import AnalysisDirMetadata
 from .metadata import ProjectMetadataFile
 from .utils import edit_file
 from .utils import get_numbered_subdir
-from .bcl2fastq_utils import get_sequencer_platform
+from .bcl2fastq.utils import get_sequencer_platform
 from .samplesheet_utils import check_and_warn
 from .settings import Settings
 from .exceptions import MissingParameterFileException

--- a/auto_process_ngs/barcodes/pipeline.py
+++ b/auto_process_ngs/barcodes/pipeline.py
@@ -29,9 +29,9 @@ import shutil
 import tempfile
 from ..analysis import AnalysisFastq
 from ..applications import Command
-from ..bcl2fastq_utils import get_nmismatches
-from ..bcl2fastq_utils import bases_mask_is_valid
-from ..bcl2fastq_utils import check_barcode_collisions
+from ..bcl2fastq.utils import get_nmismatches
+from ..bcl2fastq.utils import bases_mask_is_valid
+from ..bcl2fastq.utils import check_barcode_collisions
 from ..pipeliner import Pipeline
 from ..pipeliner import PipelineTask
 from ..pipeliner import PipelineCommandWrapper

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -63,14 +63,14 @@ from ..applications import general as general_apps
 from ..applications import bcl2fastq as bcl2fastq_apps
 from ..applications import Command
 from ..barcodes.pipeline import AnalyseBarcodes
-from ..bcl2fastq_utils import available_bcl2fastq_versions
-from ..bcl2fastq_utils import bases_mask_is_valid
-from ..bcl2fastq_utils import bcl_to_fastq_info
-from ..bcl2fastq_utils import check_barcode_collisions
-from ..bcl2fastq_utils import get_bases_mask
-from ..bcl2fastq_utils import get_nmismatches
-from ..bcl2fastq_utils import get_sequencer_platform
-from ..bcl2fastq_utils import make_custom_sample_sheet
+from ..bcl2fastq.utils import available_bcl2fastq_versions
+from ..bcl2fastq.utils import bases_mask_is_valid
+from ..bcl2fastq.utils import bcl_to_fastq_info
+from ..bcl2fastq.utils import check_barcode_collisions
+from ..bcl2fastq.utils import get_bases_mask
+from ..bcl2fastq.utils import get_nmismatches
+from ..bcl2fastq.utils import get_sequencer_platform
+from ..bcl2fastq.utils import make_custom_sample_sheet
 from ..fastq_utils import group_fastqs_by_name
 from ..fileops import Location
 from ..icell8.utils import get_bases_mask_icell8

--- a/auto_process_ngs/bcl2fastq/utils.py
+++ b/auto_process_ngs/bcl2fastq/utils.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python
 #
-#     bcl2fastq_utils.py: utility functions for bcl2fastq conversion
-#     Copyright (C) University of Manchester 2013-2019 Peter Briggs
+#     bcl2fastq/utils.py: utility functions for bcl2fastq conversion
+#     Copyright (C) University of Manchester 2013-2021 Peter Briggs
 #
 ########################################################################
 #
-# bclToFastq.py
+# bcl2fastq/utils.py
 #
 #########################################################################
 
 """
-bcl2fastq_utils.py
+bcl2fastq/utils.py
 
 Utility functions for bcl to fastq conversion operations:
 
@@ -33,13 +33,13 @@ Utility functions for bcl to fastq conversion operations:
 import os
 import re
 import logging
-from .applications import Command
-from .applications import bcl2fastq as bcl2fastq_apps
-from .applications import general as general_apps
-from .simple_scheduler import SchedulerJob
-from .utils import find_executables
-from .utils import parse_version
-from .samplesheet_utils import barcode_is_10xgenomics
+from ..applications import Command
+from ..applications import bcl2fastq as bcl2fastq_apps
+from ..applications import general as general_apps
+from ..simple_scheduler import SchedulerJob
+from ..utils import find_executables
+from ..utils import parse_version
+from ..samplesheet_utils import barcode_is_10xgenomics
 import bcftbx.IlluminaData as IlluminaData
 import bcftbx.platforms as platforms
 import bcftbx.utils as bcf_utils

--- a/auto_process_ngs/commands/setup_cmd.py
+++ b/auto_process_ngs/commands/setup_cmd.py
@@ -16,8 +16,8 @@ except ImportError:
     # Failed to get Python3 urlopen, fallback to Python2
     from urllib2 import urlopen
     from urllib2 import URLError
-from ..bcl2fastq_utils import get_sequencer_platform
-from ..bcl2fastq_utils import make_custom_sample_sheet
+from ..bcl2fastq.utils import get_sequencer_platform
+from ..bcl2fastq.utils import make_custom_sample_sheet
 from ..applications import general as general_applications
 from ..fileops import exists
 from ..fileops import Location

--- a/auto_process_ngs/icell8/utils.py
+++ b/auto_process_ngs/icell8/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     icell8.utils.py: utility functions for handling ICELL8 data
-#     Copyright (C) University of Manchester 2017-2020 Peter Briggs
+#     Copyright (C) University of Manchester 2017-2021 Peter Briggs
 #
 
 """
@@ -43,7 +43,7 @@ from bcftbx.IlluminaData import samplesheet_index_sequence
 from bcftbx.IlluminaData import fix_bases_mask
 from bcftbx.TabFile import TabFile
 from ..applications import Command
-from ..bcl2fastq_utils import get_bases_mask
+from ..bcl2fastq.utils import get_bases_mask
 from ..fastq_utils import FastqReadCounter
 from ..fastq_utils import pair_fastqs
 from ..fastq_utils import get_read_count

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -56,7 +56,7 @@ from .docwriter import List
 from .docwriter import Link
 from .docwriter import Table
 from .analysis import AnalysisProject
-from .bcl2fastq_utils import get_bases_mask
+from .bcl2fastq.utils import get_bases_mask
 from .utils import get_numbered_subdir
 from .utils import ZipArchive
 from . import css_rules

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -19,7 +19,7 @@ from auto_process_ngs.bcl2fastq.pipeline import PathJoinParam
 from auto_process_ngs.bcl2fastq.pipeline import PathExistsParam
 from auto_process_ngs.bcl2fastq.pipeline import FunctionParam
 from auto_process_ngs.bcl2fastq.pipeline import subset
-from auto_process_ngs.bcl2fastq_utils import make_custom_sample_sheet
+from auto_process_ngs.bcl2fastq.utils import make_custom_sample_sheet
 
 # Set to False to keep test output dirs
 REMOVE_TEST_OUTPUTS = True

--- a/auto_process_ngs/test/bcl2fastq/test_utils.py
+++ b/auto_process_ngs/test/bcl2fastq/test_utils.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Tests for bcl2fastq_utils.py module
+# Tests for bcl2fastq/utils.py module
 #######################################################################
 
 import unittest
@@ -8,7 +8,7 @@ import os
 import shutil
 from bcftbx.mock import RunInfoXml
 from auto_process_ngs.settings import Settings
-from auto_process_ngs.bcl2fastq_utils import *
+from auto_process_ngs.bcl2fastq.utils import *
 
 # Set to False to keep test output dirs
 REMOVE_TEST_OUTPUTS = True

--- a/bin/analyse_barcodes.py
+++ b/bin/analyse_barcodes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     analyse_barcodes.py: analyse index sequences from Illumina FASTQs
-#     Copyright (C) University of Manchester 2016,2019 Peter Briggs
+#     Copyright (C) University of Manchester 2016-2021 Peter Briggs
 #
 """
 analyse_barcodes.py
@@ -27,8 +27,8 @@ from bcftbx.utils import parse_lanes
 from auto_process_ngs.barcodes.analysis import BarcodeCounter
 from auto_process_ngs.barcodes.analysis import Reporter
 from auto_process_ngs.barcodes.analysis import report_barcodes
-from auto_process_ngs.bcl2fastq_utils import make_custom_sample_sheet
-from auto_process_ngs.bcl2fastq_utils import check_barcode_collisions
+from auto_process_ngs.bcl2fastq.utils import make_custom_sample_sheet
+from auto_process_ngs.bcl2fastq.utils import check_barcode_collisions
 from auto_process_ngs.tenx_genomics_utils import has_10x_indices
 
 from auto_process_ngs import get_version


### PR DESCRIPTION
PR which refactors the libraries to move the `bcl2fastq_utils` module into `bcl2fastq.utils`, and updates the code to accommodate the new location. The functions and classes in the module are unchanged.