### PR TITLE
Updates and fixes to processing QC and barcode analysis reports

### DIFF
--- a/auto_process_ngs/bcl2fastq/reporting.py
+++ b/auto_process_ngs/bcl2fastq/reporting.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     reporting: report processing QC from Fastq generation
-#     Copyright (C) University of Manchester 2020 Peter Briggs
+#     Copyright (C) University of Manchester 2020-2021 Peter Briggs
 #
 
 """
@@ -53,7 +53,7 @@ class ProcessingQCReport(Document):
     >>> report.write("processing_qc_report.html")
     """
     def __init__(self,analysis_dir,stats_file,per_lane_stats_file,
-                 per_lane_sample_stats_file):
+                 per_lane_sample_stats_file,name=None):
         """
         Create a new ProcessingQCReport instance
 
@@ -66,10 +66,16 @@ class ProcessingQCReport(Document):
             'per_lane_statistics.info' statistics file
           per_lane_sample_stats_file (str): path to the
             'per_lane_sample_stats.info' statistics file
+          name (str): optional identifier to add to the
+            report title
         """
+        # Set the title
+        title = "Processing report for %s" % \
+                os.path.basename(analysis_dir)
+        if name:
+            title += " (%s)" % name
         # Initialise HTML report
-        Document.__init__(self,"Processing report for %s" %
-                          os.path.basename(analysis_dir))
+        Document.__init__(self,title)
         # Store locations of data files
         self._stats_file = stats_file
         self._per_lane_stats_file = per_lane_stats_file

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -940,6 +940,11 @@ def add_analyse_barcodes_command(cmdparser):
                    dest="sample_sheet",default=None,
                    help="use an alternative sample sheet to the default "
                    "'custom_SampleSheet.csv' created on setup.")
+    p.add_argument('--id',action='store',
+                   dest='name',default=None,
+                   help="specify an identifier to be written into the "
+                   "default output barcode analysis directory name (e.g. "
+                   "'barcode_analysis_NAME') and report title")
     p.add_argument('--barcode-analysis-dir',action="store",
                    dest="barcode_analysis_dir",default=None,
                    help="specify subdirectory where barcode analysis will "
@@ -1491,6 +1496,7 @@ def analyse_barcodes(args):
                        cutoff=args.cutoff,
                        sample_sheet=args.sample_sheet,
                        barcode_analysis_dir=args.barcode_analysis_dir,
+                       name=args.name,
                        runner=runner,
                        force=args.force)
 

