### PR TITLE
transfer_data.py: add option to include 10xGenomics pipeline outputs

### DIFF
--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -22,6 +22,7 @@ from bcftbx.utils import format_file_size
 from ..analysis import AnalysisDir
 from ..command import Command
 from ..simple_scheduler import SimpleScheduler
+from ..simple_scheduler import SchedulerReporter
 from ..fileops import Location
 from ..fileops import exists
 from ..fileops import mkdir
@@ -50,6 +51,23 @@ def get_templates_dir():
         return path
     else:
         return None
+
+class TransferDataSchedulerReporter(SchedulerReporter):
+    """
+    Custom reporter for scheduler
+    """
+    def __init__(self):
+        SchedulerReporter.__init__(
+            self,
+            scheduler_status="[%(time_stamp)s] %(n_running)d running, "
+            "%(n_waiting)d waiting, %(n_finished)d finished",
+            job_scheduled="[%(time_stamp)s] scheduled job '%(job_name)s' "
+            "#%(job_number)d",
+            job_start="[%(time_stamp)s] started job '%(job_name)s' "
+            "#%(job_number)d (%(job_id)s)",
+            job_end="[%(time_stamp)s] completed job '%(job_name)s' "
+            "#%(job_number)d (%(job_id)s)"
+        )
 
 # Main function
 
@@ -396,6 +414,7 @@ def main():
 
     # Start a scheduler to run jobs
     sched = SimpleScheduler(runner=runner,
+                            reporter=TransferDataSchedulerReporter(),
                             poll_interval=settings.general.poll_interval)
     sched.start()
 

--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -234,8 +234,18 @@ def main():
         for fq in sample.fastq:
             fsize += os.lstat(fq).st_size
             nfastqs += 1
-    print("%d Fastqs from %d samples totalling %s" %
-          (nfastqs,len(samples),format_file_size(fsize)))
+    nsamples = len(samples)
+    dataset = "%s%s dataset" % ("%s " % project.info.single_cell_platform
+                                if project.info.single_cell_platform else '',
+                                project.info.library_type)
+    endedness = "paired-end" if project.info.paired_end else "single-end"
+    print("%s with %d Fastqs from %d %s sample%s totalling %s" %
+          (dataset,
+           nfastqs,
+           nsamples,
+           endedness,
+           's' if nsamples != 1 else '',
+           format_file_size(fsize)))
 
     # Check target dir
     if not Location(target_dir).is_remote:


### PR DESCRIPTION
PR which updates the `transfer_data.py` utility to add a new option `--include_10x_outputs`, which collects outputs from 10xGenomics pipelines (`cellranger count` etc) and transfers these to the final destination.

As part of this update, the following additional changes have been made:

* Use a dedicated working directory for the data transfer process;
* Run all jobs via a `SimpleScheduler` instance;
* Expand the summary of the dataset being transferred to include single cell platform and library type.