### PR TITLE
Pipeliner: lock conda envs directory when checking for and installing environments

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     pipeliner.py: utilities for building simple pipelines of tasks
-#     Copyright (C) University of Manchester 2017-2021 Peter Briggs
+#     Copyright (C) University of Manchester 2017-2022 Peter Briggs
 #
 """
 Module providing utility classes and functions for building simple
@@ -1118,6 +1118,8 @@ from .conda import CondaWrapperError
 from .conda import make_conda_env_name
 from .simple_scheduler import SimpleScheduler
 from .simple_scheduler import SchedulerReporter
+from .utils import FileLock
+from .utils import FileLockError
 
 # Module specific logger
 logger = logging.getLogger(__name__)
@@ -1417,7 +1419,7 @@ class Capturing:
     >>> for line in output.stdout:
     ...     print("Line: %s" % line)
     >>> for line in output.stderr:
-    ...     print("Err: %s" % line
+    ...     print("Err: %s" % line)
     """
     def __init__(self):
         self.stdout = list()
@@ -2096,7 +2098,7 @@ class Pipeline:
                                              "__conda",
                                              "envs")
             if not os.path.exists(conda_env_dir):
-                os.makedirs(conda_env_dir)
+                os.makedirs(conda_env_dir,exist_ok=True)
             # Set up wrapper class
             conda = CondaWrapper(conda=conda,env_dir=conda_env_dir)
             if not conda.is_installed:
@@ -3084,8 +3086,21 @@ class PipelineTask:
             self.report("using conda to resolve dependencies:")
             for dep in self.conda_dependencies:
                 self.report("- %s" % dep)
-            conda_env = self.setup_conda_env(conda,
-                                             env_dir=conda_env_dir)
+            conda_env_dir = CondaWrapper(conda=conda,
+                                         env_dir=conda_env_dir).env_dir
+            try:
+                with FileLock(conda_env_dir,timeout=600):
+                    conda_env = self.setup_conda_env(
+                        conda,
+                        env_dir=conda_env_dir)
+            except Exception as ex:
+                # Failure attempting to acquire conda env
+                self.report("ERROR failed to acquire conda "
+                            "environment: %s" % ex)
+                # Force premature exit with failure
+                self._exit_code = 1
+                self.finish_task()
+                return
         else:
             conda_env = None
         # Handle command batching


### PR DESCRIPTION
PR which implements locking of the directory used for `conda` environments for `Pipeline` instances, to avoid possible collisions between multiple pipelines running simultaneously when attempting to access the directory. Without locking, two pipelines could potentially attempt to install the same environment at the same time, or one pipeline might try to use an environment before it is completely installed by another.

The locking mechanism is implemented via a new `FileLock` class in the `utils` module, which is then used to wrap the `conda` environment checking and installation in the `PipelineTask` class. (Tasks will retry obtaining the lock for up to 600s before timing out and forcing the task to terminate with an error.)