### PR TITLE
Fix adapter content reporting to handle empty adapter data section in FastQC output

### DIFF
--- a/auto_process_ngs/qc/fastqc.py
+++ b/auto_process_ngs/qc/fastqc.py
@@ -2,11 +2,15 @@
 #
 # fastqc library
 import os
+import logging
 from collections import OrderedDict
 from bcftbx.TabFile import TabFile
 from bcftbx.htmlpagewriter import PNGBase64Encoder
 from ..docwriter import Table
 from ..docwriter import Link
+
+# Module specific logger
+logger = logging.getLogger(__name__)
 
 """
 Example Fastqc summary text file (FASTQ_fastqc/summary.txt):
@@ -448,7 +452,15 @@ class FastqcData(object):
         data = self.data("Adapter Content")
         # Get the list of adapter names from table
         # header
-        adapters = data[0].split('\t')[1:]
+        try:
+            adapters = data[0].split('\t')[1:]
+        except IndexError:
+            # It's possible that the adapter data is
+            # empty so issue a warning
+            logger.warn("Unable to extract list of adapters"
+                        "from FastQC output")
+            # Return empty (ordered) dictionary
+            return OrderedDict()
         # Summarise content for each adapter across
         # sequence by summing up content at each
         # position and dividing by total area


### PR DESCRIPTION
PR which addresses a bug in the QC reporting, when the output from `fastqc` has an empty adapter data section, by patching the `qc/fastqc` module to enable `FastqcData.adapter_content_summary()` to deal gracefully with this situation.

(It's not clear what causes this, however it has been observed when running the QC pipeline on the `undetermined` R2 Fastq outputs from 10xGenomics single cell ATAC data. So it's possible that it is due to the reads in the Fastq file are all shorter than the adapter sequences tested by `fastqc`.)