### PR TITLE
Drop support for Python 2

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -183,7 +183,7 @@ class AnalysisFastq(BaseFastqAttrs):
         else:
             return self.basename
 
-class AnalysisDir(object):
+class AnalysisDir:
     """Class describing an analysis directory
 
     Conceptually an analysis directory maps onto a sequencing run.
@@ -372,7 +372,7 @@ class AnalysisDir(object):
                                    projects))
         return projects
         
-class AnalysisProject(object):
+class AnalysisProject:
     """Class describing an analysis project
 
     Conceptually an analysis project consists of a set of samples
@@ -1082,7 +1082,7 @@ class AnalysisProject(object):
         """
         return bcf_utils.pretty_print_names(self.samples)
 
-class AnalysisSample(object):
+class AnalysisSample:
     """Class describing an analysis sample
 
     An analysis sample consists of a set of fastqs file corresponding

--- a/auto_process_ngs/applications.py
+++ b/auto_process_ngs/applications.py
@@ -52,7 +52,7 @@ from .bcl2fastq.utils import get_nmismatches
 # Classes
 #######################################################################
 
-class bcl2fastq(object):
+class bcl2fastq:
     """Bcl to fastq conversion line applications
  
     Provides static methods to create Command instances for command line
@@ -314,7 +314,7 @@ class bcl2fastq(object):
                                     num_decompression_threads)
         return bclconvert_cmd
 
-class general(object):
+class general:
     """General command line applications (e.g. rsync, make)
  
     Provides static methods to create Command instances for a class of

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -112,7 +112,7 @@ def add_command(name,f):
 @add_command("update_fastq_stats",commands.update_fastq_stats)
 @add_command("import_project",commands.import_project)
 @add_command("clone",commands.clone)
-class AutoProcess(object):
+class AutoProcess:
     """
     Class implementing an automatic fastq generation and QC
     processing procedure for Illumina sequencing data

--- a/auto_process_ngs/barcodes/analysis.py
+++ b/auto_process_ngs/barcodes/analysis.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     barcodes/analysis.py: classes and functions for analysing barcodes
-#     Copyright (C) University of Manchester 2016-2020 Peter Briggs
+#     Copyright (C) University of Manchester 2016-2021 Peter Briggs
 #
 ########################################################################
 #
@@ -29,11 +29,6 @@ FASTQ read headers:
 #######################################################################
 
 import sys
-try:
-    # Python2
-    from itertools import izip as zip
-except ImportError:
-    pass
 from bcftbx.IlluminaData import SampleSheet
 from bcftbx.IlluminaData import samplesheet_index_sequence
 from bcftbx.IlluminaData import normalise_barcode

--- a/auto_process_ngs/barcodes/analysis.py
+++ b/auto_process_ngs/barcodes/analysis.py
@@ -53,7 +53,7 @@ PROBLEMS_DETECTED_TEXT = "One or more lanes have problems"
 # Classes
 #######################################################################
 
-class BarcodeCounter(object):
+class BarcodeCounter:
     """
     Utility class to mange counts of barcode sequences
 
@@ -537,7 +537,7 @@ class BarcodeCounter(object):
         analysis['coverage'] = cum_reads
         return analysis
 
-class BarcodeGroup(object):
+class BarcodeGroup:
     """
     Class for storing groups of related barcodes
 
@@ -674,7 +674,7 @@ class BarcodeGroup(object):
     def __len__(self):
         return len(self._sequences)
 
-class SampleSheetBarcodes(object):
+class SampleSheetBarcodes:
     """
     Class for handling index sequences from a sample sheet
 
@@ -847,7 +847,7 @@ class SampleSheetBarcodes(object):
         else:
             raise KeyError("Lane %s not in sample sheet" % lane)
 
-class Reporter(object):
+class Reporter:
     """
     Class for generating reports of barcode statistics
 

--- a/auto_process_ngs/barcodes/splitter.py
+++ b/auto_process_ngs/barcodes/splitter.py
@@ -21,12 +21,6 @@ index sequences) from the read headers:
 
 """
 
-try:
-    # Python 2
-    from itertools import izip as zip
-except ImportError:
-    # Python 3
-    pass
 import logging
 import bcftbx.IlluminaData as IlluminaData
 import bcftbx.FASTQFile as FASTQFile

--- a/auto_process_ngs/barcodes/splitter.py
+++ b/auto_process_ngs/barcodes/splitter.py
@@ -30,7 +30,7 @@ from ..utils import OutputFiles
 # Classes
 #########################################################################
 
-class HammingMetrics(object):
+class HammingMetrics:
     """
     Calculate Hamming distances between two strings
 
@@ -83,7 +83,7 @@ class HammingMetrics(object):
         return sum((ch1 != ch2 or ch1 == 'N' or ch2 == 'N') \
                    for ch1, ch2 in zip(s1, s2))
 
-class HammingLookup(object):
+class HammingLookup:
     """
     Class for handling Hamming distances for multiple sequences
 
@@ -130,7 +130,7 @@ class HammingLookup(object):
         self._distances[s1][s2] = self._hamming(s1,s2)
         return self._distances[s1][s2]
 
-class BarcodeMatcher(object):
+class BarcodeMatcher:
     """
     Class to match barcode sequences against reference set
     """

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -3333,8 +3333,8 @@ class Run10xMkfastq(PipelineTask):
                         if not os.path.exists(os.path.dirname(fastq)):
                             os.mkdir(os.path.dirname(fastq))
                         # Make empty file
