### PR TITLE
Cellranger count: add Single Cell Multiome v1 chemistry to list of known assay types

### DIFF
--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -79,6 +79,7 @@ CELLRANGER_ASSAY_CONFIGS = {
     'SC3Pv3': 'Single Cell 3\' v3',
     'SC5P-PE': 'Single Cell 5\' paired-end (both R1 and R2 are used for alignment)',
     'SC5P-R2': 'Single Cell 5\' R2-only (where only R2 is used for alignment)',
+    'ARC-v1': 'Single Cell Multiome (ATAC+GEX) v1', # Not documented?
 }
 
 #######################################################################


### PR DESCRIPTION
PR which updates the `CELLRANGER_ASSAY_CONFIG` list in `tenx_genomics_utils` to include the `ARC-v1` chemistry (Single Cell Multiome v1).

This chemistry type doesn't appear to be documented except in the following FAQ ("Can I analyze only the Gene Expression data from my single cell multiome experiment?" https://kb.10xgenomics.com/hc/en-us/articles/360059656912-Can-I-analyze-only-the-Gene-Expression-data-from-my-single-cell-multiome-experiment-