### PR TITLE
Fix bug with link from top-level QC report to MultiQC report

### DIFF
--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -1466,9 +1466,7 @@ class QCReport(Document):
                     elif item == 'multiqc':
                         multiqc_report = "multi%s_report.html" \
                                          % os.path.basename(project.qc_dir)
-                        value = Link(multiqc_report,
-                                     os.path.join(project_data_dir,
-                                                  multiqc_report))
+                        value = Link(multiqc_report)
                     elif item == 'icell8_stats':
                         value = Link("icell8_stats.xlsx",
                                      os.path.join(project_data_dir,


### PR DESCRIPTION
PR which fixes a bug in the QC report generation for the link from the top-level QC report to the `multiqc` report.

The bug manifests when the QC pipeline is run through `run_qc.py` (rather than the `run_qc` command of `auto_process`).

The fix is an update to the `QCReport` class in `qc/reporting.py`, which now explicitly assumes that the `multiqc` report exists in parallel to the top-level QC report.