### PR TITLE
'make_fastqs': run barcode analysis by default for 10xGenomics datasets

### DIFF
--- a/auto_process_ngs/barcodes/pipeline.py
+++ b/auto_process_ngs/barcodes/pipeline.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     barcodes.pipeline.py: pipelines for analysing barcodes
-#     Copyright (C) University of Manchester 2019-2020 Peter Briggs
+#     Copyright (C) University of Manchester 2019-2021 Peter Briggs
 #
 
 """

--- a/auto_process_ngs/barcodes/pipeline.py
+++ b/auto_process_ngs/barcodes/pipeline.py
@@ -277,6 +277,16 @@ class AnalyseBarcodes(Pipeline):
                 raise Exception("No bcl2fastq output directory specified")
         bcl2fastq_dir = os.path.abspath(bcl2fastq_dir)
 
+        # Input sample sheet
+        if self._sample_sheet is not None:
+            if sample_sheet is None:
+                sample_sheet = self._sample_sheet
+            else:
+                raise Exception("Samplesheet already set")
+        else:
+            if sample_sheet is not None:
+                sample_sheet = os.path.abspath(sample_sheet)
+
         # Barcode analysis and counts directories
         barcode_analysis_dir = os.path.abspath(barcode_analysis_dir)
         counts_dir = os.path.join(barcode_analysis_dir,"counts")

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -1473,6 +1473,9 @@ class MakeFastqs(Pipeline):
             self.add_pipeline(analyse_barcodes,
                               params={
                                   'bcl2fastq_dir': self.params.out_dir,
+                                  'title': Param(
+                                      value="Barcode analysis for %s" %
+                                      os.path.basename(self._run_dir)),
                                   'lanes': Param(
                                       value=lanes_for_barcode_analysis),
                               },

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -530,28 +530,11 @@ class MakeFastqs(Pipeline):
                 # ICELL8 single-cell ATAC-seq
                 self._update_subset(s,
                                     create_fastq_for_index_read=True)
-            elif protocol == '10x_chromium_sc':
-                # 10xGenomics Chromium SC
-                # Turn off barcode analysis
-                self._update_subset(s,
-                                    analyse_barcodes=False)
-            elif protocol == '10x_atac':
-                # 10xGenomics ATAC-seq
-                # Turn off barcode analysis
-                self._update_subset(s,
-                                    analyse_barcodes=False)
-            elif protocol == '10x_visium':
-                # 10xGenomics Visium
-                # Turn off barcode analysis
-                self._update_subset(s,
-                                    analyse_barcodes=False)
             elif protocol == '10x_multiome':
                 # 10xGenomics multiome
-                # Turn off barcode analysis and
-                # disable adapter trimming
+                # Disable adapter trimming
                 self._update_subset(s,
-                                    trim_adapters=False,
-                                    analyse_barcodes=False)
+                                    trim_adapters=False)
             
         # Finally update parameters for user-defined
         # lane subsets (overriding both pipeline and
@@ -1471,7 +1454,7 @@ class MakeFastqs(Pipeline):
         # Append pipeline for barcode analysis
         if not self._fastq_statistics:
             do_barcode_analysis = False
-        elif len(self.subsets) == 1:
+        elif len(self.subsets) == 1 and not self.subsets[0]['lanes']:
             try:
                 do_barcode_analysis = self.subsets[0]['analyse_barcodes']
             except KeyError:
@@ -1492,7 +1475,6 @@ class MakeFastqs(Pipeline):
                                   'bcl2fastq_dir': self.params.out_dir,
                                   'lanes': Param(
                                       value=lanes_for_barcode_analysis),
-                                  'mismatches': run_bcl2fastq.output.mismatches
                               },
                               requires=fastq_generation_tasks)
 

--- a/auto_process_ngs/test/barcodes/test_pipeline.py
+++ b/auto_process_ngs/test/barcodes/test_pipeline.py
@@ -45,7 +45,7 @@ class TestAnalyseBarcodes(unittest.TestCase):
                                     "Missing %s" % fastq)
                     with gzip.open(fastq,'wb') as fp:
                         fp.write(
-                            """@ILLUMINA-545855:49:FC61RLR:2:1:10979:1695 1:N:0:TCCTGA
+                            """@ILLUMINA-545855:49:FC61RLR:1:1:10979:1695 1:N:0:TCCTGA
 GCATACTCAGCTTTAGTAATAAGTGTGATTCTGGTA
 +
 IIIIIHIIIGHHIIDGHIIIIIIHIIIIIIIIIIIH

--- a/auto_process_ngs/test/barcodes/test_pipeline.py
+++ b/auto_process_ngs/test/barcodes/test_pipeline.py
@@ -9,6 +9,7 @@ import os
 import gzip
 from bcftbx.mock import MockIlluminaData
 from bcftbx.IlluminaData import IlluminaData
+from bcftbx.IlluminaData import IlluminaFastq
 from auto_process_ngs.mock import MockAnalysisDirFactory
 from auto_process_ngs.barcodes.pipeline import AnalyseBarcodes
 
@@ -41,15 +42,16 @@ class TestAnalyseBarcodes(unittest.TestCase):
             for s in p.samples:
                 for fq in s.fastq:
                     fastq = os.path.join(s.dirn,fq)
+                    lane = IlluminaFastq(fq).lane_number
                     self.assertTrue(os.path.exists(fastq),
                                     "Missing %s" % fastq)
                     with gzip.open(fastq,'wb') as fp:
-                        fp.write(
-                            """@ILLUMINA-545855:49:FC61RLR:1:1:10979:1695 1:N:0:TCCTGA
+                        data = """@ILLUMINA-545855:49:FC61RLR:%d:1:10979:1695 1:N:0:TCCTGA
 GCATACTCAGCTTTAGTAATAAGTGTGATTCTGGTA
 +
 IIIIIHIIIGHHIIDGHIIIIIIHIIIIIIIIIIIH
-                            """.encode())
+                            """ % lane
+                        fp.write(data.encode())
 
     def test_analyse_barcodes_with_bcl2fastq_dir_no_samplesheet(self):
         """

