### PR TITLE
pipeliner: fix reporting names of failed tasks on 'immediate' failure

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2091,7 +2091,7 @@ class Pipeline(object):
                     # Terminate all tasks and stop immediately
                     self.report("Following tasks failed:")
                     for task in failed:
-                        msg = "- '%s'" % task.name
+                        msg = "- '%s'" % task.name()
                         if verbose:
                             msg += " (%s)" % task.id()
                         self.report(msg)


### PR DESCRIPTION
PR which fixes a bug when reporting the names of failed tasks in a `pipeliner` `Pipeline`, when the failure mode is 'immediate'.