### PR TITLE
Add support for Parse Evercode single cell RNA-seq data

### DIFF
--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -107,7 +107,8 @@ def setup_analysis_dirs(ap,
         sc_platform = line['SC_Platform']
         if sc_platform and sc_platform != '.':
             if not sc_platform in tenx_genomics_utils.PLATFORMS and \
-               not sc_platform in icell8.PLATFORMS:
+               not sc_platform in icell8.PLATFORMS and \
+               not sc_platform in ('Parse Evercode',):
                 logger.error("Unknown single cell platform for '%s': "
                              "'%s'" % (line['Project'],sc_platform))
                 raise Exception("Unknown single cell platform")

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -709,6 +709,9 @@ class UpdateAnalysisProject(DirectoryUpdater):
                             '10x_Multiome_GEX',) and \
                 self._project.fastq_attrs(fq).read_number == 1:
                 continue
+            elif protocol in ('ParseEvercode',) and \
+                 self._project.fastq_attrs(fq).read_number == 2:
+                continue
             for screen in ("model_organisms",
                            "other_organisms",
                            "rRNA"):

--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -1277,6 +1277,10 @@ def check_fastq_screen_outputs(project,qc_dir,screen,qc_protocol=None,
             if project.fastq_attrs(fastq).read_number == 1:
                 # No screens for R1 for single cell
                 continue
+        elif qc_protocol in ('ParseEvercode',):
+            if project.fastq_attrs(fastq).read_number == 2:
+                # No screens for R2 for Parse Evercode scRNA-seq
+                continue
         for output in [os.path.join(qc_dir,f)
                        for f in fastq_screen_output(fastq,screen,
                                                     legacy=legacy)]:
@@ -1379,8 +1383,11 @@ def check_fastq_strand_outputs(project,qc_dir,fastq_strand_conf,
                              '10x_Visium',
                              '10x_Multiome_GEX',
                              '10x_CellPlex',):
-            # Strand stats output based on R2
+            # Strand stats output based on R2 only
             fq_pair = (fq_group[1],)
+        elif qc_protocol in ('ParseEvercode',):
+            # Strand stats output based on R1 only
+            fq_pair = (fq_group[0],)
         else:
             # All other protocols use R1 (single-end)
             # or R1/R2 (paired-end)

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1182,6 +1182,9 @@ class RunFastqScreen(PipelineTask):
                                          '10x_CellPlex',) \
                 and self.args.fastq_attrs(fastq).read_number == 1:
                 continue
+            elif self.args.qc_protocol in ('ParseEvercode',) \
+                 and self.args.fastq_attrs(fastq).read_number == 2:
+                continue
             # Base name for Fastq file
             fastq_basename = os.path.basename(fastq)
             while fastq_basename.split('.')[-1] in ('fastq','gz'):

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -200,6 +200,19 @@ QC_PROTOCOLS = {
         ]
     },
 
+    "ParseEvercode": {
+        "reads": {
+            "seq_data": ('r1',),
+            "index": ('r2',)
+        },
+        "qc_modules": [
+            'fastqc',
+            'fastq_screen',
+            'sequence_lengths',
+            'strandedness'
+        ]
+    },
+
     "ICELL8_scATAC": {
         "reads": {
             "seq_data": ('r1','r2',),
@@ -251,6 +264,10 @@ def determine_qc_protocol(project):
                                   "CellPlex snRNA-seq"):
                 # 10xGenomics CellPlex (cell multiplexing)
                 protocol = "10x_CellPlex"
+        elif single_cell_platform == 'Parse Evercode':
+            if library_type == "scRNA-seq":
+                # Parse Evercode snRNAseq
+                protocol = "ParseEvercode"
         elif library_type in ("scATAC-seq",
                               "snATAC-seq",):
             if single_cell_platform == "10xGenomics Single Cell ATAC":

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -1806,6 +1806,75 @@ class TestCheckFastqScreenOutputs(unittest.TestCase):
                          [os.path.join(project.fastq_dir,
                                        "PJB1_S1_R2_001.fastq.gz")])
 
