### PR TITLE
Add 'conda' support to handle task dependencies in pipelines

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -3825,7 +3825,7 @@ class CondaWrapper(object):
         Return a list of environments in the 'envs' directory
         """
         if self._env_dir and os.path.exists(self._env_dir):
-            return os.listdir(self._env_dir)
+            return sorted(os.listdir(self._env_dir))
         else:
             return []
 

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -41,6 +41,13 @@ internal use:
 - collect_files: collect files based on glob patterns
 - resolve_parameter: get the value of arbitrary parameter or object
 
+In addition there are classes to help with managing ``conda``
+environments:
+
+- CondaWrapper: wrapper for ``conda``, including environment creation
+- CondaWrapperException: base class for exceptions from CondaWrapper
+- CondaCreateEnvError: exception for errors when creating environments
+
 Overview
 --------
 
@@ -968,6 +975,7 @@ import traceback
 import string
 import cloudpickle
 import atexit
+import tempfile
 from collections import Iterator
 try:
     # Python2
@@ -975,8 +983,16 @@ try:
 except ImportError:
     # Python3
     from io import StringIO
+try:
+    from urllib.request import urlopen
+    from urllib.error import URLError
+except ImportError:
+    # Failed to get Python3 urlopen, fallback to Python2
+    from urllib2 import urlopen
+    from urllib2 import URLError
 from functools import reduce
 from bcftbx.utils import mkdir
+from bcftbx.utils import find_program
 from bcftbx.utils import AttributeDictionary
 from bcftbx.JobRunner import ResourceLock
 from bcftbx.JobRunner import SimpleJobRunner
@@ -3532,6 +3548,223 @@ class Dispatcher(object):
         """
         with open(pickle_file,'rb') as fp:
             return self._pickler.loads(fp.read())
+
+######################################################################
+# Conda dependency handling
+######################################################################
+
+class CondaWrapper(object):
+    """
+    Class for installing conda and creating environments
+
+    Example usage:
+
+    >>> conda = Conda('/usr/local/miniconda/bin/conda',
+    ...               channels=('bioconda','conda-forge'),
+    ...               env_dir='_conda_envs')
+    >>> conda.install()
+    >>> conda.create_env('multiqc@1.9','multiqc=1.9')
+    """
+    # Details of Miniconda installer
+    _miniconda = {
+        'url':
+        "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh",
+        'sha256':
+        "1314b90489f154602fd794accfc90446111514a5a72fe1f71ab83e07de9504a7",
+    }
+    def __init__(self,conda=None,env_dir=None,channels=None):
+        """
+        Create a new CondaWrapper instance
+
+        Arguments:
+          conda (str): path to conda executable
+          env_dir (str): optional, non-default directory
+            for conda environments
+          channels (list): optional, list of non-default
+            channels to use for installing packages
+        """
+        # Conda executable
+        if conda:
+            conda_dir = os.sep.join(
+                os.path.abspath(conda).split(os.sep)[:-2])
+        else:
+            conda_dir = None
+        self._conda_dir = conda_dir
+        # Default location for environments
+        if env_dir:
+            env_dir = os.path.abspath(env_dir)
+        elif self._conda_dir:
+            env_dir = os.path.join(self._conda_dir,'envs')
+        self._env_dir = env_dir
+        # Channels
+        if channels:
+            channels = [c for c in channels]
+        self._channels = channels
+        # Lock for blocking operations
+        self._lock_manager = ResourceLock()
+
+    @property
+    def conda(self):
+        """
+        Path to conda executable
+        """
+        if self._conda_dir:
+            return os.path.join(self._conda_dir,'bin','conda')
+        else:
+            return None
+
+    @property
+    def version(self):
+        """
+        Return the conda version
+        """
+        if not self.is_installed:
+            return None
+        version_cmd = Command(self.conda,'--version')
+        output = version_cmd.subprocess_check_output()[1]
+        try:
+            return output.split()[1].strip()
+        except Exception as ex:
+            logger.warning("Unable to get conda version")
+
+    @property
+    def is_installed(self):
+        """
+        Check whether conda is installed
+        """
+        if self.conda:
+            return os.path.exists(self.conda)
+        return False
+
+    @property
+    def env_dir(self):
+        """
+        Path to the directory for conda environments
+        """
+        return self._env_dir
+
+    @property
+    def list_envs(self):
+        """
+        Return a list of environments in the 'envs' directory
+        """
+        if self._env_dir and os.path.exists(self._env_dir):
+            return os.listdir(self._env_dir)
+        else:
+            return []
+
+    def install(self):
+        """
+        Install conda
+
+        Downloads and runs the miniconda installer if
+        conda is not already installed
+        """
+        if self.is_installed:
+            # Already installed
+            return
+        # Download miniconda
+        tmpdir = tempfile.mkdtemp()
+        miniconda_installer = os.path.join(
+            tmpdir,
+            os.path.basename(self._miniconda['url'])
+        )
+        try:
+            url = urlopen(self._miniconda['url'])
+            with open(miniconda_installer,'wb') as fp:
+                fp.write(url.read())
+        except URLError as ex:
+            raise Exception("Failed to download miniconda installer from "
+                            "'%s': %s" (self._miniconda['url']))
+        # Run the installer in silent mode
+        install_cmd = Command('bash',
+                              miniconda_installer,
+                              '-b',
+                              '-p',self._conda_dir)
+        install_cmd.run_subprocess()
+
+    def create_env(self,name,*packages,**args):
+        """
+        Create a new conda environment
+
+        Arguments:
+          name (str): name of the new environment
+          packages (list): package specifications for
+            packages to install (e.g. 'fastqc=0.11.3')
+        """
+        # Get a lock on create operation
+        lock = self._lock_manager.acquire("conda.create_env")
+        if name in self.list_envs:
+            # Environment already exists
+            logger.warning("'%s': environment already exists" % name)
+        else:
+            # Create new environment
+            if not self.is_installed:
+                raise PipelineError("Can't create environment: conda not "
+                                "installed")
+            # Base command
+            create_cmd = Command(self.conda,'create','-y',)
+            # Channels
+            if self._channels:
+                create_cmd.add_args('--override-channels')
+                for channel in self._channels:
+                    create_cmd.add_args('-c',channel)
+            # Create environment in specific location
+            if self._env_dir:
+                create_cmd.add_args('--prefix',
+                                    os.path.join(self._env_dir,name))
+            else:
+                create_cmd.add_args('-n',name)
+            # Packages to install
+            create_cmd.add_args(*packages)
+            # Run the command
+            status,output = create_cmd.subprocess_check_output()
+            if status != 0:
+                # Release the lock
+                self._lock_manager.release(lock)
+                # Raise exception
+                raise CondaCreateEnvError(
+                    status=status,
+                    env_name=name,
+                    cmdline=str(create_cmd),
+                    output=output)
+        if self._env_dir:
+            env_name = os.path.join(self._env_dir,name)
+        else:
+            env_name = name
+        # Release the lock
+        self._lock_manager.release(lock)
+        # Return name/path to conda environment
+        return env_name
+
+class CondaWrapperError(Exception):
+    """
+    Base class for conda-specific exceptions
+    """
+
+class CondaCreateEnvError(CondaWrapperError):
+    """
+    Exception raised when CondaWrapper class fails
+    to create a new environment
+
+    Arguments:
+      message (str): error message
+      env_name (str): name of the environment
+      status (int): status returned by the conda command
+      cmdline (str): command line for the conda command
+        that generated the error
+      output (str): output from the conda command
+    """
+    def __init__(self,message=None,env_name=None,status=None,
+                 cmdline=None,output=None):
+        if message is None:
+            message = "Unable to create environment"
+        self.message = message
+        self.env_name = env_name
+        self.status = status
+        self.cmdline = cmdline
+        self.output = output
+        super().__init__(self.message)
 
 ######################################################################
 # Custom exceptions

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2155,6 +2155,7 @@ class Pipeline(object):
                                 sorted(
                                     task.conda_dependencies)).replace('=','@')
                             # Fetch the environment
