### PR TITLE
Improve diagnostics for failed tasks in pipelines

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2791,24 +2791,25 @@ class PipelineTask:
                 for script_file in self._scripts:
                     with open(script_file,'rt') as fp:
                         reportf("%s:" % script_file)
-                        for line in fp:
-                            reportf("SCRIPT> %s" % line.rstrip('\n'))
+                        report_text(fp.read(),
+                                    prefix="SCRIPT> ",
+                                    reportf=reportf)
             else:
                 reportf("No scripts generated for this task")
             # Stdout
             reportf("\nSTDOUT:")
             if self.stdout:
-                report_log(self.stdout,
-                           prefix="STDOUT> ",
-                           reportf=reportf)
+                report_text(self.stdout,
+                            prefix="STDOUT> ",
+                            reportf=reportf)
             else:
                 reportf("No stdout from task scripts")
             # Stderr
             reportf("\nSTDERR:")
             if self.stderr:
-                report_log(self.stderr,
-                           prefix="STDERR> ",
-                           reportf=reportf)
+                report_text(self.stderr,
+                            prefix="STDERR> ",
+                            reportf=reportf)
             else:
                 reportf("No stderr from task scripts")
         else:
@@ -2818,21 +2819,21 @@ class PipelineTask:
             stdout = self.stdout
             if stdout:
                 reportf("\nStandard ouput:")
-                report_log(stdout,
-                           head=head,
-                           tail=tail,
-                           prefix="STDOUT> ",
-                           reportf=reportf)
+                report_text(stdout,
+                            head=head,
+                            tail=tail,
+                            prefix="STDOUT> ",
+                            reportf=reportf)
             else:
                 reportf("\nNo stdout from task scripts")
             stderr = self.stderr
             if stderr:
                 reportf("\nStandard error:")
-                report_log(stderr,
-                           head=head,
-                           tail=tail,
-                           prefix="STDERR> ",
-                           reportf=reportf)
+                report_text(stderr,
+                            head=head,
+                            tail=tail,
+                            prefix="STDERR> ",
+                            reportf=reportf)
             else:
                 reportf("\nNo stderr from task scripts")
         reportf("\n**** END OF DIAGNOSTICS ****")
@@ -4233,8 +4234,8 @@ def sanitize_name(s):
             name.append(c)
     return ''.join(name)
 
-def report_log(s,head=None,tail=None,prefix=None,
-               reportf=None):
+def report_text(s,head=None,tail=None,prefix=None,
+                reportf=None):
     """
     Output text with optional topping and tailing
 
@@ -4284,17 +4285,17 @@ def report_log(s,head=None,tail=None,prefix=None,
     else:
         # Report head and/or tail only
         if head:
-            report_log('\n'.join(lines[:head]),
-                       prefix=prefix,
-                       reportf=reportf)
+            report_text('\n'.join(lines[:head]),
+                        prefix=prefix,
+                        reportf=reportf)
         reportf("%s...skipped %d line%s..." % (prefix,
                                                skipped_lines,
                                                's' if skipped_lines != 1
                                                else ''))
         if tail:
-            report_log('\n'.join(lines[-tail:]),
-                       prefix=prefix,
-                       reportf=reportf)
+            report_text('\n'.join(lines[-tail:]),
+                        prefix=prefix,
+                        reportf=reportf)
 
 def collect_files(dirn,pattern):
     """

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -32,6 +32,7 @@ from auto_process_ngs.pipeliner import PathJoinParam
 from auto_process_ngs.pipeliner import PathExistsParam
 from auto_process_ngs.pipeliner import FunctionParam
 from auto_process_ngs.pipeliner import PipelineError
+from auto_process_ngs.pipeliner import report_log
 from auto_process_ngs.pipeliner import resolve_parameter
 from bcftbx.JobRunner import SimpleJobRunner
 from bcftbx.Pipeline import Job
@@ -3817,6 +3818,131 @@ class TestDispatcher(unittest.TestCase):
         self.assertEqual(exit_code,0)
         result = d.get_result()
         self.assertEqual(result,"Hello World!")
