### PR TITLE
'run_qc' command: fix broken handling of default conda dependency resolution from command line

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -695,7 +695,7 @@ def add_run_qc_command(cmdparser):
     # Conda options
     conda = p.add_argument_group("Conda dependency resolution")
     conda.add_argument('--enable-conda',choices=["yes","no"],
-                       dest="enable_conda",default=None,
+                       dest="enable_conda",default=enable_conda,
                        help="use conda to resolve task dependencies; can "
                        "be 'yes' or 'no' (default: %s)" % enable_conda)
     # Job control options


### PR DESCRIPTION
PR which fixes a bug in the options for running the `run_qc` command, which meant that the default setting for enabling conda dependency resolution was always `None` (regardless of what was set in the configuration).

The fix ensures that the default setting in the configuration is now used unless overridden by the `--enable-conda` option.