### PR TITLE
publish_qc: update to handle multiple processing QC reports & barcode analyses

### DIFF
--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     publish_qc_cmd.py: implement auto process publish_qc command
-#     Copyright (C) University of Manchester 2017-2020 Peter Briggs
+#     Copyright (C) University of Manchester 2017-2021 Peter Briggs
 #
 #########################################################################
 

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -454,30 +454,40 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
     # Processing QC reports
     if processing_qc_reports:
         processing_stats = index_page.add_section("Processing Statistics")
-        if True in processing_qc_warnings:
-            processing_stats.add(
-                Para(WarningIcon(),"Processing QC detected some issues"))
         for html_report,has_warnings in zip(processing_qc_reports,
                                             processing_qc_warnings):
-            fileops.copy(html_report,dirn)
+            # Set name for the report
+            title = os.path.basename(html_report).split('.')[0]
+            if title.startswith("processing_qc_"):
+                title = title[len("processing_qc_"):].replace('_',
+                                                              ' ').title()
+            # Add title and link to the index page
+            p = Para()
+            if title:
+                p.add("%s:" % title)
+            p.add(Link("Processing QC report",
+                       os.path.basename(html_report)))
+            # Append a warning mark if there are issues
             if has_warnings:
-                warning_mark = WarningIcon()
-            else:
-                warning_mark = ''
-            processing_stats.add(Para(warning_mark,
-                                      Link("Processing QC report",
-                                           os.path.basename(html_report))))
+                p.add(WarningIcon())
+            processing_stats.add(p)
+            # Copy report to webserver
+            fileops.copy(html_report,dirn)
     # Barcode analysis
-    ##if barcodes_files:
     if barcode_analysis_dirs:
         # Create section
         barcodes = index_page.add_section("Barcode Analysis")
-        if True in barcodes_warnings:
-            barcodes.add(
-                Para(WarningIcon(),"Barcode analysis detected some issues"))
         # Add individual analyses
         for barcode_dir,has_warnings in zip(barcode_analysis_dirs,
                                             barcodes_warnings):
+            # Set name for the report
+            title = os.path.basename(barcode_dir)
+            if title.startswith("barcode_analysis_"):
+                title = title[len("barcode_analysis_"):].replace('_',
+                                                                 ' ').title()
+            if not title:
+                title = "Barcodes"
+            # Collect files and set destination dir
             barcode_files = []
             if len(barcode_analysis_dirs) == 1:
                 # Old style
@@ -487,11 +497,7 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                 dest_dir = os.path.basename(barcode_dir)
             # Make a new subsection
             p = Para()
-            barcodes.add(p)
-            # Add a warning mark if there are issues
-            if has_warnings:
-                p.add(WarningMark())
-            p.add("<b>%s:</b>" % str(dest_dir).title())
+            p.add("%s:" % title)
             # Add links to reports in different formats
             for f,desc in (("barcodes.report","Plain text report"),
                            ("barcodes.xls","XLS"),
@@ -503,6 +509,10 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                         p.add("|")
                     p.add(Link(desc,os.path.join(dest_dir,f)))
                     barcode_files.append(filen)
+            # Append a warning mark if there are issues
+            if has_warnings:
+                p.add(WarningMark())
+            barcodes.add(p)
             # Create subdir and copy files
             dest_barcode_dir = os.path.join(dirn,dest_dir)
             fileops.mkdir(dest_barcode_dir)

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -186,9 +186,11 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                         location)
     # Collect processing statistics
     print("Checking for processing QC reports")
-    processing_qc_reports = [f for
-                             f in glob.glob(os.path.join(ap.analysis_dir,
-                             "processing_qc*.html"))]
+    processing_qc_reports = sorted([f for
+                                    f in glob.glob(os.path.join(
+                                        ap.analysis_dir,
+                                        "processing_qc*.html"))],
+                                   key=lambda f: os.path.basename(f))
     processing_qc_warnings = []
     if processing_qc_reports:
         for html_report in processing_qc_reports:
@@ -202,11 +204,12 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
         print("...no processing QC reports found")
     # Check for barcode analysis artefacts
     print("Checking for barcode analyses")
-    barcode_analysis_dirs = \
+    barcode_analysis_dirs = sorted(
         [d for d in glob.glob(os.path.join(ap.analysis_dir,"*"))
          if os.path.exists(os.path.join(d,"barcodes.report"))
          or os.path.exists(os.path.join(d,"barcodes.xls"))
-         or os.path.exists(os.path.join(d,"barcodes.html"))]
+         or os.path.exists(os.path.join(d,"barcodes.html"))],
+        key=lambda d: os.path.basename(d))
     barcodes_files = []
     barcodes_warnings = []
     if barcode_analysis_dirs:

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -189,7 +189,6 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
     processing_qc_reports = [f for
                              f in glob.glob(os.path.join(ap.analysis_dir,
                              "processing_qc*.html"))]
