### PR TITLE
'make_fastqs': fix duplicated lanes in barcode report

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -1006,16 +1006,6 @@ class MakeFastqs(Pipeline):
             well_list = subset['icell8_well_list']
             swap_i1_and_i2 = subset['icell8_atac_swap_i1_and_i2']
             reverse_complement = subset['icell8_atac_reverse_complement']
-
-            ###################
-            # Barcode analysis
-            ###################
-            do_barcode_analysis = subset['analyse_barcodes']
-            if lanes and do_barcode_analysis:
-                lanes_for_barcode_analysis.extend(lanes)
-            self.report("  Analyse barcodes: %s" % (('yes'
-                                                     if do_barcode_analysis
-                                                     else 'no'),))
             
             ###################
             # Make samplesheet

--- a/bin/analyse_barcodes.py
+++ b/bin/analyse_barcodes.py
@@ -193,9 +193,12 @@ if __name__ == '__main__':
         counts = count_barcodes(extra_args)
     # Determine subset of lanes to examine
     if args.lanes is not None:
+        print("Lanes supplied on command line: %s" % args.lanes)
         lanes = parse_lanes(args.lanes)
     else:
+        print("Taking lanes from counts")
         lanes = counts.lanes
+    lanes = sorted(list(set(lanes)))
     # Deal with cutoff
     if args.cutoff == 0.0:
         cutoff = None
@@ -206,6 +209,11 @@ if __name__ == '__main__':
         sample_sheet = os.path.abspath(args.sample_sheet)
     else:
         sample_sheet = None
+    # Report settings
+    print("Sample sheet: %s" % sample_sheet)
+    print("Lanes       : %s" % lanes)
+    print("Cutoff      : %s" % cutoff)
+    print("Mismatches  : %s" % args.mismatches)
     # Report the counts
     if not args.no_report:
         reporter = Reporter()


### PR DESCRIPTION
PR which fixes a bug in the barcode analysis reporting in the `make_fastqs` command, for multi-lane sequencing runs (e.g. from HiSEQ platforms) where processing has been split into lane subsets. In these cases the barcode reporting was outputting details for each lane twice.

There are two updates:

* `bcl2fastq/pipeline`: remove code which was adding each lane a second time for barcode analysis/reporting;
* `analyse_barcodes.py`: normalise the list of lanes to report by removing duplicates and sorting the remaining lane numbers.