### PR TITLE
pipeliner: implement 'list'-like pipeline parameter

### DIFF
--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -25,6 +25,7 @@ from auto_process_ngs.pipeliner import PipelineFailure
 from auto_process_ngs.pipeliner import FileCollector
 from auto_process_ngs.pipeliner import Dispatcher
 from auto_process_ngs.pipeliner import BaseParam
+from auto_process_ngs.pipeliner import ListParam
 from auto_process_ngs.pipeliner import PathJoinParam
 from auto_process_ngs.pipeliner import PathExistsParam
 from auto_process_ngs.pipeliner import FunctionParam
@@ -2231,6 +2232,54 @@ class TestFileCollector(unittest.TestCase):
         self.assertEqual(len(txt_files),1)
         self.assertEqual(list(txt_files),
                          [os.path.join(self.working_dir,"test1.txt")])
+
+class TestListParam(unittest.TestCase):
+    """
+    Tests for the 'ListParam' class
+    """
+    def test_listparam_init(self):
+        """
+        ListParam: check initialisation
+        """
+        # Empty list
+        self.assertEqual(ListParam().value,[])
+        # Non-empty iterable
+        self.assertEqual(ListParam((1,2,"hello",3)).value,
+                         [1,2,"hello",3])
+
+    def test_listparam_append(self):
+        """
+        ListParam: check 'append' method
+        """
+        l = ListParam((1,2,"hello",3))
+        l.append(4)
+        self.assertEqual(l.value,[1,2,"hello",3,4])
+
+    def test_listparam_extend(self):
+        """
+        ListParam: check 'extend' method
+        """
+        l = ListParam((1,2,"hello",3))
+        l.extend((4,5,"goodbye"))
+        self.assertEqual(l.value,[1,2,"hello",3,4,5,"goodbye"])
+
+    def test_listparam_len(self):
+        """
+        ListParam: check 'len' functionality
+        """
+        self.assertEqual(len(ListParam()),0)
+        self.assertEqual(len(ListParam((1,2,"hello",3))),4)
+
+    def test_listparam_with_params(self):
+        """
+        ListParam: handle pipeline parameters as items
+        """
+        l = ListParam()
+        l.append(PipelineParam(value=1))
+        l.append(PipelineParam(value=2))
+        l.append(PipelineParam(value="hello"))
+        l.append(PipelineParam(value=3))
+        self.assertEqual(l.value,[1,2,"hello",3])
 
 class TestPathJoinParam(unittest.TestCase):
     """

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -1903,11 +1903,20 @@ class TestPipelineCommand(unittest.TestCase):
         # Make a temporary working dir
         self.working_dir = tempfile.mkdtemp(
             suffix='TestPipelineCommand')
+        # Unset the MODULEPATH env var, if found
+        if 'MODULEPATH' in os.environ:
+            self.modulepath = os.environ['MODULEPATH']
+            os.environ['MODULEPATH'] = ''
+        else:
+            self.modulepath = None
 
     def tearDown(self):
         # Remove temp dir
         if os.path.exists(self.working_dir):
             shutil.rmtree(self.working_dir)
+        # Restore the MODULEPATH env var
+        if self.modulepath:
+            os.environ['MODULEPATH'] = self.modulepath
 
     def test_pipelinecommand(self):
         """


### PR DESCRIPTION
PR which implements the `ListParam` class in the `pipeliner` module, to provide a subset of `list`-like functionality in a pipeline parameter (specifically the `append` and `extend` methods).

The advantage of using `ListParam` over a `list` is that list elements are also converted to their values when the object's `value` property is invoked.