-                        with gzip.GzipFile(filename=fastq,mode='wb') as fp:
-                            fp.write(''.encode())
+                        with gzip.GzipFile(filename=fastq,mode='wt') as fp:
+                            fp.write('')
                 else:
                     # Terminate with an exception
                     raise Exception("Failed to verify outputs against "
@@ -3965,5 +3965,5 @@ def create_placeholder_fastqs(fastqs,base_dir=None):
         if not os.path.exists(os.path.dirname(fastq)):
             os.mkdir(os.path.dirname(fastq))
         # Make empty file
-        with gzip.GzipFile(filename=fastq,mode='wb') as fp:
-            fp.write(''.encode())
+        with gzip.open(fastq,'wt') as fp:
+            fp.write('')

--- a/auto_process_ngs/command.py
+++ b/auto_process_ngs/command.py
@@ -20,7 +20,6 @@ to build command lines to execute applications.
 
 import subprocess
 import logging
-import tempfile
 from bcftbx.utils import find_program
 
 # Module specific logger
@@ -187,13 +186,9 @@ class Command(object):
     def subprocess_check_output(self,include_err=True,working_dir=None):
         """Run the command and capture the output
 
-        This runs the command using the subprocess.call() and
-        captures the output in a string which is returned to the
-        calling subprogram (along with the return code from the
+        This runs the command using ``subprocess.check_output`` and
+        returns the output (along with the return code from the
         command).
-
-        Nb it would be better if we could use the subprocess.check_output
-        function (but this is not available in Python 2.6).
 
         Arguments:
           include_err: optional, if True then stderr is included in
@@ -210,13 +205,15 @@ class Command(object):
             stderr = subprocess.STDOUT
         else:
             stderr = None
-        # Create a temporary file-like object to capture output
-        with tempfile.TemporaryFile(mode='w+t') as ftmp:
-            status = subprocess.call(self.command_line,stdout=ftmp,
-                                     cwd=working_dir,stderr=stderr)
-            # Read the output
-            ftmp.seek(0)
-            output = ftmp.read()
+        try:
+            output = subprocess.check_output(self.command_line,
+                                             cwd=working_dir,
+                                             stderr=stderr,
+                                             universal_newlines=True)
+            status = 0
+        except subprocess.CalledProcessError as ex:
+            output = ex.output
+            status = ex.returncode
         return (status,output)
 
     def make_wrapper_script(self,shell=None,filen=None,fp=None,

--- a/auto_process_ngs/command.py
+++ b/auto_process_ngs/command.py
@@ -30,7 +30,7 @@ logger.addHandler(logging.NullHandler())
 # Classes
 #######################################################################
 
-class Command(object):
+class Command:
     """Class for creating and executing command lines
 
     The Command class is intended to help with building and

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 # Constants
 #######################################################################
 
-class ReportingMode(object):
+class ReportingMode:
     CONCISE = 0
     SUMMARY = 1
     PROJECTS = 2

--- a/auto_process_ngs/commands/setup_cmd.py
+++ b/auto_process_ngs/commands/setup_cmd.py
@@ -9,13 +9,8 @@ import os
 import uuid
 import shutil
 import logging
-try:
-    from urllib.request import urlopen
-    from urllib.error import URLError
-except ImportError:
-    # Failed to get Python3 urlopen, fallback to Python2
-    from urllib2 import urlopen
-    from urllib2 import URLError
+from urllib.request import urlopen
+from urllib.error import URLError
 from ..bcl2fastq.utils import get_sequencer_platform
 from ..bcl2fastq.utils import make_custom_sample_sheet
 from ..applications import general as general_applications

--- a/auto_process_ngs/conda.py
+++ b/auto_process_ngs/conda.py
@@ -21,13 +21,8 @@ Module providing utility classes and functions to help with managing
 import os
 import tempfile
 import logging
-try:
-    from urllib.request import urlopen
-    from urllib.error import URLError
-except ImportError:
-    # Failed to get Python3 urlopen, fallback to Python2
-    from urllib2 import urlopen
-    from urllib2 import URLError
+from urllib.request import urlopen
+from urllib.error import URLError
 from bcftbx.JobRunner import ResourceLock
 from bcftbx.utils import find_program
 from .command import Command

--- a/auto_process_ngs/conda.py
+++ b/auto_process_ngs/conda.py
@@ -46,7 +46,7 @@ DEFAULT_CONDA_CHANNELS = (
 # Classes
 ######################################################################
 
-class CondaWrapper(object):
+class CondaWrapper:
     """
     Class for installing conda and creating environments
 

--- a/auto_process_ngs/docwriter.py
+++ b/auto_process_ngs/docwriter.py
@@ -68,7 +68,7 @@ WARNING_ICON_BASE64 = r'iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAkFBMVEX/
 # Classes
 #######################################################################
 
-class Document(object):
+class Document:
     """
     Utility class for constructing documents
 
@@ -196,7 +196,7 @@ class Document(object):
         html.add(self.html())
         html.write("%s" % outfile)
 
-class Section(object):
+class Section:
     """
     Class representing a generic document section
 
@@ -376,7 +376,7 @@ class Section(object):
         html.append('</div>')
         return '\n'.join(html)
 
-class Table(object):
+class Table:
     """
     Utility class for constructing HTML tables
 
@@ -615,7 +615,7 @@ class Table(object):
         html.append("</table>")
         return '\n'.join(html)
 
-class List(object):
+class List:
     """
     Utility class for creating ordered and unordered lists
 
@@ -692,7 +692,7 @@ class List(object):
         html.append("</%s>" % tag)
         return "".join(html)
 
-class Img(object):
+class Img:
     """
     Utility class for embedding <img> tags
 
@@ -772,7 +772,7 @@ class Img(object):
     def __repr__(self):
         return self.html()
 
-class Link(object):
+class Link:
     """
     Utility class for embedding <a href=...> tags
 
@@ -831,7 +831,7 @@ class Link(object):
     def __repr__(self):
         return self.html()
 
-class Target(object):
+class Target:
     """
     Utility class for embedding <a id=... /> tags
 
@@ -874,7 +874,7 @@ class Target(object):
         # Build the anchor
         return "<a id='%s' />" % self._name
 
-class Para(object):
+class Para:
     """
     Utility to wrap heterogeneous items into a single block
 

--- a/auto_process_ngs/fastq_utils.py
+++ b/auto_process_ngs/fastq_utils.py
@@ -44,7 +44,7 @@ from bcftbx.qc.report import strip_ngs_extensions
 # Classes
 #######################################################################
 
-class BaseFastqAttrs(object):
+class BaseFastqAttrs:
     """
     Base class for extracting information about a Fastq file
 
@@ -306,7 +306,7 @@ class IlluminaFastqAttrs(BaseFastqAttrs):
             fq.append("%03d" % self.set_number)
         return self.delimiter.join(fq)
 
-class FastqReadCounter(object):
+class FastqReadCounter:
     """
     Implements various methods for counting reads in FASTQ file
 

--- a/auto_process_ngs/fileops.py
+++ b/auto_process_ngs/fileops.py
@@ -66,7 +66,7 @@ logger = logging.getLogger(__name__)
 # Classes
 #########################################################################
 
-class Location(object):
+class Location:
     """
     Class for examining a file-system location specifier
 

--- a/auto_process_ngs/icell8/atac.py
+++ b/auto_process_ngs/icell8/atac.py
@@ -26,11 +26,6 @@ import sys
 import os
 import glob
 import time
-try:
-    # Python 2
-    from itertools import izip as zip
-except ImportError:
-    pass
 from collections import defaultdict
 from bcftbx.FASTQFile import SequenceIdentifier
 from bcftbx.ngsutils import getreads

--- a/auto_process_ngs/icell8/utils.py
+++ b/auto_process_ngs/icell8/utils.py
@@ -310,7 +310,7 @@ def pass_quality_filter(s,cutoff):
 # Classes
 ######################################################################
 
-class ICell8WellList(object):
+class ICell8WellList:
     """
     Class representing an ICELL8 well list file
 
@@ -354,7 +354,7 @@ class ICell8WellList(object):
         except IndexError:
             raise KeyError("Failed to locate sample for '%s'" % barcode)
 
-class ICell8Read1(object):
+class ICell8Read1:
     """
     Class representing an ICELL8 R1 read
     """
@@ -482,7 +482,7 @@ class ICell8FastqIterator(Iterator):
             logging.critical("Failed to create read pair: %s" % ex)
             raise ex
 
-class ICell8StatsCollector(object):
+class ICell8StatsCollector:
     """
     Class to collect ICELL8 barcode and UMI counts
 
@@ -585,7 +585,7 @@ class ICell8StatsCollector(object):
         print("collect_fastq_stats: returning: %s" % fastq)
         return (fastq,counts,umis)
 
-class ICell8Stats(object):
+class ICell8Stats:
     """
     Class for gathering statistics on ICELL8 FASTQ R1 files
 

--- a/auto_process_ngs/icell8/utils.py
+++ b/auto_process_ngs/icell8/utils.py
@@ -481,9 +481,6 @@ class ICell8FastqIterator(Iterator):
             print("-- Read 2:\n%s" % r2)
             logging.critical("Failed to create read pair: %s" % ex)
             raise ex
-    def next(self):
-        # Implement 'next' method for Python 2
-        return self.__next__()
 
 class ICell8StatsCollector(object):
     """

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -355,7 +355,7 @@ class MockAnalysisDir(MockIlluminaData):
         # Finished
         return self.dirn
 
-class MockAnalysisProject(object):
+class MockAnalysisProject:
     """
     Utility class for creating mock auto-process project directories
 
@@ -440,7 +440,7 @@ IIIIIHIIIGHHIIDGHIIIIIIHIIIIIIIIIIIH\n""" % (lane,read_number)
 # Classes for updating directories with mock artefacts
 #######################################################################
 
-class DirectoryUpdater(object):
+class DirectoryUpdater:
     """
     Base class for updating mock directories
 
@@ -934,7 +934,7 @@ class UpdateAnalysisProject(DirectoryUpdater):
 # Factory classes for quickly generating mock directories
 #######################################################################
 
-class MockAnalysisDirFactory(object):
+class MockAnalysisDirFactory:
     """
     Collection of convenient pre-populated test cases
     """
@@ -1006,7 +1006,7 @@ class MockAnalysisDirFactory(object):
 # Classes for making mock executables
 #######################################################################
 
-class MockBcl2fastq2Exe(object):
+class MockBcl2fastq2Exe:
     """
     Create mock bcl2fastq2 executable
 
@@ -1355,7 +1355,7 @@ bcl2fastq v%s
         shutil.rmtree(tmpname)
         return self._exit_code
 
-class MockBclConvertExe(object):
+class MockBclConvertExe:
     """
     Create mock bcl-convert executable
 
@@ -1740,7 +1740,7 @@ Copyright (c) 2014-2018 Illumina, Inc.
         shutil.rmtree(tmpname)
         return self._exit_code
 
-class Mock10xPackageExe(object):
+class Mock10xPackageExe:
     """
     Create mock 10xGenomics pipeline executable
 
@@ -2302,7 +2302,7 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
         print("Return exit code: %s" % self._exit_code)
         return self._exit_code
 
-class MockIlluminaQcSh(object):
+class MockIlluminaQcSh:
     """
     Create mock illumina_qc.sh
 
@@ -2448,7 +2448,7 @@ fastqc\t/opt/apps/bin/fastqc\t0.11.3
             MockQCOutputs.fastqc_v0_11_2(args.fastq,qc_dir)
         return self._exit_code
 
-class MockMultiQC(object):
+class MockMultiQC:
     """
     Create mock MultiQC executable
 
@@ -2557,7 +2557,7 @@ For more help, run 'multiqc --help' or visit http://multiqc.info
         # Exit
         return self._exit_code
 
-class MockFastqStrandPy(object):
+class MockFastqStrandPy:
     """
     Create mock fastq_strand.py executable
 
@@ -2669,7 +2669,7 @@ sys.exit(MockFastqStrandPy(no_outputs=%s,
         # Exit
         return self._exit_code
 
-class MockConda(object):
+class MockConda:
     """
     Create mock conda installation
 

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -422,11 +422,11 @@ IIIIIHIIIGHHIIDGHIIIIIIHIIIIIIIIIIIH\n""" % (lane,read_number)
             else:
                 read = ""
             if fq.endswith('.gz'):
-                with gzip.open(os.path.join(fqs_dir,fq),'wb') as fp:
-                    fp.write(read.encode())
+                open_func = gzip.open
             else:
-                with open(os.path.join(fqs_dir,fq),'wt') as fp:
-                    fp.write(read)
+                open_func = open
+            with open_func(os.path.join(fqs_dir,fq),'wt') as fp:
+                fp.write(read)
         # Add README.info
         if readme:
             with open(os.path.join(project_dir,'README.info'),'w') as info:
@@ -2942,7 +2942,7 @@ def make_mock_bcl2fastq2_output(out_dir,lanes,sample_sheet=None,
             fastqs.append(os.path.join(s.dirn,fq))
     for fastq in fastqs:
         read_number = IlluminaFastq(fastq).read_number
-        with gzip.open(fastq,'wb') as fp:
+        with gzip.open(fastq,'wt') as fp:
             if no_lane_splitting:
                 # Add one read per lane
                 for lane in lanes:
@@ -2950,11 +2950,11 @@ def make_mock_bcl2fastq2_output(out_dir,lanes,sample_sheet=None,
 GCATACTCAGCTTTAGTAATAAGTGTGATTCTGGTA
 +
 IIIIIHIIIGHHIIDGHIIIIIIHIIIIIIIIIIIH\n""" % (lane,read_number)
-                    fp.write(read.encode())
+                    fp.write(read)
             else:
                 lane = IlluminaFastq(fastq).lane_number
                 read = """@ILLUMINA-545855:49:FC61RLR:%s:1:10979:1695 %s:N:0:TCCTGA
 GCATACTCAGCTTTAGTAATAAGTGTGATTCTGGTA
 +
 IIIIIHIIIGHHIIDGHIIIIIIHIIIIIIIIIIIH\n""" % (lane,read_number)
-                fp.write(read.encode())
+                fp.write(read)

--- a/auto_process_ngs/mockqc.py
+++ b/auto_process_ngs/mockqc.py
@@ -29,7 +29,7 @@ from . import mockqcdata
 # Class definitions
 #######################################################################
 
-class MockQCOutputs(object):
+class MockQCOutputs:
     """
     Utility class for creating mock auto-process QC outputs
     """

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -3820,7 +3820,7 @@ class Dispatcher(object):
                 print("Traceback:\n%s" %
                       ''.join(traceback.format_tb(ex.__traceback__)))
             except AttributeError:
-                # No __traceback__ for Python 2 exceptions
+                # No __traceback__ attribute?
                 pass
             result = ex
         # Pickle the result

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -1113,7 +1113,7 @@ logger.addHandler(logging.NullHandler())
 ALLOWED_CHARS = string.ascii_lowercase + string.digits + "._-"
 
 # Pipeline failure modes
-class PipelineFailure(object):
+class PipelineFailure:
     IMMEDIATE = 0
     DEFERRED = 1
 
@@ -1121,7 +1121,7 @@ class PipelineFailure(object):
 # Generic pipeline base classes
 ######################################################################
 
-class BaseParam(object):
+class BaseParam:
     """
     Provide base class for PipelineParam-type classes
 
@@ -1388,7 +1388,7 @@ class FileCollector(Iterator):
 # ...     print("Line: %s" % line)
 # >>> for line in output.stderr:
 # ...     print("Err: %s" % line)
-class Capturing(object):
+class Capturing:
     def __init__(self):
         self.stdout = list()
         self.stderr = list()
@@ -1406,7 +1406,7 @@ class Capturing(object):
         sys.stdout = self._stdout
         sys.stderr = self._stderr
 
-class Pipeline(object):
+class Pipeline:
     """
     Class to define and run a 'pipeline' of 'tasks'
 
@@ -2357,7 +2357,7 @@ class Pipeline(object):
             self.report("Completed: ok")
             return 0
 
-class PipelineTask(object):
+class PipelineTask:
     """
     Base class defining a 'task' to run as part of a pipeline
 
@@ -3237,7 +3237,7 @@ class PipelineFunctionTask(PipelineTask):
         """
         return self._result
 
-class PipelineCommand(object):
+class PipelineCommand:
     """
     Base class for constructing program command lines
 
@@ -3697,7 +3697,7 @@ class PathExistsParam(FunctionParam):
 # Dispatching Python functions as separate processes
 ######################################################################
 
-class Dispatcher(object):
+class Dispatcher:
     """
     Class to invoke Python functions in external processes
 

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -1089,12 +1089,7 @@ import atexit
 import textwrap
 import math
 from collections import Iterator
-try:
-    # Python2
-    from cStringIO import StringIO
-except ImportError:
-    # Python3
-    from io import StringIO
+from io import StringIO
 from functools import reduce
 from bcftbx.utils import mkdir
 from bcftbx.utils import AttributeDictionary
@@ -1381,11 +1376,6 @@ class FileCollector(Iterator):
             self._files = None
             self._idx = None
             raise StopIteration
-    def next(self):
-        """
-        Implemented for Python2 compatibility
-        """
-        return self.__next__()
 
 # Capture stdout and stderr from a function call
 # Based on code from http://stackoverflow.com/a/16571630/579925
@@ -3504,7 +3494,7 @@ class PipelineScriptWrapper(PipelineCommand):
             # Multiple blocks
             blocks = []
             for block in self._scripts:
-                blocks.append("{\n%s\n}" % indent(block,"    "))
+                blocks.append("{\n%s\n}" % textwrap.indent(block,"    "))
             return Command(self._block_sep.join(blocks))
 
 ######################################################################
@@ -4016,15 +4006,3 @@ def resolve_parameter(p):
         return p.value
     except AttributeError:
         return p
-
-def indent(s,prefix):
-    """
-    Wrapper for textwrap.indent to handle Python2/3
-    """
-    try:
-        # Python3
-        return textwrap.indent(s,prefix)
-    except AttributeError:
-        # Python2
-        return '\n'.join([prefix+line.rstrip('\n')
-                          for line in s.splitlines(True)])

--- a/auto_process_ngs/qc/cellranger.py
+++ b/auto_process_ngs/qc/cellranger.py
@@ -8,7 +8,7 @@ from ..tenx_genomics_utils import MultiplexSummary
 from ..tenx_genomics_utils import MultiomeSummary
 from ..tenx_genomics_utils import CellrangerMultiConfigCsv
 
-class CellrangerCount(object):
+class CellrangerCount:
     """
     Wrapper class for handling outputs from cellranger count
 
@@ -204,7 +204,7 @@ class CellrangerCount(object):
         else:
             return None
 
-class CellrangerMulti(object):
+class CellrangerMulti:
     """
     Wrapper class for handling outputs from cellranger multi
 

--- a/auto_process_ngs/qc/fastq_stats.py
+++ b/auto_process_ngs/qc/fastq_stats.py
@@ -5,7 +5,7 @@ from builtins import range
 from bcftbx.FASTQFile import FastqIterator
 from .fastqc import FastqcData
 
-class FastqQualityStats(object):
+class FastqQualityStats:
     """
     Class for storing per-base quality stats from a FASTQ
 

--- a/auto_process_ngs/qc/fastq_strand.py
+++ b/auto_process_ngs/qc/fastq_strand.py
@@ -24,7 +24,7 @@ Example with count data:
 Genome1	13.13	93.21	391087	51339	364535
 """
 
-class Fastqstrand(object):
+class Fastqstrand:
     """
     Class representing data from a fastq_strand.py run
 

--- a/auto_process_ngs/qc/fastqc.py
+++ b/auto_process_ngs/qc/fastqc.py
@@ -50,7 +50,7 @@ rcentile
 
 """
 
-class Fastqc(object):
+class Fastqc:
     """
     Wrapper class for handling outputs from FastQC
 
@@ -293,7 +293,7 @@ class FastqcSummary(TabFile):
                             self.status(name)))
         return tbl.html()
 
-class FastqcData(object):
+class FastqcData:
     """
     Class representing data from a Fastqc data file
 

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -197,7 +197,7 @@ table th { border-bottom: solid 1px lightgray; }
 # Classes
 #######################################################################
 
-class QCReporter(object):
+class QCReporter:
     """
     Class describing QC results for an AnalysisProject
 
@@ -276,7 +276,7 @@ class QCReporter(object):
                       relative_links=relative_links,
                       make_zip=make_zip)
 
-class QCProject(object):
+class QCProject:
     """
     Gather information about the QC associated with a project
 
@@ -860,7 +860,7 @@ class QCProject(object):
             # No data for any read
             self.stats['max_sequence_length'] = None
 
-class FastqSet(object):
+class FastqSet:
     """
     Class describing a set of Fastq files
 
@@ -1917,7 +1917,7 @@ class QCReport(Document):
             # Turn off display of warnings section
             self.warnings.add_css_classes("hide")
 
-class QCReportSample(object):
+class QCReportSample:
     """
     Utility class for reporting the QC for a sample
 
@@ -2407,7 +2407,7 @@ class QCReportSample(object):
                            "table" % field)
         return value
 
-class QCReportFastqGroup(object):
+class QCReportFastqGroup:
     """
     Utility class for reporting the QC for a Fastq group
 
@@ -2906,7 +2906,7 @@ class QCReportFastqGroup(object):
                            "table" % field)
         return value
 
-class QCReportFastq(object):
+class QCReportFastq:
     """
     Provides interface to QC outputs for Fastq file
 

--- a/auto_process_ngs/qc/seqlens.py
+++ b/auto_process_ngs/qc/seqlens.py
@@ -9,7 +9,7 @@ from bcftbx.FASTQFile import FastqIterator
 # Module specific logger
 logger = logging.getLogger(__name__)
 
-class SeqLens(object):
+class SeqLens:
     """
     Wrapper class for handling sequence length data
 

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -654,7 +654,7 @@ def get_install_dir():
     'auto_process.ini.sample' file, for example: if this file is
     located in
 
-    /opt/auto_process/lib/python2.7/site-packages/auto_process_ngs
+    /opt/auto_process/lib/python3.6/site-packages/auto_process_ngs
 
     then each level will be searched until a matching 'config' dir is
     located.

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -69,7 +69,7 @@ logger = logging.getLogger(__name__)
 # Classes
 #######################################################################
 
-class Settings(object):
+class Settings:
     """
     Load parameter values from an external config file
 

--- a/auto_process_ngs/simple_scheduler.py
+++ b/auto_process_ngs/simple_scheduler.py
@@ -593,7 +593,7 @@ class SimpleScheduler(threading.Thread):
             # Wait before going round again
             time.sleep(self.__poll_interval)
 
-class SchedulerGroup(object):
+class SchedulerGroup:
     """Class providing an interface to schedule a group of jobs
 
     SchedulerGroup instances should normally be returned by a
@@ -951,7 +951,7 @@ class SchedulerJob(Job):
         """
         return ' '.join([str(x) for x in ([self.script,] + self.args)])
 
-class SchedulerCallback(object):
+class SchedulerCallback:
     """Class providing an interface to scheduled callbacks
 
     SchedulerJob instances should normally be returned by a
@@ -978,7 +978,7 @@ class SchedulerCallback(object):
             logging.error("Exception invoking callback function '%s': %s (ignored)" % \
                           (self.callback_name,ex))
 
-class SchedulerReporter(object):
+class SchedulerReporter:
     """Class to report on scheduler operations
 
     SimpleScheduler calls methods of the SchedulerReporter when

--- a/auto_process_ngs/simple_scheduler.py
+++ b/auto_process_ngs/simple_scheduler.py
@@ -26,12 +26,7 @@ import os
 import sys
 import re
 import threading
-try:
-    # Python 3
-    import queue
-except ImportError:
-    # Python 2
-    import Queue as queue
+import queue
 import logging
 
 #######################################################################

--- a/auto_process_ngs/stats.py
+++ b/auto_process_ngs/stats.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 # Classes
 #######################################################################
 
-class FastqStatistics(object):
+class FastqStatistics:
     """
     Class for collecting and reporting stats on Illumina FASTQs
 
@@ -502,7 +502,7 @@ class FastqStatistics(object):
         if fp is None and out_file is not None:
             fpp.close()
 
-class FastqStats(object):
+class FastqStats:
     """Container for storing data about a FASTQ file
 
     This is a convenience wrapper for holding together data

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -473,7 +473,7 @@ class MultiplexSummary(MetricsSummary):
         """
         return self.fetch('Median UMI counts per cell')
 
-class MultiomeLibraries(object):
+class MultiomeLibraries:
     """
     Class to handle '10x_multiome_libraries.info' files
 
@@ -621,7 +621,7 @@ class MultiomeLibraries(object):
                               project.info.library_type)))
             print("Generated %s" % filen)
 
