### PR TITLE
make_fastqs: add support for bcl2fastq --find-adapters-with-sliding-window option

### DIFF
--- a/auto_process_ngs/applications.py
+++ b/auto_process_ngs/applications.py
@@ -142,6 +142,7 @@ class bcl2fastq(object):
                    minimum_trimmed_read_length=None,
                    mask_short_adapter_reads=None,
                    create_fastq_for_index_reads=False,
+                   find_adapters_with_sliding_window=False,
                    loading_threads=None,
                    demultiplexing_threads=None,
                    processing_threads=None,
@@ -179,6 +180,11 @@ class bcl2fastq(object):
           create_fastq_for_index_reads: optional, if True then also create
             Fastq files for index reads (default, don't create index read
             Fastqs) (--create-fastq-for-index-reads)
+          find_adapters_with_sliding_window: optional, if True then
+            use the sliding window algorithm rather than string matching
+            when identifying adapter sequences for trimming (default,
+            don't use sliding window algorithm)
+            (--find-adapters-with-sliding-window)
           loading_threads: optional, specify number of threads to use
             for loading bcl data (--loading-threads)
           demultiplexing_threads: optional, specify number of threads to
@@ -221,6 +227,8 @@ class bcl2fastq(object):
                                    mask_short_adapter_reads)
         if create_fastq_for_index_reads:
             bcl2fastq_cmd.add_args('--create-fastq-for-index-read')
+        if find_adapters_with_sliding_window:
+            bcl2fastq_cmd.add_args('--find-adapters-with-sliding-window')
         if loading_threads is not None:
             bcl2fastq_cmd.add_args('-r',loading_threads)
         if demultiplexing_threads is not None:

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -324,6 +324,11 @@ def add_make_fastqs_command(cmdparser):
                               "(bcl2fastq v2 only; turn off using "
                               "--no-lane-splitting)%s" %
                               default_use_lane_splitting)
+    bcl_to_fastq.add_argument("--find-adapters-with-sliding-window",
+                              action="store_true",
+                              dest='find_adapters_with_sliding_window',
+                              help="use sliding window algorithm to "
+                              "identify adapters for trimming")
     # Creation of empty fastqs
     # Determine defaults to report to user
     create_empty_fastqs_platforms = []
@@ -1304,6 +1309,8 @@ def make_fastqs(args):
         adapter_sequence=args.adapter_sequence,
         adapter_sequence_read2=args.adapter_sequence_read2,
         create_fastq_for_index_read=args.create_fastq_for_index_read,
+        find_adapters_with_sliding_window=\
+        args.find_adapters_with_sliding_window,
         stats_file=args.stats_file,
         per_lane_stats_file=args.per_lane_stats_file,
         barcode_analysis_dir=args.barcode_analysis_dir,

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -49,6 +49,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 adapter_sequence=None,
                 adapter_sequence_read2=None,
                 create_fastq_for_index_read=False,
+                find_adapters_with_sliding_window=None,
                 generate_stats=True,stats_file=None,
                 per_lane_stats_file=None,
                 analyse_barcodes=True,barcode_analysis_dir=None,
