### PR TITLE
Update 'has_10x_indices' function to recognise broader range of Visium indices

### DIFF
--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -824,7 +824,7 @@ def has_10x_indices(sample_sheet):
 
     For Visium data the indices are assumed to be of the form:
 
-    SI-TT-[A-H][1-12]
+    SI-(TT|TS)-[A-H][1-12]
 
     e.g. 'SI-TT-B1'
 
@@ -836,7 +836,7 @@ def has_10x_indices(sample_sheet):
       Boolean: True if the sample sheet contains at least
         one 10xGenomics-style index, False if not.
     """
-    index_pattern = re.compile(r"SI-(GA|NA|TT)-[A-H](1[0-2]|[1-9])$")
+    index_pattern = re.compile(r"SI-(GA|NA|TT|TS)-[A-H](1[0-2]|[1-9])$")
     s = SampleSheet(sample_sheet)
     for line in s:
         try:


### PR DESCRIPTION
PR which fixes a bug in the `has_10x_indices` function (in `tenx_genomics_utils`), where Visium indices of the form:

    SI-TS-A1

were not recognised as 10x Genomics indices (only e.g. `SI-TT-A1` was recognised).

The PR updates the regex pattern used to detect 10x Genomics indices to include the `SI-TS-...` form.