### PR TITLE
Fix bug in headers for 10x multiplexing analysis summary table

### DIFF
--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -1611,8 +1611,15 @@ class QCReport(Document):
             "Multiplexing analysis",
             name="multiplexing_analysis_%s" % sanitize_name(project.id),
             css_classes=('single_library_summary',))
+        # Generate headers for table
+        tbl_headers = {
+            f: "<space title=\"%s\">%s</span>" %
+            ('\n'.join(textwrap.wrap(self.field_descriptions[f][1],width=20)),
+             self.field_descriptions[f][0])
+            for f in self.field_descriptions.keys()
+        }
         # Create the table
-        multiplexing_tbl = Table(fields,**self.field_descriptions)
+        multiplexing_tbl = Table(fields,**tbl_headers)
         multiplexing_tbl.add_css_classes('summary','single_library_summary')
         # Append to the summary section
         section.add(multiplexing_tbl)


### PR DESCRIPTION
PR to fix a bug in setting up the headers in the multiplexing analysis summary table (for 10xGenomics CellPlex data) in the QC reports (the `qc/reporting` module).

Without the fix the headers are written with both the name and the description text; the fix only writes the name to the header, with the description text added as `alt` text (displayed when the user mouses over the header).