### PR TITLE
qc/reporting: need to explicitly close ZipArchive in 'report' function

### DIFF
--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -485,6 +485,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
         ap.make_project_metadata_file()
     else:
         ap.update_project_metadata_file()
+    ap.save_data()
 
     # Finish
     return status

--- a/auto_process_ngs/commands/setup_cmd.py
+++ b/auto_process_ngs/commands/setup_cmd.py
@@ -304,3 +304,4 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
     # Set flags to allow parameters etc to be saved back
     ap._save_params = True
     ap._save_metadata = True
+    ap.save_data()

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -2992,6 +2992,7 @@ def report(projects,title=None,filename=None,qc_dir=None,
                     zip_file.add(f)
                 else:
                     raise Exception("Unable to add missing file '%s'" % f)
+            zip_file.close()
             # Rename temporary ZIP to final location
             os.rename(tmp_zip,zip_name)
         except Exception as ex:


### PR DESCRIPTION
PR which fixes bugs in the Python 3.7 and 3.8 tests:

- Failing tests for the QC reporting (specifically the generation of a zip archive with the QC report) from the `report` function of `qc/reporting.py`, where the unit tests fail complaining that the generated archive is not  a valid zip file.  The bug manifests under Python 3.7 and 3.8, and the fix is to explicitly close the `ZipArchive` object that is used to create the archive.
- Failed test for the Fastq generation command, where the post-test clean up complains that the output directory isn't empty. This bug manifests under Python 3.7 and appears to be addressed by removing the `__del__` method of the `AutoProcess` class from  `autoprocessor.py`, replacing it with save and clean-up methods that can be called explicitly and that are also invoked via `atexit`. (NB this also addresses issue #185.)