### PR TITLE
Fix QC reporting of strandededness for Fastq sets containing mixture of R1/R2 and R2-only

### DIFF
--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -2048,9 +2048,10 @@ class QCReportFastqGroup(object):
         Arguments:
           document (Section): section to add report to
         """
+        rd = self.reads[0]
         strandedness_report = document.add_subsection(
             "Strandedness",
-            name="strandedness_%s" % self.reporters['r1'].safe_name)
+            name="strandedness_%s" % self.reporters[rd].safe_name)
         strandedness_report.add_css_classes("strandedness")
         # Locate strandedness
         txt = self.fastq_strand_txt


### PR DESCRIPTION
PR that fixes a bug in the QC reporting (specifically in the `report_strandedness` method of the `QCReportFastqGroup` class, in the qc/reporting` module), in the specific case that:

* Fastqs consist of a mixture of R1/R2 pairs and R2-only singles, and
* Strandedness outputs are present for both.

Without the fix the reporting crashes for strandedness outputs for the R2-only Fastqs.