--- a/auto_process_ngs/commands/analyse_barcodes_cmd.py
+++ b/auto_process_ngs/commands/analyse_barcodes_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     analyse_barcodes_cmd.py: implement analyse_barcodes command
-#     Copyright (C) University of Manchester 2019 Peter Briggs
+#     Copyright (C) University of Manchester 2019,2021 Peter Briggs
 #
 #########################################################################
 
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 def analyse_barcodes(ap,unaligned_dir=None,lanes=None,
                      mismatches=None,cutoff=None,
                      barcode_analysis_dir=None,
-                     sample_sheet=None,runner=None,
-                     force=False):
+                     sample_sheet=None,name=None,
+                     runner=None,force=False):
     """Analyse the barcode sequences for Fastqs for each specified lane
 
     Run 'analyse_barcodes.py' for one or more lanes, to analyse the
@@ -46,13 +46,15 @@ def analyse_barcodes(ap,unaligned_dir=None,lanes=None,
         of associated reads than specified cutoff from reporting (e.g.
         '0.001' excludes barcodes with < 0.1% of reads); default is to
         include all barcodes
-      sample_sheet (str): if set then use this as the input samplesheet
-        to check barcode sequences against (by default will use the
-        sample sheet defined in the parameter file for the run)
       barcode_analysis_dir (str): (optional) explicitly specify the
         subdirectory to use for barcode analysis. Counts will be
         written to and read from the 'counts' subdirectory of this
         directory (defaults to 'barcode_analysis')
+      sample_sheet (str): if set then use this as the input samplesheet
+        to check barcode sequences against (by default will use the
+        sample sheet defined in the parameter file for the run)
+      name (str): (optional) identifier for output directory (if
+        'barcode_analysis_dir' not explicitly set) and report title
       runner (JobRunner): (optional) specify a non-default job runner
         to use for barcode analysis
       force (bool): if True then forces regeneration of any existing
@@ -73,6 +75,8 @@ def analyse_barcodes(ap,unaligned_dir=None,lanes=None,
     if barcode_analysis_dir is not None:
         # Create a subdirectory for barcode analysis
         ap.params['barcode_analysis_dir'] = barcode_analysis_dir
+    elif name is not None:
+        ap.params['barcode_analysis_dir'] = 'barcode_analysis_%s' % name
     elif ap.params['barcode_analysis_dir'] is None:
         ap.params['barcode_analysis_dir'] = 'barcode_analysis'
     barcode_analysis_dir = ap.params['barcode_analysis_dir']
@@ -81,6 +85,8 @@ def analyse_barcodes(ap,unaligned_dir=None,lanes=None,
                                             barcode_analysis_dir)
     # Report title
     title = "Barcode analysis for %s" % ap.metadata.run_name
+    if name:
+        title = title + " (%s)" % name
     # Create a pipeline for barcode analysis
     barcode_analysis = AnalyseBarcodes(os.path.join(
         ap.params['analysis_dir'],ap.params['unaligned_dir']))

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -210,7 +210,6 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
          or os.path.exists(os.path.join(d,"barcodes.xls"))
          or os.path.exists(os.path.join(d,"barcodes.html"))],
         key=lambda d: os.path.basename(d))
-    barcodes_files = []
     barcodes_warnings = []
     if barcode_analysis_dirs:
         for barcode_analysis_dir in barcode_analysis_dirs:
@@ -221,7 +220,6 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                 filen = os.path.join(barcode_analysis_dir,f)
                 if os.path.exists(filen):
                     print("...found %s" % os.path.basename(filen))
-                    barcodes_files.append(filen)
             # Check for warnings
             has_warnings = detect_barcodes_warnings(
                 os.path.join(barcode_analysis_dir,'barcodes.report'))
@@ -516,7 +514,7 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
             # Create subdir and copy files
             dest_barcode_dir = os.path.join(dirn,dest_dir)
             fileops.mkdir(dest_barcode_dir)
-            for filen in barcodes_files:
+            for filen in barcode_files:
                 fileops.copy(filen,dest_barcode_dir)
     # 10xGenomics mkfastq QC summaries
     if cellranger_qc_html:

--- a/auto_process_ngs/commands/update_fastq_stats_cmd.py
+++ b/auto_process_ngs/commands/update_fastq_stats_cmd.py
@@ -174,8 +174,15 @@ def fastq_statistics(ap,stats_file=None,per_lane_stats_file=None,
             if not force:
                 # Don't rerun the stats, just regenerate the report
                 processing_qc_html = os.path.join(ap.analysis_dir,
-                                                  "processing_qc.html")
-                report_processing_qc(ap,processing_qc_html)
+                                                  processing_qc_html)
+                report_processing_qc(ap,
+                                     processing_qc_html,
+                                     full_stats_file=full_stats_file,
+                                     per_lane_stats_file=\
+                                     per_lane_stats_file,
+                                     per_lane_sample_stats_file=\
+                                     per_lane_sample_stats_file,
+                                     name=name)
                 return
     # Set up runner
     if runner is None:
@@ -230,9 +237,19 @@ def fastq_statistics(ap,stats_file=None,per_lane_stats_file=None,
     print("Generating processing QC report")
     processing_qc_html = os.path.join(ap.analysis_dir,
                                       processing_qc_html)
-    report_processing_qc(ap,processing_qc_html)
+    report_processing_qc(ap,
+                         processing_qc_html,
+                         full_stats_file=full_stats_file,
+                         per_lane_stats_file=\
+                         per_lane_stats_file,
+                         per_lane_sample_stats_file=\
+                         per_lane_sample_stats_file,
+                         name=name)
 
-def report_processing_qc(ap,html_file):
+def report_processing_qc(ap,html_file,name=None,
+                         full_stats_file=None,
+                         per_lane_stats_file=None,
+                         per_lane_sample_stats_file=None):
     """
     Generate HTML report for processing statistics
 
