### PR TITLE
pipeliner: update handling of task requirements

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -3115,7 +3115,10 @@ class FunctionParam(BaseParam):
                 kws[kw] = self._kws[kw].value
             except AttributeError:
                 kws[kw] = self._kws[kw]
-        return self._f(*args,**kws)
+        try:
+            return self._f(*args,**kws)
+        except Exception as ex:
+            raise Exception("Failed to evaluate function: %s" % ex)
 
 class PathJoinParam(FunctionParam):
     """

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -1135,12 +1135,14 @@ class PipelineParam(BaseParam):
             instance
         """
         BaseParam.__init__(self)
+        self._name = None
         self._value = None
         self._type = type
         self._default = default
         if value is not None:
             self.set(value)
-        self._name = str(name)
+        if name:
+            self._name = str(name)
         self._replace_with = None
     def set(self,newvalue):
         """
@@ -1204,6 +1206,16 @@ class PipelineParam(BaseParam):
         Return the name of the parameter (if supplied)
         """
         return self._name
+    def __repr__(self):
+        args = []
+        if self._name:
+            args.append("name='%s'" % self._name)
+        args.append("value='%s'" % (self._value,))
+        if self._type:
+            args.append("type='%s'" % self._type)
+        if self._default:
+            args.append("default='%s'" % (self._default,))
+        return "PipelineParam(%s)" % ','.join(args)
 
 class FileCollector(Iterator):
     """

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2457,9 +2457,19 @@ class PipelineTask(object):
                 task_id = t.id()
             except AttributeError:
                 raise Exception("%s: not a task?" % t)
-            # Add ID if not already a requirement
-            if task_id not in self._required_task_ids:
-                self._required_task_ids.append(task_id)
+            # Add ID
+            self.requires_id(task_id)
+
+    def requires_id(self,task_id):
+        """
+        Add task ID to list of requirements
+
+        Arguments:
+          task_id (str): UUID of the task to be added
+            as a requirement
+        """
+        if task_id not in self._required_task_ids:
+            self._required_task_ids.append(task_id)
         self._required_task_ids = sorted(self._required_task_ids)
 
     @property

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -1763,7 +1763,8 @@ class Pipeline(object):
             the tasks that will run first)
         """
         ranks = self.rank_tasks()
-        return [self.get_task(t)[0] for t in ranks[0]]
+        return sorted([self.get_task(t)[0] for t in ranks[0]],
+                      key=lambd t: t.id())
 
     @property
     def final_tasks(self):
@@ -1779,7 +1780,7 @@ class Pipeline(object):
         for task_id in self.task_list():
             if not self.get_dependent_tasks(task_id):
                 final_tasks.append(self.get_task(task_id)[0])
-        return final_tasks
+        return sorted(final_tasks,key=lambda t: t.id())
 
     def get_dependent_tasks(self,task_id):
         """

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -1764,7 +1764,7 @@ class Pipeline(object):
         """
         ranks = self.rank_tasks()
         return sorted([self.get_task(t)[0] for t in ranks[0]],
-                      key=lambd t: t.id())
+                      key=lambda t: t.id())
 
     @property
     def final_tasks(self):

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -26,6 +26,10 @@ Additional supporting classes:
 - PathJoinParam: PipelineParameter-like dynamic file path joiner
 - PathExistsParam: PipelineParameter-like dynamic file existence checker
 
+The following exception classes are defined:
+
+- PipelineError: general pipeline-related exception
+
 There are some underlying classes and functions that are intended for
 internal use:
 
@@ -1882,7 +1886,7 @@ class Pipeline(object):
                 if r in self.runners:
                     self.runners[r].set(runners[r])
                 else:
-                    raise Exception("Undefined runner '%s'" % r)
+                    raise PipelineError("Undefined runner '%s'" % r)
         if default_runner:
             self.runners['default'].set(default_runner)
         # Deal with environment modules
@@ -2261,8 +2265,8 @@ class PipelineTask(object):
         # Execute the init method
         self.invoke(self.init,self._args,self._kws)
         if self._exit_code != 0:
