### PR TITLE
Update how indexes and reference datasets are configured in settings

### DIFF
--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -115,21 +115,43 @@ def run_qc(ap,projects=None,ungzip_fastqs=False,
     if len(projects) == 0:
         logger.warning("No projects found for QC analysis")
         return 1
+    # Set up dictionaries for indices and reference data
+    # STAR indexes
+    star_indexes = dict()
+    for organism in ap.settings.organisms:
+        star_index = ap.settings.organisms[organism].star_index
+        if star_index:
+            star_indexes[organism] = star_index
     # Set 10x cellranger reference data
     if not cellranger_transcriptomes:
         cellranger_transcriptomes = dict()
-    if ap.settings['10xgenomics_transcriptomes']:
-        for organism in ap.settings['10xgenomics_transcriptomes']:
-            if organism not in cellranger_transcriptomes:
-                cellranger_transcriptomes[organism] = \
-                    ap.settings['10xgenomics_transcriptomes'][organism]
     if not cellranger_premrna_references:
         cellranger_premrna_references = dict()
-    if ap.settings['10xgenomics_premrna_references']:
-        for organism in ap.settings['10xgenomics_premrna_references']:
-            if organism not in cellranger_premrna_references:
-                cellranger_premrna_references[organism] = \
-                    ap.settings['10xgenomics_premrna_references'][organism]
+    cellranger_atac_references = dict()
+    cellranger_multiome_references = dict()
+    for organism in ap.settings.organisms:
+        reference_datasets = ap.settings.organisms[organism]
+        # Transcriptomes
+        cellranger_reference = reference_datasets.cellranger_reference
+        if cellranger_reference:
+            cellranger_transcriptomes[organism] = cellranger_reference
+        # Pre-mRNA references
+        cellranger_premrna_reference = \
+            reference_datasets.cellranger_premrna_reference
+        if cellranger_premrna_reference:
+            cellranger_premrna_references[organism] = \
+                cellranger_premrna_reference
+        # ATAC
+        cellranger_atac_reference = \
+            reference_datasets.cellranger_atac_reference
+        if cellranger_atac_reference:
+            cellranger_atac_references[organism] = cellranger_atac_reference
+        # Multiome
+        cellranger_arc_reference = \
+            reference_datasets.cellranger_arc_reference
+        if cellranger_arc_reference:
+            cellranger_multiome_references[organism] = \
+                cellranger_arc_reference
     # Set up runners
     if runner is None:
         default_runner = ap.settings.general.default_runner
@@ -186,12 +208,9 @@ def run_qc(ap,projects=None,ungzip_fastqs=False,
     cellranger_jobinterval = cellranger_settings.cellranger_jobinterval
     cellranger_localcores = cellranger_settings.cellranger_localcores
     cellranger_localmem = cellranger_settings.cellranger_localmem
-    cellranger_atac_references = ap.settings['10xgenomics_atac_genome_references']
-    cellranger_multiome_references = ap.settings['10xgenomics_multiome_references']
     # Run the QC
     status = runqc.run(nthreads=nthreads,
-                       fastq_strand_indexes=
-                       ap.settings.fastq_strand_indexes,
+                       fastq_strand_indexes=star_indexes,
                        cellranger_transcriptomes=cellranger_transcriptomes,
                        cellranger_premrna_references=\
                        cellranger_premrna_references,

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -210,7 +210,7 @@ def run_qc(ap,projects=None,ungzip_fastqs=False,
     cellranger_localmem = cellranger_settings.cellranger_localmem
     # Run the QC
     status = runqc.run(nthreads=nthreads,
-                       fastq_strand_indexes=star_indexes,
+                       star_indexes=star_indexes,
                        cellranger_transcriptomes=cellranger_transcriptomes,
                        cellranger_premrna_references=\
                        cellranger_premrna_references,

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -161,6 +161,13 @@ class Settings(object):
         self.qc['fastq_screen_subset'] = config.getint('qc',
                                                        'fastq_screen_subset',
                                                        100000)
+        # Organisms
+        self.add_section('organisms')
+        for section in filter(lambda x: x.startswith('organism:'),
+                              config.sections()):
+            organism = section.split(':')[1]
+            self.organisms[organism] = self.get_organism_config(
+                section,config)
         # fastq_strand indexes
         self.add_section('fastq_strand_indexes')
         try:
@@ -395,6 +402,42 @@ class Settings(object):
         values['include_qc_report'] = config.getboolean(
             section,'include_qc_report',False)
         values['hard_links'] = config.getboolean(section,'hard_links',False)
+        return values
+
+    def get_organism_config(self,section,config):
+        """
+        Retrieve 'organism' configuration options from .ini file
+
+        Given the name of a section (e.g. 'organism:Human'),
+        fetch the data association with the organism and return in
+        an AttributeDictionary object.
+
+        The items that can be extracted are:
+
+        - star_index (str, path to STAR index)
+        - bowtie_index (str, path to Bowtie index)
+        - cellranger_reference (str)
+        - cellranger_premrna_reference (str)
+        - cellranger_atac_reference (str)
+        - cellranger_arc_reference (str)
+
+        Arguments:
+          section (str): name of the section to retrieve the
+            settings from
+          config (Config): Config object with settings loaded
+
+        Returns:
+          AttributeDictionary: dictionary of option:value pairs.
+        """
+        values = AttributeDictionary()
+        for param in (
+                'star_index',
+                'bowtie_index',
+                'cellranger_reference',
+                'cellranger_premrna_reference',
+                'cellranger_atac_reference',
+                'cellranger_arc_reference'):
+            values[param] = config.get(section,param,None)
         return values
 
     def get_sequencer_config(self,section,config):

--- a/auto_process_ngs/test/commands/test_run_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_run_qc_cmd.py
@@ -128,9 +128,11 @@ poll_interval = 0.5
             s.write("""[general]
 poll_interval = 0.5
 
-[fastq_strand_indexes]
-human = /data/genomeIndexes/hg38/STAR
-mouse = /data/genomeIndexes/mm10/STAR
+[organism:human]
+star_index = /data/genomeIndexes/hg38/STAR
+
+[organism:mouse]
+star_index = /data/genomeIndexes/mm10/STAR
 """)
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn,
@@ -203,9 +205,11 @@ mouse = /data/genomeIndexes/mm10/STAR
             s.write("""[general]
 poll_interval = 0.5
 
-[fastq_strand_indexes]
-human = /data/genomeIndexes/hg38/STAR
-mouse = /data/genomeIndexes/mm10/STAR
+[organism:human]
+star_index = /data/genomeIndexes/hg38/STAR
+
+[organism:mouse]
+star_index = /data/genomeIndexes/mm10/STAR
 """)
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn,
@@ -279,9 +283,11 @@ mouse = /data/genomeIndexes/mm10/STAR
             s.write("""[general]
 poll_interval = 0.5
 
-[fastq_strand_indexes]
-human = /data/genomeIndexes/hg38/STAR
-mouse = /data/genomeIndexes/mm10/STAR
+[organism:human]
+star_index = /data/genomeIndexes/hg38/STAR
+
+[organism:mouse]
+star_index = /data/genomeIndexes/mm10/STAR
 """)
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn,
@@ -360,13 +366,13 @@ mouse = /data/genomeIndexes/mm10/STAR
             s.write("""[general]
 poll_interval = 1.0
 
-[fastq_strand_indexes]
-human = /data/genomeIndexes/hg38/STAR
-mouse = /data/genomeIndexes/mm10/STAR
+[organism:human]
+star_index = /data/genomeIndexes/hg38/STAR
+cellranger_reference = /data/cellranger/transcriptomes/hg38
 
-[10xgenomics_transcriptomes]
-human = /data/cellranger/transcriptomes/hg38
-mouse = /data/cellranger/transcriptomes/mm10
+[organism:mouse]
+star_index = /data/genomeIndexes/mm10/STAR
+cellranger_reference = /data/cellranger/transcriptomes/mm10
 """)
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn,
@@ -452,13 +458,13 @@ mouse = /data/cellranger/transcriptomes/mm10
             s.write("""[general]
 poll_interval = 1.0
 
-[fastq_strand_indexes]
-human = /data/genomeIndexes/hg38/STAR
-mouse = /data/genomeIndexes/mm10/STAR
+[organism:human]
+star_index = /data/genomeIndexes/hg38/STAR
+cellranger_premrna_reference = /data/cellranger/transcriptomes/hg38_pre_mrna
 
-[10xgenomics_premrna_references]
-human = /data/cellranger/transcriptomes/hg38_pre_mrna
-mouse = /data/cellranger/transcriptomes/mm10_pre_mrna
+[organism:mouse]
+star_index = /data/genomeIndexes/mm10/STAR
+cellranger_premrna_reference = /data/cellranger/transcriptomes/mm10_pre_mrna
 """)
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn,
@@ -545,13 +551,13 @@ mouse = /data/cellranger/transcriptomes/mm10_pre_mrna
             s.write("""[general]
 poll_interval = 1.0
 
-[fastq_strand_indexes]
-human = /data/genomeIndexes/hg38/STAR
-mouse = /data/genomeIndexes/mm10/STAR
+[organism:human]
+star_index = /data/genomeIndexes/hg38/STAR
+cellranger_reference = /data/cellranger/transcriptomes/hg38
 
-[10xgenomics_transcriptomes]
-human = /data/cellranger/transcriptomes/hg38
-mouse = /data/cellranger/transcriptomes/mm10
+[organism:mouse]
+star_index = /data/genomeIndexes/mm10/STAR
+cellranger_reference = /data/cellranger/transcriptomes/mm10
 """)
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn,
@@ -638,13 +644,13 @@ mouse = /data/cellranger/transcriptomes/mm10
             s.write("""[general]
 poll_interval = 1.0
 
-[fastq_strand_indexes]
-human = /data/genomeIndexes/hg38/STAR
-mouse = /data/genomeIndexes/mm10/STAR
+[organism:human]
+star_index = /data/genomeIndexes/hg38/STAR
+cellranger_reference = /data/cellranger/transcriptomes/hg38
 
-[10xgenomics_transcriptomes]
-human = /data/cellranger/transcriptomes/hg38
-mouse = /data/cellranger/transcriptomes/mm10
+[organism:mouse]
+star_index = /data/genomeIndexes/mm10/STAR
+cellranger_reference = /data/cellranger/transcriptomes/mm10
 """)
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn,
@@ -730,13 +736,13 @@ mouse = /data/cellranger/transcriptomes/mm10
             s.write("""[general]
 poll_interval = 1.0
 
-[fastq_strand_indexes]
-human = /data/genomeIndexes/hg38/STAR
-mouse = /data/genomeIndexes/mm10/STAR
+[organism:human]
+star_index = /data/genomeIndexes/hg38/STAR
+cellranger_atac_reference = /data/cellranger/atac_references/hg38
 
-[10xgenomics_atac_genome_references]
-human = /data/cellranger/atac_references/hg38
-mouse = /data/cellranger/atac_references/mm10
+[organism:mouse]
+star_index = /data/genomeIndexes/mm10/STAR
+cellranger_atac_reference = /data/cellranger/atac_references/mm10
 """)
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn,
@@ -819,9 +825,11 @@ mouse = /data/cellranger/atac_references/mm10
             s.write("""[general]
 poll_interval = 1.0
 
-[fastq_strand_indexes]
-human = /data/genomeIndexes/hg38/STAR
-mouse = /data/genomeIndexes/mm10/STAR
+[organism:human]
+star_index = /data/genomeIndexes/hg38/STAR
+
+[organism:mouse]
+star_index = /data/genomeIndexes/mm10/STAR
 """)
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn,
@@ -896,9 +904,11 @@ mouse = /data/genomeIndexes/mm10/STAR
             s.write("""[general]
 poll_interval = 1.0
 
-[fastq_strand_indexes]
-human = /data/genomeIndexes/hg38/STAR
-mouse = /data/genomeIndexes/mm10/STAR
+[organism:human]
+star_index = /data/genomeIndexes/hg38/STAR
+
+[organism:mouse]
+star_index = /data/genomeIndexes/mm10/STAR
 """)
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn,
@@ -973,9 +983,11 @@ mouse = /data/genomeIndexes/mm10/STAR
             s.write("""[general]
 poll_interval = 1.0
 
-[fastq_strand_indexes]
-human = /data/genomeIndexes/hg38/STAR
-mouse = /data/genomeIndexes/mm10/STAR
+[organism:human]
+star_index = /data/genomeIndexes/hg38/STAR
+
+[organism:mouse]
+star_index = /data/genomeIndexes/mm10/STAR
 """)
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn,

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -100,7 +100,7 @@ class TestQCPipeline(unittest.TestCase):
         runqc.add_project(AnalysisProject("PJB",
                                           os.path.join(self.wd,"PJB")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            poll_interval=0.5,
                            max_jobs=1,
@@ -138,7 +138,7 @@ class TestQCPipeline(unittest.TestCase):
         runqc.add_project(AnalysisProject("PJB",
                                           os.path.join(self.wd,"PJB")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            poll_interval=0.5,
                            max_jobs=1,
@@ -610,7 +610,7 @@ class TestQCPipeline(unittest.TestCase):
         runqc.add_project(AnalysisProject("PJB",
                                           os.path.join(self.wd,"PJB")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_transcriptomes=
                            { 'human': '/data/refdata-cellranger-GRCh38-1.2.0' },
@@ -669,7 +669,7 @@ class TestQCPipeline(unittest.TestCase):
         runqc.add_project(AnalysisProject("PJB",
                                           os.path.join(self.wd,"PJB")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_transcriptomes=
                            { 'human': '/data/refdata-gex-GRCh38-2020-A' },
@@ -728,7 +728,7 @@ class TestQCPipeline(unittest.TestCase):
         runqc.add_project(AnalysisProject("PJB",
                                           os.path.join(self.wd,"PJB")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_transcriptomes=
                            { 'human': '/data/refdata-gex-GRCh38-2020-A' },
@@ -790,7 +790,7 @@ class TestQCPipeline(unittest.TestCase):
         runqc.add_project(AnalysisProject("PJB",
                                           os.path.join(self.wd,"PJB")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_transcriptomes=
                            { 'human': '/data/refdata-gex-GRCh38-2020-A' },
@@ -851,7 +851,7 @@ class TestQCPipeline(unittest.TestCase):
         runqc.add_project(AnalysisProject("PJB",
                                           os.path.join(self.wd,"PJB")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_premrna_references=
                            { 'human': '/data/refdata-cellranger-GRCh38-1.2.0_premrna' },
@@ -911,7 +911,7 @@ class TestQCPipeline(unittest.TestCase):
         runqc.add_project(AnalysisProject("PJB",
                                           os.path.join(self.wd,"PJB")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_transcriptomes=
                            { 'human': '/data/refdata-gex-GRCh38-2020-A' },
@@ -971,7 +971,7 @@ class TestQCPipeline(unittest.TestCase):
         runqc.add_project(AnalysisProject("PJB",
                                           os.path.join(self.wd,"PJB")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_transcriptomes=
                            { 'human': '/data/refdata-gex-GRCh38-2020-A' },
@@ -1031,7 +1031,7 @@ class TestQCPipeline(unittest.TestCase):
         runqc.add_project(AnalysisProject("PJB",
                                           os.path.join(self.wd,"PJB")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_atac_references=
                            { 'human':
@@ -1092,7 +1092,7 @@ class TestQCPipeline(unittest.TestCase):
         runqc.add_project(AnalysisProject("PJB",
                                           os.path.join(self.wd,"PJB")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_atac_references=
                            { 'human':
@@ -1152,7 +1152,7 @@ class TestQCPipeline(unittest.TestCase):
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB_ATAC")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_arc_references=
                            { 'human':
@@ -1196,7 +1196,7 @@ class TestQCPipeline(unittest.TestCase):
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB_GEX")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_arc_references=
                            { 'human':
@@ -1270,7 +1270,7 @@ class TestQCPipeline(unittest.TestCase):
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB_ATAC")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_arc_references=
                            { 'human':
@@ -1358,7 +1358,7 @@ class TestQCPipeline(unittest.TestCase):
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB_ATAC")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_arc_references=
                            { 'human':
@@ -1446,7 +1446,7 @@ class TestQCPipeline(unittest.TestCase):
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB_GEX")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_arc_references=
                            { 'human':
@@ -1534,7 +1534,7 @@ class TestQCPipeline(unittest.TestCase):
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB_GEX")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_arc_references=
                            { 'human':
@@ -1613,7 +1613,7 @@ PBB,CMO302,PBB
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_arc_references=
                            { 'human':
@@ -1673,7 +1673,7 @@ PBB,CMO302,PBB
                           multiqc=True,
                           qc_protocol="10x_scRNAseq",
                           organism="human")
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            cellranger_transcriptomes=
                            { 'human': '/data/refdata-gex-GRCh38-2020-A' },
@@ -1731,7 +1731,7 @@ PBB,CMO302,PBB
         runqc.add_project(AnalysisProject("PJB",
                                           os.path.join(self.wd,"PJB")),
                           multiqc=True)
-        status = runqc.run(fastq_strand_indexes=
+        status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
                            poll_interval=0.5,
                            max_jobs=1,

--- a/auto_process_ngs/test/test_settings.py
+++ b/auto_process_ngs/test/test_settings.py
@@ -307,6 +307,123 @@ cellranger_arc_reference = /data/10x/refdata-cellranger-arc-mm10-2020-A-2.0.0
                          '/data/mm10/bowtie')
         self.assertEqual(s.organisms['mouse']['cellranger_reference'],
                          '/data/10x/refdata-gex-mm10-2020-A')
+        self.assertEqual(s.organisms['mouse']['cellranger_premrna_reference'],
+                         None)
+        self.assertEqual(s.organisms['mouse']['cellranger_atac_reference'],
+                         '/data/10x/refdata-cellranger-atac-mm10-2020-A-2.0.0')
+        self.assertEqual(s.organisms['mouse']['cellranger_arc_reference'],
+                         '/data/10x/refdata-cellranger-arc-mm10-2020-A-2.0.0')
+
+    def test_legacy_organism_definitions(self):
+        """Settings: handle sections for specific indices (no 'organism:...' sections)
+        """
+        # Settings file
+        settings_file = os.path.join(self.dirn,"auto_process.ini")
+        with open(settings_file,'w') as s:
+            s.write("""[fastq_strand_indexes]
+human = /data/hg38/star
+mouse = /data/mm10/star
+
+[10xgenomics_transcriptomes]
+human = /data/10x/refdata-gex-GRCh38-2020-A
+mouse = /data/10x/refdata-gex-mm10-2020-A
+
+[10xgenomics_premrna_references]
+human = /data/10x/refdata-cellranger-GRCh38-1.0.1-pre_mrna
+
+[10xgenomics_atac_genome_references]
+human = /data/10x/refdata-cellranger-atac-GRCh38-2020-A-2.0.0
+mouse = /data/10x/refdata-cellranger-atac-mm10-2020-A-2.0.0
+
+[10xgenomics_multiome_references]
+human = /data/10x/refdata-cellranger-arc-GRCh38-2020-A-2.0.0
+mouse = /data/10x/refdata-cellranger-arc-mm10-2020-A-2.0.0
+""")
+        # Load settings
+        s = Settings(settings_file)
+        # Check organism settings
+        self.assertTrue('human' in s.organisms)
+        self.assertEqual(s.organisms['human']['star_index'],
+                         '/data/hg38/star')
+        self.assertEqual(s.organisms['human']['bowtie_index'],None)
+        self.assertEqual(s.organisms['human']['cellranger_reference'],
+                         '/data/10x/refdata-gex-GRCh38-2020-A')
+        self.assertEqual(s.organisms['human']['cellranger_premrna_reference'],
+                         '/data/10x/refdata-cellranger-GRCh38-1.0.1-pre_mrna')
+        self.assertEqual(s.organisms['human']['cellranger_atac_reference'],
+                         '/data/10x/refdata-cellranger-atac-GRCh38-2020-A-2.0.0')
+        self.assertEqual(s.organisms['human']['cellranger_arc_reference'],
+                         '/data/10x/refdata-cellranger-arc-GRCh38-2020-A-2.0.0')
+        self.assertTrue('mouse' in s.organisms)
+        self.assertEqual(s.organisms['mouse']['star_index'],
+                         '/data/mm10/star')
+        self.assertEqual(s.organisms['mouse']['bowtie_index'],None)
+        self.assertEqual(s.organisms['mouse']['cellranger_reference'],
+                         '/data/10x/refdata-gex-mm10-2020-A')
+        self.assertEqual(s.organisms['mouse']['cellranger_premrna_reference'],
+                         None)
+        self.assertEqual(s.organisms['mouse']['cellranger_atac_reference'],
+                         '/data/10x/refdata-cellranger-atac-mm10-2020-A-2.0.0')
+        self.assertEqual(s.organisms['mouse']['cellranger_arc_reference'],
+                         '/data/10x/refdata-cellranger-arc-mm10-2020-A-2.0.0')
+
+    def test_mixed_organism_definitions(self):
+        """Settings: handle mixture of 'organism:...' and index sections
+        """
+        # Settings file
+        settings_file = os.path.join(self.dirn,"auto_process.ini")
+        with open(settings_file,'w') as s:
+            s.write("""[organism:human]
+bowtie_index = /data/hg38/bowtie
+
+[organism:mouse]
+star_index = /data/mm10/star
+bowtie_index = /data/mm10/bowtie
+cellranger_reference = /data/10x/refdata-gex-mm10-2020-A
+cellranger_atac_reference = /data/10x/refdata-cellranger-atac-mm10-2020-A-2.0.0
+cellranger_arc_reference = /data/10x/refdata-cellranger-arc-mm10-2020-A-2.0.0
+
+[fastq_strand_indexes]
+human = /data/hg38/star
+mouse = /data/mm10/star
+
+[10xgenomics_transcriptomes]
+human = /data/10x/refdata-gex-GRCh38-2020-A
+
+[10xgenomics_premrna_references]
+human = /data/10x/refdata-cellranger-GRCh38-1.0.1-pre_mrna
+
+[10xgenomics_atac_genome_references]
+human = /data/10x/refdata-cellranger-atac-GRCh38-2020-A-2.0.0
+
+[10xgenomics_multiome_references]
+human = /data/10x/refdata-cellranger-arc-GRCh38-2020-A-2.0.0
+""")
+        # Load settings
+        s = Settings(settings_file)
+        # Check organism settings
+        self.assertTrue('human' in s.organisms)
+        self.assertEqual(s.organisms['human']['star_index'],
+                         '/data/hg38/star')
+        self.assertEqual(s.organisms['human']['bowtie_index'],
+                         '/data/hg38/bowtie')
+        self.assertEqual(s.organisms['human']['cellranger_reference'],
+                         '/data/10x/refdata-gex-GRCh38-2020-A')
+        self.assertEqual(s.organisms['human']['cellranger_premrna_reference'],
+                         '/data/10x/refdata-cellranger-GRCh38-1.0.1-pre_mrna')
+        self.assertEqual(s.organisms['human']['cellranger_atac_reference'],
+                         '/data/10x/refdata-cellranger-atac-GRCh38-2020-A-2.0.0')
+        self.assertEqual(s.organisms['human']['cellranger_arc_reference'],
+                         '/data/10x/refdata-cellranger-arc-GRCh38-2020-A-2.0.0')
+        self.assertTrue('mouse' in s.organisms)
+        self.assertEqual(s.organisms['mouse']['star_index'],
+                         '/data/mm10/star')
+        self.assertEqual(s.organisms['mouse']['bowtie_index'],
+                         '/data/mm10/bowtie')
+        self.assertEqual(s.organisms['mouse']['cellranger_reference'],
+                         '/data/10x/refdata-gex-mm10-2020-A')
+        self.assertEqual(s.organisms['mouse']['cellranger_premrna_reference'],
+                         None)
         self.assertEqual(s.organisms['mouse']['cellranger_atac_reference'],
                          '/data/10x/refdata-cellranger-atac-mm10-2020-A-2.0.0')
         self.assertEqual(s.organisms['mouse']['cellranger_arc_reference'],

--- a/auto_process_ngs/test/test_settings.py
+++ b/auto_process_ngs/test/test_settings.py
@@ -262,3 +262,52 @@ model = "HiSeq 2500"
         self.assertRaises(Exception,
                           Settings,
                           settings_file)
+
+    def test_organism_definitions(self):
+        """Settings: handle 'organism:...' sections
+        """
+        # Settings file
+        settings_file = os.path.join(self.dirn,"auto_process.ini")
+        with open(settings_file,'w') as s:
+            s.write("""[organism:human]
+star_index = /data/hg38/star
+bowtie_index = /data/hg38/bowtie
+cellranger_reference = /data/10x/refdata-gex-GRCh38-2020-A
+cellranger_premrna_reference = /data/10x/refdata-cellranger-GRCh38-1.0.1-pre_mrna
+cellranger_atac_reference = /data/10x/refdata-cellranger-atac-GRCh38-2020-A-2.0.0
+cellranger_arc_reference = /data/10x/refdata-cellranger-arc-GRCh38-2020-A-2.0.0
+
+[organism:mouse]
+star_index = /data/mm10/star
+bowtie_index = /data/mm10/bowtie
+cellranger_reference = /data/10x/refdata-gex-mm10-2020-A
+cellranger_atac_reference = /data/10x/refdata-cellranger-atac-mm10-2020-A-2.0.0
+cellranger_arc_reference = /data/10x/refdata-cellranger-arc-mm10-2020-A-2.0.0
+""")
+        # Load settings
+        s = Settings(settings_file)
+        # Check organism settings
+        self.assertTrue('human' in s.organisms)
+        self.assertEqual(s.organisms['human']['star_index'],
+                         '/data/hg38/star')
+        self.assertEqual(s.organisms['human']['bowtie_index'],
+                         '/data/hg38/bowtie')
+        self.assertEqual(s.organisms['human']['cellranger_reference'],
+                         '/data/10x/refdata-gex-GRCh38-2020-A')
+        self.assertEqual(s.organisms['human']['cellranger_premrna_reference'],
+                         '/data/10x/refdata-cellranger-GRCh38-1.0.1-pre_mrna')
+        self.assertEqual(s.organisms['human']['cellranger_atac_reference'],
+                         '/data/10x/refdata-cellranger-atac-GRCh38-2020-A-2.0.0')
+        self.assertEqual(s.organisms['human']['cellranger_arc_reference'],
+                         '/data/10x/refdata-cellranger-arc-GRCh38-2020-A-2.0.0')
+        self.assertTrue('mouse' in s.organisms)
+        self.assertEqual(s.organisms['mouse']['star_index'],
+                         '/data/mm10/star')
+        self.assertEqual(s.organisms['mouse']['bowtie_index'],
+                         '/data/mm10/bowtie')
+        self.assertEqual(s.organisms['mouse']['cellranger_reference'],
+                         '/data/10x/refdata-gex-mm10-2020-A')
+        self.assertEqual(s.organisms['mouse']['cellranger_atac_reference'],
+                         '/data/10x/refdata-cellranger-atac-mm10-2020-A-2.0.0')
+        self.assertEqual(s.organisms['mouse']['cellranger_arc_reference'],
+                         '/data/10x/refdata-cellranger-arc-mm10-2020-A-2.0.0')

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -678,7 +678,7 @@ if __name__ == "__main__":
                       multiqc=(not args.no_multiqc))
     status = runqc.run(nthreads=nthreads,
                        fastq_subset=args.fastq_screen_subset,
-                       fastq_strand_indexes=star_indexes,
+                       star_indexes=star_indexes,
                        cellranger_chemistry=\
                        args.cellranger_chemistry,
                        cellranger_transcriptomes=cellranger_transcriptomes,

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -445,29 +445,49 @@ if __name__ == "__main__":
     else:
         enable_conda = (args.enable_conda == "yes")
 
-    # Cellranger data
+    # STAR indexes
+    star_indexes = dict()
+    for organism in __settings.organisms:
+        star_index = __settings.organisms[organism].star_index
+        if star_index:
+            star_indexes[organism] = star_index
+
+    # Cellranger settings
     cellranger_settings = __settings['10xgenomics']
+
+    # Cellranger reference datasets
     cellranger_transcriptomes = dict()
-    if __settings['10xgenomics_transcriptomes']:
-        for organism in __settings['10xgenomics_transcriptomes']:
-            if organism not in cellranger_transcriptomes:
-                cellranger_transcriptomes[organism] = \
-                    __settings['10xgenomics_transcriptomes'][organism]
+    for organism in __settings.organisms:
+        if __settings.organisms[organism].cellranger_reference:
+            cellranger_transcriptomes[organism] = \
+                __settings.organisms[organism].cellranger_reference
+    cellranger_premrna_references = dict()
+    for organism in __settings.organisms:
+        if __settings.organisms[organism].cellranger_premrna_reference:
+            cellranger_premrna_references[organism] = \
+                __settings.organisms[organism].cellranger_premrna_reference
+    cellranger_atac_references = dict()
+    for organism in __settings.organisms:
+        if __settings.organisms[organism].cellranger_atac_reference:
+            cellranger_atac_references[organism] = \
+                __settings.organisms[organism].cellranger_atac_reference
+    cellranger_multiome_references = dict()
+    for organism in __settings.organisms:
+        if __settings.organisms[organism].cellranger_arc_reference:
+            cellranger_multiome_references[organism] = \
+                __settings.organisms[organism].cellranger_arc_reference
+
+    # Add in organism-specific references supplied on the command line
     if args.cellranger_transcriptomes:
         for transcriptome in args.cellranger_transcriptomes:
             organism,reference =  transcriptome.split('=')
             cellranger_transcriptomes[organism] = reference
-    cellranger_premrna_references = dict()
-    if __settings['10xgenomics_premrna_references']:
-        for organism in __settings['10xgenomics_premrna_references']:
-            if organism not in cellranger_premrna_references:
-                cellranger_premrna_references[organism] = \
-                    __settings['10xgenomics_premrna_references'][organism]
     if args.cellranger_premrna_references:
         for premrna_reference in args.cellranger_premrna_references:
             organism,reference =  premrna_reference.split('=')
             cellranger_premrna_references[organism] = reference
-    cellranger_atac_references = __settings['10xgenomics_atac_genome_references']
+
+    # Single reference supplied on command line
     cellranger_reference_dataset = args.cellranger_reference_dataset
     if cellranger_reference_dataset:
         cellranger_reference_dataset = os.path.abspath(
@@ -658,14 +678,14 @@ if __name__ == "__main__":
                       multiqc=(not args.no_multiqc))
     status = runqc.run(nthreads=nthreads,
                        fastq_subset=args.fastq_screen_subset,
-                       fastq_strand_indexes=
-                       __settings.fastq_strand_indexes,
+                       fastq_strand_indexes=star_indexes,
                        cellranger_chemistry=\
                        args.cellranger_chemistry,
                        cellranger_transcriptomes=cellranger_transcriptomes,
                        cellranger_premrna_references=\
                        cellranger_premrna_references,
                        cellranger_atac_references=cellranger_atac_references,
+                       cellranger_arc_references=cellranger_multiome_references,
                        cellranger_jobmode=cellranger_jobmode,
                        cellranger_maxjobs=max_jobs,
                        cellranger_mempercore=cellranger_mempercore,

--- a/config/auto_process.ini.sample
+++ b/config/auto_process.ini.sample
@@ -50,29 +50,26 @@ create_empty_fastqs = True
 # Organisms
 # Define an 'organism:NAME' section for each
 # organism and set the corresponding parameters
-# pointing to the reference datasets
+# pointing to the reference datasets:
+# - star_index
+# - bowtie_index
+# - cellranger_reference
+# - cellranger_premrna_reference
+# - cellranger_atac_reference
+# - cellranger_arc_reference
 # These values will be specific to the local site
 #[organism:human]
-#star_index = None
-#bowtie_index = None
-#annotation_bed = None
-#annotation_gtf = None
-#cellranger_reference = None
-#cellranger_premrna_reference = None
-#cellranger_atac_reference = None
-#cellranger_arc_reference = None
+#star_index = /data/genomeIndexes/hg38/STAR/
+#bowtie_index = /data/genomeIndexes/hg38/bowtie/
+#cellranger_reference = /data/cellranger/refdata-cellranger-GRCh38-1.2.0
+#cellranger_premrna_reference = /data/cellranger/refdata-cellranger-GRCh38-1.0.1-pre_mrna
+#cellranger_atac_reference = /data/cellranger/refdata-cellranger-atac-GRCh38-1.0.1
+#cellranger_arc_reference = /data/cellranger/refdata-cellranger-arc-GRCh38-2020-A
 
 # QC settings
 [qc]
 nprocessors = 1
 fastq_screen_subset = 100000
-
-# Strandedness
-# Assign organism name to path to STAR index to use
-# for that organism in fastq_strand
-[fastq_strand_indexes]
-#human = /data/genomeIndexes/hg38/STAR/
-#mouse = /data/genomeIndexes/mm10/STAR/
 
 # icell8 settings
 [icell8]
@@ -97,38 +94,6 @@ cellranger_jobinterval = 100
 # is 'local'
 cellranger_localmem = 5
 cellranger_localcores = 1
-
-# 10xGenomics transcriptomes
-# Assign organism name to path to cellranger
-# transcriptome reference data to use for that
-# organism in single library analysis
-[10xgenomics_transcriptomes]
-#human = /data/cellranger/refdata-cellranger-GRCh38-1.2.0
-#mouse = /data/cellranger/refdata-cellranger-mm10-1.2.0
-
-# 10xGenomics snRNA-seq pre-mRNA references
-# Assign organism name to path to cellranger
-# snRNA-seq reference data to use for that
-# organism in single library analysis
-[10xgenomics_premrna_references]
-#human = /data/cellranger/refdata-cellranger-GRCh38-1.0.1-pre_mrna
-#mouse = /data/cellranger/refdata-cellranger-mm10-1.0.1-pre_mrna
-
-# 10xGenomics ATAC-seq genome references
-# Assign organism name to path to cellranger-atac
-# ATAC-seq reference data to use for that
-# organism in single library analysis
-[10xgenomics_atac_genome_references]
-#human = /data/cellranger/refdata-cellranger-atac-GRCh38-1.0.1
-#mouse = /data/cellranger/refdata-cellranger-atac-mm10-1.0.1
-
-# 10xGenomics single cell multiome reference datasets
-# Assign organism name to path to cellranger-arc
-# single cell multiome reference data to use for that
-# organism in single library analysis
-[10xgenomics_multiome_references]
-#human = /data/cellranger/refdata-cellranger-arc-GRCh38-2020-A
-#mouse = /data/cellranger/refdata-cellranger-arc-mm10-2020-A
 
 # Platform specific settings
 # Make sections [platform:NAME] and add parameters to

--- a/config/auto_process.ini.sample
+++ b/config/auto_process.ini.sample
@@ -47,6 +47,21 @@ create_empty_fastqs = True
 #model = "HiSeq 2500"
 #platform = hiseq
 
+# Organisms
+# Define an 'organism:NAME' section for each
+# organism and set the corresponding parameters
+# pointing to the reference datasets
+# These values will be specific to the local site
+#[organism:human]
+#star_index = None
+#bowtie_index = None
+#annotation_bed = None
+#annotation_gtf = None
+#cellranger_reference = None
+#cellranger_premrna_reference = None
+#cellranger_atac_reference = None
+#cellranger_arc_reference = None
+
 # QC settings
 [qc]
 nprocessors = 1

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -106,52 +106,39 @@ described here:
 
 * https://genomics-bcftbx.readthedocs.io/en/latest/config.html#set-up-reference-data
 
-In addition the strandedness determination requires ``STAR``
-indexes for each organism of interest. These can then be
-defined in the ``fastq_strand_indexes`` section of the
-``auto_process.ini`` file, for example::
+Other reference data are required for the calculation of
+various QC metrics:
 
-  [fastq_strand_indexes]
-  human = /data/genomeIndexes/hg38/STAR/
-  mouse = /data/genomeIndexes/mm10/STAR/
+* Strandedness determination requires ``STAR`` indexes for
+  each organism of interest;
+* Single library analyses of 10xGenomics single cell data
+  require the appropriate compatible reference datasets for
+  ``cellranger[-atac|-arc] count``:
+  - **scRNA-seq data**: transcriptome reference data set
+  - **snRNA-seq data**: "pre-mRNA" reference data set (which
+    includes both intronic and exonic information)
+  - **sc/snATAC-seq**: Cell Ranger ATAC compatible genome
+    reference
+  - **single cell multiome GEX+ATAC data**: ``cellranger-arc``
+    compatible reference package
 
-For 10xGenomics single cell data, the single library analysis
-requires appropriate compatible reference data for
-``cellranger[-atac|-arc] count``:
-
-* **scRNA-seq data**: transcriptome reference data set
-* **snRNA-seq data**: "pre-mRNA" reference data set (which
-  includes both intronic and exonic information)
-* **sc/snATAC-seq**: Cell Ranger ATAC compatible genome
-  reference
-* **single cell multiome GEX+ATAC data**: ``cellranger-arc``
-  compatible reference package
-
-The reference data sets can be assigned to different organisms
-in the ``10xgenomics_transcriptomes``,
-``10xgenomics_premrna_references`` and
-``10xgenomics_atac_genome_references``
-sections of the ``auto_process.ini`` file.
-
-For example:
+These can be defined in ``[organism:...]`` sections of the
+``auto_process.ini`` file, for example:
 
 ::
 
-   [10xgenomics_transcriptomes]
-   human = /data/cellranger/refdata-cellranger-GRCh38-1.2.0
-   mouse = /data/cellranger/refdata-cellranger-mm10-1.2.0
+   [organism: human]
+   star_index = /data/genomeIndexes/hg38/STAR/
+   cellranger_reference = /data/10x/refdata-cellranger-GRCh38-1.2.0
+   cellranger_premrna_reference = /data/10x/refdata-cellranger-GRCh38-1.2.0_premrna
+   cellranger_atac_reference = /data/10x/refdata-cellranger-atac-GRCh38-1.0.1
+   cellranger_arc_reference = /data/10x/refdata-cellranger-arc-GRCh38-2020-A
    
-   [10xgenomics_premrna_references]
-   human = /data/cellranger/refdata-cellranger-GRCh38-1.2.0_premrna
-   mouse = /data/cellranger/refdata-cellranger-mm10-1.2.0_premrnaferences``
-
-   [10xgenomics_atac_genome_references]
-   human = /data/cellranger/refdata-cellranger-atac-GRCh38-1.0.1
-   mouse = /data/cellranger/refdata-cellranger-atac-mm10-1.0.1
-
-   [10xgenomics_multiome_references]
-   human = /data/cellranger/refdata-cellranger-arc-GRCh38-2020-A
-   mouse = /data/cellranger/refdata-cellranger-arc-mm10-2020-A
+   [organism: mouse]
+   star_index = /data/genomeIndexes/mm10/STAR/
+   cellranger_reference = /data/10x/refdata-cellranger-mm10-1.2.0
+   cellranger_atac_reference = /data/10x/refdata-cellranger-atac-mm10-1.0.1
+   cellranger_arc_reference = /data/10x/refdata-cellranger-arc-mm10-2020-A
 
 .. note::
 
@@ -175,6 +162,14 @@ Pre-mRNA references are currently not available, but the documentation
 explains how to generate a custom reference package for these data:
 
 * https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/advanced/references#premrna
+
+.. note::
+
+   The ``[organism:...]`` sections supersede the old
+   ``fastq_strand_indexes`` and ``10xgenomics...`` sections
+   of the ``auto_process.ini`` file; the old sections are
+   still recognised for now but are deprecated and likely to
+   be dropped in future.
   
 .. _auto_process_reference_data_icell8:
 


### PR DESCRIPTION
PR which updates how indexes (specifically for `STAR`) and reference datasets (for `cellranger[-atac|-arc]`) are specified in the configuration file: the `[fastq_strand_indexes]` and `[10xgenomics_...]` sections have been dropped in favour of `[organism:...]` sections (which now group all the reference datasets for an organism together in a single place).

For example:

    [organism:mouse]
    star_index = /data/mm10/STAR/
    cellranger_reference = /data/10x/refdata-gex-mm10-2.0.0/

The old sections are still recognised (for backwards compatibility) but are now deprecated.

As part of this update there are also minor updates to the QC pipeline to generalise the `fastq_strand_indexes` to `star_indexes`.