### PR TITLE
update_fastq_stats: add options to specify sample sheet and identifier for output files

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1007,6 +1007,11 @@ def add_update_fastq_stats_command(cmdparser):
                    dest='unaligned_dir',default='bcl2fastq',
                    help="explicitly set the (sub)directory with "
                    "bcl-to-fastq outputs")
+    p.add_argument('--sample-sheet',action="store",
+                   dest="sample_sheet",default=None,
+                   help="explicitly specify the sample sheet to use "
+                   "(defaults to the sample sheet stored in the "
+                   "analysis directory parameters)")
     p.add_argument('--stats-file',action='store',
                    dest='stats_file',default=None,
                    help="specify output file for fastq statistics")
@@ -1522,6 +1527,7 @@ def update_fastq_stats(args):
     # Do the update
     d.update_fastq_stats(
         unaligned_dir=args.unaligned_dir,
+        sample_sheet=args.sample_sheet,
         stats_file=args.stats_file,
         per_lane_stats_file=args.per_lane_stats_file,
         add_data=args.add_data,

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1012,6 +1012,11 @@ def add_update_fastq_stats_command(cmdparser):
                    help="explicitly specify the sample sheet to use "
                    "(defaults to the sample sheet stored in the "
                    "analysis directory parameters)")
+    p.add_argument('--id',action='store',
+                   dest='name',default=None,
+                   help="specify an identifier to be written into the "
+                   "output statistics file name (e.g. "
+                   "'statistics.NAME.info')")
     p.add_argument('--stats-file',action='store',
                    dest='stats_file',default=None,
                    help="specify output file for fastq statistics")
