### PR TITLE
QC report: update single library summary for cellranger-atac 2.0.0

### DIFF
--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -1045,13 +1045,13 @@ class QCReport(Document):
                     pkg = 'cellranger-atac'
                     single_library_fields = ['sample',
                                              '10x_cells',
-                                             '10x_fragments_per_cell']
+                                             '10x_fragments_per_cell',
+                                             '10x_tss_enrichment_score']
                     for v in project.software[pkg]:
                         # Add version specific fields to summary table
                         v = v.split('.')
                         if v[0] == '2':
-                            extra_fields = ['10x_fragments_overlapping_peaks',
-                                            '10x_tss_enrichment_score']
+                            extra_fields = ['10x_fragments_overlapping_peaks']
                         else:
                             extra_fields = ['10x_fragments_overlapping_targets']
                         for f in extra_fields:
@@ -1851,7 +1851,7 @@ class QCReportSample(object):
                             (metrics.frac_fragments_overlapping_peaks*100.0,)
                 elif field == "10x_tss_enrichment_score":
                     try:
-                        value = metrics.tss_enrichment_score
+                        value = "%.4f" % (metrics.tss_enrichment_score,)
                     except AttributeError:
                         value = 'N/A'
                 elif field == "10x_atac_fragments_per_cell":

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -819,6 +819,7 @@ class QCReport(Document):
         '10x_fragments_per_cell': '#fragments/cell',
         '10x_fragments_overlapping_targets': '%fragments overlapping targets',
         '10x_fragments_overlapping_peaks': '%fragments overlapping peaks',
+        '10x_tss_enrichment_score': 'TSS enrichment score',
         '10x_atac_fragments_per_cell': '#ATAC fragments/cell',
         '10x_gex_cells_per_gene': '#GEX cells/gene',
         '10x_pipeline': 'Pipeline',
@@ -1049,7 +1050,8 @@ class QCReport(Document):
                         # Add version specific fields to summary table
                         v = v.split('.')
                         if v[0] == '2':
-                            extra_fields = ['10x_fragments_overlapping_peaks']
+                            extra_fields = ['10x_fragments_overlapping_peaks',
+                                            '10x_tss_enrichment_score']
                         else:
                             extra_fields = ['10x_fragments_overlapping_targets']
                         for f in extra_fields:
@@ -1774,6 +1776,7 @@ class QCReportSample(object):
         - 10x_fragments_per_cell
         - 10x_fragments_overlapping_targets
         - 10x_fragments_overlapping_peaks
+        - 10x_tss_enrichment_score
         - 10x_atac_fragments_per_cell
         - 10x_gex_cells_per_gene
         - 10x_pipeline
@@ -1837,11 +1840,20 @@ class QCReportSample(object):
                     value = pretty_print_reads(
                         metrics.median_fragments_per_cell)
                 elif field == "10x_fragments_overlapping_targets":
-                    value = "%.1f%%" % \
-                            (metrics.frac_fragments_overlapping_targets*100.0,)
+                    try:
+                        value = "%.1f%%" % \
+                                (metrics.frac_fragments_overlapping_targets
+                                 *100.0,)
+                    except AttributeError:
+                        value = 'N/A'
                 elif field == "10x_fragments_overlapping_peaks":
                     value = "%.1f%%" % \
                             (metrics.frac_fragments_overlapping_peaks*100.0,)
+                elif field == "10x_tss_enrichment_score":
+                    try:
+                        value = metrics.tss_enrichment_score
+                    except AttributeError:
+                        value = 'N/A'
                 elif field == "10x_atac_fragments_per_cell":
                     value = pretty_print_reads(
                         metrics.atac_median_high_quality_fragments_per_cell)

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -1851,7 +1851,7 @@ class QCReportSample(object):
                             (metrics.frac_fragments_overlapping_peaks*100.0,)
                 elif field == "10x_tss_enrichment_score":
                     try:
-                        value = "%.4f" % (metrics.tss_enrichment_score,)
+                        value = "%.2f" % (metrics.tss_enrichment_score,)
                     except AttributeError:
                         value = 'N/A'
                 elif field == "10x_atac_fragments_per_cell":

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -320,8 +320,7 @@ class AtacSummary(MetricsSummary):
         try:
             return self.fetch('TSS enrichment score')
         except KeyError:
-            # Not supported
-            raise AttributeError
+            return self.fetch('tss_enrichment_score')
     @property
     def frac_fragments_overlapping_peaks(self):
         """

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -310,7 +310,18 @@ class AtacSummary(MetricsSummary):
         try:
             return self.fetch('frac_fragments_overlapping_targets')
         except KeyError:
-            return self.fetch('Fraction of high-quality fragments overlapping TSS')
+            # Not supported
+            raise AttributeError
+    @property
+    def tss_enrichment_score(self):
+        """
+        Return the TSS enrichment score
+        """
+        try:
+            return self.fetch('TSS enrichment score')
+        except KeyError:
+            # Not supported
+            raise AttributeError
     @property
     def frac_fragments_overlapping_peaks(self):
         """

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -516,6 +516,7 @@ class TestAtacSummary(unittest.TestCase):
                          0.575082094792)
         self.assertEqual(s.frac_fragments_overlapping_peaks,
                          0.556428090013)
+        self.assertEqual(s.tss_enrichment_score,6.91438390781)
         self.assertRaises(AttributeError,
                           getattr,
                           s,'estimated_number_of_cells')

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -530,14 +530,17 @@ class TestAtacSummary(unittest.TestCase):
         self.assertEqual(s.version,"2.0.0")
         self.assertEqual(s.estimated_number_of_cells,3582)
         self.assertEqual(s.median_fragments_per_cell,51354.5)
-        self.assertEqual(s.frac_fragments_overlapping_targets,0.291)
         self.assertEqual(s.frac_fragments_overlapping_peaks,0.4856)
+        self.assertEqual(s.tss_enrichment_score,6.8333)
         self.assertRaises(AttributeError,
                           getattr,
                           s,'cells_detected')
         self.assertRaises(AttributeError,
                           getattr,
                           s,'annotated_cells')
+        self.assertRaises(AttributeError,
+                          getattr,
+                          s,'frac_fragments_overlapping_targets')
 
 class TestMultiomeSummary(unittest.TestCase):
     """


### PR DESCRIPTION
PR which updates the fields reported in the single library summary table for `cellranger-atac` 2.0.0 single library analysis - specifically:

* For 2.0.0, no longer falls back to reporting the fraction of high-quality fragments overlapping the TSS instead of the fraction overlapping targets (instead reports `N/A`), and
* For 2.0.0 and earlier, now includes the TSS enrichment score in the summary table.