### PR TITLE
setup_analysis_dirs: implement '--id' option to add identifier to project names

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     cli/auto_process.py: command line interface for auto_process_ngs
-#     Copyright (C) University of Manchester 2013-2020 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2021 Peter Briggs
 #
 #########################################################################
 #
@@ -620,6 +620,8 @@ def add_setup_analysis_dirs_command(cmdparser):
                    dest='link_to_fastqs',default=False,
                    help="create symbolic links to original fastqs from "
                    "project directory (default is to make hard links)")
+    p.add_argument('--id',action='store',dest='name',default=None,
+                   help="identifier to append to project names")
     add_debug_option(p)
     p.add_argument('analysis_dir',metavar="ANALYSIS_DIR",nargs="?",
                    help="auto_process analysis directory (optional: defaults "
@@ -1343,7 +1345,8 @@ def setup_analysis_dirs(args):
     if not analysis_dir:
         analysis_dir = os.getcwd()
     d = AutoProcess(analysis_dir)
-    d.setup_analysis_dirs(unaligned_dir=args.unaligned_dir,
+    d.setup_analysis_dirs(name=args.name,
+                          unaligned_dir=args.unaligned_dir,
                           ignore_missing_metadata=
                           args.ignore_missing_metadata,
                           undetermined_project=args.undetermined,

--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 #######################################################################
 
 def setup_analysis_dirs(ap,
+                        name=None,
                         unaligned_dir=None,
                         project_metadata_file=None,
                         ignore_missing_metadata=False,
@@ -39,6 +40,8 @@ def setup_analysis_dirs(ap,
     Arguments:
       unaligned_dir (str): optional, name of 'unaligned'
         subdirectory (defaults to value stored in parameters)
+      name (str): (optional) identifier to append to output
+        project directories
       project_metadata_file (str): optional, name of the
         'projects.info' metadata file to take project
         information from
@@ -125,11 +128,16 @@ def setup_analysis_dirs(ap,
         if projects and project_name not in projects:
             logger.warning("Skipping '%s'" % project_name)
             continue
+        # Append the identifier, if supplied
+        if name:
+            new_project_name = project_name + '_' + name
+        else:
+            new_project_name = project_name
         # Create the project
         project = analysis.AnalysisProject(
-            project_name,
+            new_project_name,
             os.path.join(ap.analysis_dir,
-                         project_name),
+                         new_project_name),
             user=user,
             PI=PI,
             organism=organism,
@@ -143,7 +151,7 @@ def setup_analysis_dirs(ap,
             logging.warning("Project '%s' already exists, skipping" %
                             project.name)
             continue
-        print("Creating project: '%s'" % project_name)
+        print("Creating project: '%s'" % new_project_name)
         try:
             project.create_directory(
                 illumina_data.get_project(project_name),
@@ -152,7 +160,7 @@ def setup_analysis_dirs(ap,
             n_projects += 1
         except IlluminaData.IlluminaDataError as ex:
             logger.warning("Failed to create project '%s': %s" %
-                           (project_name,ex))
+                           (new_project_name,ex))
             continue
         # Create template control files for 10xGenomics projects
         if single_cell_platform == "10xGenomics Single Cell Multiome":
@@ -253,6 +261,8 @@ def setup_analysis_dirs(ap,
     # Also set up analysis directory for undetermined reads
     if undetermined_project is None:
         undetermined_project = 'undetermined'
+        if name:
+            undetermined_project = undetermined_project + '_' + name
     undetermined = illumina_data.undetermined
     if illumina_data.undetermined is not None:
         undetermined = analysis.AnalysisProject(

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -517,6 +517,38 @@ the full set of available options:
 * :ref:`commands_update_fastq_stats`
 * :ref:`commands_analyse_barcodes`
 
+.. _make_fastqs-processing-same-run-multiple-times:
+
+Processing a single run multiple times
+--------------------------------------
+
+Sometimes it is necessary to process a single run multiple times,
+(for example, to try different parameter sets) while keeping the
+outputs from each processing attempt in the same analysis
+directory.
+
+The ``--id`` option of the ``make_fastqs`` command can be used to
+facilitate this, by allowing an identifier (e.g. ``no_trimming``)
+to be supplied which will then be appended to the outputs from the
+Fastq generation (including the output directories holding the
+generated Fastqs, the barcode analysis directories, and the
+statistics and processing report files).
+
+For example:
+
+::
+
+   auto_process.py make_fastqs --id=no_trimming --no-adapter-trimming
+
+would produce ``bcl2fastq_no_trimming``, ``barcodes_no_trimming``,
+``statistics_no_trimming.info`` and so on.
+
+.. note::
+
+   The ``--id`` option of the ``setup_analysis_dirs`` command
+   can be used to create projects which carry the same identifier,
+   see :ref:`setup_analysis_dirs-add-identifier`.
+
 .. _make_fastqs-outputs:
 
 Outputs

--- a/docs/source/using/setup_analysis_dirs.rst
+++ b/docs/source/using/setup_analysis_dirs.rst
@@ -105,3 +105,39 @@ For example:
 
    Lines starting with a comment character (``#``) will be
    ignored when setting up the single library analysis.
+
+.. _setup_analysis_dirs-add-identifier:
+
+-----------------------------------------------
+Adding an identifier to project directory names
+-----------------------------------------------
+
+Sometimes it can be useful to create multiple projects in
+parallel from the same ``projects.info`` data (for example,
+when a run has been processed in several different ways -
+see :ref:`make_fastqs-processing-same-run-multiple-times`).
+
+In this case the ``--id`` option of the ``setup_analysis_dirs``
+command can be used to create project directories where
+each name is taken from the ``projects.info`` file but has
+an identifier (e.g. ``no_trimming``) appended.
+
+For example:
+
+::
+
+   auto_process.py setup_analysis_dirs --id=no_trimming
+
+would produce projects named ``<PROJECT>_no_trimming``.
+
+When multiple ``bcl2fastq`` output directories exist in the
+same analysis directory, the ``--id`` option can be paired with
+the ``--unaligned-dir`` option to produce sets of projects
+derived from specific ``bcl2fastq`` outputs.
+
+For example:
+
+::
+
+   auto_process.py setup_analysis_dirs \
+      --unaligned-dir=bcl2fastq_no_trimming --id=no_trimming


### PR DESCRIPTION
PR which implements a new option `--id` for the `setup_analysis_dirs` command, to allow an optional identifier to be specified that will then be appended to the projects that are created.

For example:

    auto_process.py setup_analysis_dirs --id test

will append `_test` to all created project names (including `undetermined`, unless otherwise explicitly defined).

Note that there is a potential issue that the project names in `projects.info` are not updated, which could result in problems downstream when using this option.