### PR TITLE
Report outputs from multiple 10x single cell pipelines in one project

### DIFF
--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -845,13 +845,13 @@ class UpdateAnalysisProject(DirectoryUpdater):
             cellranger_output_files = ("web_summary.html",
                                        "metrics_summary.csv")
         elif cellranger == 'cellranger-atac':
-            cmdline = "cellranger --reference %s" \
+            cmdline = "cellranger-atac --reference %s" \
                       % reference_data_path
             metrics_data = mock10xdata.ATAC_SUMMARY_2_0_0
             cellranger_output_files = ("web_summary.html",
                                        "summary.csv")
         elif cellranger == 'cellranger-arc':
-            cmdline = "cellranger --reference %s" \
+            cmdline = "cellranger-arc --reference %s" \
                       % reference_data_path
             metrics_data = mock10xdata.MULTIOME_SUMMARY_2_0_0
             cellranger_output_files = ("web_summary.html",

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -2244,7 +2244,7 @@ class QCReportSample:
             # Check package
             if cellranger_count.pipeline_name != package:
                 # Skip
-                return True
+                continue
             # Shortcut to metrics
             metrics = cellranger_count.metrics
             web_summary = cellranger_count.web_summary


### PR DESCRIPTION
PR which updates the QC reporting to detect and report the outputs from multiple different 10xGenomics single cell pipelines (`cellranger count`, `cellranger multi`, `cellranger-atac count` etc) in the same project.

The use cases for this include:

* Single cell multiome datasets where the `cellranger-arc count` analyses might co-exist with `cellranger count` or `cellranger-atac count` outputs, and
* Cellplex datasets where the `cellranger multi` analyses might co-exist with `cellranger count` outputs.