### PR TITLE
pipeliner: update PipelineTask.add_cmd() method to handle 'Command' instances and scripts

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2668,16 +2668,38 @@ class PipelineTask(object):
         else:
             self.report("completed: %s" % status)
 
-    def add_cmd(self,pipeline_job):
+    def add_cmd(self,*args):
         """
         Add a PipelineCommand to the task
 
+        The arguments can be one of:
+
+        - Single argument: PipelineCommand instance
+        - Two arguments: title string and Command instance
+        - Two arguments: title string and script (as string)
+
         Arguments:
-           pipeline_job (PipelineCommand): a PipelineCommand
-             instance to be executed by the task when it
-             runs
+           Variable (see above)
         """
-        self._commands.append(pipeline_job)
+        if len(args) == 1:
+            # Assume PipelineCommand instance
+            self._commands.append(args[0])
+        elif len(args) == 2:
+            # Assume name and command
+            try:
+                # Try adding Command instance
+                self._commands.append(
+                    PipelineCommandWrapper(args[0],
+                                           *args[1].command_line))
+            except AttributeError:
+                # Try adding as a script
+                self._commands.append(
+                    PipelineScriptWrapper(args[0],args[1]))
+        else:
+            # Incorrect number of arguments
+            raise TypeError("add_cmd() invoked with incorrect arguments: "
+                            "either 'pipeline_command', or 'name' and "
+                            "'command', or 'name' and 'script'")
 
     def requires(self,*tasks):
         """

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2964,7 +2964,9 @@ class PipelineTask(object):
                 # single command
                 batch_cmd = PipelineScriptWrapper(
                     "Batch commands for %s" % self.name(),
-                    *[b.cmd().make_wrapper_script() for b in batch])
+                    *[b.cmd().make_wrapper_script(
+                        quote_spaces=b.quote_spaces())
+                      for b in batch])
                 if verbose:
                     self.report("%s" % batch_cmd.cmd())
                 script_file = batch_cmd.make_wrapper_script(
@@ -3267,8 +3269,14 @@ class PipelineCommand(object):
                                        shell=shell,
                                        prologue='\n'.join(prologue),
                                        epilogue='\n'.join(epilogue),
-                                       quote_spaces=self._quote_spaces)
+                                       quote_spaces=self.quote_spaces())
         return script_file
+
+    def quote_spaces(self):
+        """
+        Indicate whether spaces should be quoted in wrapper script
+        """
+        return self._quote_spaces
 
     def init(self):
         """

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2960,14 +2960,11 @@ class PipelineTask(object):
             while remaining_cmds:
                 # Grab a batch of commands
                 batch = remaining_cmds[:batch_size]
-                # Combine batch into a single command
-                batch_cmd = PipelineCommandWrapper(
+                # Combine batch commands and scripts into a
+                # single command
+                batch_cmd = PipelineScriptWrapper(
                     "Batch commands for %s" % self.name(),
-                    *batch[0].cmd().command_line)
-                for cmd in batch[1:]:
-                    batch_cmd.add_args("&&",
-                                       "\\\n",
-                                       *cmd.cmd().command_line)
+                    *[b.cmd().make_wrapper_script() for b in batch])
                 if verbose:
                     self.report("%s" % batch_cmd.cmd())
                 script_file = batch_cmd.make_wrapper_script(

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -3495,7 +3495,7 @@ class PipelineScriptWrapper(PipelineCommand):
             # Multiple blocks
             blocks = []
             for block in self._scripts:
-                blocks.append("{\n%s\n}" % textwrap.indent(block,"    "))
+                blocks.append("{\n%s\n}" % indent(block,"    "))
             return Command(self._block_sep.join(blocks))
 
 ######################################################################
@@ -4224,3 +4224,14 @@ def resolve_parameter(p):
         return p.value
     except AttributeError:
         return p
+
+def indent(s,prefix):
+    """
+    Wrapper for textwrap.indent to handle Python2/3
+    """
+    try:
+        # Python3
+        return textwrap.indent(s,prefix)
+    except AttributeError:
+        # Python2
+        return '\n'.join([prefix+line for line in s.splitlines(True)])

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -4234,4 +4234,5 @@ def indent(s,prefix):
         return textwrap.indent(s,prefix)
     except AttributeError:
         # Python2
-        return '\n'.join([prefix+line for line in s.splitlines(True)])
+        return '\n'.join([prefix+line.rstrip('\n')
+                          for line in s.splitlines(True)])

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -323,7 +323,10 @@ class TestPipeline(unittest.TestCase):
         ppl = Pipeline()
         task = EchoMany("Write items",
                         ("out1.txt","item"),
-                        ("out2.txt","item"),)
+                        ("out2.txt","item"),
+                        ("out3.txt","item"),
+                        ("out4.txt","item"),
+                        ("out5.txt","item"),)
         ppl.add_task(task)
         # Run the pipeline
         exit_status = ppl.run(working_dir=self.working_dir,
@@ -332,7 +335,11 @@ class TestPipeline(unittest.TestCase):
         # Check the outputs
         self.assertEqual(exit_status,0)
         out_files = [os.path.join(self.working_dir,f)
-                     for f in ("out1.txt","out2.txt")]
+                     for f in ("out1.txt",
+                               "out2.txt",
+                               "out3.txt",
+                               "out4.txt",
+                               "out5.txt")]
         for out_file in out_files:
             self.assertTrue(os.path.exists(out_file))
             with open(out_file,'rt') as fp:
