### PR TITLE
QC pipeline: fix conda dependencies for RunIlluminaQC task

### DIFF
--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -930,6 +930,9 @@ class RunIlluminaQC(PipelineTask):
         self.conda("fastqc=0.11.3",
                    "fastq-screen=0.14.0",
                    "bowtie=1.2.3")
+        # Need older version of libwebp for compatibility
+        # with Perl GD
+        self.conda("libwebp=0.5.2")
         # Also need to specify tbb=2020.2 for bowtie
         # See https://www.biostars.org/p/494922/
         self.conda("tbb=2020.2")


### PR DESCRIPTION
PR which fixes the `conda` dependencies for the `RunIlluminaQC` task in the QC pipeline, to address an incompatibility between the `libwebp` module (defaults to 1.2.0) needed for the Perl `GD::Graph::bars` modules in Fastq-screen 0.14.0.

Without the fix, the `libwebp.so.6` shared library is missing (`libwebp.so.7` is present instead) so the Perl modules can't be loaded, and Fastq-screen is unable to create the PNG plots for the screens (nb this results in a warning rather than raising an error, so was difficult to spot at first).

With `libwebp=0.5.2` explicitly specified `libwebp.so.6` is installed and the Perl modules can be loaded successfully.