-class CellrangerMultiConfigCsv(object):
+class CellrangerMultiConfigCsv:
     """
     Class to handle cellranger multi 'config.csv' files
 

--- a/auto_process_ngs/test/barcodes/test_pipeline.py
+++ b/auto_process_ngs/test/barcodes/test_pipeline.py
@@ -45,13 +45,13 @@ class TestAnalyseBarcodes(unittest.TestCase):
                     lane = IlluminaFastq(fq).lane_number
                     self.assertTrue(os.path.exists(fastq),
                                     "Missing %s" % fastq)
-                    with gzip.open(fastq,'wb') as fp:
+                    with gzip.open(fastq,'wt') as fp:
                         data = """@ILLUMINA-545855:49:FC61RLR:%d:1:10979:1695 1:N:0:TCCTGA
 GCATACTCAGCTTTAGTAATAAGTGTGATTCTGGTA
 +
 IIIIIHIIIGHHIIDGHIIIIIIHIIIIIIIIIIIH
                             """ % lane
-                        fp.write(data.encode())
+                        fp.write(data)
 
     def test_analyse_barcodes_with_bcl2fastq_dir_no_samplesheet(self):
         """

--- a/auto_process_ngs/test/bcl2fastq/test_utils.py
+++ b/auto_process_ngs/test/bcl2fastq/test_utils.py
@@ -13,7 +13,7 @@ from auto_process_ngs.bcl2fastq.utils import *
 # Set to False to keep test output dirs
 REMOVE_TEST_OUTPUTS = True
 