@@ -142,6 +143,9 @@ def make_fastqs(ap,protocol='standard',platform=None,
       create_fastq_for_index_reads (boolean): if True then also create
         Fastq files for index reads (default, don't create index read
         Fastqs)
+      find_adapters_with_sliding_window (boolean): if True then use
+        sliding window algorithm to identify adapter sequences for
+        trimming
       stats_file (str): if set then use this as the name of the output
         per-fastq stats file.
       per_lane_stats_file (str): if set then use this as the name of
@@ -410,6 +414,8 @@ def make_fastqs(ap,protocol='standard',platform=None,
                              no_lane_splitting=no_lane_splitting,
                              create_fastq_for_index_read=\
                              create_fastq_for_index_read,
+                             find_adapters_with_sliding_window=\
+                             find_adapters_with_sliding_window,
                              create_empty_fastqs=create_empty_fastqs,
                              stats_file=stats_file,
                              per_lane_stats=per_lane_stats_file,

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1027,9 +1027,12 @@ class MockBcl2fastq2Exe(object):
       `assert_minimum_trimmed_read_length`
       and `assert_mask_short_adapter_reads`
       arguments
-    - adpater sequences can be checked via
+    - adapter sequences can be checked via
       the `assert_adapter` and
       `assert_adapter2` arguments
+    - sliding window algorith for adapter
+      trimming can be checked via
+      `assert_find_adapters_with_sliding_window`
     """
 
     @staticmethod
@@ -1040,6 +1043,7 @@ class MockBcl2fastq2Exe(object):
                assert_minimum_trimmed_read_length=None,
                assert_mask_short_adapter_reads=None,
                assert_adapter=None,assert_adapter2=None,
+               assert_find_adapters_with_sliding_window=None,
                version='2.20.0.422'):
         """
         Create a "mock" bcl2fastq executable
@@ -1083,6 +1087,10 @@ class MockBcl2fastq2Exe(object):
             assert that the adapter sequence
             for read2 in the sample sheet matches
             the supplied value
+          assert_find_adapters_with_sliding_window
+            (bool): if set then assert that
+            --find-adapters-with-sliding-window
+            matches the supplied boolean value
           version (str): version of bcl2fastq2
             to imitate
         """
@@ -1104,6 +1112,7 @@ sys.exit(MockBcl2fastq2Exe(exit_code=%s,
                            assert_mask_short_adapter_reads=%s,
                            assert_adapter=%s,
                            assert_adapter2=%s,
+                           assert_find_adapters_with_sliding_window=%s,
                            version=%s).main(sys.argv[1:]))
             """ % (exit_code,
                    missing_fastqs,
@@ -1123,6 +1132,7 @@ sys.exit(MockBcl2fastq2Exe(exit_code=%s,
                    ("\"%s\"" % assert_adapter2
                     if assert_adapter2 is not None
                     else None),
+                   assert_find_adapters_with_sliding_window,
                    ("\"%s\"" % version
                     if version is not None
                     else None)))
@@ -1142,6 +1152,7 @@ sys.exit(MockBcl2fastq2Exe(exit_code=%s,
                  assert_mask_short_adapter_reads=None,
                  assert_adapter=None,
                  assert_adapter2=None,
+                 assert_find_adapters_with_sliding_window=None,
                  version=None):
         """
         Internal: configure the mock bcl2fastq2
@@ -1159,6 +1170,8 @@ sys.exit(MockBcl2fastq2Exe(exit_code=%s,
                                 assert_mask_short_adapter_reads
         self._assert_adapter = assert_adapter
         self._assert_adapter2 = assert_adapter2
+        self._assert_find_adapters_with_sliding_window = \
+                                assert_find_adapters_with_sliding_window
         self._version = version
 
     def main(self,args):
@@ -1190,6 +1203,8 @@ bcl2fastq v%s
         p.add_argument("--ignore-missing-bcls",action="store_true")
         p.add_argument("--no-lane-splitting",action="store_true")
         p.add_argument("--create-fastq-for-index-read",action="store_true")
+        p.add_argument("--find-adapters-with-sliding-window",
+                       action="store_true")
         p.add_argument("-r",action="store")
         if self._version.startswith("2.17."):
             p.add_argument("-d",action="store")
@@ -1222,6 +1237,12 @@ bcl2fastq v%s
                   args.mask_short_adapter_reads)
             assert(int(args.mask_short_adapter_reads) ==
                    int(self._assert_mask_short_adapter_reads))
+        # Check --find-adapters-with-sliding-window
+        if self._assert_find_adapters_with_sliding_window is not None:
+            print("Checking --find-adapters-with-sliding-window: %s" %
+                  args.find_adapters_with_sliding_window)
+            assert(args.find_adapters_with_sliding_window ==
+                   self._assert_find_adapters_with_sliding_window)
         # Platform
         print("Platform (default): %s" % self._platform)
         # Run folder (input data)

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -499,6 +499,80 @@ class TestMakeFastqs(unittest.TestCase):
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_find_adapters_with_sliding_window(self):
+        """
+        MakeFastqs: standard protocol: use sliding window for adapter trimming
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        # Check that --find-adapters-with-sliding-window is set
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 assert_find_adapters_with_sliding_window=True)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet)
+        status = p.run(analysis_dir,
+                       find_adapters_with_sliding_window=True,
+                       poll_interval=0.5)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
     def test_makefastqs_standard_protocol_disable_fastq_statistics(self):
         """
         MakeFastqs: standard protocol: disable Fastq statistics


### PR DESCRIPTION
PR which adds support to the `make_fastqs` command for Bcl2fastq's `--find-adapters-with-sliding-window` option, to set the algorithm used for identifying adapter sequences when performing trimming and masking.