+    def test_check_fastq_screen_outputs_parseevercode_all_missing(self):
+        """
+        check_fastq_screen_outputs: all screen outputs missing (ParseEvercode)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # Get the outputs
+        project = AnalysisProject("PJB",os.path.join(self.wd,"PJB"))
+        # Check
+        # NB no screens expected for R1 (only R2)
+        self.assertEqual(check_fastq_screen_outputs(project,
+                                                    qc_dir="qc",
+                                                    screen="model_organisms",
+                                                    qc_protocol="ParseEvercode"),
+                         [os.path.join(project.fastq_dir,
+                                       "PJB1_S1_R1_001.fastq.gz")])
+
+    def test_check_fastq_screen_outputs_parseevercode_all_present(self):
+        """
+        check_fastq_screen_outputs: all screen outputs present (ParseEvercode)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # Add QC artefacts
+        project = AnalysisProject("PJB",os.path.join(self.wd,"PJB"))
+        UpdateAnalysisProject(project).add_qc_outputs(
+            protocol="ParseEvercode",
+            include_fastq_strand=False,
+            include_multiqc=False)
+        # Check
+        self.assertEqual(check_fastq_screen_outputs(project,
+                                                    qc_dir="qc",
+                                                    screen="model_organisms",
+                                                    qc_protocol="ParseEvercode"),
+                         [])
+
+    def test_check_fastq_screen_outputs_parseevercode_some_missing(self):
+        """
+        check_fastq_screen_outputs: some screen outputs missing (ParseEvercode)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # Add QC artefacts
+        project = AnalysisProject("PJB",os.path.join(self.wd,"PJB"))
+        UpdateAnalysisProject(project).add_qc_outputs(
+            protocol="ParseEvercode",
+            include_fastq_strand=False,
+            include_multiqc=False)
+        # Remove a screen output
+        os.remove(os.path.join(
+            project.qc_dir,
+            "PJB1_S1_R1_001_screen_model_organisms.txt"))
+        # Check
+        self.assertEqual(check_fastq_screen_outputs(project,
+                                                    qc_dir="qc",
+                                                    screen="model_organisms",
+                                                    qc_protocol="ParseEvercode"),
+                         [os.path.join(project.fastq_dir,
+                                       "PJB1_S1_R1_001.fastq.gz")])
+
 class TestCheckFastQCOutputs(unittest.TestCase):
     """
     Tests for the 'check_fastqc_outputs' function
@@ -2142,6 +2211,50 @@ class TestCheckFastqStrandOutputs(unittest.TestCase):
                                                     "qc",
                                                     fastq_strand_conf,
                                                     qc_protocol="singlecell"),
+                         [])
+
+    def test_check_fastq_strand_outputs_parseevercode_missing(self):
+        """
+        check_fastq_strand_outputs: fastq_strand.py output missing (ParseEvercode)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",os.path.join(self.wd,"PJB"))
+        # Make fastq_strand.conf
+        fastq_strand_conf = os.path.join(project.dirn,"fastq_strand.conf")
+        with open(fastq_strand_conf,'w') as fp:
+            fp.write("")
+        # Check the outputs
+        self.assertEqual(check_fastq_strand_outputs(project,
+                                                    "qc",
+                                                    fastq_strand_conf,
+                                                    qc_protocol="ParseEvercode"),
+                         [(os.path.join(project.fastq_dir,
+                                        "PJB1_S1_R1_001.fastq.gz"),),])
+
+    def test_check_fastq_strand_outputs_parseevercode_present(self):
+        """
+        check_fastq_strand_outputs: fastq_strand.py output present (ParseEvercode)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",os.path.join(self.wd,"PJB"))
+        UpdateAnalysisProject(project).add_qc_outputs(
+            protocol="ParseEvercode",
+            include_fastq_strand=True,
+            include_multiqc=False)
+        fastq_strand_conf = os.path.join(project.dirn,"fastq_strand.conf")
+        # Check the outputs
+        self.assertEqual(check_fastq_strand_outputs(project,
+                                                    "qc",
+                                                    fastq_strand_conf,
+                                                    qc_protocol="ParseEvercode"),
                          [])
 
 class TestCheckCellrangerCountOutputs(unittest.TestCase):

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -2332,6 +2332,58 @@ PBB,CMO302,PBB
                                                         "PJB",f)),
                             "Missing %s" % f)
 
