### PR TITLE
QC pipeline: update conda env and script for FastqScreen

### DIFF
--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1048,9 +1048,6 @@ class RunFastqScreen(PipelineTask):
         """
         self.conda("fastq-screen=0.14.0",
                    "bowtie=1.2.3")
-        # Need older version of libwebp for compatibility
-        # with Perl GD
-        self.conda("libwebp=0.5.2")
         # Also need to specify tbb=2020.2 for bowtie
         # See https://www.biostars.org/p/494922/
         self.conda("tbb=2020.2")

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1106,20 +1106,27 @@ class RunFastqScreen(PipelineTask):
                     """
                     # Make temporary working directory
                     WORKDIR=$(mktemp -d --tmpdir=.)
-                    cd $WORKDIR
                     # Run FastqScreen: {screen_name}
                     fastq_screen \\
                     --conf {fastq_screen_conf} \\
                     --threads {nthreads} {subset_option} \\
-                    --outdir . --force \\
+                    --outdir $WORKDIR --force \\
                     {fastq}
                     # Rename and move outputs to final location
-                    /bin/mv {fastq_basename}_screen.txt \\
-                        {qc_dir}/{screen_basename}.txt
-                    /bin/mv {fastq_basename}_screen.png \\
-                        {qc_dir}/{screen_basename}.png
-                    # Return to initial directory
-                    cd ..
+                    out_txt=$WORKDIR/{fastq_basename}_screen.txt
+                    if [ -e $out_txt ] ; then
+                        /bin/mv $out_txt {qc_dir}/{screen_basename}.txt
+                    else
+                       echo "ERROR missing $out_txt" >&2
+                       exit 1
+                    fi
+                    out_png=$WORKDIR/{fastq_basename}_screen.png
+                    if [ -e $out_png ] ; then
+                        /bin/mv $out_png {qc_dir}/{screen_basename}.png
+                    else
+                       echo "ERROR missing $out_png output" >&2
+                       exit 1
+                    fi
                     """.format(screen_name=screen,
                                fastq=fastq,
                                qc_dir=self.args.qc_dir,


### PR DESCRIPTION
PR which makes updates to the `RunFastqScreen`:

* Update the script for running `fastq_screen` to exit with an error if either the `.txt` or `.png` outputs are missing
* Remove the explicitly requirement for `libwebp` from the `conda` dependencies (as this is no longer needed and appears to result in a broken install where the `GD::Graph::bars` Perl module is no longer installed)