### PR TITLE
Fix failing documentation builds on ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,13 +4,10 @@
 
 version: 2
 
-# Set the version of Python and other tools you might need
-build:
-  tools:
-    python: "3.6"
-
 python:
   install:
     - requirements: requirements.txt
     - requirements: docs/requirements.txt
+    - method: pip
+      path: .
   system_packages: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+python:
+  install:
+    - requirements: requirements.txt
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,13 @@
 
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  tools:
+    python: "3.6"
+
 python:
   install:
     - requirements: requirements.txt
     - requirements: docs/requirements.txt
+  system_packages: true

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx==4.2.0
+sphinx_rtd_theme==1.0.0
+readthedocs-sphinx-search==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,7 @@ pandas
 cloudpickle
 psutil
 future
+sphinx==4.2.0
+sphinx_rtd_theme==1.0.0
+readthedocs-sphinx-search==0.1.1
 git+https://github.com/fls-bioinformatics-core/genomics.git#egg=genomics-bcftbx

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,4 @@ pandas
 cloudpickle
 psutil
 future
-sphinx==4.2.0
-sphinx_rtd_theme==1.0.0
-readthedocs-sphinx-search==0.1.1
 git+https://github.com/fls-bioinformatics-core/genomics.git#egg=genomics-bcftbx


### PR DESCRIPTION
PR which updates the contents of the `requirements.txt` file, to specify the versions of sphinx etc needed to build the documentation and fix issue #715.