--- a/auto_process_ngs/test/barcodes/test_pipeline.py
+++ b/auto_process_ngs/test/barcodes/test_pipeline.py
@@ -203,6 +203,88 @@ CDE4,CDE4,,,D702,ATGTAACT,D501,CGTGTAGG,CDE,
             # Expect 12 lines of content in total
             self.assertEqual(contents.count('\n'),12)
 
+    def test_analyse_barcodes_with_samplesheet_and_10x_indices(self):
+        """
+        AnalyseBarcodes: sample sheet with 10xGenomics indices
+        """
+        # Create sample sheet
+        sample_sheet = os.path.join(self.wd,"custom_SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write("""[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+AB1,AB1,,,D501,SI-GA-A2,AB,
+AB2,AB2,,,D501,SI-GA-B2,AB,
+CDE3,CDE3,,,D501,SI-GA-C2,CDE,
+CDE4,CDE4,,,D501,SI-GA-D2,CDE,
+""")
+        # Set up pipeline before bcl2fastq directory exists
+        p = AnalyseBarcodes(sample_sheet=sample_sheet)
+        # Create the bcl2fastq directory before running pipeline
+        datadir = MockIlluminaData(
+            os.path.join(self.wd,
+                         "200428_M00879_0087_000000000-AGEW9"),
+            "bcl2fastq2",
+            unaligned_dir="bcl2fastq",
+            paired_end=True)
+        datadir.add_fastq_batch("AB","AB1","AB1_S1")
+        datadir.add_fastq_batch("AB","AB2","AB2_S2")
+        datadir.add_fastq_batch("CDE","CDE3","CDE3_S3")
+        datadir.add_fastq_batch("CDE","CDE4","CDE4_S4")
+        datadir.add_fastq_batch("","Undetermined","Undetermined_S0")
+        datadir.create()
+        # Add data to Fastq files
+        self._insert_fastq_reads(
+            os.path.join(self.wd,"200428_M00879_0087_000000000-AGEW9"))
+        # Run the pipeline
+        exit_code = p.run(os.path.join(self.wd,"barcode_analysis"),
+                          bcl2fastq_dir=os.path.join(
+                              self.wd,
+                              "200428_M00879_0087_000000000-AGEW9",
+                              "bcl2fastq"),
+                          working_dir=self.wd,
+                          poll_interval=0.5)
+        # Check outputs
+        self.assertEqual(exit_code,0)
+        self.assertTrue(os.path.isdir(os.path.join(self.wd,
+                                                   "barcode_analysis")),
+                        "Missing dir: barcode_analysis")
+        self.assertTrue(os.path.isdir(os.path.join(self.wd,
+                                                   "barcode_analysis",
+                                                   "counts")),
+                            "Missing dir: barcode_analysis/counts")
+        for f in (
+                "AB.AB1_S1_L001_R1_001.fastq.gz.counts",
+                "AB.AB2_S2_L001_R1_001.fastq.gz.counts",
+                "CDE.CDE3_S3_L001_R1_001.fastq.gz.counts",
+                "CDE.CDE4_S4_L001_R1_001.fastq.gz.counts",
+                "__undetermined__.Undetermined_S0_L001_R1_001.fastq.gz.counts"):
+            self.assertTrue(os.path.isfile(os.path.join(self.wd,
+                                                        "barcode_analysis",
+                                                        "counts",f)),
+                            "Missing file: %s" % f)
+        self.assertTrue(os.path.isfile(os.path.join(self.wd,
+                                                    "barcode_analysis",
+                                                    "barcodes.report")),
+                        "Missing file: barcodes.report")
+        self.assertTrue(os.path.isfile(os.path.join(self.wd,
+                                                    "barcode_analysis",
+                                                    "barcodes.xls")),
+                        "Missing file: barcodes.xls")
+        self.assertTrue(os.path.isfile(os.path.join(self.wd,
+                                                    "barcode_analysis",
+                                                    "barcodes.html")),
+                        "Missing file: barcodes.html")
+        # Check that the report content is non-trivial
+        barcodes_report = os.path.join(self.wd,
+                                       "barcode_analysis",
+                                       "barcodes.report")
+        with open(barcodes_report,'rt') as fp:
+            contents = fp.read()
+            self.assertTrue("Barcode analysis for lane #1" in contents)
+            self.assertTrue("#Rank\tIndex\tSample\tN_seqs\tN_reads\t%reads\t(%Total_reads)" in contents)
+            # Expect 12 lines of content in total
+            self.assertEqual(contents.count('\n'),12)
+
     def test_analyse_barcodes_with_no_inputs(self):
         """
         AnalyseBarcodes: raise exception if no inputs supplied

--- a/auto_process_ngs/test/barcodes/test_pipeline.py
+++ b/auto_process_ngs/test/barcodes/test_pipeline.py
@@ -51,9 +51,9 @@ GCATACTCAGCTTTAGTAATAAGTGTGATTCTGGTA
 IIIIIHIIIGHHIIDGHIIIIIIHIIIIIIIIIIIH
                             """.encode())
 
-    def test_analyse_barcodes_with_bcl2fastq_dir(self):
+    def test_analyse_barcodes_with_bcl2fastq_dir_no_samplesheet(self):
         """
-        AnalyseBarcodes: bcl2fastq directory as input
+        AnalyseBarcodes: bcl2fastq directory as input (no samplesheet)
         """
         # Make a mock bcl2fastq output directory
         datadir = MockIlluminaData(
@@ -120,6 +120,95 @@ IIIIIHIIIGHHIIDGHIIIIIIHIIIIIIIIIIIH
             self.assertTrue("#Rank\tIndex\tSample\tN_seqs\tN_reads\t%reads\t(%Total_reads)" in contents)
             # Expect 12 lines of content in total
             self.assertEqual(contents.count('\n'),12)
+
+    def test_analyse_barcodes_with_bcl2fastq_dir_and_samplesheet(self):
+        """
+        AnalyseBarcodes: bcl2fastq directory as input (with samplesheet)
+        """
+        # Make a mock bcl2fastq output directory
+        datadir = MockIlluminaData(
+            os.path.join(self.wd,
+                         "200428_M00879_0087_000000000-AGEW9"),
+            "bcl2fastq2",
+            unaligned_dir="bcl2fastq",
+            paired_end=True)
+        datadir.add_fastq_batch("AB","AB1","AB1_S1")
+        datadir.add_fastq_batch("AB","AB2","AB2_S2")
+        datadir.add_fastq_batch("CDE","CDE3","CDE3_S3")
+        datadir.add_fastq_batch("CDE","CDE4","CDE4_S4")
+        datadir.add_fastq_batch("","Undetermined","Undetermined_S0")
+        datadir.create()
+        # Add data to Fastq files
+        self._insert_fastq_reads(
+            os.path.join(self.wd,"200428_M00879_0087_000000000-AGEW9"))
+        # Create sample sheet
+        sample_sheet = os.path.join(self.wd,"custom_SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write("""[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+AB1,AB1,,,D701,CGTGTAGG,D501,GACCTGAA,AB,
+AB2,AB2,,,D702,CGTGTAGG,D501,ATGTAACT,AB,
+CDE3,CDE3,,,D701,GACCTGAA,D501,CGTGTAGG,CDE,
+CDE4,CDE4,,,D702,ATGTAACT,D501,CGTGTAGG,CDE,
+""")
+        # Set up and run pipeline
+        p = AnalyseBarcodes(bcl2fastq_dir=
+                            os.path.join(self.wd,
+                                         "200428_M00879_0087_000000000-AGEW9",
+                                         "bcl2fastq"))
+        exit_code = p.run(os.path.join(self.wd,"barcode_analysis"),
+                          sample_sheet=sample_sheet,
+                          working_dir=self.wd,
+                          poll_interval=0.5)
+        # Check outputs
+        self.assertEqual(exit_code,0)
+        self.assertTrue(os.path.isdir(os.path.join(self.wd,
+                                                   "barcode_analysis")),
+                        "Missing dir: barcode_analysis")
+        self.assertTrue(os.path.isdir(os.path.join(self.wd,
+                                                   "barcode_analysis",
+                                                   "counts")),
+                            "Missing dir: barcode_analysis/counts")
+        for f in (
+                "AB.AB1_S1_L001_R1_001.fastq.gz.counts",
+                "AB.AB2_S2_L001_R1_001.fastq.gz.counts",
+                "CDE.CDE3_S3_L001_R1_001.fastq.gz.counts",
+                "CDE.CDE4_S4_L001_R1_001.fastq.gz.counts",
+                "__undetermined__.Undetermined_S0_L001_R1_001.fastq.gz.counts"):
+            self.assertTrue(os.path.isfile(os.path.join(self.wd,
+                                                        "barcode_analysis",
+                                                        "counts",f)),
+                            "Missing file: %s" % f)
+        self.assertTrue(os.path.isfile(os.path.join(self.wd,
+                                                    "barcode_analysis",
+                                                    "barcodes.report")),
+                        "Missing file: barcodes.report")
+        self.assertTrue(os.path.isfile(os.path.join(self.wd,
+                                                    "barcode_analysis",
+                                                    "barcodes.xls")),
+                        "Missing file: barcodes.xls")
+        self.assertTrue(os.path.isfile(os.path.join(self.wd,
+                                                    "barcode_analysis",
+                                                    "barcodes.html")),
+                        "Missing file: barcodes.html")
+        # Check that the report content is non-trivial
+        barcodes_report = os.path.join(self.wd,
+                                       "barcode_analysis",
+                                       "barcodes.report")
+        with open(barcodes_report,'rt') as fp:
+            contents = fp.read()
+            self.assertTrue("Barcode analysis for lane #1" in contents)
+            self.assertTrue("#Rank\tIndex\tSample\tN_seqs\tN_reads\t%reads\t(%Total_reads)" in contents)
+            self.assertTrue("Problems detected:\n * Underrepresented samples" in contents)
+            self.assertTrue("   1\tTCCTGA\t\t1\t4\t100.0%\t(100.0%)" in contents)
+            self.assertTrue("The following samples are underrepresented:" in contents)
+            for line in ("AB1\tCGTGTAGG+GACCTGAA\t\t<0.1%",
+	                 "AB2\tCGTGTAGG+ATGTAACT\t\t<0.1%",
+	                 "CDE3\tGACCTGAA+CGTGTAGG\t\t<0.1%",
+	                 "CDE4\tATGTAACT+CGTGTAGG\t\t<0.1%",):
+                self.assertTrue(line in contents)
+            # Expect at least 12 lines of content in total
+            self.assertTrue(contents.count('\n') >= 12)
 
     def test_analyse_barcodes_with_samplesheet(self):
         """
@@ -200,8 +289,16 @@ CDE4,CDE4,,,D702,ATGTAACT,D501,CGTGTAGG,CDE,
             contents = fp.read()
             self.assertTrue("Barcode analysis for lane #1" in contents)
             self.assertTrue("#Rank\tIndex\tSample\tN_seqs\tN_reads\t%reads\t(%Total_reads)" in contents)
-            # Expect 12 lines of content in total
-            self.assertEqual(contents.count('\n'),12)
+            self.assertTrue("Problems detected:\n * Underrepresented samples" in contents)
+            self.assertTrue("   1\tTCCTGA\t\t1\t4\t100.0%\t(100.0%)" in contents)
+            self.assertTrue("The following samples are underrepresented:" in contents)
+            for line in ("AB1\tCGTGTAGG+GACCTGAA\t\t<0.1%",
+	                 "AB2\tCGTGTAGG+ATGTAACT\t\t<0.1%",
+	                 "CDE3\tGACCTGAA+CGTGTAGG\t\t<0.1%",
+	                 "CDE4\tATGTAACT+CGTGTAGG\t\t<0.1%",):
+                self.assertTrue(line in contents)
+            # Expect at least 12 lines of content in total
+            self.assertTrue(contents.count('\n') >= 12)
 
     def test_analyse_barcodes_with_samplesheet_and_10x_indices(self):
         """

--- a/auto_process_ngs/test/barcodes/test_pipeline.py
+++ b/auto_process_ngs/test/barcodes/test_pipeline.py
@@ -377,6 +377,98 @@ CDE4,CDE4,,,D702,ATGTAACT,D501,CGTGTAGG,CDE,
             # Expect at least 12 lines of content in total
             self.assertTrue(contents.count('\n') >= 12)
 
+    def test_analyse_barcodes_with_multi_lane_samplesheet(self):
+        """
+        AnalyseBarcodes: multi-lane sample sheet as input
+        """
+        # Create sample sheet
+        sample_sheet = os.path.join(self.wd,"custom_SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write("""[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,AB1,,,D701,CGTGTAGG,D501,GACCTGAA,AB,
+1,AB2,AB2,,,D702,CGTGTAGG,D501,ATGTAACT,AB,
+2,CDE3,CDE3,,,D701,GACCTGAA,D501,CGTGTAGG,CDE,
+2,CDE4,CDE4,,,D702,ATGTAACT,D501,CGTGTAGG,CDE,
+""")
+        # Set up pipeline before bcl2fastq directory exists
+        p = AnalyseBarcodes(sample_sheet=sample_sheet)
+        # Create the bcl2fastq directory before running pipeline
+        datadir = MockIlluminaData(
+            os.path.join(self.wd,
+                         "200428_M00879_0087_000000000-AGEW9"),
+            "bcl2fastq2",
+            unaligned_dir="bcl2fastq",
+            paired_end=True)
+        datadir.add_fastq_batch("AB","AB1","AB1_S1",lanes=(1,))
+        datadir.add_fastq_batch("AB","AB2","AB2_S2",lanes=(1,))
+        datadir.add_fastq_batch("CDE","CDE3","CDE3_S3",lanes=(2,))
+        datadir.add_fastq_batch("CDE","CDE4","CDE4_S4",lanes=(2,))
+        datadir.add_fastq_batch("","Undetermined","Undetermined_S0",
+                                lanes=(1,2))
+        datadir.create()
+        # Add data to Fastq files
+        self._insert_fastq_reads(
+            os.path.join(self.wd,"200428_M00879_0087_000000000-AGEW9"))
+        # Run the pipeline
+        exit_code = p.run(os.path.join(self.wd,"barcode_analysis"),
+                          bcl2fastq_dir=os.path.join(
+                              self.wd,
+                              "200428_M00879_0087_000000000-AGEW9",
+                              "bcl2fastq"),
+                          working_dir=self.wd,
+                          poll_interval=0.5)
+        # Check outputs
+        self.assertEqual(exit_code,0)
+        self.assertTrue(os.path.isdir(os.path.join(self.wd,
+                                                   "barcode_analysis")),
+                        "Missing dir: barcode_analysis")
+        self.assertTrue(os.path.isdir(os.path.join(self.wd,
+                                                   "barcode_analysis",
+                                                   "counts")),
+                            "Missing dir: barcode_analysis/counts")
+        for f in (
+                "AB.AB1_S1_L001_R1_001.fastq.gz.counts",
+                "AB.AB2_S2_L001_R1_001.fastq.gz.counts",
+                "CDE.CDE3_S3_L002_R1_001.fastq.gz.counts",
+                "CDE.CDE4_S4_L002_R1_001.fastq.gz.counts",
+                "__undetermined__.Undetermined_S0_L001_R1_001.fastq.gz.counts"):
+            self.assertTrue(os.path.isfile(os.path.join(self.wd,
+                                                        "barcode_analysis",
+                                                        "counts",f)),
+                            "Missing file: %s" % f)
+        self.assertTrue(os.path.isfile(os.path.join(self.wd,
+                                                    "barcode_analysis",
+                                                    "barcodes.report")),
+                        "Missing file: barcodes.report")
+        self.assertTrue(os.path.isfile(os.path.join(self.wd,
+                                                    "barcode_analysis",
+                                                    "barcodes.xls")),
+                        "Missing file: barcodes.xls")
+        self.assertTrue(os.path.isfile(os.path.join(self.wd,
+                                                    "barcode_analysis",
+                                                    "barcodes.html")),
+                        "Missing file: barcodes.html")
+        # Check that the report content is non-trivial
+        barcodes_report = os.path.join(self.wd,
+                                       "barcode_analysis",
+                                       "barcodes.report")
+        with open(barcodes_report,'rt') as fp:
+            contents = fp.read()
+            self.assertTrue("Barcode analysis for lane #1" in contents)
+            self.assertTrue("Barcode analysis for lane #2" in contents)
+            self.assertTrue("#Rank\tIndex\tSample\tN_seqs\tN_reads\t%reads\t(%Total_reads)" in contents)
+            self.assertTrue("Problems detected:\n * Underrepresented samples" in contents)
+            self.assertTrue("   1\tTCCTGA\t\t1\t2\t100.0%\t(100.0%)" in contents)
+            self.assertTrue("The following samples are underrepresented:" in contents)
+            for line in ("AB1\tCGTGTAGG+GACCTGAA\t\t<0.1%",
+	                 "AB2\tCGTGTAGG+ATGTAACT\t\t<0.1%",
+	                 "CDE3\tGACCTGAA+CGTGTAGG\t\t<0.1%",
+	                 "CDE4\tATGTAACT+CGTGTAGG\t\t<0.1%",):
+                self.assertTrue(line in contents)
+            # Expect at least 12 lines of content in total
+            self.assertTrue(contents.count('\n') >= 12)
+
     def test_analyse_barcodes_with_samplesheet_and_10x_indices(self):
         """
         AnalyseBarcodes: sample sheet with 10xGenomics indices

--- a/auto_process_ngs/test/barcodes/test_pipeline.py
+++ b/auto_process_ngs/test/barcodes/test_pipeline.py
@@ -110,6 +110,16 @@ IIIIIHIIIGHHIIDGHIIIIIIHIIIIIIIIIIIH
                                                     "barcode_analysis",
                                                     "barcodes.html")),
                         "Missing file: barcodes.html")
+        # Check that the report content is non-trivial
+        barcodes_report = os.path.join(self.wd,
+                                       "barcode_analysis",
+                                       "barcodes.report")
+        with open(barcodes_report,'rt') as fp:
+            contents = fp.read()
+            self.assertTrue("Barcode analysis for lane #1" in contents)
+            self.assertTrue("#Rank\tIndex\tSample\tN_seqs\tN_reads\t%reads\t(%Total_reads)" in contents)
+            # Expect 12 lines of content in total
+            self.assertEqual(contents.count('\n'),12)
 
     def test_analyse_barcodes_with_samplesheet(self):
         """
@@ -182,6 +192,16 @@ CDE4,CDE4,,,D702,ATGTAACT,D501,CGTGTAGG,CDE,
                                                     "barcode_analysis",
                                                     "barcodes.html")),
                         "Missing file: barcodes.html")
+        # Check that the report content is non-trivial
+        barcodes_report = os.path.join(self.wd,
+                                       "barcode_analysis",
+                                       "barcodes.report")
+        with open(barcodes_report,'rt') as fp:
+            contents = fp.read()
+            self.assertTrue("Barcode analysis for lane #1" in contents)
+            self.assertTrue("#Rank\tIndex\tSample\tN_seqs\tN_reads\t%reads\t(%Total_reads)" in contents)
+            # Expect 12 lines of content in total
+            self.assertEqual(contents.count('\n'),12)
 
     def test_analyse_barcodes_with_no_inputs(self):
         """

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -2851,13 +2851,11 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
-                       "bcl2fastq",):
+                       "bcl2fastq",
+                       "barcode_analysis",):
             self.assertTrue(os.path.isdir(
                 os.path.join(analysis_dir,subdir)),
                             "Missing subdir: %s" % subdir)
