### PR TITLE
'docwriter': add support for Javascript and 'style' attribute

### DIFF
--- a/auto_process_ngs/docwriter.py
+++ b/auto_process_ngs/docwriter.py
@@ -243,9 +243,11 @@ class Section:
       css_classes (list): list or iterable with
         names of CSS classes to associate with
         the section
+      style (str): style information to put into
+        the 'style' attribute of the section
     """
     def __init__(self,title=None,name=None,level=2,
-                 css_classes=None):
+                 css_classes=None,style=None):
         """
         Create a new Section instance
         """
@@ -256,6 +258,7 @@ class Section:
         self._level = level
         if css_classes:
             self.add_css_classes(*css_classes)
+        self._style = style
 
     @property
     def name(self):
@@ -317,7 +320,7 @@ class Section:
             self._content.append(content)
 
     def add_subsection(self,title=None,section=None,name=None,
-                       css_classes=None):
+                       css_classes=None,style=None):
         """
         Add subsection within the section
 
@@ -335,6 +338,8 @@ class Section:
           css_classes (list): list or iterable with
             names of CSS classes to associate with
             the new section.
+          style (str): style information to put into
+            the 'style' attribute of the section
 
         Returns:
           Section: the appended section.
@@ -342,7 +347,8 @@ class Section:
         if section is None:
             subsection = Section(title=title,name=name,
                                  level=self._level+1,
-                                 css_classes=css_classes)
+                                 css_classes=css_classes,
+                                 style=style)
         else:
             subsection = section
         self.add(subsection)
@@ -358,11 +364,14 @@ class Section:
         """
         if self._title is None and \
            not self._content and \
-           not self._css_classes:
+           not self._css_classes and \
+           not self._style:
             return ""
         div = "<div"
         if self.name:
             div += " id='%s'" % self.name
+        if self._style:
+            div += " style='%s'" % self._style
         if self._css_classes:
             div += " class='%s'" % ' '.join(self._css_classes)
         div += ">"

--- a/auto_process_ngs/docwriter.py
+++ b/auto_process_ngs/docwriter.py
@@ -101,6 +101,7 @@ class Document:
         self._title = title
         self._sections = []
         self._css_rules = []
+        self._scripts = []
 
     @property
     def title(self):
@@ -159,6 +160,16 @@ class Document:
         """
         self._css_rules.append(css_rule)
 
+    def add_javascript(self,script):
+        """
+        Add Javascript code to the document
+
+        Arguments:
+          script (str): script block to include in
+            the final document header
+        """
+        self._scripts.append(script)
+
     def html(self):
         """
         Generate HTML version of the document contents
@@ -193,6 +204,8 @@ class Document:
         html = HTMLPageWriter(self._title)
         for css_rule in self._css_rules:
             html.addCSSRule(css_rule)
+        for script in self._scripts:
+            html.addJavaScript(script)
         html.add(self.html())
         html.write("%s" % outfile)
 

--- a/auto_process_ngs/test/test_docwriter.py
+++ b/auto_process_ngs/test/test_docwriter.py
@@ -111,6 +111,27 @@ class TestDocument(unittest.TestCase):
                              "<h1>Test Document</h1></body>\n"
                              "</html>\n")
 
+    def test_document_write_to_file_with_javascript(self):
+        d = Document("Test Document")
+        d.add_javascript("// Placeholder for script code")
+        outfile = os.path.join(self.dirn,"test.html")
+        self.assertFalse(os.path.exists(outfile))
+        d.write(outfile)
+        self.assertTrue(os.path.exists(outfile))
+        with open(outfile,'r') as fp:
+            html = fp.read()
+            self.assertEqual(html,
+                             "<html>\n"
+                             "<head>\n"
+                             "<title>Test Document</title>\n"
+                             "<script language='javascript' type='text/javascript'><!--\n"
+                             "// Placeholder for script code\n"
+                             "--></script>\n"
+                             "</head>\n"
+                             "<body>\n"
+                             "<h1>Test Document</h1></body>\n"
+                             "</html>\n")
+
 class TestSection(unittest.TestCase):
     """
     Tests for the Section class

--- a/auto_process_ngs/test/test_docwriter.py
+++ b/auto_process_ngs/test/test_docwriter.py
@@ -131,6 +131,15 @@ class TestSection(unittest.TestCase):
                          "<div class='clear'>\n"
                          "</div>")
 
+    def test_empty_section_with_style_attribute(self):
+        s = Section(style="display: block;")
+        self.assertEqual(s.title,None)
+        self.assertEqual(s.name,None)
+        self.assertEqual(s.level,2)
+        self.assertEqual(s.html(),
+                         "<div style='display: block;'>\n"
+                         "</div>")
+
     def test_section_no_content(self):
         s = Section("Empty section")
         self.assertEqual(s.title,"Empty section")
@@ -189,6 +198,22 @@ class TestSection(unittest.TestCase):
                          "<div id='Section_with_subsection_and_CSS_classes'>\n"
                          "<h2>Section with subsection and CSS classes</h2>\n"
                          "<div id='Subsection' class='subsection new'>\n"
+                         "<h3>Subsection</h3>\n"
+                         "</div>\n"
+                         "</div>")
+
+    def test_section_with_subsection_and_style_attribute(self):
+        s = Section("Section with subsection and style attribute")
+        sub = s.add_subsection("Subsection",style="display: block;")
+        self.assertTrue(isinstance(sub,Section))
+        self.assertEqual(s.title,"Section with subsection and style attribute")
+        self.assertEqual(s.name,"Section_with_subsection_and_style_attribute")
+        self.assertEqual(s.level,2)
+        self.assertEqual(sub.level,3)
+        self.assertEqual(s.html(),
+                         "<div id='Section_with_subsection_and_style_attribute'>\n"
+                         "<h2>Section with subsection and style attribute</h2>\n"
+                         "<div id='Subsection' style='display: block;'>\n"
                          "<h3>Subsection</h3>\n"
                          "</div>\n"
                          "</div>")


### PR DESCRIPTION
PR which adds support for including Javascript and 'style' attributes to classes in the `docwriter` module:

* Adds new method `add_javascript` to the `Document` class, which allows arbitrary Javascript code to be written to the output HTML header, and
* Adds new argument `style` to the `Section` class, which allows arbitrary styles to be written to the `style` attribute of the section in the HTML document.

The `style` is also supported by the `add_subsection` method of the the `Section` class, and the `add_section` method of the `Document` class.