-class MockBaseExe(object):
+class MockBaseExe:
     """
     Base class for mock BCL to Fastq converters
 

--- a/auto_process_ngs/test/commands/test_analyse_barcodes_cmd.py
+++ b/auto_process_ngs/test/commands/test_analyse_barcodes_cmd.py
@@ -59,13 +59,13 @@ poll_interval = 0.5
                     fastq = os.path.join(s.dirn,fq)
                     self.assertTrue(os.path.exists(fastq),
                                     "Missing %s" % fastq)
-                    with gzip.open(fastq,'wb') as fp:
+                    with gzip.open(fastq,'wt') as fp:
                         fp.write(
                             """@ILLUMINA-545855:49:FC61RLR:2:1:10979:1695 1:N:0:TCCTGA
 GCATACTCAGCTTTAGTAATAAGTGTGATTCTGGTA
 +
 IIIIIHIIIGHHIIDGHIIIIIIHIIIIIIIIIIIH
-                            """.encode())
+""")
 
     def test_analyse_barcodes_with_stored_bases_mask(self):
         """analyse_barcodes: test with stored bases mask

--- a/auto_process_ngs/test/commands/test_merge_fastq_dirs_cmd.py
+++ b/auto_process_ngs/test/commands/test_merge_fastq_dirs_cmd.py
@@ -99,14 +99,14 @@ poll_interval = 0.5
         for n,dirn in enumerate(('bcl2fastq.AB','bcl2fastq.CDE')):
             undetermined_r1 = os.path.join(m1,dirn,'Undetermined_S0_R1_001.fastq.gz')
             undetermined_r2 = os.path.join(m1,dirn,'Undetermined_S0_R2_001.fastq.gz')
-            with gzip.GzipFile(undetermined_r1,'wb') as fq:
+            with gzip.open(undetermined_r1,'wt') as fq:
                 for i in range(4):
                     reads = "%s\n" % fastq_reads_r1[n*4+i]
-                    fq.write(reads.encode())
-            with gzip.GzipFile(undetermined_r2,'wb') as fq:
+                    fq.write(reads)
+            with gzip.open(undetermined_r2,'wt') as fq:
                 for i in range(4):
                     reads = "%s\n" % fastq_reads_r2[n*4+i]
-                    fq.write(reads.encode())
+                    fq.write(reads)
         print(m2)
         return m1
 

--- a/auto_process_ngs/test/commands/test_setup_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_cmd.py
@@ -740,12 +740,12 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         for root,dirs,files in os.walk(casava_outputs.dirn):
             for f in files:
                 if f.endswith(".fastq.gz"):
-                    with gzip.GzipFile(os.path.join(root,f),'wb') as fq:
+                    with gzip.open(os.path.join(root,f),'wt') as fq:
                         try:
                             f.index("_R1_")
-                            fq.write(fastq_r1_data.encode())
+                            fq.write(fastq_r1_data)
                         except ValueError:
-                            fq.write(fastq_r2_data.encode())
+                            fq.write(fastq_r2_data)
         # Set up autoprocessor
         run_dir = "151125_M00879_0001_000000000-ABCDE1"
         analysis_dir = "%s_analysis" % run_dir
@@ -820,12 +820,12 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
         for root,dirs,files in os.walk(bcl2fastq2_outputs.dirn):
             for f in files:
                 if f.endswith(".fastq.gz"):
-                    with gzip.GzipFile(os.path.join(root,f),'wb') as fq:
+                    with gzip.open(os.path.join(root,f),'wt') as fq:
                         try:
                             f.index("_R1_")
-                            fq.write(fastq_r1_data.encode())
+                            fq.write(fastq_r1_data)
                         except ValueError:
-                            fq.write(fastq_r2_data.encode())
+                            fq.write(fastq_r2_data)
         # Set up autoprocessor
         run_dir = "151125_M00879_0001_000000000-ABCDE1"
         analysis_dir = "%s_analysis" % run_dir
@@ -909,12 +909,12 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
                   'AB2_AGTCAA_L001_R1_001.fastq.gz',
                   'AB2_AGTCAA_L001_R2_001.fastq.gz',):
             if f.endswith(".fastq.gz"):
-                with gzip.GzipFile(os.path.join(unaligned_dir,f),'wb') as fq:
+                with gzip.open(os.path.join(unaligned_dir,f),'wt') as fq:
                     try:
                         f.index("_R1_")
-                        fq.write(fastq_r1_data.encode())
+                        fq.write(fastq_r1_data)
                     except ValueError:
-                        fq.write(fastq_r2_data.encode())
+                        fq.write(fastq_r2_data)
         # Set up autoprocessor
         analysis_dir = "%s_analysis" % run_dir
         ap = AutoProcess(settings=self.settings())

--- a/auto_process_ngs/test/test_applications.py
+++ b/auto_process_ngs/test/test_applications.py
@@ -3,11 +3,7 @@
 #######################################################################
 from auto_process_ngs.applications import *
 import unittest
-try:
-    from cStringIO import StringIO
-except ImportError:
-    # cStringIO not available in Python3
-    from io import StringIO
+from io import StringIO
 
 class TestBcl2Fastq(unittest.TestCase):
 

--- a/auto_process_ngs/test/test_command.py
+++ b/auto_process_ngs/test/test_command.py
@@ -3,11 +3,7 @@
 #######################################################################
 from auto_process_ngs.command import Command
 import unittest
-try:
-    from cStringIO import StringIO
-except ImportError:
-    # cStringIO not available in Python3
-    from io import StringIO
+from io import StringIO
 
 class TestCommand(unittest.TestCase):
 

--- a/auto_process_ngs/test/test_config.py
+++ b/auto_process_ngs/test/test_config.py
@@ -3,11 +3,7 @@
 #######################################################################
 
 import unittest
-try:
-    from cStringIO import StringIO
-except ImportError:
-    # cStringIO not available in Python3
-    from io import StringIO
+from io import StringIO
 from bcftbx.JobRunner import SimpleJobRunner,GEJobRunner
 from auto_process_ngs.config import *
 

--- a/auto_process_ngs/test/test_fastq_utils.py
+++ b/auto_process_ngs/test/test_fastq_utils.py
@@ -421,11 +421,11 @@ class TestFastqReadCounter(unittest.TestCase):
         self._make_working_dir()
         filen = os.path.join(self.wd,name)
         if filen.endswith(".gz"):
-            with gzip.GzipFile(filen,'wb') as fp:
-                fp.write(contents.encode())
+            open_func = gzip.open
         else:
-            with open(filen,'wt') as fp:
-                fp.write(contents)
+            open_func = open
+        with open_func(filen,'wt') as fp:
+            fp.write(contents)
         return filen
 
     def tearDown(self):

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -40,7 +40,7 @@ REMOVE_TEST_OUTPUTS = True
 
 # Helpers
 
-class _Mock(object):
+class _Mock:
     """
     Helper class for mocking executables for testing
     """

--- a/auto_process_ngs/test/test_simple_scheduler.py
+++ b/auto_process_ngs/test/test_simple_scheduler.py
@@ -63,7 +63,7 @@ class MockJobRunner(BaseJobRunner):
         # Allow error state on jobs to be set manually for testing
         self.__error_states[job_id] = state
 
-class CallbackTester(object):
+class CallbackTester:
     """Utility class for testing callbacks from scheduler
 
     To use: create a CallbackTester instance e.g.:

