### PR TITLE
tenx_genomics_utils: add "10xGenomics Chromium 3'v3.1" to list of platforms

### DIFF
--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -62,6 +62,7 @@ PLATFORMS = (
     "10xGenomics Chromium",
     "10xGenomics Chromium 3'v2",
     "10xGenomics Chromium 3'v3",
+    "10xGenomics Chromium 3'v3.1",
     "10xGenomics Single Cell ATAC",
     "10xGenomics Visium",
     "10xGenomics Single Cell Multiome",


### PR DESCRIPTION
PR which updates the list of single cell platforms in the `tenx_genomics_utils` module to include `10xGenomics Chromium 3'v3.1`.