### PR TITLE
Fix PipelineTask 'stdout' and 'stderr' methods when expect logs don't exist

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2583,7 +2583,7 @@ class PipelineTask:
         """
         stdout = []
         for f in self._stdout_files:
-            if f is not None:
+            if f is not None and os.path.exists(f):
                 with open(f,'r') as fp:
                     stdout.append(fp.read())
         return ''.join(stdout)
@@ -2598,7 +2598,7 @@ class PipelineTask:
         """
         stderr = []
         for f in self._stderr_files:
-            if f is not None:
+            if f is not None and os.path.exists(f):
                 with open(f,'r') as fp:
                     stderr.append(fp.read())
         return ''.join(stderr)


### PR DESCRIPTION
PR which fixes a bug in the `stdout` and `stderr` methods of the `PipelineTask` class in `pipeliner`, where the diagnostic reporting crashes the pipeline when one of either the stdout or stderr files doesn't exist but the reporting tries to open them anyway.

(This situation is most likely to arise when log file joining is specified, so that stderr is merged into stdout and there is no stderr file.)

The fix checks that the file exists on the system before attempting to open and read its contents.