### PR TITLE
simple_scheduler: scheduler 'stop' method() terminates all running jobs

### DIFF
--- a/auto_process_ngs/simple_scheduler.py
+++ b/auto_process_ngs/simple_scheduler.py
@@ -157,10 +157,19 @@ class SimpleScheduler(threading.Thread):
         self.__reporter = reporter
 
     def stop(self):
-        """Stop the scheduler
+        """Stop the scheduler and terminate running jobs
 
         """
         self.__active = False
+        if self.__running:
+            logging.debug("Terminating running jobs:")
+            for job in self.__running:
+                logging.debug("\t#%d (%s): \"%s\" (%s)" % (
+                    job.job_number,
+                    job.job_id,
+                    job.name,
+                    date_and_time(job.start_time)))
+                job.terminate()
 
     @property
     def n_waiting(self):
@@ -266,13 +275,6 @@ class SimpleScheduler(threading.Thread):
         except KeyboardInterrupt:
             print("KeyboardInterrupt")
             self.stop()
-            print("Terminating running jobs:")
-            for job in self.__running:
-                print("\t#%d (%s): \"%s\" (%s)" % (job.job_number,
-                                                   job.job_id,
-                                                   job.name,
-                                                   date_and_time(job.start_time)))
-                job.terminate()
             print("Finished")
 
     def wait_for(self,names,timeout=None):

--- a/auto_process_ngs/simple_scheduler.py
+++ b/auto_process_ngs/simple_scheduler.py
@@ -28,6 +28,7 @@ import re
 import threading
 import queue
 import random
+import atexit
 import logging
 
 ######################################################################
@@ -155,6 +156,8 @@ class SimpleScheduler(threading.Thread):
         if reporter is None:
             reporter = default_scheduler_reporter()
         self.__reporter = reporter
+        # Stop scheduler on exit
+        atexit.register(cleanup_atexit,self)
 
     def stop(self):
         """Stop the scheduler and terminate running jobs
@@ -1222,6 +1225,18 @@ def default_scheduler_reporter():
         group_added="Group has been added: #%(group_id)d: \"%(group_name)s\" (%(time_stamp)s)",
         group_end="Group completed: #%(group_id)d: \"%(group_name)s\" (%(time_stamp)s)"
     )
+
+def cleanup_atexit(sched):
+    """
+    Perform clean up actions on exit
+
+    Stops the scheduler which should kill any running jobs
+    """
+    try:
+        print("Stopping scheduler")
+        sched.stop()
+    except Exception as ex:
+        print("Exception stopping scheduler (ignored): %s" % ex)
 
 #######################################################################
 # Exception classes

--- a/auto_process_ngs/test/test_simple_scheduler.py
+++ b/auto_process_ngs/test/test_simple_scheduler.py
@@ -197,6 +197,32 @@ class TestSimpleScheduler(unittest.TestCase):
         self.assertTrue(sched.is_empty())
         sched.stop()
 
+    def test_simple_scheduler_run_multiple_jobs(self):
+        """
+        SimpleScheduler: 'stop' terminates running jobs
+        """
+        sched = SimpleScheduler(runner=MockJobRunner(),
+                                poll_interval=0.01)
+        sched.start()
+        job_1 = sched.submit(['sleep','10'])
+        job_2 = sched.submit(['sleep','20'])
+        job_3 = sched.submit(['sleep','30'])
+        # Wait for scheduler to catch up
+        time.sleep(0.1)
+        self.assertEqual(sched.n_waiting,0)
+        self.assertEqual(sched.n_running,3)
+        self.assertFalse(sched.is_empty())
+        self.assertTrue(job_1.is_running)
+        self.assertTrue(job_2.is_running)
+        self.assertTrue(job_3.is_running)
+        # Halt scheduler, wait for scheduler to catch up
+        sched.stop()
+        time.sleep(0.1)
+        # Check that running jobs have been terminated
+        self.assertFalse(job_1.is_running)
+        self.assertFalse(job_2.is_running)
+        self.assertFalse(job_3.is_running)
+
     def test_simple_scheduler_run_multiple_jobs_with_limit(self):
         """Run several jobs with limit on maximum concurrent jobs
 


### PR DESCRIPTION
PR  which addresses issue #610 by updating the `SimpleScheduler.stop()` method to also terminate any running jobs.