+                            conda_env = None
                             if env_name not in conda.list_envs:
                                 # Create new environment
                                 self.report("attempting to create new conda "
@@ -2175,9 +2176,12 @@ class Pipeline(object):
                                         "\n**** CONDA DIAGNOSTICS ****\n")
                                     self.report("Command: %s\n" % ex.cmdline)
                                     self.report("Status : %s\n" % ex.status)
-                                    self.report("Output:\n\n%s\n" % ex.output)
+                                    self.report("Output:\n\n%s" % ex.output)
                                     self.report(
-                                        "\n**** END OF DIAGNOSTICS ****")
+                                        "\n**** END OF DIAGNOSTICS ****\n")
+                                    self.report("WARNING the task may fail "
+                                                "as the required environment "
+                                                "couldn't be created")
                             else:
                                 # Use existing environment
                                 self.report("using existing conda environment "
@@ -2188,7 +2192,8 @@ class Pipeline(object):
                             if 'conda' not in kws:
                                 kws['conda'] = conda.conda
                             if 'conda_env' not in kws:
-                                kws['conda_env'] = conda_env
+                                if conda_env:
+                                    kws['conda_env'] = conda_env
                     if 'runner' not in kws:
                         kws['runner'] = default_runner
                     if 'working_dir' not in kws:

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -3940,7 +3940,7 @@ class CondaCreateEnvError(CondaWrapperError):
         self.status = status
         self.cmdline = cmdline
         self.output = output
-        super().__init__(self.message)
+        CondaWrapperError.__init__(self,self.message)
 
 ######################################################################
 # Custom exceptions

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -793,12 +793,12 @@ setting up tasks, for example:
 The values will be set when the pipeline's ``run`` method is
 invoked.
 
-Defining execution environment for a task: runners and envmodules
------------------------------------------------------------------
+Defining execution environment for a task: runners, modules & conda
+-------------------------------------------------------------------
 
 It is possible to define the execution environment on a per-task
-basis within a pipeline, by defining job runners and environment
-modules.
+basis within a pipeline, by defining job runners, environment
+modules and conda dependencies.
 
 Runners and environments can be declared in a parameterised
 fashion when a pipline is created, using the ``add_runner`` and
@@ -852,6 +852,24 @@ default runner is used for that task; this defaults to a
 ``default_runner`` argument of the ``Pipeline`` instance's ``run``
 method.
 
+Execution environments can also be defined with ``conda`` packages.
+The packages and versions required by a task are declared in a
+task's ``init`` method with calls to the ``conda`` method, for
+example:
+
+::
+
+   class RunFastqc(PipelineTask):
+       def init(self,fastq,out_dir):
+           self.conda("fastqc=0.11.3")
+           ...
+
+If ``conda`` dependency resolution is enabled when the pipeline is
+executed then these declarations will be used to generate ``conda``
+environments that are activated when the tasks run (otherwise they
+are ignored) (see the section "Enabling conda to create task environments
+automatically" for details).
+
 Defining outputs from a pipeline
 --------------------------------
 
@@ -891,6 +909,33 @@ the pipeline's ``run`` method to ``False``. For example:
 It is recommended that outputs are defined as ``PipelineParam``
 instances, to take advantage of the implicit task requirement
 gathering mechanism.
+
+Enabling conda to create task environments automatically
+--------------------------------------------------------
+
+The ``conda`` package manager can be used within ``Pipeline``s
+to automatically create run-time environments for any tasks which
+declare ``conda`` dependencies in their ``init`` methods.
+
+To enable the use of conda when a pipeline is executed, specify
+the following arguments when invoking the pipeline's ``run``
+method:
+
+1. ``enable_conda`` must be set to ``True``, and
+2. The path to an existing ``conda`` installation must be supplied
+   using via ``conda`` argument.
+
+For example:
+
+::
+
+    ppl = Pipeline()
+    ...
+    ppl.run(enable_conda=True,conda='/usr/local/miniconda3/bin/conda)
+
+(By default new ``conda`` environments are created in a subdirectory of
+the working directory, but it is possible to explicitly specify a
+different location via the ``conda_env_dir`` of the ``run`` method.)
 
 PipelineCommand versus PipelineCommandWrapper
 ---------------------------------------------

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -127,6 +127,7 @@ export PATH=$PATH:${1}
         # Return path to mock conda
         return conda_
 
+    @staticmethod
     def conda_with_failing_create(bin_dir):
         """
         Make a mock conda executable with failing 'create' command

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -1768,6 +1768,44 @@ class TestPipelineTask(unittest.TestCase):
         # Unpickle it
         unpickled = cloudpickle.loads(pickled)
 
+    def test_pipelinetask_no_conda_dependencies(self):
+        """
+        PipelineTask: check when no conda dependencies are declared
+        """
+        # Define a task without conda dependencies
+        class NoCondaDeps(PipelineTask):
+            def init(self,fq):
+                pass
+            def setup(self):
+                self.add_cmd(PipelineCommandWrapper(
+                    "Run FastQC","fastqc",self.args.fq))
+        # Make a task instance
+        task = NoCondaDeps("Test","Sample1_S1_R1_001.fastq.gz")
+        # Check conda dependencies
+        self.assertEqual(task.conda_dependencies,[])
+
+    def test_pipelinetask_conda_dependencies(self):
+        """
+        PipelineTask: check declaring conda dependencies
+        """
+        # Define a task with conda dependencies
+        class WithCondaDeps(PipelineTask):
+            def init(self,fq):
+                self.conda("fastqc=0.11.3")
+                self.conda("fastq-screen=0.14.0",
+                           "bowtie=1.2.3")
+            def setup(self):
+                self.add_cmd(
+                    PipelineCommandWrapper(
+                        "Run FastQC","fastqc",self.args.fq))
+        # Make a task instance
+        task = WithCondaDeps("Test","Sample1_S1_R1_001.fastq.gz")
+        # Check conda dependencies
+        self.assertEqual(task.conda_dependencies,
+                         ["fastqc=0.11.3",
+                          "fastq-screen=0.14.0",
+                          "bowtie=1.2.3"])
+
 class TestPipelineFunctionTask(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
PR that addresses issue #569 by updating the `Pipeline` and `PipelineTask` classes in the `pipeliner` module so that tasks can declare `conda` dependencies that the pipeline will use to automatically generate `conda` environments which are then activated when the tasks run.

The updates include:

* Implementation of a new `CondaWrapper` class, which is used to manage interactions with `conda` (essentially, creating new environments on demand)
* The `PipelineTask` class allows `conda` packages to be declared using a new `conda()` method, and uses these to generate environments within its `run()` method (or reuse existing environments) (if `conda` support is enabled).
* The `make_wrapper_script()` method of the `PipelineCommand` class has been updated to enable a `conda` environment to be activated within the generated wrapper script.