### PR TITLE
pipeliner: updates and fixes to CondaWrapper class and unit tests

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -1136,7 +1136,7 @@ class PipelineFailure(object):
     DEFERRED = 1
 
 # Default channels for conda dependency resolution
-CONDA_CHANNELS = (
+DEFAULT_CONDA_CHANNELS = (
     'conda-forge',
     'bioconda',
     'defaults',
@@ -2080,9 +2080,7 @@ class Pipeline(object):
             if not os.path.exists(conda_env_dir):
                 os.makedirs(conda_env_dir)
             # Set up wrapper class
-            conda = CondaWrapper(conda=conda,
-                                 env_dir=conda_env_dir,
-                                 channels=CONDA_CHANNELS)
+            conda = CondaWrapper(conda=conda,env_dir=conda_env_dir)
             if not conda.is_installed:
                 raise PipelineError("Conda dependency resolution enabled "
                                     "but conda couldn't be found")
@@ -2898,12 +2896,12 @@ class PipelineTask(object):
             (defaults to environments directory belonging to the
             supplied conda installation)
           channels (list): optional list of channel names to use
-            with conda operations
+            with conda operations (overrides defaults)
         """
         # Set up conda wrapper
         conda = CondaWrapper(conda=conda,
                              env_dir=env_dir,
-                             channels=CONDA_CHANNELS)
+                             channels=channels)
         # Make a name for the environment
         env_name = self.conda_env_name
         # Fetch the environment
@@ -4023,6 +4021,10 @@ class CondaWrapper(object):
         # Channels
         if channels:
             channels = [c for c in channels]
+        elif channels is None:
+            channels = DEFAULT_CONDA_CHANNELS
+        else:
+            channels = list()
         self._channels = channels
         # Lock for blocking operations
         self._lock_manager = ResourceLock()

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -3352,14 +3352,8 @@ class PipelineCommand(object):
                 if module is not None:
                     prologue.append("module load %s" % module)
         if conda_env:
-            if not conda:
-                conda = find_program("conda")
-            if not conda:
-                raise PipelineError("Unable to locate conda")
-            conda_dir = os.sep.join(
-                os.path.abspath(conda).split(os.sep)[:-2])
             conda_activate_cmd = \
-                "source %s/bin/activate %s" % (conda_dir,conda_env)
+                str(CondaWrapper(conda).activate_env_cmd(conda_env))
             prologue.extend(["echo %s" % conda_activate_cmd,
                              conda_activate_cmd])
         if working_dir:
@@ -4163,6 +4157,26 @@ class CondaWrapper(object):
         self._lock_manager.release(lock)
         # Return name/path to conda environment
         return env_name
+
+    def activate_env_cmd(self,name):
+        """
+        Fetch command to activate a conda environment
+
+        Arguments:
+          name (str): name/path of the environment to
+            activate
+
+        Returns:
+          Command: Command instance to activate the
+            named environment.
+        """
+        if self._conda_dir:
+            return Command(
+                'source',
+                os.path.join(self._conda_dir,'bin','activate'),
+                name)
+        else:
+            return None
 
 class CondaWrapperError(Exception):
     """

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2884,7 +2884,7 @@ class PipelineTask(object):
         Return a name for conda environment based on packages
         """
         if self.conda_dependencies:
-            return '+'.join(sorted(self.conda_dependencies)).replace('=','@')
+            return make_conda_env_name(*self.conda_dependencies)
         else:
             return None
 
@@ -4206,6 +4206,31 @@ class CondaCreateEnvError(CondaWrapperError):
         self.cmdline = cmdline
         self.output = output
         CondaWrapperError.__init__(self,self.message)
+
+def make_conda_env_name(*pkgs):
+    """
+    Return a name for a conda env based on package list
+
+    Constructs a name for a conda environment, based on
+    the packages specified for inclusion in the
+    environment.
+
+    The name consists of components of the form
+    "NAME[@VERSION]" for each package specification
+    "NAME[=VERSION]" (e.g. 'star=2.4.2a' becomes
+    'star@2.4.2a').
+
+    Components are joined by '+' and are sorted by package
+    name (regardless of the order they are supplied in).
+
+    Arguments:
+      pkgs (list): list of conda package specifiers
+
+    Returns:
+      String: environment name constructed from package
+        list.
+    """
+    return '+'.join(sorted([str(p) for p in pkgs])).replace('=','@')
 
 ######################################################################
 # Custom exceptions

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -3709,10 +3709,10 @@ class TestCondaWrapper(unittest.TestCase):
             os.makedirs(d)
         # Create mock conda using supplied function
         self.conda = mock_conda_func(self.conda_bin_dir)
-        # Update PATH
-        os.environ['PATH'] = os.environ['PATH'] + \
-                             os.sep + \
-                             self.conda_bin_dir
+        # Update PATH (put mock conda first)
+        os.environ['PATH'] = self.conda_bin_dir + \
+                             os.pathsep + \
+                             os.environ['PATH']
 
     def test_conda_wrapper_conda_version(self):
         """

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -3831,6 +3831,18 @@ class TestCondaWrapper(unittest.TestCase):
             self.assertEqual(contents,
                              "fastqc=0.11.3 fastq-screen=0.14.0 bowtie=1.2.3")
 
+    def test_conda_wrapper_activate_command(self):
+        """
+        CondaWrapper: check environment activation command
+        """
+        self._make_mock_conda(_Mock.conda)
+        conda = CondaWrapper(conda=self.conda)
+        self.assertEqual(conda.activate_env_cmd("fastqc@0.11.3").command_line,
+                         Command(
+                             'source',
+                             os.path.join(self.conda_bin_dir,'activate'),
+                             'fastqc@0.11.3').command_line)
+
     def test_conda_wrapper_create_env_raise_exception_on_error(self):
         """
         CondaWrapper: raise exception on error when creating environment

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -87,7 +87,6 @@ elif [ "$1" == "create" ] ; then
          shift
          ;;
        --override-channels)
-         shift
          ;;
        *)
          PACKAGES="$PACKAGES $2"

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -3722,6 +3722,18 @@ class TestCondaWrapper(unittest.TestCase):
         conda = CondaWrapper(conda=self.conda)
         self.assertEqual(conda.version,"4.10.3")
 
+    def test_conda_wrapper_conda_not_specified(self):
+        """
+        CondaWrapper: check properties when conda exe not specified
+        """
+        self._make_mock_conda(_Mock.conda)
+        print(os.environ['PATH'])
+        conda = CondaWrapper()
+        self.assertEqual(conda.conda,self.conda)
+        self.assertTrue(conda.is_installed)
+        self.assertEqual(conda.env_dir,self.conda_env_dir)
+        self.assertEqual(conda.list_envs,[])
+
     def test_conda_wrapper_conda_defaults(self):
         """
         CondaWrapper: check properties for default env dir
@@ -3752,12 +3764,15 @@ class TestCondaWrapper(unittest.TestCase):
         """
         CondaWrapper: check properties for 'null' wrapper
         """
+        save_path = os.environ['PATH']
+        os.environ['PATH'] = ''
         conda = CondaWrapper()
         self.assertEqual(conda.conda,None)
         self.assertFalse(conda.is_installed)
         self.assertEqual(conda.env_dir,None)
         self.assertEqual(conda.list_envs,[])
         self.assertEqual(conda.version,None)
+        os.environ['PATH'] = save_path
 
     def test_conda_wrapper_missing_conda_executable(self):
         """

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -33,6 +33,7 @@ from auto_process_ngs.pipeliner import FunctionParam
 from auto_process_ngs.pipeliner import CondaWrapper
 from auto_process_ngs.pipeliner import PipelineError
 from auto_process_ngs.pipeliner import CondaCreateEnvError
+from auto_process_ngs.pipeliner import make_conda_env_name
 from auto_process_ngs.pipeliner import resolve_parameter
 from bcftbx.JobRunner import SimpleJobRunner
 
@@ -3855,6 +3856,19 @@ class TestCondaWrapper(unittest.TestCase):
                           "fastqc=0.11.3",
                           "fastq-screen=0.14.0",
                           "bowtie=1.2.3")
+
+class TestMakeCondaEnvName(unittest.TestCase):
+
+    def test_make_conda_env_name(self):
+        """
+        make_conda_env_name: returns consistent environment name
+        """
+        self.assertEqual(make_conda_env_name("fastq-screen=0.14.0",
+                                             "bowtie=1.2.3"),
+                         "bowtie@1.2.3+fastq-screen@0.14.0")
+        self.assertEqual(make_conda_env_name("bowtie=1.2.3",
+                                             "fastq-screen=0.14.0"),
+                         "bowtie@1.2.3+fastq-screen@0.14.0")
 
 class TestResolveParameter(unittest.TestCase):
 


### PR DESCRIPTION
PR which implements a number of updates to the `CondaWrapper` class in the `pipeliner` module:

* Now automatically attempts to locate a `conda` executable if one isn't supplied when the class is instantiated;
* Adds new method `activate_env_cmd` to generate the command required to activate an environment;
* Implicitly sets the default conda channel list on instantiation, unless explicitly overridden by the `channels` argument.

There is also a new function `make_conda_env_name` which wraps the construction of consistent conda environment names based on package specifications (to make it easier to reuse), and fixes to the unit tests.