+
+class TestReportLog(unittest.TestCase):
+
+    def test_report_log(self):
+        """
+        report_log: check writing to output
+        """
+        input_text = """Example logfile
+with some example
+contents
+
+and blank lines
+"""
+        output = io.StringIO()
+        write_output = lambda s: output.write("%s\n" % s)
+        report_log(input_text,
+                   reportf=write_output)
+        self.assertEqual(output.getvalue(),input_text)
+
+    def test_report_log_with_prefix(self):
+        """
+        report_log: check writing to output with prefix
+        """
+        input_text = """Example logfile
+with some example
+contents
+
+and blank lines
+"""
+        output_text = """PREFIX> Example logfile
+PREFIX> with some example
+PREFIX> contents
+PREFIX> 
+PREFIX> and blank lines
+"""
+        output = io.StringIO()
+        write_output = lambda s: output.write("%s\n" % s)
+        report_log(input_text,
+                   prefix="PREFIX> ",
+                   reportf=write_output)
+        self.assertEqual(output.getvalue(),output_text)
+
+    def test_report_log_head(self):
+        """
+        report_log: check writing head to output
+        """
+        input_text = """Example logfile
+with some example
+contents
+
+and blank lines
+"""
+        output_text = """Example logfile
+with some example
+contents
+...skipped 2 lines...
+"""
+        output = io.StringIO()
+        write_output = lambda s: output.write("%s\n" % s)
+        report_log(input_text,
+                   head=3,
+                   reportf=write_output)
+        self.assertEqual(output.getvalue(),output_text)
+
+    def test_report_log_tail(self):
+        """
+        report_log: check writing tail to output
+        """
+        input_text = """Example logfile
+with some example
+contents
+
+and blank lines
+"""
+        output_text = """...skipped 2 lines...
+contents
+
+and blank lines
+"""
+        output = io.StringIO()
+        write_output = lambda s: output.write("%s\n" % s)
+        report_log(input_text,
+                   tail=3,
+                   reportf=write_output)
+        self.assertEqual(output.getvalue(),output_text)
+
+    def test_report_log_head_and_tail(self):
+        """
+        report_log: check writing head and tail to output
+        """
+        input_text = """Example logfile
+with some example
+contents
+
+and blank lines
+"""
+        output_text = """Example logfile
+with some example
+...skipped 1 line...
+
+and blank lines
+"""
+        output = io.StringIO()
+        write_output = lambda s: output.write("%s\n" % s)
+        report_log(input_text,
+                   head=2,tail=2,
+                   reportf=write_output)
+        self.assertEqual(output.getvalue(),output_text)
+
+    def test_report_log_head_and_tail_overlap(self):
+        """
+        report_log: check writing overlapping head and tail to output
+        """
+        input_text = """Example logfile
+with some example
+contents
+
+and blank lines
+"""
+        output = io.StringIO()
+        write_output = lambda s: output.write("%s\n" % s)
+        report_log(input_text,
+                   head=3,tail=3,
+                   reportf=write_output)
+        self.assertEqual(output.getvalue(),input_text)
 
 class TestResolveParameter(unittest.TestCase):
 

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -32,7 +32,7 @@ from auto_process_ngs.pipeliner import PathJoinParam
 from auto_process_ngs.pipeliner import PathExistsParam
 from auto_process_ngs.pipeliner import FunctionParam
 from auto_process_ngs.pipeliner import PipelineError
-from auto_process_ngs.pipeliner import report_log
+from auto_process_ngs.pipeliner import report_text
 from auto_process_ngs.pipeliner import resolve_parameter
 from bcftbx.JobRunner import SimpleJobRunner
 from bcftbx.Pipeline import Job
@@ -3819,11 +3819,11 @@ class TestDispatcher(unittest.TestCase):
         result = d.get_result()
         self.assertEqual(result,"Hello World!")
 
-class TestReportLog(unittest.TestCase):
+class TestReportText(unittest.TestCase):
 
-    def test_report_log(self):
+    def test_report_text(self):
         """
-        report_log: check writing to output
+        report_text: check writing to output
         """
         input_text = """Example logfile
 with some example
@@ -3833,13 +3833,13 @@ and blank lines
 """
         output = io.StringIO()
         write_output = lambda s: output.write("%s\n" % s)
