### PR TITLE
pipeliner: transfer 'MODULEPATH' in environment to wrapper scripts

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2775,6 +2775,12 @@ class PipelineCommand(object):
                     "echo \"#### START $(date)\""]
         if envmodules:
             shell += " --login"
+            try:
+                modulepath = os.environ['MODULEPATH']
+                if modulepath:
+                    prologue.append("export MODULEPATH=%s" % modulepath)
+            except KeyError:
+                pass
             for module in envmodules:
                 if module is not None:
                     prologue.append("module load %s" % module)


### PR DESCRIPTION
PR which fixes an issue when using environment modules in a `pipeliner` pipeline, for cases where the `MODULEPATH` environment variable is required to locate module files but is only set in the shell where the pipeline is invoked (and not in e.g. the `.bashrc` file).

In these cases `MODULEPATH` is not set in the wrapper script generated to run the command, and `module load` fails.

The fix is to explicitly set the `MODULEPATH` environment variable in the wrapper script to its value (if any) in the invoking shell.