### PR TITLE
Update 'bases_mask_is_valid' function to handle leading 'N's in bases mask

### DIFF
--- a/auto_process_ngs/bcl2fastq/utils.py
+++ b/auto_process_ngs/bcl2fastq/utils.py
@@ -450,7 +450,7 @@ def bases_mask_is_valid(bases_mask):
     """
     try:
         for read in bases_mask.upper().split(','):
-            if not re.match(r'^([IY][0-9]+|[IY]*)(N[0-9]+|N*)$',read):
+            if not re.match(r'^([IYN][0-9]+|[IYN]*)+$',read):
                 return False
         return True
     except AttributeError:

--- a/auto_process_ngs/test/bcl2fastq/test_utils.py
+++ b/auto_process_ngs/test/bcl2fastq/test_utils.py
@@ -951,6 +951,7 @@ class TestBasesMaskIsValid(unittest.TestCase):
         self.assertTrue(bases_mask_is_valid('y250,I6n2,I6n2,y250'))
         self.assertTrue(bases_mask_is_valid('y25n76,I8,I8,y101'))
         self.assertTrue(bases_mask_is_valid('y250,I16'))
+        self.assertTrue(bases_mask_is_valid('n5y245,I8,I8,n5y245'))
         self.assertTrue(bases_mask_is_valid('yyyyyyyyy,IIIIII'))
         self.assertTrue(bases_mask_is_valid('yyyyyyyyy,IIIInn'))
         self.assertFalse(bases_mask_is_valid(123))


### PR DESCRIPTION
PR which updates the `bases_mask_is_valid` function (in `bcl2fastq/utils`) to correctly handle leading `N`s in the bases mask string (specifically strings for Aligent SureSelect XT HS2 data which can have the form `N5Y*,I8,I8,N5Y*`).