### PR TITLE
setup_analysis_dirs: make template 10xGenomics configuration files for multiome and CellPlex data

### DIFF
--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -162,9 +162,10 @@ def setup_analysis_dirs(ap,
             f = os.path.join(project.dirn,f)
             try:
                 with open(f,'wt') as fp:
-                    fp.write("## 10x_multiome_libraries.info\n")
-                    fp.write("## Link samples with complementary samples\n"
-                             "## (can be in other runs and/or projects)\n")
+                    fp.write("## 10x_multiome_libraries.info\n"
+                             "## Link samples with complementary samples\n"
+                             "## (can be in other runs and/or projects)\n"
+                             "## See https://auto-process-ngs.readthedocs.io/en/latest/using/setup_analysis_dirs.html#xgenomics-single-cell-multiome-linked-samples\n")
                     for sample in project.samples:
                         fp.write("#%s\t[RUN:][PROJECT][/SAMPLE]\n" % sample)
             except Exception as ex:
@@ -186,7 +187,8 @@ def setup_analysis_dirs(ap,
             f = os.path.join(project.dirn,f)
             try:
                 with open(f,'wt') as fp:
-                    fp.write("## 10x_multi_config.csv\n")
+                    fp.write("## 10x_multi_config.csv\n"
+                             "## See https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/multi#cellranger-multi\n")
                     # Gene expression section
                     fp.write("[gene-expression]\n"
                              "reference,%s\n" %

--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -197,7 +197,7 @@ def setup_analysis_dirs(ap,
                     fp.write("[libraries]\n"
                              "fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate\n")
                     for sample in project.samples:
-                        fp.write("{sample},{fastqs_dir},{sample},any,[gene expression|Multiplexing Capture],\n".fmt(
+                        fp.write("{sample},{fastqs_dir},{sample},any,[gene expression|Multiplexing Capture],\n".format(
                             sample=sample.name,
                             fastqs_dir=project.fastq_dir))
                     fp.write("\n")

--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -154,6 +154,21 @@ def setup_analysis_dirs(ap,
             logger.warning("Failed to create project '%s': %s" %
                            (project_name,ex))
             continue
+        # Create template control files for 10xGenomics projects
+        if single_cell_platform == "10xGenomics Single Cell Multiome":
+            # Make template 10x_multiome_libraries.info file
+            f = "10x_multiome_libraries.info.template"
+            print("-- making %s" % f)
+            f = os.path.join(project.dirn,f)
+            try:
+                with open(f,'wt') as fp:
+                    fp.write("## 10x_multiome_libraries.info\n")
+                    fp.write("## Link samples with complementary samples\n"
+                             "## (can be in other runs and/or projects)\n")
+                    for sample in project.samples:
+                        fp.write("#%s\t[RUN:][PROJECT][/SAMPLE]\n" % sample)
+            except Exception as ex:
+                logger.warning("Failed to create '%s': %s" % (f,ex))
         # Copy in additional data files
         if single_cell_platform == "ICELL8 ATAC":
             # Copy across the ATAC report files

--- a/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
@@ -331,6 +331,74 @@ AB\tAB1,AB2\tAlan Brown\tGEX\t10xGenomics Single Cell Multiome\tHuman\tAudrey Be
                 self.assertFalse(os.path.exists(template_libraries_file),
                                  "Found %s" % template_libraries_file)
 
+    def test_setup_analysis_dirs_10x_cellplex(self):
+        """
+        setup_analysis_dirs: test create new analysis dir for 10x CellPlex
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901" },
+            reads=('R1','R2','I1','I2'),
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq")))
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq","AB")))
+        # Add required metadata to 'projects.info'
+        projects_info = os.path.join(mockdir.dirn,"projects.info")
+        with open(projects_info,"w") as fp:
+            fp.write(
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+AB\tAB1,AB2\tAlan Brown\tCellPlex scRNA-seq\t10xGenomics Chromium 3'v3\tHuman\tAudrey Benson\t1% PhiX
+""")
+        # Expected data
+        projects = {
+            "AB": ["AB1_S1_R1_001.fastq.gz",
+                   "AB1_S1_R2_001.fastq.gz",
+                   "AB1_S1_I1_001.fastq.gz",
+                   "AB1_S1_I2_001.fastq.gz",
+                   "AB2_S2_R1_001.fastq.gz",
+                   "AB2_S2_R2_001.fastq.gz",
+                   "AB2_S2_I1_001.fastq.gz",
+                   "AB2_S2_I2_001.fastq.gz"],
+            "undetermined": ["Undetermined_S0_R1_001.fastq.gz",]
+        }
+        # Check project dirs don't exist
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertFalse(os.path.exists(project_dir_path))
+        # Setup the project dirs
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        setup_analysis_dirs(ap)
+        # Check project dirs and contents
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertTrue(os.path.exists(project_dir_path))
+            # Check README.info file
+            readme_file = os.path.join(project_dir_path,
+                                       "README.info")
+            self.assertTrue(os.path.exists(readme_file))
+            # Check Fastqs
+            fastqs_dir = os.path.join(project_dir_path,
+                                      "fastqs")
+            self.assertTrue(os.path.exists(fastqs_dir))
+            for fq in projects[project]:
+                fastq = os.path.join(fastqs_dir,fq)
+                self.assertTrue(os.path.exists(fastq))
+            # Check template 10x_multi_config.csv
+            template_multi_config_file = os.path.join(
+                project_dir_path,
+                "10x_multi_config.csv.template")
+            if project == "AB":
+                # Template file should exist
+                self.assertTrue(os.path.exists(template_multi_config_file),
+                                "Missing %s" % template_multi_config_file)
+            else:
+                # No template file
+                self.assertFalse(os.path.exists(template_multi_config_file),
+                                 "Found %s" % template_multi_config_file)
+
     def test_setup_analysis_dirs_missing_metadata(self):
         """
         setup_analysis_dirs: raise exception if metadata not set

--- a/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
@@ -265,22 +265,6 @@ AB\tAB1,AB2\tAlan Brown\tscATAC-seq\t10xGenomics Visium\tHuman\tAudrey Benson\t1
                 fastq = os.path.join(fastqs_dir,fq)
                 self.assertTrue(os.path.exists(fastq))
 
-    def test_setup_analysis_dirs_missing_metadata(self):
-        """
-        setup_analysis_dirs: raise exception if metadata not set
-        """
-        # Make a mock auto-process directory
-        mockdir = MockAnalysisDirFactory.bcl2fastq2(
-            '170901_M00879_0087_000000000-AGEW9',
-            'miseq',
-            metadata={ "instrument_datestamp": "170901" },
-            top_dir=self.dirn)
-        mockdir.create(no_project_dirs=True)
-        # Attempt to set up the project dirs
-        ap = AutoProcess(analysis_dir=mockdir.dirn)
-        self.assertRaises(Exception,
-                          setup_analysis_dirs,ap)
-
     def test_setup_analysis_dirs_10x_multiome(self):
         """
         setup_analysis_dirs: test create new analysis dir for 10x Multiome
@@ -290,7 +274,7 @@ AB\tAB1,AB2\tAlan Brown\tscATAC-seq\t10xGenomics Visium\tHuman\tAudrey Benson\t1
             '170901_M00879_0087_000000000-AGEW9',
             'miseq',
             metadata={ "instrument_datestamp": "170901" },
-            reads=('R1','R2','R3','I1'),
+            reads=('R1','R2','I1'),
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
         print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq")))
@@ -300,17 +284,15 @@ AB\tAB1,AB2\tAlan Brown\tscATAC-seq\t10xGenomics Visium\tHuman\tAudrey Benson\t1
         with open(projects_info,"w") as fp:
             fp.write(
 """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
-AB\tAB1,AB2\tAlan Brown\tscATAC-seq\t10xGenomics Single Cell Multiome\tHuman\tAudrey Benson\t1% PhiX
+AB\tAB1,AB2\tAlan Brown\tGEX\t10xGenomics Single Cell Multiome\tHuman\tAudrey Benson\t1% PhiX
 """)
         # Expected data
         projects = {
             "AB": ["AB1_S1_R1_001.fastq.gz",
                    "AB1_S1_R2_001.fastq.gz",
-                   "AB1_S1_R3_001.fastq.gz",
                    "AB1_S1_I1_001.fastq.gz",
                    "AB2_S2_R1_001.fastq.gz",
                    "AB2_S2_R2_001.fastq.gz",
-                   "AB2_S2_R3_001.fastq.gz",
                    "AB2_S2_I1_001.fastq.gz"],
             "undetermined": ["Undetermined_S0_R1_001.fastq.gz",]
         }
@@ -336,6 +318,34 @@ AB\tAB1,AB2\tAlan Brown\tscATAC-seq\t10xGenomics Single Cell Multiome\tHuman\tAu
             for fq in projects[project]:
                 fastq = os.path.join(fastqs_dir,fq)
                 self.assertTrue(os.path.exists(fastq))
+            # Check template 10x_multiome_libraries.info
+            template_libraries_file = os.path.join(
+                project_dir_path,
+                "10x_multiome_libraries.info.template")
+            if project == "AB":
+                # Template file should exist
+                self.assertTrue(os.path.exists(template_libraries_file),
+                                "Missing %s" % template_libraries_file)
+            else:
+                # No template file
+                self.assertFalse(os.path.exists(template_libraries_file),
+                                 "Found %s" % template_libraries_file)
+
+    def test_setup_analysis_dirs_missing_metadata(self):
+        """
+        setup_analysis_dirs: raise exception if metadata not set
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901" },
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        # Attempt to set up the project dirs
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        self.assertRaises(Exception,
+                          setup_analysis_dirs,ap)
 
     def test_setup_analysis_dirs_ignore_missing_metadata(self):
         """

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -72,26 +72,11 @@ In addition for 10xGenomics scRNA-seq, snRNA-seq and scATAC data:
  * Single library analysis is run using the ``count`` command of
    either `cellranger`_ or `cellranger_atac`_ (as appropriate)
 
-.. note::
-
-   If a ``10x_multiome_libraries.info`` file is present then the
-   single library will be run for single cell multiome data via
-   the ``count`` command of `cellranger_arc`_ (see
-   :ref:`10x_multiome_libraries_info`).
+See :ref:`run_qc_additional_files` for additional analyses that
+may be triggered by the presence of certain special files.
 
 .. _cellranger: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/what-is-cell-ranger
 .. _cellranger_atac: https://support.10xgenomics.com/single-cell-atac/software/pipelines/latest/what-is-cell-ranger-atac
-.. _cellranger_arc: https://support.10xgenomics.com/single-cell-multiome-atac-gex/software/pipelines/latest/what-is-cell-ranger-arc
-
-For 10xGenomics CellPlex (cell multiplexing) data:
-
- * Multiplexing analyses are run using the `cellranger`_ ``multi``
-   command, provided that a ``10x_multi_config.csv`` file is also
-   present in the project directory.
-
-   This file should have the format outlined at `cellranger_multi`_.
-
-.. _cellranger_multi: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/multi#cellranger-multi
 
 `multiQC`_ is also run to summarise the QC from all the Fastqs in the
 project.
@@ -109,6 +94,32 @@ there for sharing using the :doc:`publish_qc command <publish_qc>`.
    section on :doc:`running the QC standalone <run_qc_standalone>`.
 
 .. _multiqc: http://multiqc.info/
+
+.. _run_qc_additional_files:
+
+----------------
+Additional Files
+----------------
+
+10xGenomics Single Cell Multiome Data
+*************************************
+
+If a ``10x_multiome_libraries.info`` file is present then the single
+library will be run for single cell multiome data via the ``count``
+command of `cellranger_arc`_ (see :ref:`10x_multiome_libraries_info`).
+.. _cellranger_arc: https://support.10xgenomics.com/single-cell-multiome-atac-gex/software/pipelines/latest/what-is-cell-ranger-arc
+
+10xGenomics CellPlex Data
+*************************
+
+For 10xGenomics CellPlex (cell multiplexing) data, multiplexing
+analyses are run using the `cellranger`_ ``multi`` command, provided
+that a ``10x_multi_config.csv`` file is also present in the project
+directory.
+
+This file should have the format outlined at `cellranger_multi`_.
+
+.. _cellranger_multi: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/multi#cellranger-multi
 
 ---------------------------
 Configuring the QC pipeline

--- a/docs/source/using/setup_analysis_dirs.rst
+++ b/docs/source/using/setup_analysis_dirs.rst
@@ -55,6 +55,11 @@ For certain types of data there are additional files that should
 be added to the project directory manually after running
 ``setup_analysis_dirs``.
 
+Note that for some of these files ``setup_analysis_dirs`` will
+generate partially-populated template versions, with the
+``.template`` extension. These can be edited and renamed before
+use in downstream processing stages (e.g. the QC pipeline).
+
 .. _10x_multiome_libraries_info:
 
 10xGenomics single cell multiome linked samples


### PR DESCRIPTION
PR which addresses issue #689 by implementing generation of template `10x_multiome_libraries.info` and `10x_multi_config.csv` files for 10xGenomics Single Cell Multiome and 10xGenomics CellPlex data respectively.

The templates are partially populated but will need to be edited and renamed to remove the `.template` extension before they can be used by the QC pipeline.