-        self.assertFalse(os.path.exists(
-            os.path.join(analysis_dir,"barcode_analysis")),
-                         "Found subdir: barcode_analysis")
         self.assertTrue(os.path.islink(
             os.path.join(analysis_dir,
                          "primary_data",
@@ -2948,13 +2946,11 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "10X_ILLUMINA_RUN"),
-                       "bcl2fastq",):
+                       "bcl2fastq",
+                       "barcode_analysis",):
             self.assertTrue(os.path.isdir(
                 os.path.join(analysis_dir,subdir)),
                             "Missing subdir: %s" % subdir)
-        self.assertFalse(os.path.exists(
-            os.path.join(analysis_dir,"barcode_analysis")),
-                         "Found subdir: barcode_analysis")
         self.assertTrue(os.path.islink(
             os.path.join(analysis_dir,
                          "primary_data",
@@ -3066,13 +3062,11 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
-                       "bcl2fastq",):
+                       "bcl2fastq",
+                       "barcode_analysis",):
             self.assertTrue(os.path.isdir(
                 os.path.join(analysis_dir,subdir)),
                             "Missing subdir: %s" % subdir)
-        self.assertFalse(os.path.exists(
-            os.path.join(analysis_dir,"barcode_analysis")),
-                         "Found subdir: barcode_analysis")
         self.assertTrue(os.path.islink(
             os.path.join(analysis_dir,
                          "primary_data",
@@ -3162,13 +3156,11 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
-                       "bcl2fastq",):
+                       "bcl2fastq",
+                       "barcode_analysis",):
             self.assertTrue(os.path.isdir(
                 os.path.join(analysis_dir,subdir)),
                             "Missing subdir: %s" % subdir)
-        self.assertFalse(os.path.exists(
-            os.path.join(analysis_dir,"barcode_analysis")),
-                         "Found subdir: barcode_analysis")
         self.assertTrue(os.path.islink(
             os.path.join(analysis_dir,
                          "primary_data",
@@ -3280,13 +3272,11 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
-                       "bcl2fastq",):
+                       "bcl2fastq",
+                       "barcode_analysis",):
             self.assertTrue(os.path.isdir(
                 os.path.join(analysis_dir,subdir)),
                             "Missing subdir: %s" % subdir)
-        self.assertFalse(os.path.exists(
-            os.path.join(analysis_dir,"barcode_analysis")),
-                         "Found subdir: barcode_analysis")
         self.assertTrue(os.path.islink(
             os.path.join(analysis_dir,
                          "primary_data",
@@ -3376,13 +3366,11 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
-                       "bcl2fastq",):
+                       "bcl2fastq",
+                       "barcode_analysis",):
             self.assertTrue(os.path.isdir(
                 os.path.join(analysis_dir,subdir)),
                             "Missing subdir: %s" % subdir)
-        self.assertFalse(os.path.exists(
-            os.path.join(analysis_dir,"barcode_analysis")),
-                         "Found subdir: barcode_analysis")
         self.assertTrue(os.path.islink(
             os.path.join(analysis_dir,
                          "primary_data",
@@ -3472,13 +3460,11 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
-                       "bcl2fastq",):
+                       "bcl2fastq",
+                       "barcode_analysis",):
             self.assertTrue(os.path.isdir(
                 os.path.join(analysis_dir,subdir)),
                             "Missing subdir: %s" % subdir)
-        self.assertFalse(os.path.exists(
-            os.path.join(analysis_dir,"barcode_analysis")),
-                         "Found subdir: barcode_analysis")
         self.assertTrue(os.path.islink(
             os.path.join(analysis_dir,
                          "primary_data",
@@ -3567,13 +3553,11 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
-                       "bcl2fastq",):
+                       "bcl2fastq",
+                       "barcode_analysis",):
             self.assertTrue(os.path.isdir(
                 os.path.join(analysis_dir,subdir)),
                             "Missing subdir: %s" % subdir)
-        self.assertFalse(os.path.exists(
-            os.path.join(analysis_dir,"barcode_analysis")),
-                         "Found subdir: barcode_analysis")
         self.assertTrue(os.path.islink(
             os.path.join(analysis_dir,
                          "primary_data",

--- a/auto_process_ngs/test/commands/test_analyse_barcodes_cmd.py
+++ b/auto_process_ngs/test/commands/test_analyse_barcodes_cmd.py
@@ -205,10 +205,7 @@ CDE4,CDE4,,,D702,ATGTAACT,D501,CGTGTAGG,CDE,
         with open(sample_sheet,'w') as fp:
             fp.write("""[Data]
 Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
-AB1,AB1,,,D701,CGTGTAGG,D501,GACCTGAA,AB,
-AB2,AB2,,,D702,CGTGTAGG,D501,ATGTAACT,AB,
 CDE3,CDE3,,,D701,,D501,,CDE,
-CDE4,CDE4,,,D702,,D501,,CDE,
 """)
         # Analyse barcodes
         ap = AutoProcess(mockdir.dirn,


### PR DESCRIPTION
PR which addresses issue #655 by updating the `MakeFastqs` pipeline to run barcode analysis for 10xGenomics datasets by default (previously the default was to disable the analyses for these type of data).

The changes include a number of bug fixes:

* `barcodes/pipeline.py`: when the barcode analysis pipeline object `AnalyseBarcodes` was created from an input sample sheet, the sample sheet would not be used when the pipeline was executed unless it was explicitly supplied to the pipeline's `run` method. Now the input sample sheet is used implicitly.
* `barcodes/pipeline.py`: deal with empty index sequences in the sample sheet, and raise an exception for cases where empty index sequences are mixed in with non-empty indices in the same lane.
* `bin/analyse_barcodes.py`: if the input sample sheet included 10xGenomics indices then the reporting would be skipped completely for the lanes that contained them. Now the reporting is performed without the sample sheet (so barcodes are not assigned to samples) for these lanes.