-        report_log(input_text,
-                   reportf=write_output)
+        report_text(input_text,
+                    reportf=write_output)
         self.assertEqual(output.getvalue(),input_text)
 
-    def test_report_log_with_prefix(self):
+    def test_report_text_with_prefix(self):
         """
-        report_log: check writing to output with prefix
+        report_text: check writing to output with prefix
         """
         input_text = """Example logfile
 with some example
@@ -3855,14 +3855,14 @@ PREFIX> and blank lines
 """
         output = io.StringIO()
         write_output = lambda s: output.write("%s\n" % s)
-        report_log(input_text,
-                   prefix="PREFIX> ",
-                   reportf=write_output)
+        report_text(input_text,
+                    prefix="PREFIX> ",
+                    reportf=write_output)
         self.assertEqual(output.getvalue(),output_text)
 
-    def test_report_log_head(self):
+    def test_report_text_head(self):
         """
-        report_log: check writing head to output
+        report_text: check writing head to output
         """
         input_text = """Example logfile
 with some example
@@ -3877,14 +3877,14 @@ contents
 """
         output = io.StringIO()
         write_output = lambda s: output.write("%s\n" % s)
-        report_log(input_text,
-                   head=3,
-                   reportf=write_output)
+        report_text(input_text,
+                    head=3,
+                    reportf=write_output)
         self.assertEqual(output.getvalue(),output_text)
 
-    def test_report_log_tail(self):
+    def test_report_text_tail(self):
         """
-        report_log: check writing tail to output
+        report_text: check writing tail to output
         """
         input_text = """Example logfile
 with some example
@@ -3899,14 +3899,14 @@ and blank lines
 """
         output = io.StringIO()
         write_output = lambda s: output.write("%s\n" % s)
-        report_log(input_text,
-                   tail=3,
-                   reportf=write_output)
+        report_text(input_text,
+                    tail=3,
+                    reportf=write_output)
         self.assertEqual(output.getvalue(),output_text)
 
-    def test_report_log_head_and_tail(self):
+    def test_report_text_head_and_tail(self):
         """
-        report_log: check writing head and tail to output
+        report_text: check writing head and tail to output
         """
         input_text = """Example logfile
 with some example
@@ -3922,14 +3922,15 @@ and blank lines
 """
         output = io.StringIO()
         write_output = lambda s: output.write("%s\n" % s)
-        report_log(input_text,
-                   head=2,tail=2,
-                   reportf=write_output)
+        report_text(input_text,
+                    head=2,
+                    tail=2,
+                    reportf=write_output)
         self.assertEqual(output.getvalue(),output_text)
 
-    def test_report_log_head_and_tail_overlap(self):
+    def test_report_text_head_and_tail_overlap(self):
         """
-        report_log: check writing overlapping head and tail to output
+        report_text: check writing overlapping head and tail to output
         """
         input_text = """Example logfile
 with some example
@@ -3939,9 +3940,10 @@ and blank lines
 """
         output = io.StringIO()
         write_output = lambda s: output.write("%s\n" % s)
-        report_log(input_text,
-                   head=3,tail=3,
-                   reportf=write_output)
+        report_text(input_text,
+                    head=3,
+                    tail=3,
+                    reportf=write_output)
         self.assertEqual(output.getvalue(),input_text)
 
 class TestResolveParameter(unittest.TestCase):


### PR DESCRIPTION
PR which improves the reporting from failed tasks in pipelines which have been implemented using the `pipeliner` module.

Specifically this extends the `report_diagnostics` method of the `PipelineTask` class to also report captured stderr from jobs run by the task (nb this also requires https://github.com/fls-bioinformatics-core/genomics/pull/201). It also implements a non-verbose mode which only reports partial stdout and stderr from the task, when these are very long, and uses this mode to report diagnostics from tasks when one or more jobs have failed (i.e. exited with non-zero status).

It is hoped that this enhanced diagnostic reporting will make it easier to more often identify the causes of pipeline failures directly from the top-level logs.