### PR TITLE
icell8/utils: fix bug in ICell8FastqIterator

### DIFF
--- a/auto_process_ngs/icell8/utils.py
+++ b/auto_process_ngs/icell8/utils.py
@@ -470,8 +470,8 @@ class ICell8FastqIterator(Iterator):
         self._fqr2 = FastqIterator(fqr2)
     def __next__(self):
         self._read_count += 1
-        r1 = self._fqr1.next()
-        r2 = self._fqr2.next()
+        r1 = next(self._fqr1)
+        r2 = next(self._fqr2)
         try:
             return ICell8ReadPair(r1,r2)
         except Exception as ex:


### PR DESCRIPTION
PR which fixes a bug in the `ICell8FastqIterator` class (in `icell8.utils`), which has been exposed by changes to the `bcftbx.FASTQFile.FastqIterator`: the latter dropped the `next` method (part of removing support for Python2), which was used in the former.

The fix is to replace the invocation of the `next` method with an invocation of the `next` function on the `FastqIterator` instances within the `ICell8FastqIterator` class.