### PR TITLE
Add --comment option to 'import_project' (plus minor fixes)

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1040,6 +1040,10 @@ def add_import_project_command(cmdparser):
                    "to the current directory)")
     p.add_argument('project_dir',metavar="PROJECT_DIR",
                    help="path to project directory to import")
+    p.add_argument('--comment',action='store',
+                   dest='comment',default=None,
+                   help="specify comment text to be appended to the stored "
+                   "comments associated with the project")
 
 def add_update_fastq_stats_command(cmdparser):
     """
@@ -1569,7 +1573,8 @@ def import_project(args):
     if not analysis_dir:
         analysis_dir = os.getcwd()
     d = AutoProcess(analysis_dir)
-    d.import_project(args.project_dir)
+    d.import_project(args.project_dir,
+                     comment=args.comment)
 
 def update_fastq_stats(args):
     """

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1033,7 +1033,10 @@ def add_import_project_command(cmdparser):
     p = cmdparser.add_command('import_project',
                               help="Import a project directory",
                               description="Copy a project directory "
-                              "PROJECT_DIR into ANALYSIS_DIR.")
+                              "PROJECT_DIR from another analysis "
+                              "directory into ANALYSIS_DIR, update "
+                              "metadata appropriately, and regenerate "
+                              "QC reports.")
     add_debug_option(p)
     p.add_argument('analysis_dir',metavar="ANALYSIS_DIR",nargs="?",
                    help="auto_process analysis directory (optional: defaults "

--- a/auto_process_ngs/commands/import_project_cmd.py
+++ b/auto_process_ngs/commands/import_project_cmd.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 # Command functions
 #######################################################################
 
-def import_project(ap,project_dir,runner=None):
+def import_project(ap,project_dir,comment=None,runner=None):
     """
     Import a project directory into an analysis directory
 
@@ -37,11 +37,16 @@ def import_project(ap,project_dir,runner=None):
       imported project
     - Updating the project metadata and the QC report
 
+    Optionally the comments associated with the project can
+    also be extended.
+
     Arguments:
       ap (AutoProcessor): autoprocessor pointing to the parent
         analysis directory
       project_dir (str): path to project directory to be
         imported
+      comment (str): optional comment to append to the
+        comments stored with the project after import
       runner (JobRunner): explicitly specify the job runner to
         send jobs to (overrides default runner set in the
         configuration)
@@ -94,6 +99,16 @@ def import_project(ap,project_dir,runner=None):
     print("Updating projects.info file with imported project")
     project_metadata = ap.load_project_metadata()
     sample_names = [s.name for s in project.samples]
+    comments = project.info.comments
+    if comment is not None:
+        comment = str(comment).strip()
+        print("Appending comment: '%s'" % comment)
+        if comments:
+            # Append
+            comments += "; %s" % comment
+        else:
+            # New comment
+            comments = comment
     project_metadata.add_project(
         project.name,
         sample_names,
@@ -102,7 +117,7 @@ def import_project(ap,project_dir,runner=None):
         single_cell_platform=project.info.single_cell_platform,
         organism=project.info.organism,
         PI=project.info.PI,
-        comments=project.info.comments)
+        comments=comments)
     project_metadata.save()
     # Report
     print("Projects now in metadata file:")
@@ -116,6 +131,7 @@ def import_project(ap,project_dir,runner=None):
                       % (project.name,ex))
         return
     project.info['run'] = ap.run_name
+    project.info['comments'] = comments
     project.info.save()
     print("Set run to %s for project '%s'" % (project.info.run,
                                               project.name))

--- a/auto_process_ngs/commands/import_project_cmd.py
+++ b/auto_process_ngs/commands/import_project_cmd.py
@@ -135,11 +135,14 @@ def import_project(ap,project_dir,runner=None):
             qc_info.save()
         if verify_qc(project,log_dir=ap.log_dir,runner=runner):
             try:
-                report_qc(project,
-                          zip_outputs=True,
-                          multiqc=True,
-                          runner=runner,
-                          log_dir=ap.log_dir)
+                status = report_qc(project,
+                                   zip_outputs=True,
+                                   multiqc=True,
+                                   runner=runner,
+                                   log_dir=ap.log_dir)
+                if status != 0:
+                    raise Exception("Report generation returned non-zero "
+                                    "exit code (%s)" % status)
                 print("Updated QC report for %s" % project.name)
             except Exception as ex:
                 raise Exception("Project '%s' imported but failed to "

--- a/auto_process_ngs/commands/import_project_cmd.py
+++ b/auto_process_ngs/commands/import_project_cmd.py
@@ -66,7 +66,8 @@ def import_project(ap,project_dir,runner=None):
     print("Importing project directory contents for '%s'" % project.name)
     try:
         excludes = ['--exclude=tmp.*',
-                    '--exclude=qc_report.*']
+                    '--exclude=qc_report.*',
+                    '--exclude=multi_qc*']
         rsync = applications_general.rsync(project_dir,
                                            ap.analysis_dir,
                                            extra_options=excludes)

--- a/auto_process_ngs/test/commands/test_import_project.py
+++ b/auto_process_ngs/test/commands/test_import_project.py
@@ -133,6 +133,44 @@ Comments\t1% PhiX spike in
             f = os.path.join(ap2.analysis_dir,'NewProj',f)
             self.assertTrue(os.path.exists(f),"Missing %s" % f)
 
+    def test_import_project_with_comment(self):
+        """import_project: check comment is appended
+        """
+        # Make an auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '160621_M00879_0087_000000000-AGEW9',
+            'miseq',
+            top_dir=self.dirn)
+        mockdir.create()
+        # Check that the project is not currently present
+        ap = AutoProcess(mockdir.dirn)
+        self.assertFalse('NewProj' in [p.name
+                                       for p in ap.get_analysis_projects()])
+        self.assertFalse('NewProj' in [p.name
+                                       for p in ap.get_analysis_projects_from_dirs()])
+        self.assertFalse(os.path.exists(os.path.join(ap.analysis_dir,'NewProj')))
+        # Import the project and append a comment
+        import_project(ap,self.new_project_dir,
+                       comment="imported from elsewhere")
+        self.assertTrue('NewProj' in [p.name
+                                      for p in ap.get_analysis_projects()])
+        self.assertTrue('NewProj' in [p.name
+                                      for p in ap.get_analysis_projects_from_dirs()])
+        self.assertTrue(os.path.exists(os.path.join(ap.analysis_dir,'NewProj')))
+        # Verify via fresh AutoProcess object
+        ap2 = AutoProcess(mockdir.dirn)
+        self.assertTrue('NewProj' in [p.name
+                                      for p in ap2.get_analysis_projects()])
+        self.assertTrue('NewProj' in [p.name
+                                      for p in ap2.get_analysis_projects_from_dirs()])
+        self.assertTrue(os.path.exists(os.path.join(ap2.analysis_dir,'NewProj')))
+        # Check the comment has been updated
+        with open(os.path.join(mockdir.dirn,'NewProj','README.info'),'rt') \
+             as fp:
+            self.assertTrue(
+                "Comments\t1% PhiX spike in; imported from elsewhere"
+                in fp.read())
+
     def test_import_project_already_in_metadata_file(self):
         """import_project: fails when project is already in projects.info
         """

--- a/auto_process_ngs/test/commands/test_import_project.py
+++ b/auto_process_ngs/test/commands/test_import_project.py
@@ -31,7 +31,7 @@ class TestAutoProcessImportProject(unittest.TestCase):
         project_dir = os.path.join(self.dirn,'NewProj')
         os.mkdir(project_dir)
         os.mkdir(os.path.join(project_dir,'fastqs'))
-        for fq in ('NP01_S1_R1_001.fastq.gz','NP01_S1_R1_001.fastq.gz'):
+        for fq in ('NP01_S1_R1_001.fastq.gz','NP01_S1_R2_001.fastq.gz'):
             with open(os.path.join(project_dir,'fastqs',fq),'wt') as fp:
                 fp.write('')
         with open(os.path.join(project_dir,'README.info'),'wt') as fp:

--- a/docs/source/using/import_project.rst
+++ b/docs/source/using/import_project.rst
@@ -6,7 +6,7 @@ analysis projects from one analysis directory into another (for example,
 when the raw sequencing data has been reprocessed to generate new Fastqs
 using different parameters).
 
-While the required steps can be performed manually, in these cases the
+While the required steps can be performed manually, in these cases
 it is recommended that the ``import_project`` command is used as this
 automates the process.
 

--- a/docs/source/using/import_project.rst
+++ b/docs/source/using/import_project.rst
@@ -29,6 +29,13 @@ The following steps are peformed:
   stored paths are consistent with the new location;
 * QC reports and ZIP archives are automatically regenerated.
 
-Note that if a project directory already exists in the target analysis
-directory with the same name as the one being imported, then the
-``import_project`` command will stop with a warning.
+.. note::
+
+   If a project directory already exists in the target analysis
+   directory with the same name as the one being imported, then the
+   ``import_project`` command will stop with a warning.
+
+The command supports the following additional options:
+
+* ``--comment``: allows comment text to be specified which will be
+  appended to any existing comments associated with the project.


### PR DESCRIPTION
PR which implements a new `--comment` option on the `import_project` command, which extends the comments associated with the imported project when it's copied into the target analysis directory.

The PR also includes some minor fixes to the documentation and unit test setup, improves the detection of errors from the QC report generation, and expands the descriptive text shown by the `--help` CLI option.