-            raise Exception("Error running 'init' method for task '%s' "
-                            "(%s)" % (self._name,self.__class__))
+            raise PipelineError("Error running 'init' method for task '%s' "
+                                "(%s)" % (self._name,self.__class__))
 
     @property
     def args(self):
@@ -2565,7 +2569,7 @@ class PipelineTask(object):
             try:
                 task_id = t.id()
             except AttributeError:
-                raise Exception("%s: not a task?" % t)
+                raise PipelineError("%s: not a task?" % t)
             # Add ID
             self.requires_id(task_id)
 
@@ -3118,7 +3122,7 @@ class FunctionParam(BaseParam):
         try:
             return self._f(*args,**kws)
         except Exception as ex:
-            raise Exception("Failed to evaluate function: %s" % ex)
+            raise PipelineError("Failed to evaluate function: %s" % ex)
 
 class PathJoinParam(FunctionParam):
     """
@@ -3370,7 +3374,7 @@ class Dispatcher(object):
             else:
                 return result
         else:
-            raise Exception("Pickled output not found")
+            raise PipelineError("Pickled output not found")
 
     def _pickle_object(self,obj,pickle_file=None):
         """
@@ -3405,6 +3409,15 @@ class Dispatcher(object):
         """
         with open(pickle_file,'rb') as fp:
             return self._pickler.loads(fp.read())
+
+######################################################################
+# Custom exceptions
+######################################################################
+
+class PipelineError(Exception):
+    """
+    Base class for pipeline-specific exceptions
+    """
 
 ######################################################################
 # Utility functions

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -966,18 +966,48 @@ class PipelineFailure(object):
 class BaseParam(object):
     """
     Provide base class for PipelineParam-type classes
+
+    Implements core functionality that should be
+    shared across all parameter-like classes, including
+    assigning a UUID and enabling a task ID to be
+    associated with the parameter.
+
+    Provides the following attributes:
+
+    - uuid
+    - associated_task_id
+
+    and the following methods:
+
+    - associate_task
     """
     def __init__(self):
         """
         Base class for PipelineParam-type class
         """
         self._uuid = uuid.uuid4()
+        self._associated_task_id = None
+    def associate_task(self,task):
+        """
+        Associate a task with the parameter
+
+        Arguments:
+          task (PipelineTask): a task object to
+            associate with the parameter
+        """
+        self._associated_task_id = task.id()
     @property
     def uuid(self):
         """
         Return the unique identifier (UUID) of the parameter
         """
         return self._uuid
+    @property
+    def associated_task_id(self):
+        """
+        Return the task ID of the associated task (or None)
+        """
+        return self._associated_task_id
 
 class PipelineParam(BaseParam):
     """

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -451,8 +451,11 @@ Requirements can be specified in different ways:
    method then a list of required tasks can also be specified
    via the ``requires`` argument;
 
-2. Requirements can also be added directly to a task using
-   its ``requires`` method.
+2. Requirements can be added directly to a task using its
+   ``requires`` method.
+
+3. A task can be made the requirement of other tasks using
+   its ``required_by`` method.
 
 Note that these two approaches are not exclusive, and can be
 used together on the same task to specify requirements in a
@@ -2552,6 +2555,21 @@ class PipelineTask(object):
                 raise Exception("%s: not a task?" % t)
             # Add ID
             self.requires_id(task_id)
