### PR TITLE
Enable conda environment directory to be specified when running QC pipeline

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -639,6 +639,7 @@ def add_run_qc_command(cmdparser):
     max_cores = __settings.general.max_cores
     max_batches = __settings.general.max_batches
     enable_conda = ("yes" if __settings.conda.enable_conda else "no")
+    conda_env_dir = __settings.conda.env_dir
     # Build parser
     p.add_argument('--projects',action='store',
                    dest='project_pattern',default=None,
@@ -703,6 +704,12 @@ def add_run_qc_command(cmdparser):
                        dest="enable_conda",default=enable_conda,
                        help="use conda to resolve task dependencies; can "
                        "be 'yes' or 'no' (default: %s)" % enable_conda)
+    conda.add_argument('--conda-env-dir',action='store',
+                       dest="conda_env_dir",default=conda_env_dir,
+                       help="specify directory for conda enviroments "
+                       "(default: %s)" % ('temporary directory'
+                                          if not conda_env_dir else
+                                          conda_env_dir))
     # Job control options
     job_control = p.add_argument_group("Job control options")
     job_control.add_argument('-j','--maxjobs',type=int,action='store',
@@ -1387,6 +1394,7 @@ def run_qc(args):
                        max_cores=args.max_cores,
                        batch_limit=args.max_batches,
                        enable_conda=(args.enable_conda == 'yes'),
+                       conda_env_dir=args.conda_env_dir,
                        working_dir=args.working_dir,
                        verbose=args.verbose)
     sys.exit(retcode)

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -34,7 +34,7 @@ def run_qc(ap,projects=None,ungzip_fastqs=False,
            working_dir=None,verbose=None,
            max_jobs=None,max_cores=None,
            batch_limit=None,enable_conda=None,
-           poll_interval=None):
+           conda_env_dir=None,poll_interval=None):
     """Run QC pipeline script for projects
 
     Run the illumina_qc.sh script to perform QC on projects.
@@ -92,6 +92,8 @@ def run_qc(ap,projects=None,ungzip_fastqs=False,
          exceed this limit
       enable_conda (bool): if True then use conda to resolve
         dependencies declared on tasks in the pipeline
+      conda_env_dir (str): path to non-default directory for conda
+        environments
       poll_interval (float): specifies non-default polling
         interval for scheduler used for running QC
 
@@ -212,6 +214,7 @@ def run_qc(ap,projects=None,ungzip_fastqs=False,
                        runners=runners,
                        default_runner=default_runner,
                        enable_conda=enable_conda,
+                       conda_env_dir=conda_env_dir,
                        envmodules=envmodules,
                        working_dir=working_dir,
                        verbose=verbose)

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -152,6 +152,9 @@ class Settings(object):
         self.conda['enable_conda'] = config.getboolean('conda',
                                                        'enable_conda',
                                                        False)
+        self.conda['env_dir'] = config.get('conda','env_dir',None)
+        if self.conda['env_dir']:
+            self.conda['env_dir'] = os.path.expandvars(self.conda.env_dir)
         # bcl2fastq
         self.add_section('bcl2fastq')
         self.bcl2fastq = self.get_bcl2fastq_config('bcl2fastq',config)

--- a/auto_process_ngs/test/test_settings.py
+++ b/auto_process_ngs/test/test_settings.py
@@ -53,6 +53,7 @@ class TestSettings(unittest.TestCase):
         self.assertEqual(s.modulefiles.report_qc,None)
         # Conda
         self.assertEqual(s.conda.enable_conda,False)
+        self.assertEqual(s.conda.env_dir,None)
         # Bcl2fastq
         self.assertEqual(s.bcl2fastq.nprocessors,1)
         self.assertEqual(s.bcl2fastq.default_version,'>=1.8.4')
@@ -105,6 +106,7 @@ nprocessors = 8
         self.assertEqual(s.modulefiles.run_qc,None)
         # Conda
         self.assertEqual(s.conda.enable_conda,False)
+        self.assertEqual(s.conda.env_dir,None)
         # Fastq_stats
         self.assertEqual(s.fastq_stats.nprocessors,8)
 
@@ -133,6 +135,40 @@ SN7001251 = hiseq
         self.assertTrue('SN7001251' in s.sequencers)
         self.assertEqual(s.sequencers['SN7001251']['platform'],'hiseq')
         self.assertEqual(s.sequencers.SN7001251.platform,'hiseq')
+
+    def test_conda_settings(self):
+        """Settings: check conda options are set correctly
+        """
+        # Settings file
+        settings_file = os.path.join(self.dirn,"auto_process.ini")
+        with open(settings_file,'w') as s:
+            s.write("""[conda]
+enable_conda = true
+env_dir = /scratch/conda_envs
+""")
+        # Load settings
+        s = Settings(settings_file)
+        # Check conda settings
+        self.assertTrue(s.conda.enable_conda)
+        self.assertEqual(s.conda.env_dir,"/scratch/conda_envs")
+
+    def test_conda_env_dir(self):
+        """Settings: check conda env dir expands env variable
+        """
+        # Settings file
+        settings_file = os.path.join(self.dirn,"auto_process.ini")
+        with open(settings_file,'w') as s:
+            s.write("""[conda]
+enable_conda = true
+env_dir = /scratch/$USER/conda_envs
+""")
+        # Load settings
+        s = Settings(settings_file)
+        # Check conda settings
+        self.assertTrue(s.conda.enable_conda)
+        self.assertEqual(s.conda.env_dir,os.path.join("/scratch",
+                                                      os.environ['USER'],
+                                                      "conda_envs"))
 
     def test_destination_definitions(self):
         """Settings: handle 'destination:...' sections

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -206,6 +206,12 @@ if __name__ == "__main__":
                        help="use conda to resolve task dependencies; can "
                        "be 'yes' or 'no' (default: %s)" %
                        ("yes" if __settings.conda.enable_conda else "no"))
