### PR TITLE
make_fastqs: enable identifier to be specified for outputs

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -1497,8 +1497,8 @@ class MakeFastqs(Pipeline):
     def run(self,analysis_dir,out_dir=None,barcode_analysis_dir=None,
             primary_data_dir=None,force_copy_of_primary_data=False,
             no_lane_splitting=None,create_fastq_for_index_read=None,
-            create_empty_fastqs=None,stats_file=None,stats_full=None,
-            per_lane_stats=None,per_lane_sample_stats=None,
+            create_empty_fastqs=None,name=None,stats_file=None,
+            stats_full=None,per_lane_stats=None,per_lane_sample_stats=None,
             nprocessors=None,require_bcl2fastq=None,
             cellranger_jobmode='local',cellranger_mempercore=None,
             cellranger_maxjobs=None,cellranger_jobinterval=None,
@@ -1530,6 +1530,8 @@ class MakeFastqs(Pipeline):
             (--create-fastq-for-index-read)
           create_empty_fastqs (bool): if True then create empty
             "placeholder" Fastqs if not created by bcl2fastq
+          name (str): optional identifier for output
+            stats and report files
           stats_file (str): path to statistics output file
           stats_full (str): path to full statistics output file
           per_lane_stats (str): path to per-lane statistics
@@ -1610,29 +1612,51 @@ class MakeFastqs(Pipeline):
         # Statistics files
         # Basic stats
         if stats_file is None:
-            stats_file = "statistics.info"
+            if name:
+                stats_file = "statistics.%s.info" % name
+            else:
+                stats_file = "statistics.info"
         if not os.path.isabs(stats_file):
             stats_file = os.path.join(analysis_dir,stats_file)
         # Full stats
         if stats_full is None:
-            stats_full = "statistics_full.info"
+            if name:
+                stats_full = "statistics_full.%s.info" % name
+            else:
+                stats_full = "statistics_full.info"
         if not os.path.isabs(stats_full):
             stats_full = os.path.join(analysis_dir,stats_full)
         # Per-lane stats
         if per_lane_stats is None:
-            per_lane_stats = "per_lane_statistics.info"
+            if name:
+                per_lane_stats = "per_lane_statistics.%s.info" % name
+            else:
+                per_lane_stats = "per_lane_statistics.info"
         if not os.path.isabs(per_lane_stats):
             per_lane_stats = os.path.join(analysis_dir,per_lane_stats)
         # Per-lane per-sample stats
         if per_lane_sample_stats is None:
-            per_lane_sample_stats = "per_lane_sample_stats.info"
+            if name:
+                per_lane_sample_stats = "per_lane_sample_stats.%s.info" % name
+            else:
+                per_lane_sample_stats = "per_lane_sample_stats.info"
         if not os.path.isabs(per_lane_sample_stats):
             per_lane_sample_stats = os.path.join(analysis_dir,
                                                  per_lane_sample_stats)
 
+        # QC report
+        if name:
+            qc_report = "processing_qc_%s.html" % name
+        else:
+            qc_report = "processing_qc.html"
+        qc_report = os.path.join(analysis_dir,qc_report)
+
         # Barcode analysis directory
         if barcode_analysis_dir is None:
-            barcode_analysis_dir = "barcode_analysis"
+            if name:
+                barcode_analysis_dir = "barcode_analysis_%s" % name
+            else:
+                barcode_analysis_dir = "barcode_analysis"
         if not os.path.isabs(barcode_analysis_dir):
             barcode_analysis_dir = os.path.join(analysis_dir,
                                                 barcode_analysis_dir)
@@ -1654,8 +1678,7 @@ class MakeFastqs(Pipeline):
             'primary_data_dir': primary_data_dir,
             'barcode_analysis_dir': barcode_analysis_dir,
             'counts_dir': os.path.join(barcode_analysis_dir,"counts"),
-            'qc_report': os.path.join(analysis_dir,
-                                      "processing_qc.html"),
+            'qc_report': qc_report,
             'force_copy_of_primary_data': force_copy_of_primary_data,
             'no_lane_splitting': no_lane_splitting,
             'create_fastq_for_index_read': create_fastq_for_index_read,

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -224,6 +224,8 @@ def add_make_fastqs_command(cmdparser):
     add_modulefiles_option(p)
     add_no_save_option(p)
     add_debug_option(p)
+    p.add_argument('--id',action='store',dest='name',default=None,
+                   help="identifier for output files")
     # Primary data management
     primary_data = p.add_argument_group('Primary data management')
     primary_data.add_argument('--force-copy',action='store_true',
@@ -1254,6 +1256,7 @@ def make_fastqs(args):
         runner = None
     # Do the make_fastqs step
     d.make_fastqs(
+        name=args.name,
         protocol=args.protocol,
         nprocessors=args.nprocessors,
         runner=runner,

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     make_fastqs_cmd.py: implement auto process make_fastqs command
-#     Copyright (C) University of Manchester 2018-2020 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2021 Peter Briggs
 #
 #########################################################################
 

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -39,7 +39,7 @@ BCL2FASTQ_DEFAULTS = {
 
 def make_fastqs(ap,protocol='standard',platform=None,
                 unaligned_dir=None,sample_sheet=None,
-                lanes=None,lane_subsets=None,
+                name=None,lanes=None,lane_subsets=None,
                 icell8_well_list=None,
                 nprocessors=None,require_bcl2fastq_version=None,
                 bases_mask=None,no_lane_splitting=False,
@@ -94,6 +94,8 @@ def make_fastqs(ap,protocol='standard',platform=None,
         for bcl-to-fastq conversion. Default is 'bcl2fastq' (unless
         an alternative is already specified in the config file)
       sample_sheet (str): if set then use this as the input samplesheet
+      name (str): (optional) identifier for outputs that are not
+        set explicitly
       lanes (list): (optional) specify a list of lane numbers to
         use in the processing; lanes not in the list will be excluded
         (default is to include all lanes)
@@ -193,6 +195,8 @@ def make_fastqs(ap,protocol='standard',platform=None,
                         "%s)" % (protocol,','.join(PROTOCOLS)))
 
     # Output (unaligned) dir
+    if not unaligned_dir and name:
+        unaligned_dir = 'bcl2fastq_%s' % name
     if unaligned_dir is not None:
         ap.params['unaligned_dir'] = unaligned_dir
     elif ap.params['unaligned_dir'] is None:
@@ -227,6 +231,8 @@ def make_fastqs(ap,protocol='standard',platform=None,
                                 "in samplesheet" % l)
 
     # Barcode analysis
+    if not barcode_analysis_dir and name:
+        barcode_analysis_dir = 'barcode_analysis_%s' % name
     if barcode_analysis_dir is not None:
         ap.params['barcode_analysis_dir'] = barcode_analysis_dir
     elif ap.params.barcode_analysis_dir is None:
@@ -238,18 +244,24 @@ def make_fastqs(ap,protocol='standard',platform=None,
 
     # Statistics files
     if stats_file is None:
-        if ap.params['stats_file'] is not None:
+        if name:
+            stats_file='statistics.%s.info' % name
+        elif ap.params['stats_file'] is not None:
             stats_file = ap.params['stats_file']
         else:
             stats_file='statistics.info'
     if per_lane_stats_file is None:
-        if ap.params['per_lane_stats_file'] is not None:
+        if name:
+            per_lane_stats_file='per_lane_statistics.%s.info' % name
+        elif ap.params['per_lane_stats_file'] is not None:
             per_lane_stats_file = ap.params['per_lane_stats_file']
         else:
             per_lane_stats_file='per_lane_statistics.info'
 
     # Log dir
     log_dir = 'make_fastqs'
+    if name:
+        log_dir += "_%s" % name
     if protocol != 'standard':
         log_dir += "_%s" % protocol
     if lanes:
@@ -346,18 +358,18 @@ def make_fastqs(ap,protocol='standard',platform=None,
 
     # Set up pipeline environment modules
     envmodules = {}
-    for name in ('bcl2fastq',
-                 'cellranger_mkfastq',
-                 'cellranger_atac_mkfastq',
-                 'cellranger_arc_mkfastq',
-                 'spaceranger_mkfastq',):
+    for envmod in ('bcl2fastq',
+                   'cellranger_mkfastq',
+                   'cellranger_atac_mkfastq',
+                   'cellranger_arc_mkfastq',
+                   'spaceranger_mkfastq',):
         try:
-            envmodules[name] = ap.settings.modulefiles[name]
+            envmodules[envmod] = ap.settings.modulefiles[envmod]
         except KeyError:
             try:
-                envmodules[name] = ap.settings.modulefiles['make_fastqs']
+                envmodules[envmod] = ap.settings.modulefiles['make_fastqs']
             except KeyError:
-                envmodules[name] = None
+                envmodules[envmod] = None
 
     # Other pipeline settings
     poll_interval = ap.settings.general.poll_interval
@@ -386,6 +398,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
                              fastq_statistics=generate_stats,
                              analyse_barcodes=analyse_barcodes)
     status = make_fastqs.run(ap.analysis_dir,
+                             name=name,
                              out_dir=ap.params.unaligned_dir,
                              barcode_analysis_dir=barcode_analysis_dir,
                              primary_data_dir=ap.params.primary_data_dir,

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -350,6 +350,81 @@ class TestMakeFastqs(unittest.TestCase):
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_set_id(self):
+        """
+        MakeFastqs: standard protocol: set identifier for outputs
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 version="2.20.0.422")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet)
+        status = p.run(analysis_dir,
+                       name="test",
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.test.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,
+                                      "statistics_full.test.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.test.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.test.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis_test",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertEqual(p.output.missing_fastqs,[])
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.test.info",
+                      "statistics_full.test.info",
+                      "per_lane_statistics.test.info",
+                      "per_lane_sample_stats.test.info",
+                      "processing_qc_test.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
     def test_makefastqs_standard_protocol_create_fastq_for_index_read(self):
         """
         MakeFastqs: standard protocol: create Fastqs for index reads

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -175,6 +175,62 @@ poll_interval = 0.5
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_make_fastqs_standard_protocol_specify_id(self):
+        """make_fastqs: standard protocol (specify id)
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,"bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Do the test
+        ap = AutoProcess(settings=self.settings)
+        ap.setup(os.path.join(self.wd,
+                              "171020_M00879_00002_AHGXXXX"))
+        self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
+        make_fastqs(ap,protocol="standard",name="test")
+        # Check parameters
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(self.wd,
+                                      "171020_M00879_00002_AHGXXXX_analysis",
+                                      "primary_data"))
+        self.assertTrue(ap.params.acquired_primary_data)
+        self.assertEqual(ap.params.unaligned_dir,"bcl2fastq_test")
+        self.assertEqual(ap.params.barcode_analysis_dir,"barcode_analysis_test")
+        self.assertEqual(ap.params.stats_file,"statistics.test.info")
+        # Check outputs
+        analysis_dir = os.path.join(
+            self.wd,
+            "171020_M00879_00002_AHGXXXX_analysis")
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       os.path.join("logs",
+                                    "002_make_fastqs"),
+                       "bcl2fastq_test",
+                       "barcode_analysis_test",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        for filen in ("statistics.test.info",
+                      "statistics_full.test.info",
+                      "per_lane_statistics.test.info",
+                      "per_lane_sample_stats.test.info",
+                      "projects.info",
+                      "processing_qc_test.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
     def test_make_fastqs_standard_protocol_exception_for_chromium_sc_indices(self):
         """make_fastqs: standard protocol with Chromium SC indices raises exception
         """

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -214,7 +214,7 @@ poll_interval = 0.5
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
                        os.path.join("logs",
-                                    "002_make_fastqs"),
+                                    "002_make_fastqs_test"),
                        "bcl2fastq_test",
                        "barcode_analysis_test",):
             self.assertTrue(os.path.isdir(


### PR DESCRIPTION
PR which updates the Fastq generation pipeline and the `make_fastqs` command, to enable a new `--id` option (similar to that implemented for the `update_fastq_stats` command in PR #674), which specifies an identifier which is insered into the default names for the output stats and QC report files.