+
+    def required_by(self,*tasks):
+        """
+        Add this task as a requirement of others
+
+        Each specified task will wait for this task
+        to complete before they can run.
+
+        Arguments:
+          tasks (List): list of PipelineTask objects
+            that will have this task added as a
+            requirement
+        """
+        for t in tasks:
+            t.requires(self)
 
     def requires_id(self,task_id):
         """

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -2371,6 +2371,27 @@ class TestFunctionParam(unittest.TestCase):
         pz.set("backwards")
         self.assertEqual(func_param.value,("goodbye","hello","backwards"))
 
+    def test_functionparam_trap_exceptions_from_function(self):
+        """
+        FunctionParam: trap exceptions from function call
+        """
+        # Trap type error
+        exception = False
+        try:
+            FunctionParam(lambda x: int(x),"non integer").value
+        except Exception:
+            exception = True
+        self.assertTrue(exception,"Should have raised exception")
+        # Trap attribute error
+        exception = False
+        try:
+            FunctionParam(lambda x: x.missing,123).value
+        except AttributeError:
+            pass
+        except Exception:
+            exception = True
+        self.assertTrue(exception,"Should have raised exception")
+
 class TestDispatcher(unittest.TestCase):
 
     def setUp(self):

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -1251,6 +1251,27 @@ class TestPipelineTask(unittest.TestCase):
         self.assertEqual(t3.required_task_ids,
                          sorted([t2.id(),t1.id()]))
 
+    def test_pipelinetask_implied_requirement_from_input_param(self):
+        """
+        PipelineTask: check implied task requirements from inputs
+        """
+        # Define task for testing
+        class AppendTask(PipelineTask):
+            def init(self,*inputs,**kws):
+                self.add_output('result',PipelineParam(type=list()))
+            def setup(self):
+                for x in self.args.inputs:
+                    self.output.results.value.append(x)
+        # Instantiate tasks
+        t1 = AppendTask("Task1",1,2)
+        t2 = AppendTask("Task2",t1.output.result,4)
+        t3 = AppendTask("Task3",t1.output.result,extras=t2.output.result)
+        # Check requirements on both tasks
+        self.assertEqual(t1.required_task_ids,[])
+        self.assertEqual(t2.required_task_ids,[t1.id()])
+        self.assertEqual(t3.required_task_ids,
+                         sorted([t2.id(),t1.id()]))
+
     def test_pipelinetask_raise_exception_for_non_task_requirement(self):
         """
         PipelineTask: raise exception if requirement is not a task

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -1301,6 +1301,37 @@ class TestPipelineTask(unittest.TestCase):
         self.assertEqual(t3.required_task_ids,
                          sorted([t2.id(),t1.id()]))
 
+    def test_pipelinetask_required_by(self):
+        """
+        PipelineTask: check tasks required by others
+        """
+        # Define task for testing
+        class AppendTask(PipelineTask):
+            def init(self,*inputs):
+                self.add_output('result',list())
+            def setup(self):
+                for x in self.args.inputs:
+                    self.output.results.append(x)
+        # Instantiate tasks
+        t1 = AppendTask("Task1",1,2)
+        t2 = AppendTask("Task2",3,4)
+        t3 = AppendTask("Task3",5,6)
+        # Check requirements on all tasks
+        self.assertEqual(t1.required_task_ids,[])
+        self.assertEqual(t2.required_task_ids,[])
+        self.assertEqual(t3.required_task_ids,[])
+        # Make second and third task depend on first
+        t1.required_by(t2,t3)
+        self.assertEqual(t1.required_task_ids,[])
+        self.assertEqual(t2.required_task_ids,[t1.id()])
+        self.assertEqual(t3.required_task_ids,[t1.id()])
+        # Make third task depend on second
+        t2.required_by(t3)
+        self.assertEqual(t1.required_task_ids,[])
+        self.assertEqual(t2.required_task_ids,[t1.id()])
+        self.assertEqual(t3.required_task_ids,
+                         sorted([t2.id(),t1.id()]))
+
     def test_pipelinetask_implied_requirement_from_input_param(self):
         """
         PipelineTask: check implied task requirements from inputs

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -923,7 +923,8 @@ prepend-path PATH %s
         ppl.add_task(task3,requires=(task1,))
         ppl.add_task(task4,requires=(task3,))
         # Check the initial tasks
-        self.assertEqual(ppl.final_tasks,[task2,task4])
+        self.assertEqual(ppl.final_tasks,sorted([task2,task4],
+                                                key=lambda x: x.id()))
 
     def test_pipeline_method_get_dependent_tasks(self):
         """

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -1191,7 +1191,7 @@ class TestPipelineTask(unittest.TestCase):
         """
         PipelineTask: check task requirements
         """
-        # Define stask for testing
+        # Define task for testing
         class AppendTask(PipelineTask):
             def init(self,*inputs):
                 self.add_output('result',list())
@@ -1199,10 +1199,10 @@ class TestPipelineTask(unittest.TestCase):
                 for x in self.args.inputs:
                     self.output.results.append(x)
         # Instantiate tasks
