### PR TITLE
Fix reporting of legacy screens in QC reports

### DIFF
--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -3032,7 +3032,6 @@ class QCReportFastq:
                                  f.startswith(fastq_base) and
                                  f.endswith("_%s_screen.txt" % screen_name),
                                  os.listdir(qc_dir))):
-                screen_name = f[:-len("_screen.txt")]
                 png,txt = fastq_screen_output(fastq,screen_name,
                                               legacy=True)
                 png = os.path.join(qc_dir,png)


### PR DESCRIPTION
PR which fixes a bug in the reporting of `fastq_screen` outputs in the QC pipeline, for legacy screen names (i.e. `<FASTQ>_<SCREEN>+_screen.png` etc)

The bug caused the screen names to be reset incorrectly, resulting in the reporting not being able to locate the output files (and hence not being able to generate the microplots in the report).