### PR TITLE
Pipeliner tasks create dedicated working directories

### DIFF
--- a/auto_process_ngs/barcodes/pipeline.py
+++ b/auto_process_ngs/barcodes/pipeline.py
@@ -296,9 +296,10 @@ class AnalyseBarcodes(Pipeline):
         if not os.path.exists(working_dir):
             os.mkdir(working_dir)
 
-        # Log and script directories
+        # Log, script and task directories
         log_dir = os.path.join(working_dir,"logs")
         scripts_dir = os.path.join(working_dir,"scripts")
+        tasks_work_dir = os.path.join(working_dir,"work")
 
         # Input bcl2fastq directory
         if self._bcl2fastq_dir is not None:
@@ -335,6 +336,7 @@ class AnalyseBarcodes(Pipeline):
                               log_dir=log_dir,
                               scripts_dir=scripts_dir,
                               log_file=log_file,
+                              tasks_work_dir=tasks_work_dir,
                               batch_size=batch_size,
                               exit_on_failure=PipelineFailure.IMMEDIATE,
                               params={

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     bcl2fastq.pipeline.py: pipelines for Fastq generation
-#     Copyright (C) University of Manchester 2020-2021 Peter Briggs
+#     Copyright (C) University of Manchester 2020-2022 Peter Briggs
 #
 
 """
@@ -1367,7 +1367,9 @@ class MakeFastqs(Pipeline):
                     PathExistsParam(fastq_out_dir))
                 
                 # Temporary dir for intermediate Fastqs
-                tmp_bcl2fastq_dir = "bcl2fastq.icell8_atac%s" % lanes_id
+                tmp_bcl2fastq_dir = PathJoinParam(
+                    self.params.WORKING_DIR,
+                    "bcl2fastq.icell8_atac%s" % lanes_id)
                 # Get bcl2fastq information
                 if get_bcl2fastq is None:
                     # Create a new task only if one doesn't already
@@ -1886,10 +1888,11 @@ class MakeFastqs(Pipeline):
             barcode_analysis_dir = os.path.join(analysis_dir,
                                                 barcode_analysis_dir)
 
-        # Log and script directories
+        # Log, script and task directories
         if log_dir is None:
             log_dir = os.path.join(working_dir,"logs")
         scripts_dir = os.path.join(working_dir,"scripts")
+        tasks_work_dir = os.path.join(working_dir,"work")
 
         # Runners
         if runners is None:
@@ -1930,6 +1933,7 @@ class MakeFastqs(Pipeline):
                               log_dir=log_dir,
                               scripts_dir=scripts_dir,
                               log_file=log_file,
+                              tasks_work_dir=tasks_work_dir,
                               batch_size=batch_size,
                               batch_limit=batch_limit,
                               exit_on_failure=PipelineFailure.DEFERRED,

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -745,6 +745,7 @@ class QCPipeline(Pipeline):
             mkdir(working_dir)
 
         # Log and script directories
+        tasks_work_dir = os.path.join(working_dir,"work")
         log_dir = os.path.join(working_dir,"logs")
         scripts_dir = os.path.join(working_dir,"scripts")
 
@@ -755,6 +756,7 @@ class QCPipeline(Pipeline):
         # Execute the pipeline
         status = Pipeline.run(self,
                               working_dir=working_dir,
+                              tasks_work_dir=tasks_work_dir,
                               log_dir=log_dir,
                               scripts_dir=scripts_dir,
                               log_file=log_file,

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -134,7 +134,8 @@ class TestPipeline(unittest.TestCase):
                         ">>",self.args.f))
         # Build the pipeline
         ppl = Pipeline()
-        task1 = Echo("Write item1","out.txt","item1")
+        out_file = os.path.join(self.working_dir,"out.txt")
+        task1 = Echo("Write item1",out_file,"item1")
         task2 = Echo("Write item2",task1.output.file,"item2")
         ppl.add_task(task2,requires=(task1,))
         # Run the pipeline
@@ -142,7 +143,6 @@ class TestPipeline(unittest.TestCase):
                               poll_interval=0.1)
         # Check the outputs
         self.assertEqual(exit_status,0)
-        out_file = os.path.join(self.working_dir,"out.txt")
         self.assertTrue(os.path.exists(out_file))
         with open(out_file,'rt') as fp:
             self.assertEqual(fp.read(),"item1\nitem2\n")
@@ -167,18 +167,17 @@ class TestPipeline(unittest.TestCase):
                 for f,s in self.args.s:
                     self.output.files.append(f)
         # Build the pipeline
+        out_files = [os.path.join(self.working_dir,f)
+                     for f in ("out1.txt","out2.txt")]
+        inputs = [(f,"item") for f in out_files]
         ppl = Pipeline()
-        task = EchoMany("Write items",
-                        ("out1.txt","item"),
-                        ("out2.txt","item"),)
+        task = EchoMany("Write items",*inputs)
         ppl.add_task(task)
         # Run the pipeline
         exit_status = ppl.run(working_dir=self.working_dir,
                               poll_interval=0.1)
         # Check the outputs
         self.assertEqual(exit_status,0)
-        out_files = [os.path.join(self.working_dir,f)
-                     for f in ("out1.txt","out2.txt")]
         for out_file in out_files:
             self.assertTrue(os.path.exists(out_file))
             with open(out_file,'rt') as fp:
@@ -205,12 +204,14 @@ class TestPipeline(unittest.TestCase):
                     self.output.files.append(f)
         # Build the pipeline
         ppl = Pipeline()
-        task = EchoMany("Write items",
-                        ("out1.txt","item"),
-                        ("out2.txt","item"),
-                        ("out3.txt","item"),
-                        ("out4.txt","item"),
-                        ("out5.txt","item"),)
+        out_files = [os.path.join(self.working_dir,f)
+                     for f in ("out1.txt",
+                               "out2.txt",
+                               "out3.txt",
+                               "out4.txt",
+                               "out5.txt")]
+        inputs = [(f,"item") for f in out_files]
+        task = EchoMany("Write items",*inputs)
         ppl.add_task(task)
         # Run the pipeline
         exit_status = ppl.run(working_dir=self.working_dir,
@@ -218,14 +219,9 @@ class TestPipeline(unittest.TestCase):
                               batch_size=2)
         # Check the outputs
         self.assertEqual(exit_status,0)
-        out_files = [os.path.join(self.working_dir,f)
-                     for f in ("out1.txt",
-                               "out2.txt",
-                               "out3.txt",
-                               "out4.txt",
-                               "out5.txt")]
         for out_file in out_files:
-            self.assertTrue(os.path.exists(out_file))
+            self.assertTrue(os.path.exists(out_file),
+                            "Missing %s" % out_file)
             with open(out_file,'rt') as fp:
                 self.assertEqual(fp.read(),"item\n")
 
@@ -250,12 +246,14 @@ class TestPipeline(unittest.TestCase):
                     self.output.files.append(f)
         # Build the pipeline
         ppl = Pipeline()
-        task = EchoMany("Write items",
-                        ("out1.txt","item"),
-                        ("out2.txt","item"),
-                        ("out3.txt","item"),
-                        ("out4.txt","item"),
-                        ("out5.txt","item"),)
+        out_files = [os.path.join(self.working_dir,f)
+                     for f in ("out1.txt",
+                               "out2.txt",
+                               "out3.txt",
+                               "out4.txt",
+                               "out5.txt")]
+        inputs = [(f,"item") for f in out_files]
+        task = EchoMany("Write items",*inputs)
         ppl.add_task(task)
         # Run the pipeline
         exit_status = ppl.run(working_dir=self.working_dir,
@@ -263,14 +261,9 @@ class TestPipeline(unittest.TestCase):
                               batch_limit=3)
         # Check the outputs
         self.assertEqual(exit_status,0)
-        out_files = [os.path.join(self.working_dir,f)
-                     for f in ("out1.txt",
-                               "out2.txt",
-                               "out3.txt",
-                               "out4.txt",
-                               "out5.txt")]
         for out_file in out_files:
-            self.assertTrue(os.path.exists(out_file))
+            self.assertTrue(os.path.exists(out_file),
+                            "Missing %s" % out_file)
             with open(out_file,'rt') as fp:
                 self.assertEqual(fp.read(),"item\n")
 
@@ -293,8 +286,9 @@ class TestPipeline(unittest.TestCase):
         s = PipelineParam("hello")
         self.assertEqual(s.value,"hello")
         # Build the pipeline
+        out_file = os.path.join(self.working_dir,"out.txt")
         ppl = Pipeline()
-        task = Echo("Write item1","out.txt",s)
+        task = Echo("Write item1",out_file,s)
         ppl.add_task(task)
         # Update the pipeline param
         s.set("goodbye")
@@ -303,7 +297,6 @@ class TestPipeline(unittest.TestCase):
                               poll_interval=0.1)
         # Check the outputs
         self.assertEqual(exit_status,0)
-        out_file = os.path.join(self.working_dir,"out.txt")
         self.assertTrue(os.path.exists(out_file))
         with open(out_file,'rt') as fp:
             self.assertEqual(fp.read(),"goodbye\n")
@@ -325,7 +318,8 @@ class TestPipeline(unittest.TestCase):
                         ">>",self.args.f))
         # Build the pipeline
         ppl = Pipeline()
-        task1 = Echo("Write item1","out.txt","item1")
+        out_file = os.path.join(self.working_dir,"out.txt")
+        task1 = Echo("Write item1",out_file,"item1")
         task2 = Echo("Write item2",task1.output.file,"item2")
         ppl.add_task(task2,requires=(task1,))
         # Get a scheduler
@@ -336,7 +330,6 @@ class TestPipeline(unittest.TestCase):
                               poll_interval=0.1)
         # Check the outputs
         self.assertEqual(exit_status,0)
-        out_file = os.path.join(self.working_dir,"out.txt")
         self.assertTrue(os.path.exists(out_file))
         with open(out_file,'rt') as fp:
             self.assertEqual(fp.read(),"item1\nitem2\n")

--- a/bin/process_icell8.py
+++ b/bin/process_icell8.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     process_icell8.py: perform processing of Wafergen iCell8 data
-#     Copyright (C) University of Manchester 2017-2020 Peter Briggs
+#     Copyright (C) University of Manchester 2017-2022 Peter Briggs
 #
 """
 process_icell8.py
@@ -437,7 +437,8 @@ if __name__ == "__main__":
                           runners=runners,
                           envmodules=envmodules,
                           max_jobs=max_jobs,
-                          verbose=args.verbose)
+                          verbose=args.verbose,
+                          isolate_tasks=False)
     if exit_status != 0:
         # Finished with error
         logger.critical("Pipeline failed: exit status %s" % exit_status)


### PR DESCRIPTION
PR which updates the `pipeliner` module so that by default tasks now create their own dedicated "isolated" working directories. This is primarily intended to avoid collisions between directory names when multiple instances of a single task class are run within a pipeline.

The PR also updates the QC, Fastq-generation and barcode analysis pipelines.

Isolated task directories can be disabled by specifying `isolate_tasks=False` when running the pipeline (restoring the legacy behaviour) - this has been added to the `process_icell8.py` utility (as the changes have not been tested for the pipelines it uses).