-        t1 = AppendTask(1,2)
-        t2 = AppendTask(3,4)
-        t3 = AppendTask(5,6)
-        # Check requirements on both tasks
+        t1 = AppendTask("Task1",1,2)
+        t2 = AppendTask("Task2",3,4)
+        t3 = AppendTask("Task3",5,6)
+        # Check requirements on all tasks
         self.assertEqual(t1.required_task_ids,[])
         self.assertEqual(t2.required_task_ids,[])
         self.assertEqual(t3.required_task_ids,[])

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -875,6 +875,56 @@ prepend-path PATH %s
                          sorted([task2.id(),task3.id()]))
         self.assertEqual(ranked_tasks[2],[task4.id()])
 
+    def test_pipeline_method_initial_tasks(self):
+        """
+        Pipeline: test the 'initial_tasks' method
+        """
+        # Define a reusable task
+        # Appends item to a list
+        class Append(PipelineTask):
+            def init(self,l,s):
+                self.add_output('list',list())
+            def setup(self):
+                for item in self.args.l:
+                    self.output.list.append(item)
+                self.output.list.append(self.args.s)
+        # Make a pipeline
+        ppl = Pipeline()
+        task1 = Append("Append 1",(),"item1")
+        task2 = Append("Append 2",task1.output.list,"item2")
+        task3 = Append("Append 3",task1.output.list,"item3")
+        task4 = Append("Append 4",task3.output.list,"item4")
+        ppl.add_task(task2,requires=(task1,))
+        ppl.add_task(task3,requires=(task1,))
+        ppl.add_task(task4,requires=(task3,))
+        # Check the initial tasks
+        self.assertEqual(ppl.initial_tasks,[task1])
+
+    def test_pipeline_method_final_tasks(self):
+        """
+        Pipeline: test the 'final_tasks' method
+        """
+        # Define a reusable task
+        # Appends item to a list
+        class Append(PipelineTask):
+            def init(self,l,s):
+                self.add_output('list',list())
+            def setup(self):
+                for item in self.args.l:
+                    self.output.list.append(item)
+                self.output.list.append(self.args.s)
+        # Make a pipeline
+        ppl = Pipeline()
+        task1 = Append("Append 1",(),"item1")
+        task2 = Append("Append 2",task1.output.list,"item2")
+        task3 = Append("Append 3",task1.output.list,"item3")
+        task4 = Append("Append 4",task3.output.list,"item4")
+        ppl.add_task(task2,requires=(task1,))
+        ppl.add_task(task3,requires=(task1,))
+        ppl.add_task(task4,requires=(task3,))
+        # Check the initial tasks
+        self.assertEqual(ppl.final_tasks,[task2,task4])
+
     def test_pipeline_method_get_dependent_tasks(self):
         """
         Pipeline: test the 'get_dependent_tasks' method

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -24,6 +24,7 @@ from auto_process_ngs.pipeliner import PipelineParam
 from auto_process_ngs.pipeliner import PipelineFailure
 from auto_process_ngs.pipeliner import FileCollector
 from auto_process_ngs.pipeliner import Dispatcher
+from auto_process_ngs.pipeliner import BaseParam
 from auto_process_ngs.pipeliner import PathJoinParam
 from auto_process_ngs.pipeliner import PathExistsParam
 from auto_process_ngs.pipeliner import FunctionParam
@@ -1937,6 +1938,32 @@ class TestPipelineCommandWrapper(unittest.TestCase):
         # Add argument and check updated command
         cmd.add_args("there")
         self.assertEqual(str(cmd.cmd()),"echo hello there")
+
+class TestBaseParam(unittest.TestCase):
+
+    def test_baseparam_uuid(self):
+        """
+        BaseParam: check UUID
+        """
+        p = BaseParam()
+        self.assertNotEqual(p.uuid,None)
+
+    def test_associated_task(self):
+        """
+        BaseParam: check associated task
+        """
+        # Define a simple task
+        class SimpleTask(PipelineTask):
+            def init(self,x):
+                pass
+            def setup(self):
+                print(x)
+        t = SimpleTask("Simple task",x=12)
+        # Create and test associated task in a BaseParam
+        p = BaseParam()
+        self.assertEqual(p.associated_task_id,None)
+        p.associate_task(t)
+        self.assertEqual(p.associated_task_id,t.id())
 
 class TestPipelineParam(unittest.TestCase):
 

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -1218,6 +1218,38 @@ class TestPipelineTask(unittest.TestCase):
         self.assertEqual(t3.required_task_ids,
                          sorted([t2.id(),t1.id()]))
 
+    def test_pipelinetask_requirements_as_ids(self):
+        """
+        PipelineTask: check task requirements supplied as IDs
+        """
+        # Define task for testing
+        class AppendTask(PipelineTask):
+            def init(self,*inputs):
+                self.add_output('result',list())
+            def setup(self):
+                for x in self.args.inputs:
+                    self.output.results.append(x)
+        # Instantiate tasks
+        t1 = AppendTask("Task1",1,2)
+        t2 = AppendTask("Task2",3,4)
+        t3 = AppendTask("Task3",5,6)
+        # Check requirements on all tasks
+        self.assertEqual(t1.required_task_ids,[])
+        self.assertEqual(t2.required_task_ids,[])
+        self.assertEqual(t3.required_task_ids,[])
+        # Make second task depend on first
+        t2.requires_id(t1.id())
+        self.assertEqual(t1.required_task_ids,[])
+        self.assertEqual(t2.required_task_ids,[t1.id()])
+        self.assertEqual(t3.required_task_ids,[])
+        # Make third task depend on first and second
+        t3.requires_id(t1.id())
+        t3.requires_id(t2.id())
+        self.assertEqual(t1.required_task_ids,[])
+        self.assertEqual(t2.required_task_ids,[t1.id()])
+        self.assertEqual(t3.required_task_ids,
+                         sorted([t2.id(),t1.id()]))
+
     def test_pipelinetask_raise_exception_for_non_task_requirement(self):
         """
         PipelineTask: raise exception if requirement is not a task

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -2106,7 +2106,7 @@ class TestPipelineParam(unittest.TestCase):
         p.set(123)
         self.assertEqual(p.value,"123")
         self.assertEqual(repr(p),
-                         "PipelineParam(value='123',type='<class 'str'>')")
+                         "PipelineParam(value='123',type='%s')" % str(str))
         # Specify type function as 'int'
         p = PipelineParam(type=int)
         p.set(123)
