### PR TITLE
Update 'AnalysisDir' to set 'run_name' when metadata.info file is missing

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -272,6 +272,8 @@ class AnalysisDir(object):
         try:
             self.run_name = self.metadata.run_name
         except AttributeError:
+            self.run_name = None
+        if not self.run_name:
             self.run_name = self._analysis_dir[0:-len('_analysis')]
         self.run_name = os.path.basename(self.run_name)
         self.date_stamp,\

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -208,6 +208,22 @@ class TestAnalysisDir(unittest.TestCase):
         self.assertEqual(analysis_dir.n_projects,2)
         self.assertTrue(analysis_dir.paired_end)
 
+    def test_analysisdir_no_metadata_info(self):
+        """Check AnalysisDir with missing metadata.info file
+        """
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '160621_M00879_0087_000000000-AGEW9',
+            'miseq',
+            top_dir=self.dirn)
+        mockdir.create()
+        os.remove(os.path.join(mockdir.dirn,"metadata.info"))
+        analysis_dir = AnalysisDir(mockdir.dirn)
+        self.assertEqual(analysis_dir.analysis_dir,mockdir.dirn)
+        self.assertEqual(analysis_dir.run_name,mockdir.run_name)
+        self.assertEqual(analysis_dir.n_sequencing_data,1)
+        self.assertEqual(analysis_dir.n_projects,2)
+        self.assertTrue(analysis_dir.paired_end)
+
     def test_handle_non_project_dir(self):
         """Check AnalysisDir with non-project directory
         """


### PR DESCRIPTION
PR which updates the `AnalysisDir` class in the `analysis` module, to fix a bug when there is no `metadata.info` file in the analysis directory (which is the case for analyses performed using older versions of `auto_process`). In these cases the fix sets the run name value based on the analysis directory name.