--- a/auto_process_ngs/test/test_stats.py
+++ b/auto_process_ngs/test/test_stats.py
@@ -142,11 +142,11 @@ class AugmentedMockIlluminaData(MockIlluminaData):
         # Create or append fake reads to a FASTQ file
         fastq = os.path.join(self.unaligned_dir,path)
         if append:
-            mode = 'ab'
+            mode = 'at'
         else:
-            mode = 'wb'
+            mode = 'wt'
         # Write the required number of reads to the file
-        with gzip.GzipFile(fastq,mode) as fq:
+        with gzip.open(fastq,mode) as fq:
             if read_number == 1:
                 r = """@HISEQ:1:000000000-A2Y1L:%s:1101:19264:2433 1:N:0:AGATCGC
 AGATAGCCGA
@@ -160,7 +160,7 @@ GCCGATATGC
 ??A??ABBDD
 """ % lane
             for i in range(nreads):
-                fq.write(r.encode())
+                fq.write(r)
 
 # FastqStatistics
 class TestFastqStatisticsCasava(unittest.TestCase):

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -66,7 +66,7 @@ DEFAULT_BUFFER_SIZE = 8192
 # Classes
 #######################################################################
 
-class OutputFiles(object):
+class OutputFiles:
     """Class for managing multiple output files
 
     Usage:
@@ -314,7 +314,7 @@ class BufferedOutputFiles(OutputFiles):
             for name in names:
                 self.close(name)
 
-class ZipArchive(object):
+class ZipArchive:
     """
     Utility class for creating .zip archive files
 
