### PR TITLE
'make_fastqs': disable adapter trimming for 10xGenomics datasets

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -530,6 +530,21 @@ class MakeFastqs(Pipeline):
                 # ICELL8 single-cell ATAC-seq
                 self._update_subset(s,
                                     create_fastq_for_index_read=True)
+            elif protocol == '10x_chromium_sc':
+                # 10xGenomics Chromium SC
+                # Disable adapter trimming
+                self._update_subset(s,
+                                    trim_adapters=False)
+            elif protocol == '10x_atac':
+                # 10xGenomics ATAC-seq
+                # Disable adapter trimming
+                self._update_subset(s,
+                                    trim_adapters=False)
+            elif protocol == '10x_visium':
+                # 10xGenomics Visium
+                # Disable adapter trimming
+                self._update_subset(s,
+                                    trim_adapters=False)
             elif protocol == '10x_multiome':
                 # 10xGenomics multiome
                 # Disable adapter trimming


### PR DESCRIPTION
PR which updates the `make_fastqs` pipeline (`bcl2fastq/pipeline.py`) to disable the implicit adapter trimming for all 10xGenomics datasets (i.e. adapter sequences in the input samplesheet file will be ignored by default for these data).

This is consistent with advice from 10xGenomics tech support.