### PR TITLE
download_fastqs.py: bugfix for detecting checksum filenames with hyphens

### DIFF
--- a/bin/download_fastqs.py
+++ b/bin/download_fastqs.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
     index_page = str(urlopen(args.url).read())
     print_("Locating chksum file",end='')
     for line in index_page.split('\n'):
-        chksum_file = re.search('[A-Za-z0-9_]*\.chksums',line)
+        chksum_file = re.search('[A-Za-z0-9_\-]*\.chksums',line)
         if chksum_file:
             break
     if not chksum_file:


### PR DESCRIPTION
PR that addresses a bug in the `download_fastqs.py` script (used to bulk download files from a webserver to a local machine, which had previously been uploaded e.g. by `transfer_data.py`), when the checksum file name contains a hyphen (e.g. `Peter-Briggs.chksum`).