### PR TITLE
'run_qc' command: get default conda env dir from settings

### DIFF
--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -186,6 +186,8 @@ def run_qc(ap,projects=None,ungzip_fastqs=False,
     # Conda dependency resolution
     if enable_conda is None:
         enable_conda = ap.settings.conda.enable_conda
+    if conda_env_dir is None:
+        conda_env_dir = ap.settings.conda.env_dir
     # Set scheduler parameters
     if poll_interval is None:
         poll_interval = ap.settings.general.poll_interval


### PR DESCRIPTION
PR which patches the `run_qc` command internals so that the default value of `conda_env_dir` (the location where the `conda` dependency resolver creates and looks for environments to use in the QC pipeline) is taken from the settings file.