@@ -241,32 +258,45 @@ def report_processing_qc(ap,html_file):
         processing from
       html_file (str): destination path and file name for
         HTML report
+      name (str): identifier to insert into report title
+      full_stats_file (str): path of full stats file (defaults
+        to 'statistics_full.info')
+      per_lane_stats_file (str): path of per-lane statistics
+        file (defaults to 'per_lane_statistics.info')
+      per_lane_sample_stats_file (str): path of per-lane sample
+        statistics file (defaults to 'per_lane_sample_stats.info')
     """
-    # Per-lane statistics
-    per_lane_stats_file = ap.params.per_lane_stats_file
-    if per_lane_stats_file is None:
-        per_lane_stats_file = "per_lane_statistics.info"
-    per_lane_stats_file = get_absolute_file_path(per_lane_stats_file,
-                                                 base=ap.analysis_dir)
-    # Per lane by sample statistics
-    per_lane_sample_stats_file = get_absolute_file_path(
-        "per_lane_sample_stats.info",
-        base=ap.analysis_dir)
-    # Per fastq statistics
-    stats_file = get_absolute_file_path("statistics_full.info",
+    # Per Fastq statistics
+    if not full_stats_file:
+        full_stats_file = "statistics_full.info"
+    stats_file = get_absolute_file_path(full_stats_file,
                                         base=ap.analysis_dir)
     if not os.path.exists(stats_file):
-        if ap.params.stats_file is not None:
+        # Fall back for legacy datasets (no full stats file)
+        if ap.params.stats_file:
             stats_file = ap.params.stats_file
         else:
             stats_file = "statistics.info"
     stats_file = get_absolute_file_path(stats_file,
                                         base=ap.analysis_dir)
+    # Per-lane statistics
+    if not per_lane_stats_file:
+        per_lane_stats_file = ap.params.per_lane_stats_file
+        if not per_lane_stats_file:
+            per_lane_stats_file = "per_lane_statistics.info"
+    per_lane_stats_file = get_absolute_file_path(per_lane_stats_file,
+                                                 base=ap.analysis_dir)
+    # Per lane by sample statistics
+    if not per_lane_sample_stats_file:
+        per_lane_sample_stats_file = get_absolute_file_path(
+            "per_lane_sample_stats.info",
+            base=ap.analysis_dir)
     # Generate the report
     ProcessingQCReport(ap.analysis_dir,
                        stats_file,
                        per_lane_stats_file,
-                       per_lane_sample_stats_file).write(html_file)
+                       per_lane_sample_stats_file,
+                       name=name).write(html_file)
 
 def get_absolute_file_path(p,base=None):
     """


### PR DESCRIPTION
PR with various fixes and updates to the processing QC and barcode analysis reports (following on from PRs #673 and #674).

Bug fixes:

* Fix broken generation of processing QC report when non-default stats file names are used (e.g. when `--id` option is used on `update_fastq_stats` command)
* Fix broken generation of processing QC report when stats files don't need updating (because Fastqs are older) in `update_fastq_stats` command
* Fix broken copying of multiple barcode analysis reports by `publish_qc` command

Updates:

* Add identifier to processing QC report titles (when using `--id` option on `update_fastq_stats` command)
* Implement new `--id` option for `analyse_barcodes` command (similar to `--id` on `update_fastq_stats` command)