@@ -1528,6 +1533,7 @@ def update_fastq_stats(args):
     d.update_fastq_stats(
         unaligned_dir=args.unaligned_dir,
         sample_sheet=args.sample_sheet,
+        name=args.name,
         stats_file=args.stats_file,
         per_lane_stats_file=args.per_lane_stats_file,
         add_data=args.add_data,

--- a/auto_process_ngs/commands/update_fastq_stats_cmd.py
+++ b/auto_process_ngs/commands/update_fastq_stats_cmd.py
@@ -23,9 +23,10 @@ logger = logging.getLogger(__name__)
 # Command functions
 #######################################################################
 
-def update_fastq_stats(ap,stats_file=None,per_lane_stats_file=None,
-                       unaligned_dir=None,add_data=False,force=False,
-                       nprocessors=None,runner=None):
+def update_fastq_stats(ap,sample_sheet=None,stats_file=None,
+                       per_lane_stats_file=None,unaligned_dir=None,
+                       add_data=False,force=False,nprocessors=None,
+                       runner=None):
     """Update statistics for Fastq files
 
     Updates the statistics for all Fastq files found in the
@@ -35,6 +36,9 @@ def update_fastq_stats(ap,stats_file=None,per_lane_stats_file=None,
     Arguments
       ap (AutoProcessor): autoprocessor pointing to the analysis
         directory to create Fastqs for
+      sample_sheet (str): path to sample sheet file used in
+        bcl-to-fastq conversion (defaults to the sample sheet
+        stored in the analysis directory parameters)
       stats_file (str): path of a non-default file to write the
         statistics to (defaults to 'statistics.info' unless
         over-ridden by local settings)
@@ -58,6 +62,7 @@ def update_fastq_stats(ap,stats_file=None,per_lane_stats_file=None,
     ap.set_log_dir(ap.get_log_subdir("update_fastq_stats"))
     fastq_statistics(ap,
                      unaligned_dir=unaligned_dir,
+                     sample_sheet=sample_sheet,
                      stats_file=stats_file,
                      per_lane_stats_file=per_lane_stats_file,
                      add_data=add_data,
@@ -120,6 +125,9 @@ def fastq_statistics(ap,stats_file=None,per_lane_stats_file=None,
     # Check for sample sheet
     if sample_sheet is None:
         sample_sheet = ap.params['sample_sheet']
+    if not os.path.exists(sample_sheet):
+        logger.error("Sample sheet '%s' not found" % sample_sheet)
+        raise Exception("Missing sample sheet")
     # Check if any Fastqs are newer than stats files
     newest_mtime = 0
     for f in (stats_file,per_lane_stats_file,):

--- a/auto_process_ngs/commands/update_fastq_stats_cmd.py
+++ b/auto_process_ngs/commands/update_fastq_stats_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     update_fastq_stats_cmd.py: implement update_fastq_stats command
-#     Copyright (C) University of Manchester 2019-2020 Peter Briggs
+#     Copyright (C) University of Manchester 2019-2021 Peter Briggs
 #
 #########################################################################
 

--- a/auto_process_ngs/commands/update_fastq_stats_cmd.py
+++ b/auto_process_ngs/commands/update_fastq_stats_cmd.py
@@ -128,9 +128,11 @@ def fastq_statistics(ap,stats_file=None,per_lane_stats_file=None,
     if not name:
         per_lane_sample_stats_file = 'per_lane_sample_stats.info'
         full_stats_file = 'statistics_full.info'
+        processing_qc_html = 'processing_qc.html'
     else:
         per_lane_sample_stats_file = 'per_lane_sample_stats.%s.info' % name
         full_stats_file = 'statistics_full.%s.info' % name
+        processing_qc_html = 'processing_qc_%s.html' % name
     # Sort out unaligned_dir
     if unaligned_dir is None:
         if ap.params.unaligned_dir is None:
@@ -227,7 +229,7 @@ def fastq_statistics(ap,stats_file=None,per_lane_stats_file=None,
     print("Statistics generation completed: %s" % ap.params.stats_file)
     print("Generating processing QC report")
     processing_qc_html = os.path.join(ap.analysis_dir,
-                                      "processing_qc.html")
+                                      processing_qc_html)
     report_processing_qc(ap,processing_qc_html)
 
 def report_processing_qc(ap,html_file):

--- a/auto_process_ngs/test/commands/test_update_fastq_stats_cmd.py
+++ b/auto_process_ngs/test/commands/test_update_fastq_stats_cmd.py
@@ -68,6 +68,36 @@ class TestAutoProcessUpdateFastqStats(unittest.TestCase):
             self.assertTrue(os.path.exists(os.path.join(mockdir.dirn,filen)),
                              "%s: missing" % filen)
 
+    def test_update_fastq_stats_with_name(self):
+        """update_fastq_stats: specify id for output statistics files
+        """
+        # Make an auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '190104_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "190104" },
+            top_dir=self.wd)
+        mockdir.create(no_project_dirs=True)
+        # Statistics files
+        stats_files = (
+            "statistics.test.info",
+            "statistics_full.test.info",
+            "per_lane_statistics.test.info",
+            "per_lane_sample_stats.test.info",
+        )
+        # Check stats files don't already exist
+        for filen in stats_files:
+            self.assertFalse(os.path.exists(os.path.join(mockdir.dirn,filen)),
+                             "%s: file exists, but shouldn't" %
+                             filen)
+        # Update (i.e. generate) stats
+        ap = AutoProcess(mockdir.dirn)
+        update_fastq_stats(ap,name="test")
+        # Check files now exist
+        for filen in stats_files:
+            self.assertTrue(os.path.exists(os.path.join(mockdir.dirn,filen)),
+                             "%s: missing" % filen)
+
     def test_update_fastq_stats_missing_samplesheet(self):
         """update_fastq_stats: raises exception if sample sheet is missing
         """

--- a/auto_process_ngs/test/commands/test_update_fastq_stats_cmd.py
+++ b/auto_process_ngs/test/commands/test_update_fastq_stats_cmd.py
@@ -54,6 +54,7 @@ class TestAutoProcessUpdateFastqStats(unittest.TestCase):
             "statistics_full.info",
             "per_lane_statistics.info",
             "per_lane_sample_stats.info",
+            "processing_qc.html",
         )
         # Check stats files don't already exist
         for filen in stats_files:
@@ -84,6 +85,7 @@ class TestAutoProcessUpdateFastqStats(unittest.TestCase):
             "statistics_full.test.info",
             "per_lane_statistics.test.info",
             "per_lane_sample_stats.test.info",
+            "processing_qc_test.html",
         )
         # Check stats files don't already exist
         for filen in stats_files:

--- a/auto_process_ngs/test/commands/test_update_fastq_stats_cmd.py
+++ b/auto_process_ngs/test/commands/test_update_fastq_stats_cmd.py
@@ -68,6 +68,21 @@ class TestAutoProcessUpdateFastqStats(unittest.TestCase):
             self.assertTrue(os.path.exists(os.path.join(mockdir.dirn,filen)),
                              "%s: missing" % filen)
 
+    def test_update_fastq_stats_missing_samplesheet(self):
+        """update_fastq_stats: raises exception if sample sheet is missing
+        """
+        # Make an auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '190104_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "190104" },
+            top_dir=self.wd)
+        mockdir.create(no_project_dirs=True)
+        # Check exception is raised
+        self.assertRaises(Exception,
+                          update_fastq_stats,
+                          sample_sheet="doesnt_exist.csv")
+
 class TestReportProcessingQC(unittest.TestCase):
     """
     Tests for report_processing_qc function


### PR DESCRIPTION
PR which adds new features to the `update_fastq_stats` command, specifically:

* New option `--sample-sheet` enables a sample sheet file to specified
* New option `--id` enables an identifier to be specified, which is then written into the output statistics file names

Additionally, if a sample sheet cannot be located (either explicitly specified via the `--sample-sheet` option, or implicitly from the analysis directory's parameter file) then the command will now stop with an error.