@@ -2114,7 +2114,7 @@ class TestPipelineParam(unittest.TestCase):
         p.set("123")
         self.assertEqual(p.value,123)
         self.assertEqual(repr(p),
-                         "PipelineParam(value='123',type='<class 'int'>')")
+                         "PipelineParam(value='123',type='%s')" % str(int))
         # Exception for bad value
         p.set("abc")
         self.assertRaises(ValueError,lambda: p.value)
@@ -2125,7 +2125,7 @@ class TestPipelineParam(unittest.TestCase):
         p.set("1.23")
         self.assertEqual(p.value,1.23)
         self.assertEqual(repr(p),
-                         "PipelineParam(value='1.23',type='<class 'float'>')")
+                         "PipelineParam(value='1.23',type='%s')" % str(float))
         # Exception for bad value
         p.set("abc")
         self.assertRaises(ValueError,lambda: p.value)

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -28,6 +28,7 @@ from auto_process_ngs.pipeliner import BaseParam
 from auto_process_ngs.pipeliner import PathJoinParam
 from auto_process_ngs.pipeliner import PathExistsParam
 from auto_process_ngs.pipeliner import FunctionParam
+from auto_process_ngs.pipeliner import PipelineError
 from auto_process_ngs.pipeliner import resolve_parameter
 from bcftbx.JobRunner import SimpleJobRunner
 
@@ -1233,7 +1234,7 @@ class TestPipelineTask(unittest.TestCase):
                             self.args.d,
                             self.args.e)
                 self.output.results.append(result)
