### PR TITLE
run_qc.py: add new options to set metadata (library type/single cell platform)

### DIFF
--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -143,6 +143,15 @@ if __name__ == "__main__":
                           "'human', 'mouse'). Multiple organisms "
                           "should be separated by commas (e.g. "
                           "'human,mouse')")
+    metadata.add_argument('--library-type',metavar='LIBRARY',
+                          action='store',dest='library_type',default=None,
+                          help="explicitly specify library type (e.g. "
+                          "'RNA-seq', 'ChIP-seq')")
+    metadata.add_argument('--single-cell-platform',metavar='PLATFORM',
+                          action='store',dest='single_cell_platform',
+                          default=None,
+                          help="explicitly specify the single cell "
+                          "platform (e.g. '10xGenomics Chromium 3'v3')")
     # QC pipeline options
     qc_options = p.add_argument_group('QC options')
     qc_options.add_argument('-p','--protocol',metavar='PROTOCOL',
@@ -151,7 +160,7 @@ if __name__ == "__main__":
                             help="explicitly specify the QC protocol to "
                             "use; can be one of %s. If not set then "
                             "protocol will be determined automatically "
-                            "based on directory contents." %
+                            "based on directory contents and metadata." %
                             ", ".join(["'%s'" % x for x in PROTOCOLS]))
     qc_options.add_argument('--fastq_screen_subset',metavar='SUBSET',
                             action='store',dest='fastq_screen_subset',
@@ -622,6 +631,10 @@ if __name__ == "__main__":
         project_metadata['name'] = os.path.basename(out_dir)
     if args.organism:
         project_metadata['organism'] = args.organism
+    if args.library_type:
+        project_metadata['library_type'] = args.library_type
+    if args.single_cell_platform:
+        project_metadata['single_cell_platform'] = args.single_cell_platform
 
     # Import extra files specified by the user
     for f in list(extra_files):

--- a/docs/source/using/run_qc_standalone.rst
+++ b/docs/source/using/run_qc_standalone.rst
@@ -52,7 +52,13 @@ determine which metrics are run:
 
 * ``--protocol``: specify the QC protocol (see :doc:`run_qc`
   for a complete list)
-* ``--organism``: specify the organism(s)
+* ``--organism``: specify the organism(s) (e.g. ``human``,
+  ``mouse`` etc)
+* ``--library-type``: specify the library type (e.g. ``RNA-seq``,
+  ``ChIP-seq`` etc)
+* ``--single-cell-platform``: specify the name for the single
+  cell platform (e.g. ``10xGenomics Chromium 3'v3``; see
+  :doc:`projects_info` for a complete list)
 
 .. note::
 


### PR DESCRIPTION
PR which updates the `run_qc.py` utility to add new options for setting additional metadata items. specifically:

* `--library-type`
* `--single-cell-platform`