### PR TITLE
Fix handling of 'cellranger-atac count' --chemistry option for 10xGenomics scATAC-seq data

### DIFF
--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -2135,7 +2135,8 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
         elif self._package_name == "cellranger-atac":
             count.add_argument("--reference",action="store")
             if version[0] >= 2:
-                count.add_argument("--chemistry",action="store")
+                count.add_argument("--chemistry",choices=['ATAC-v1',
+                                                          'ARC-v1'])
         elif self._package_name == "cellranger-arc":
             count.add_argument("--reference",action="store")
             count.add_argument("--libraries",action="store")

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -2007,7 +2007,12 @@ class RunCellrangerCount(PipelineTask):
                 # Additional options for cellranger-atac 2+
                 if cellranger_major_version >= 2:
                     # Enable chemistry to be specified
-                    cmd.add_args("--chemistry",self.args.chemistry)
+                    if self.args.chemistry == "auto":
+                        # 'auto' not recognised by cellranger-atac 2.0.0
+                        print("Dropping \"--chemistry='auto'\" from "
+                              "cellranger-atac 2+ command line")
+                    else:
+                        cmd.add_args("--chemistry",self.args.chemistry)
             elif cellranger_package == "cellranger-arc":
                 # Cellranger-ARC (multiome GEX + ATAC data)
                 cmd.add_args("--reference",


### PR DESCRIPTION
PR which fixes a bug in the handling of the `--chemistry` option of `cellranger-atac`, when running the QC pipeline on 10xGenomics single-cell ATAC-seq data.

The bug is due to `cellranger-atac count` 2.0.0 not recognising `auto` as a valid value for the chemistry; the fix is to remove the `--chemistry` option for `auto` when constructing the `cellranger-atac` command line in the `RunCellrangerCount` task in the `qc.pipeline` module.

(Note that this PR also includes an update to the `Mock10xPackageExe` class in the `mock` module so that the correct behaviour of `cellranger-atac` 2.0.0 is replicated in testing.)