@@ -1760,9 +1767,19 @@ class TestPipelineTask(unittest.TestCase):
                         PipelineCommandWrapper(
                             "Echo text","echo",s))
         # Make a task instance
-        task = EchoMany("Echo string","Hello!","Goodbye!")
+        task = EchoMany("Echo string",
+                        "Hello!",
+                        "Bonjour!",
+                        "Takk!",
+                        "Wilkommen!",
+                        "Benvenuto!")
         # Check initial state
-        self.assertEqual(task.args.s,("Hello!","Goodbye!"))
+        self.assertEqual(task.args.s,
+                         ("Hello!",
+                          "Bonjour!",
+                          "Takk!",
+                          "Wilkommen!",
+                          "Benvenuto!"))
         self.assertFalse(task.completed)
         self.assertEqual(task.exit_code,None)
         self.assertFalse(task.output)
@@ -1783,21 +1800,160 @@ class TestPipelineTask(unittest.TestCase):
         # #### START Thu Aug 17 08:38:14 BST 2017
         # #### CWD /tmp/dir
         # Hello!
-        # Goodbye!
+        # Bonjour!
+        # #### END Thu Aug 17 08:38:14 BST 2017
+        # #### EXIT_CODE 0
+        # #### COMMAND Batch commands for Echo string
+        # #### HOSTNAME popov
+        # #### USER pjb
+        # #### START Thu Aug 17 08:38:14 BST 2017
+        # #### CWD /tmp/dir
+        # Takk!
+        # Wilkommen!
+        # #### END Thu Aug 17 08:38:14 BST 2017
+        # #### EXIT_CODE 0
+        # #### COMMAND Batch commands for Echo string
+        # #### HOSTNAME popov
+        # #### USER pjb
+        # #### START Thu Aug 17 08:38:14 BST 2017
+        # #### CWD /tmp/dir
+        # Benvenuto!
         # #### END Thu Aug 17 08:38:14 BST 2017
         # #### EXIT_CODE 0
         stdout = task.stdout.split("\n")
-        self.assertEqual(len(stdout),10) # 10 = 9 + trailing newline
-        self.assertEqual(stdout[0],
-                         "#### COMMAND Batch commands for Echo string")
+        self.assertEqual(len(stdout),27) # 27 = 26 + trailing newline
+        self.assertEqual(stdout[0],"#### COMMAND Batch commands for Echo "
+                         "string")
         self.assertEqual(stdout[1],"#### HOSTNAME %s" % self._hostname())
         self.assertEqual(stdout[2],"#### USER %s" % self._user())
         self.assertTrue(stdout[3].startswith("#### START "))
         self.assertEqual(stdout[4],"#### CWD %s" % self.working_dir)
         self.assertEqual(stdout[5],"Hello!")
-        self.assertEqual(stdout[6],"Goodbye!")
+        self.assertEqual(stdout[6],"Bonjour!")
         self.assertTrue(stdout[7].startswith("#### END "))
         self.assertEqual(stdout[8],"#### EXIT_CODE 0")