@@ -398,7 +398,7 @@ class ZipArchive(object):
     def __del__(self):
         self.close()
 
-class ProgressChecker(object):
+class ProgressChecker:
     """
     Check if an index is a multiple of a value or percentage
 

--- a/bin/demultiplex_icell8_atac.py
+++ b/bin/demultiplex_icell8_atac.py
@@ -22,11 +22,6 @@ import tempfile
 import shutil
 import json
 from argparse import ArgumentParser
-try:
-    # Python 2
-    from itertools import izip as zip
-except ImportError:
-    pass
 from multiprocessing import Pool
 from bcftbx.simple_xls import XLSWorkBook
 from auto_process_ngs import get_version

--- a/bin/download_fastqs.py
+++ b/bin/download_fastqs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     download_fastqs.py: utility to download fastq files from web server
-#     Copyright (C) University of Manchester 2015 Peter Briggs
+#     Copyright (C) University of Manchester 2015,2021 Peter Briggs
 #
 #########################################################################
 #
@@ -29,11 +29,7 @@ try:
 except ImportError:
     # hashlib not available, use deprecated md5 module
     import md5
-try:
-    from urllib.request import urlopen
-except ImportError:
-    # Failed to get Python3 urlopen, fallback to Python2
-    from urllib2 import urlopen
+from urllib.request import urlopen
 
 #######################################################################
 # Constants

--- a/bin/icell8_contamination_filter.py
+++ b/bin/icell8_contamination_filter.py
@@ -27,11 +27,6 @@ import tempfile
 import logging
 import argparse
 import shutil
-try:
-    # Python 2
-    from itertools import izip as zip
-except ImportError:
-    pass
 from bcftbx.utils import mkdir
 from bcftbx.FASTQFile import FastqIterator
 from bcftbx.utils import strip_ext

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -11,13 +11,9 @@ Supported Python versions
 The package consists predominantly of code written in Python, and the
 following versions are supported:
 
-* Python 2.7
 * Python 3.6
 * Python 3.7
 * Python 3.8
-
-However as Python 2.7 is now end-of-life, support for this version with
-be withdrawn in the near future.
 
 .. _software_dependencies:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-configparser
-pillow
-pandas
 cloudpickle
+configparser
+matplotlib
+pandas
+pillow
 psutil
-future
 git+https://github.com/fls-bioinformatics-core/genomics.git#egg=genomics-bcftbx

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ for pattern in ('bin/*.py','bin/*.sh',):
 # Installation requirements
 install_requires = ['cloudpickle',
                     'configparser',
-                    'future',
                     'genomics-bcftbx',
                     'matplotlib',
                     'pandas',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 Setup script to install auto_process_ngs
 
-Copyright (C) University of Manchester 2013-20 Peter Briggs
+Copyright (C) University of Manchester 2013-2021 Peter Briggs
 
 """
 