+    conda.add_argument('--conda-env-dir',action='store',
+                       dest="conda_env_dir",default=__settings.conda.env_dir,
+                       help="specify directory for conda enviroments "
+                       "(default: %s)" % ('temporary directory'
+                                          if not __settings.conda.env_dir else
+                                          __settings.conda.env_dir))
     # Pipeline/job options
     pipeline = p.add_argument_group('Job control options')
     pipeline.add_argument('--local',action='store_true',
@@ -697,6 +703,7 @@ if __name__ == "__main__":
                        default_runner=default_runner,
                        envmodules=envmodules,
                        enable_conda=enable_conda,
+                       conda_env_dir=args.conda_env_dir,
                        working_dir=working_dir,
                        verbose=args.verbose)
     if status:

--- a/config/auto_process.ini.sample
+++ b/config/auto_process.ini.sample
@@ -30,6 +30,7 @@ fastq_screen = None
 # Conda dependency resolution
 [conda]
 enable_conda = False
+env_dir = None
 
 # bcl2fastq settings
 [bcl2fastq]

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -406,6 +406,14 @@ To do this by default, set the ``enable_conda`` parameter in the
 Note that this requires ``conda`` to be installed and available on the
 user's ``PATH`` at run-time.
 
+By default a temporary directory will be used when creating and reusing
+``conda`` environments, but this can be overriden by setting the
+``env_dir`` parameter, e.g.::
+
+    [conda]
+    enable_conda = true
+    env_dir = $HOME/conda_envs
+
 .. _required_bcl2fastq_versions:
 
 ---------------------------


### PR DESCRIPTION
PR which adds configuration and command line options for setting the directory used by `conda` for creating its environments when resolving dependencies in pipelines.

The updates include:

* New option `env_dir` in the `conda` section of the `auto_process.ini` configuration file
* New command line option `--conda-env-dir` added to the `run_qc` command and the `run_qc.py` utility

These options allow a custom location to be specified for the "env dir" used for `conda` environments created by the QC pipeline.