### PR TITLE
Use read numbers from protocols to filter Fastqs for QC pipeline

### DIFF
--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -43,6 +43,7 @@ This module also provides the following functions:
 
 - determine_qc_protocol: get QC protocol for a project
 - fetch_protocol_definition: get the definition for a QC protocol
+- get_read_numbers: get the read numbers associated with a QC protocol
 """
 
 #######################################################################
@@ -319,3 +320,29 @@ def fetch_protocol_definition(name):
         raise Exception("%s: exception loading QC protocol "
                         "definition: %s" % (name,ex))
     return (reads,qc_modules)
+
+def get_read_numbers(protocol):
+    """
+    Return the read numbers for a QC protocol definition
+
+    Given a QC protocol, returns the integer read numbers
+    for sequence data reads, index reads, and QC reads
+    associated with that protocol.
+
+    Arguments:
+      protocol (str): name of the QC protocol
+
+    Returns:
+      AttributeDictionary: dictionary with keys 'seq_data',
+        'index' and 'qc', mapping to lists of read numbers
+        for each type of read data.
+    """
+    reads,qc_modules = fetch_protocol_definition(protocol)
+    read_numbers = AttributeDictionary(seq_data=[],
+                                       index=[],
+                                       qc=[])
+    for name in ('seq_data','index','qc'):
+        for read in reads[name]:
+            if read.startswith('r'):
+                read_numbers[name].append(int(read[1:]))
+    return read_numbers

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -10,6 +10,7 @@ from auto_process_ngs.analysis import AnalysisProject
 from auto_process_ngs.mock import MockAnalysisProject
 from auto_process_ngs.qc.protocols import determine_qc_protocol
 from auto_process_ngs.qc.protocols import fetch_protocol_definition
+from auto_process_ngs.qc.protocols import get_read_numbers
 
 # Set to False to keep test output dirs
 REMOVE_TEST_OUTPUTS = True
@@ -435,3 +436,25 @@ class TestFetchProtocolDefinition(unittest.TestCase):
         self.assertRaises(KeyError,
                           fetch_protocol_definition,
                           "whazzdis?")
+
+class TestGetReadNumbers(unittest.TestCase):
+
+    def test_get_read_numbers(self):
+        """
+        get_read_numbers: check for sample protocol definitions
+        """
+        # Standard PE
+        read_numbers = get_read_numbers("standardPE")
+        self.assertEqual(read_numbers.seq_data,[1,2])
+        self.assertEqual(read_numbers.index,[])
+        self.assertEqual(read_numbers.qc,[1,2])
+        # 10x single cell RNA-seq
+        read_numbers = get_read_numbers("10x_scRNAseq")
+        self.assertEqual(read_numbers.seq_data,[2])
+        self.assertEqual(read_numbers.index,[1])
+        self.assertEqual(read_numbers.qc,[1,2])
+        # 10x single cell ATAC
+        read_numbers = get_read_numbers("10x_scATAC")
+        self.assertEqual(read_numbers.seq_data,[1,3])
+        self.assertEqual(read_numbers.index,[])
+        self.assertEqual(read_numbers.qc,[1,3])


### PR DESCRIPTION
PR which updates the filtering of Fastqs by read number in the output checking and QC pipeline setup for FastqScreen, FastQC and strandedness, to use read numbers from QC protocol definitions (and removing the hardcoding for specific protocols).

The PR introduces a new function `get_read_numbers`  in the `qc/protocols` module, which returns lists of integer read numbers from the specified QC protocol definition. This is then used in the `qc/outputs` module for filtering Fastqs when checking outputs for FastqScreen, FastQC and strandedness, and in the `qc/pipeline` module for setting up FastqScreen and FastQC jobs.

This PR should make it easier to add new QC protocols, by reducing the amount of custom code required on top of the definitions in the `qc/protocols` module.