-        self.assertRaises(Exception,
+        self.assertRaises(PipelineError,
                           FailInit,
                           "This will fail on init",
                           "a",
@@ -1371,7 +1372,7 @@ class TestPipelineTask(unittest.TestCase):
         self.assertEqual(t1.required_task_ids,[])
         # Raise exception by trying to adding a non-task
         # object as a requirement
-        self.assertRaises(Exception,
+        self.assertRaises(PipelineError,
                           t1.requires,
                           "not_a_task")
 
@@ -2379,17 +2380,19 @@ class TestFunctionParam(unittest.TestCase):
         exception = False
         try:
             FunctionParam(lambda x: int(x),"non integer").value
-        except Exception:
+        except PipelineError:
             exception = True
+        except Exception:
+            pass
         self.assertTrue(exception,"Should have raised exception")
         # Trap attribute error
         exception = False
         try:
             FunctionParam(lambda x: x.missing,123).value
-        except AttributeError:
-            pass
-        except Exception:
+        except PipelineError:
             exception = True
+        except Exception:
+            pass
         self.assertTrue(exception,"Should have raised exception")
 
 class TestDispatcher(unittest.TestCase):

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -2081,6 +2081,7 @@ class TestPipelineParam(unittest.TestCase):
         self.assertEqual(p.value,"abc")
         p.set(123)
         self.assertEqual(p.value,123)
+        self.assertEqual(repr(p),"PipelineParam(value='123')")
 
     def test_pipelineparam_with_initial_value(self):
         """
@@ -2091,6 +2092,7 @@ class TestPipelineParam(unittest.TestCase):
         self.assertEqual(p.value,"abc")
         p = PipelineParam(value="def")
         self.assertEqual(p.value,"def")
+        self.assertEqual(repr(p),"PipelineParam(value='def')")
 
     def test_pipelineparam_with_type(self):
         """
@@ -2102,12 +2104,16 @@ class TestPipelineParam(unittest.TestCase):
         self.assertEqual(p.value,"abc")
         p.set(123)
         self.assertEqual(p.value,"123")
+        self.assertEqual(repr(p),
+                         "PipelineParam(value='123',type='<class 'str'>')")
         # Specify type function as 'int'
         p = PipelineParam(type=int)
         p.set(123)
         self.assertEqual(p.value,123)
         p.set("123")
         self.assertEqual(p.value,123)
+        self.assertEqual(repr(p),
+                         "PipelineParam(value='123',type='<class 'int'>')")
         # Exception for bad value
         p.set("abc")
         self.assertRaises(ValueError,lambda: p.value)
@@ -2117,6 +2123,8 @@ class TestPipelineParam(unittest.TestCase):
         self.assertEqual(p.value,1.23)
         p.set("1.23")
         self.assertEqual(p.value,1.23)
+        self.assertEqual(repr(p),
+                         "PipelineParam(value='1.23',type='<class 'float'>')")
         # Exception for bad value
         p.set("abc")
         self.assertRaises(ValueError,lambda: p.value)
@@ -2138,6 +2146,8 @@ class TestPipelineParam(unittest.TestCase):
         # Specify a name
         p = PipelineParam(name="my_param")
         self.assertEqual(p.name,"my_param")
+        self.assertEqual(repr(p),
+                         "PipelineParam(name='my_param',value='None')")
 
     def test_pipelineparam_handles_None_value(self):
         """


### PR DESCRIPTION
PR which addresses issue #642 and enables explicit task requirements to be specified directly on task instances via a new `requires` method, e.g.

    ...
    task1 = PipelineTask(...)
    task2 = PipelineTask(...)
    task2.requires(task1)
    ...

Task requirements can also be specified "in reverse" using the new `required_by` method, e.g.

    ...
    task1 = PipelineTask(...)
    task2 = PipelineTask(...)
    task1.required_by(task2)
    ...

Finally, using parameter-like objects (i.e. those based on ``BaseParam``) output from one task as input to another task implicitly adds a requirement for the first task onto the second (this is implemented via new functionality in ``BaseParam``, to enable a task ID to be associated with the parameter; when parameter-like outputs are added to a task, the task ID is also added to the output and is subsequently used to define requirements when it's used as input to another task).

Other changes related to implementing this functionality are included in the PR:

- new `initial_tasks` and `final_tasks` properties added to `Pipeline` instances, and used when combining pipelines together;
- implemented `__repr__` method on `PipelineParam` instances;
- bugfix for `FunctionParam` to trap for exceptions when evaluating the stored function;
- new custom exception class `PipelineError` used when raising pipeline-specific exceptions.