### PR TITLE
'run_qc.py': fix for including MultiQC report in ZIP archive for Fastqs in subdirectory of project

### DIFF
--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -586,15 +586,16 @@ class QCProject(object):
             # Store the fastq_strand files
             output_files.extend(fastq_strand)
         # Look for ICELL8 outputs
+        icell8_top_dir = os.path.dirname(self.qc_dir)
         print("Checking for ICELL8 reports in %s/stats" %
-              self.project.dirn)
-        icell8_stats_xlsx = os.path.join(self.project.dirn,
+              icell8_top_dir)
+        icell8_stats_xlsx = os.path.join(icell8_top_dir,
                                          "stats",
                                          "icell8_stats.xlsx")
         if os.path.exists(icell8_stats_xlsx):
             outputs.add("icell8_stats")
             output_files.append(icell8_stats_xlsx)
-        icell8_report_html = os.path.join(self.project.dirn,
+        icell8_report_html = os.path.join(icell8_top_dir,
                                           "icell8_processing.html")
         if os.path.exists(icell8_report_html):
             outputs.add("icell8_report")
@@ -669,8 +670,9 @@ class QCProject(object):
             if cellranger_name and versions:
                 software[cellranger_name] = sorted(list(versions))
         # Look for MultiQC report
-        print("Checking for MultiQC report in %s" % self.project.dirn)
-        multiqc_report = os.path.join(self.project.dirn,
+        multiqc_dir = os.path.dirname(self.qc_dir)
+        print("Checking for MultiQC report in %s" % multiqc_dir)
+        multiqc_report = os.path.join(multiqc_dir,
                                       "multi%s_report.html"
                                       % os.path.basename(self.qc_dir))
         if os.path.isfile(multiqc_report):

--- a/bin/reportqc.py
+++ b/bin/reportqc.py
@@ -113,6 +113,14 @@ def main():
     # Report name and version
     print("%s version %s" % (os.path.basename(sys.argv[0]),__version__))
 
+    # Report arguments
+    if sys.argv[1:]:
+        print("\n%s" % ' '.join(['"%s"' % arg if ' ' in arg else arg
+                                 for arg in sys.argv[1:]]))
+
+    # Report working directory
+    print("\nCWD %s" % os.getcwd())
+
     # Check for MultiQC if required
     if args.multiqc:
         if find_program("multiqc") is None:
@@ -275,15 +283,15 @@ def main():
                     '--force')
                 for p in report_projects:
                     multiqc_cmd.add_args(p.qc_dir)
-                print("Running %s" % multiqc_cmd)
+                print("\nRunning %s" % multiqc_cmd)
                 multiqc_retval = multiqc_cmd.run_subprocess()
                 if multiqc_retval == 0 and os.path.exists(multiqc_report):
-                    print("MultiQC: %s" % multiqc_report)
+                    print("MultiQC: %s\n" % multiqc_report)
                 else:
                     print("MultiQC: FAILED")
                     retval += 1
             else:
-                print("MultiQC: %s (already exists)" % multiqc_report)
+                print("MultiQC: %s (already exists)\n" % multiqc_report)
         # Create data directory?
         use_data_dir = (len(projects) > 1)
         if args.use_data_dir:


### PR DESCRIPTION
PR which fixes a bug manifesting in the standalone QC utility `run_qc.py`, when the Fastqs are in a subdirectory of an existing project and the QC was already run for the "canonical" Fastqs.

For example: say there is an analysis project `210614_SN123456_ABXXXXX_analysis/PeterBriggs` which has already had the QC run; if there are then more Fastqs in a subdirectory `210614_SN123456_ABXXXXX_analysis/PeterBriggs/extra_processing/more_fastqs` and we execute `run_qc.py` in that subdirectory, then the QC reporting will erroneously pick up the MultiQC report in the project - not the one in `more_fastqs` - causing the ZIP archiving to fail.

The fix is actually in the `QCReporter._detect_outputs` method, and updates the locations where the reporter looks for the MultiQC and ICell8 reports.