@@ -14,19 +14,14 @@ for pattern in ('bin/*.py','bin/*.sh',):
     scripts.extend(glob(pattern))
 
 # Installation requirements
-install_requires = ['configparser',
-                    'pillow',
-                    'pandas',
-                    'cloudpickle',
-                    'psutil',
+install_requires = ['cloudpickle',
+                    'configparser',
                     'future',
-                    'genomics-bcftbx']
-# Handle matplotlib for Python2/3
-import sys
-if sys.version_info < (3,):
-    install_requires.append('matplotlib<=2.2.3')
-else:
-    install_requires.append('matplotlib')
+                    'genomics-bcftbx',
+                    'matplotlib',
+                    'pandas',
+                    'pillow',
+                    'psutil']
 
 # If we're on ReadTheDocs then we can reduce this
 # to a smaller set (to avoid build timeouts)
@@ -76,8 +71,6 @@ setup(name = "auto_process_ngs",
           "Operating System :: MacOS",
           "Topic :: Scientific/Engineering",
           "Topic :: Scientific/Engineering :: Bio-Informatics",
-          "Programming Language :: Python :: 2",
-          "Programming Language :: Python :: 2.7"
           "Programming Language :: Python :: 3",
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
PR to address issue #506 and remove code which enables support for Python 2 (documentation and testing is also updated); only specific versions of Python 3 will be supported going forward.

Updates include:

* Remove Python 2.7 from `setup.py` and from the Github CI testing workflow
* Remove import fallbacks for Python 2 equivalents of Python 3 libraries and functions (e.g. `izip`, `urlopen`, `cStringIO`)
* Update writing to gzipped files to use `gzip.open(FILE,'wt')` and remove `encode()` calls on strings being written to those files
* Drop requirement for `future` module
* Remove `next` methods implemented in parallel to `__next__` for iterators (only needed for Python 2)
* Remove explicit subclassing of `object` when declaring classes