+    def test_qcpipeline_with_parse_evercode_scrnaseq_data(self):
+        """QCPipeline: Parse Evercode single cell RNA-seq QC run (ParseEvercode)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           'Parse Evercode',
+                                           'Library type': 'scRNA-seq' })
+        p.create(top_dir=self.wd)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject("PJB",
+                                          os.path.join(self.wd,"PJB")),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"ParseEvercode")
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
     def test_qcpipeline_with_10x_scRNAseq_no_project_metadata(self):
         """QCPipeline: single cell RNA-seq QC run with no project metadata
         """

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -393,6 +393,26 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
         self.assertEqual(determine_qc_protocol(project),
                          "10x_Multiome_GEX")
 
+    def test_determine_qc_protocol_parse_evercode(self):
+        """determine_qc_protocol: Parse Evercode single cell RNA-seq run
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz",
+                                       "PJB1_S1_I1_001.fastq.gz",
+                                       "PJB1_S1_I2_001.fastq.gz"),
+                                metadata={'Single cell platform':
+                                          "Parse Evercode",
+                                          'Library type':
+                                          "scRNA-seq"})
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        self.assertEqual(determine_qc_protocol(project),
+                         "ParseEvercode")
+
 class TestFetchProtocolDefinition(unittest.TestCase):
 
     def test_fetch_protocol_definition(self):

--- a/docs/source/using/projects_info.rst
+++ b/docs/source/using/projects_info.rst
@@ -86,6 +86,7 @@ Single cell platform                  Library types
 ``10xGenomics Chromium 3'v2``         ``scRNA-seq``, ``snRNA-seq``
 ``10xGenomics Single Cell ATAC``      ``scATAC-seq``, ``snATAC-seq``
 ``10xGenomics Single Cell Multiome``  ``ATAC``, ``GEX``
+``Parse Evercode``                    ``scRNA-seq``
 ``ICELL8``                            ``scRNA-seq``
 ``ICELL8 ATAC``                       ``scATAC-seq``
 ===================================== ==============================

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -37,6 +37,7 @@ QC protocol           Used for
 ``10x_Multiome_ATAC`` 10xGenomics Visium multiome ATAC-seq data
 ``10x_Multiome_GEX``  10xGenomics Visium multiome gene expression data
 ``10x_CellPlex``      10xGenomics CellPlex cell multiplexing data
+``ParseEvercode``     Parse Evercode single cell RNA-seq
 ``singlecell``        ICELL8 single cell RNA-seq
 ``ICELL8_scATAC``     ICELL8 single cell ATAC-seq
 ===================== ==========================


### PR DESCRIPTION
PR which updates `auto_process_ngs` to support Parse Evercode single cell RNA-seq data:

* Adds `Parse Evercode` as a recognised single cell platform (for the `setup_analysis_dirs` command), and
* Adds a new QC protocol `ParseEvercode` which is used to process single RNA-seq data from this platform. 

Specifically, as the data consists of R1 and R2 Fastq pairs where:

* R1 contains cDNA reads from cell RNA, and
* R2 contains barcode and poly-N sequences

(essentially the opposite of 10x Genomics Chromium data, for example), screens and strandedness QC are only run using the R1 data under this new protocol.