### PR TITLE
bcl2fastq/pipeline: update reporting of parameters when initialising lane subsets

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -822,11 +822,18 @@ class MakeFastqs(Pipeline):
         #################
         self.report("Building pipeline for lane subsets:")
         for s in self.subsets:
-            self.report("- Lanes: %s" % ','.join([str(l)
-                                                  for l in s['lanes']]))
+            self.report("- **** Lanes: %s ***" %
+                        (','.join([str(l) for l in s['lanes']])
+                         if s['lanes'] else 'all'))
             for attr in s:
                 if attr != 'lanes' and s[attr] is not None:
-                    self.report("- %s: %s" % (attr,s[attr]))
+                    try:
+                        value = s[attr].value
+                    except AttributeError:
+                        value = s[attr]
+                    self.report("- %s: %s" % (attr,
+                                              (value if value is not None
+                                               else '<not set>')))
 
         #####################
         # Fetch primary data


### PR DESCRIPTION
PR which updates how parameter values are reported when the lane subsets are initialised as part of building the pipeline in `MakeFastqs` in `bcl2fastq/pipeline.py`.