+        self.assertEqual(stdout[9],"#### COMMAND Batch commands for Echo "
+                         "string")
+        self.assertEqual(stdout[10],"#### HOSTNAME %s" % self._hostname())
+        self.assertEqual(stdout[11],"#### USER %s" % self._user())
+        self.assertTrue(stdout[12].startswith("#### START "))
+        self.assertEqual(stdout[13],"#### CWD %s" % self.working_dir)
+        self.assertEqual(stdout[14],"Takk!")
+        self.assertEqual(stdout[15],"Wilkommen!")
+        self.assertTrue(stdout[16].startswith("#### END "))
+        self.assertEqual(stdout[17],"#### EXIT_CODE 0")
+        self.assertEqual(stdout[18],"#### COMMAND Batch commands for Echo "
+                         "string")
+        self.assertEqual(stdout[19],"#### HOSTNAME %s" % self._hostname())
+        self.assertEqual(stdout[20],"#### USER %s" % self._user())
+        self.assertTrue(stdout[21].startswith("#### START "))
+        self.assertEqual(stdout[22],"#### CWD %s" % self.working_dir)
+        self.assertEqual(stdout[23],"Benvenuto!")
+        self.assertTrue(stdout[24].startswith("#### END "))
+        self.assertEqual(stdout[25],"#### EXIT_CODE 0")
+
+    def test_pipelinetask_with_batched_scripts(self):
+        """
+        PipelineTask: run task with batched scripts
+        """
+        # Define a task with a command
+        # Echoes text via shell command
+        class EchoMany(PipelineTask):
+            def init(self,*s):
+                pass
+            def setup(self):
+                for s in self.args.s:
+                    self.add_cmd(
+                        PipelineScriptWrapper(
+                            "Echo text",
+                            """
+                            echo {s}
+                            """.format(s=s)))
+        # Make a task instance
+        task = EchoMany("Echo string",
+                        "Hello!",
+                        "Bonjour!",
+                        "Takk!",
+                        "Wilkommen!",
+                        "Benvenuto!")
+        # Check initial state
+        self.assertEqual(task.args.s,
+                         ("Hello!",
+                          "Bonjour!",
+                          "Takk!",
+                          "Wilkommen!",
+                          "Benvenuto!"))
+        self.assertFalse(task.completed)
+        self.assertEqual(task.exit_code,None)
+        self.assertFalse(task.output)
+        # Run the task with batches
+        task.run(sched=self.sched,
+                 working_dir=self.working_dir,
+                 batch_size=2,
+                 asynchronous=False)
+        # Check final state
+        self.assertTrue(task.completed)
+        self.assertEqual(task.exit_code,0)
+        self.assertFalse(task.output)
+        # Check stdout
+        # Should look like:
+        # #### COMMAND Batch commands for Echo string
+        # #### HOSTNAME popov
+        # #### USER pjb
+        # #### START Thu Aug 17 08:38:14 BST 2017
+        # #### CWD /tmp/dir
+        # Hello!
+        # Bonjour!
+        # #### END Thu Aug 17 08:38:14 BST 2017
+        # #### EXIT_CODE 0
+        # #### COMMAND Batch commands for Echo string
+        # #### HOSTNAME popov
+        # #### USER pjb
+        # #### START Thu Aug 17 08:38:14 BST 2017
+        # #### CWD /tmp/dir
+        # Takk!
+        # Wilkommen!
+        # #### END Thu Aug 17 08:38:14 BST 2017
+        # #### EXIT_CODE 0
+        # #### COMMAND Batch commands for Echo string
+        # #### HOSTNAME popov
+        # #### USER pjb
+        # #### START Thu Aug 17 08:38:14 BST 2017
+        # #### CWD /tmp/dir
+        # Benvenuto!
+        # #### END Thu Aug 17 08:38:14 BST 2017
+        # #### EXIT_CODE 0
+        stdout = task.stdout.split("\n")
+        self.assertEqual(len(stdout),27) # 27 = 26 + trailing newline
+        self.assertEqual(stdout[0],"#### COMMAND Batch commands for Echo "
+                         "string")
+        self.assertEqual(stdout[1],"#### HOSTNAME %s" % self._hostname())
+        self.assertEqual(stdout[2],"#### USER %s" % self._user())
+        self.assertTrue(stdout[3].startswith("#### START "))
+        self.assertEqual(stdout[4],"#### CWD %s" % self.working_dir)
+        self.assertEqual(stdout[5],"Hello!")
+        self.assertEqual(stdout[6],"Bonjour!")
+        self.assertTrue(stdout[7].startswith("#### END "))
+        self.assertEqual(stdout[8],"#### EXIT_CODE 0")
+        self.assertEqual(stdout[9],"#### COMMAND Batch commands for Echo "
+                         "string")
+        self.assertEqual(stdout[10],"#### HOSTNAME %s" % self._hostname())
+        self.assertEqual(stdout[11],"#### USER %s" % self._user())
+        self.assertTrue(stdout[12].startswith("#### START "))
+        self.assertEqual(stdout[13],"#### CWD %s" % self.working_dir)
+        self.assertEqual(stdout[14],"Takk!")
+        self.assertEqual(stdout[15],"Wilkommen!")
+        self.assertTrue(stdout[16].startswith("#### END "))
+        self.assertEqual(stdout[17],"#### EXIT_CODE 0")
+        self.assertEqual(stdout[18],"#### COMMAND Batch commands for Echo "
+                         "string")
+        self.assertEqual(stdout[19],"#### HOSTNAME %s" % self._hostname())
+        self.assertEqual(stdout[20],"#### USER %s" % self._user())
+        self.assertTrue(stdout[21].startswith("#### START "))
+        self.assertEqual(stdout[22],"#### CWD %s" % self.working_dir)
+        self.assertEqual(stdout[23],"Benvenuto!")
+        self.assertTrue(stdout[24].startswith("#### END "))
+        self.assertEqual(stdout[25],"#### EXIT_CODE 0")
 
     def test_pipelinetask_with_commands_as_command_instances(self):
         """


### PR DESCRIPTION
PR which updates the `add_cmd` method of the `PipelineTask` class to enable it to handle `Command` instances and scripts, as alternatives to supplying a `PipelineCommand` subclass.

A new `PipelineCommand` subclass `PipelineScriptWrapper` is implemented as part of the PR; it also fixes some issues with batching jobs within tasks, while enabling `Command` instances to be passed directly aims to address issue #658.