### PR TITLE
Fix bug with reporting sequence length data for reports combining multiple projects

### DIFF
--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -656,6 +656,8 @@ class QCProject(object):
                 else:
                     max_seq_length[read] = max(max_seq_length[read],
                                                seqlens_data.max_length)
+            # Store the sequence length files
+            output_files.extend(seq_lens)
         # Look for ICELL8 outputs
         icell8_top_dir = os.path.dirname(self.qc_dir)
         print("Checking for ICELL8 reports in %s/stats" %


### PR DESCRIPTION
PR which fixes a bug in the `qc.reporting` module, where where the sequencing length files were not being added to the list of output files. For QC reports that combine data from multiple projects (e.g. 10xGenomics single cell multiome linked runs) this caused the reporting of various metrics (read lengths, adapters etc) to fail.