### PR TITLE
Fix display of 'organism:...' sections reported by 'auto_process.py config'

### DIFF
--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -595,6 +595,8 @@ class Settings(object):
         for section in self._sections:
             if section == 'sequencers':
                 display_name = 'sequencer'
+            elif section == 'organisms':
+                display_name = 'organism'
             else:
                 display_name = section
             if self.has_subsections(section):


### PR DESCRIPTION
PR which fixes a minor bug in the `settings`  module, when reporting the `[organsim:...]` sections e.g. when running `auto_process.py config` (previously they were reported as `[organisms:...]`). The fix updates the display name for the sections in the `Settings.report_settings()` method.