-    print(processing_qc_reports)
     processing_qc_warnings = []
     if processing_qc_reports:
         for html_report in processing_qc_reports:

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -507,11 +507,15 @@ class UpdateAnalysisDir(DirectoryUpdater):
         self._ap = ap
         DirectoryUpdater.__init__(self,ap.analysis_dir)
 
-    def add_processing_report(self):
+    def add_processing_report(self,name="processing_qc.html"):
         """
         Add a 'processing_qc.html' file
+
+        Arguments:
+          name (str): optionally, specify a non-standard
+            report name (default: 'processing_qc.html')
         """
-        self.add_file("processing_qc.html")
+        self.add_file(name)
 
     def add_barcode_analysis(self,
                              barcode_analysis_dir="barcode_analysis"):

--- a/auto_process_ngs/test/commands/test_publish_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_publish_qc_cmd.py
@@ -173,6 +173,44 @@ poll_interval = 0.5
                              item)
             self.assertTrue(os.path.exists(f),"Missing %s" % f)
 
+    def test_publish_qc_multiple_barcode_analyses(self):
+        """publish_qc: handle multiple barcode analyses outputs
+        """
+        # Make an auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '160621_K00879_0087_000000000-AGEW9',
+            'hiseq',
+            metadata={ "run_number": 87,
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
+        # Add processing and multiple barcode analysis reports
+        UpdateAnalysisDir(ap).add_processing_report()
+        UpdateAnalysisDir(ap).add_barcode_analysis("barcode_analysis_v1")
+        UpdateAnalysisDir(ap).add_barcode_analysis("barcode_analysis_v2")
+        # Make a mock publication area
+        publication_dir = os.path.join(self.dirn,'QC')
+        os.mkdir(publication_dir)
+        # Publish QC
+        publish_qc(ap,location=publication_dir)
+        # Check outputs
+        outputs = ("index.html",
+                   "processing_qc.html",
+                   os.path.join("barcode_analysis_v1","barcodes.report"),
+                   os.path.join("barcode_analysis_v1","barcodes.xls"),
+                   os.path.join("barcode_analysis_v1","barcodes.html"),
+                   os.path.join("barcode_analysis_v2","barcodes.report"),
+                   os.path.join("barcode_analysis_v2","barcodes.xls"),
+                   os.path.join("barcode_analysis_v2","barcodes.html"))
+        for item in outputs:
+            f = os.path.join(publication_dir,
+                             "160621_K00879_0087_000000000-AGEW9_analysis",
+                             item)
+            self.assertTrue(os.path.exists(f),"Missing %s" % f)
+
     def test_publish_qc_with_projects_no_multiqc(self):
         """publish_qc: projects with QC outputs (no MultiQC)
         """

--- a/auto_process_ngs/test/commands/test_publish_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_publish_qc_cmd.py
@@ -107,6 +107,38 @@ poll_interval = 0.5
                              item)
             self.assertTrue(os.path.exists(f),"Missing %s" % f)
 
+    def test_publish_qc_multiple_processing_qc(self):
+        """publish_qc: handle multiple processing QC reports
+        """
+        # Make an auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '160621_K00879_0087_000000000-AGEW9',
+            'hiseq',
+            metadata={ "run_number": 87,
+                       "source": "local",
+                       "instrument_datestamp": "160621" },
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        ap = AutoProcess(mockdir.dirn,
+                         settings=self.settings)
+        # Add multiple processing reports with non-standard names
+        UpdateAnalysisDir(ap).add_processing_report("processing_qc_v1.html")
+        UpdateAnalysisDir(ap).add_processing_report("processing_qc_v2.html")
+        # Make a mock publication area
+        publication_dir = os.path.join(self.dirn,'QC')
+        os.mkdir(publication_dir)
+        # Publish QC
+        publish_qc(ap,location=publication_dir)
+        # Check outputs
+        outputs = ("index.html",
+                   "processing_qc_v1.html",
+                   "processing_qc_v2.html",)
+        for item in outputs:
+            f = os.path.join(publication_dir,
+                             "160621_K00879_0087_000000000-AGEW9_analysis",
+                             item)
+            self.assertTrue(os.path.exists(f),"Missing %s" % f)
+
     def test_publish_qc_barcode_analysis(self):
         """publish_qc: barcode analysis outputs
         """


### PR DESCRIPTION
PR which updates the `publish_qc` command to enable it to handle multiple processing reports and barcode analyses.

With these changes all processing QC reports of the form `processing_qc*.html` and barcode analyses of the form `barcode_analysis*` will be included when the QC is published; this should allow reporting of multiple processing attempts associated with the same data in a single analysis dir.