### PR TITLE
Update the 'report_qc' function to use conda dependency resolution

### DIFF
--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -241,8 +241,12 @@ def report_qc(project,qc_dir=None,fastq_dir=None,qc_protocol=None,
             logger.warn("failed to acquire conda environment '%s': %s" %
                         (env_name,ex))
     # Wrap the command in a script
-    report_script = os.path.join(project.dirn,
-                                 "ScriptCode",
+    scripts_dir = os.path.join(project.dirn,"ScriptCode")
+    if not os.path.isdir(scripts_dir):
+        logger.warn("no ScriptCode directory found in '%s'" %
+                    project.name)
+        scripts_dir = project.dirn
+    report_script = os.path.join(scripts_dir,
                                  "report_qc.%s.sh" % project.name)
     report_cmd.make_wrapper_script(filen=report_script,
                                    prologue=conda_activate_cmd,

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -230,12 +230,12 @@ def report_qc(project,qc_dir=None,fastq_dir=None,qc_protocol=None,
         report_qc_conda_pkgs = ("multiqc=1.8",
                                 "pillow",
                                 "python=3.8")
-        env_name = make_conda_env_name(report_qc_conda_pkgs)
+        env_name = make_conda_env_name(*report_qc_conda_pkgs)
         try:
             conda.create_env(env_name,*report_qc_conda_pkgs)
             conda_env = os.path.join(conda_env_dir,env_name)
             # Script fragment to activate the environment
-            conda_activate_cmd = conda.activate_cmd(conda_env)
+            conda_activate_cmd = conda.activate_env_cmd(conda_env)
         except CondaWrapperError as ex:
             # Failed to acquire the environment
             logger.warn("failed to acquire conda environment '%s': %s" %


### PR DESCRIPTION
PR which updates the `report_qc` function in `qc/utils` to use conda dependency resolution, if this has been enabled in the configuration settings.

Without this change it is likely that the reporting will fail in production environments as it needs MultiQC to be available in the runtime environment, and there is no other way to ensure this. (Therefore this PR is also considered a bugfix.)