### PR TITLE
Update QC pipeline for Cellranger 7.0.0

### DIFF
--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1868,7 +1868,7 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
         self._package_name = os.path.basename(self._path)
         if version is None:
             if self._package_name == 'cellranger':
-                self._version = '6.0.0'
+                self._version = '7.0.0'
             elif self._package_name == 'cellranger-atac':
                 self._version = '2.0.0'
             elif self._package_name == 'cellranger-arc':
@@ -2085,9 +2085,16 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
         if self._package_name == "cellranger":
             count.add_argument("--transcriptome",action="store")
             count.add_argument("--chemistry",action="store")
-            if version[0] >= 5:
+            if version[0] == 7:
+                # Cellranger 7: include introns on by default
+                count.add_argument("--include-introns",
+                                   choices=['true','false'],
+                                   default='true')
+            elif version[0] in (5,6):
+                # Cellranger 5,6: include introns off by default
                 count.add_argument("--include-introns",
                                    action="store_true")
+            if version[0] >= 5:
                 count.add_argument("--r1-length",action="store")
                 count.add_argument("--r2-length",action="store")
         elif self._package_name == "cellranger-atac":
@@ -2125,8 +2132,16 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
         # Check --include-introns
         if self._assert_include_introns is not None:
             print("Checking --include-introns")
-            assert(("--include-introns" in cmdline.split()) ==
-                   self._assert_include_introns)
+            try:
+                include_introns = args.include_introns
+            except AttributeError:
+                # Earlier versions don't support --include_introns
+                include_introns = False
+            if include_introns == 'true':
+                include_introns = True
+            elif include_introns == 'false':
+                include_introns = False
+            assert(include_introns == self._assert_include_introns)
         # Check --chemistry
         if self._assert_chemistry:
             print("Checking chemistry: %s" % args.chemistry)

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1994,9 +1994,13 @@ class RunCellrangerCount(PipelineTask):
                     # Hard-trim the input R1 sequence to 26bp
                     cmd.add_args("--r1-length=26")
                     if self.args.qc_protocol == "10x_snRNAseq":
-                    # For single nuclei RNA-seq specify the
-                    # --include-introns for cellranger 5.0+
-                        cmd.add_args("--include-introns")
+                        # For single nuclei RNA-seq specify the
+                        # --include-introns for cellranger 5.0+
+                        if cellranger_major_version == 7:
+                            cmd.add_args("--include-introns",
+                                         "true")
+                        else:
+                            cmd.add_args("--include-introns")
             elif cellranger_package == "cellranger-atac":
                 # Cellranger-ATAC
                 cmd.add_args("--fastqs",fastq_dir,

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -3801,7 +3801,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(p.output.cellranger_info,
                          (os.path.join(self.bin,"cellranger"),
                           "cellranger",
-                          "6.0.0"))
+                          "7.0.0"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))
@@ -3937,7 +3937,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(p.output.cellranger_info,
                          (os.path.join(self.bin,"cellranger"),
                           "cellranger",
-                          "6.0.0"))
+                          "7.0.0"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))
@@ -4083,7 +4083,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(p.output.cellranger_info,
                          (os.path.join(self.bin,"cellranger"),
                           "cellranger",
-                          "6.0.0"))
+                          "7.0.0"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))
@@ -4982,6 +4982,99 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_makefastqs_10x_chromium_sc_protocol_700(self):
+        """
+        MakeFastqs: '10x_chromium_sc' protocol (Cellranger 7.0.0)
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics Chromium SC indices
+        samplesheet_chromium_sc_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-GA-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_chromium_sc_indices)
+        # Create mock bcl2fastq and cellranger
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        MockCellrangerExe.create(os.path.join(self.bin,
+                                              "cellranger"),
+                                 version="7.0.0")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="10x_chromium_sc")
+        status = p.run(analysis_dir,
+                       poll_interval=POLL_INTERVAL)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,
+                         (os.path.join(self.bin,"cellranger"),
+                          "cellranger",
+                          "7.0.0"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html",):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
     def test_makefastqs_10x_chromium_sc_protocol_non_standard_dir_name(self):
         """
         MakeFastqs: '10x_chromium_sc' protocol (non-standard directory name)
@@ -5042,7 +5135,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.cellranger_info,
                          (os.path.join(self.bin,"cellranger"),
                           "cellranger",
-                          "6.0.0"))
+                          "7.0.0"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))
@@ -5157,7 +5250,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.cellranger_info,
                          (os.path.join(self.bin,"cellranger"),
                           "cellranger",
-                          "6.0.0"))
+                          "7.0.0"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -1102,6 +1102,78 @@ class TestQCPipeline(unittest.TestCase):
                                                         "PJB",f)),
                             "Missing %s" % f)
 
+    def test_qcpipeline_with_cellranger_count_scRNA_seq_700(self):
+        """QCPipeline: single cell RNA-seq QC run with 'cellranger count' (v7.0.0)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="7.0.0",
+                                 assert_include_introns=True)
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v2',
+                                           'Library type': 'scRNA-seq' })
+        p.create(top_dir=self.wd)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject("PJB",
+                                          os.path.join(self.wd,"PJB")),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           cellranger_transcriptomes=
+                           { 'human': '/data/refdata-gex-GRCh38-2020-A' },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"10x_scRNAseq")
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.cellranger_version,"7.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-gex-GRCh38-2020-A")
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/_cmdline",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/web_summary.html",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/metrics_summary.csv",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/_cmdline",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/web_summary.html",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/_cmdline",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/web_summary.html",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/metrics_summary.csv",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/_cmdline",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/web_summary.html",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
     def test_qcpipeline_with_cellranger_count_specify_exe(self):
         """QCPipeline: single cell RNA-seq QC run with 'cellranger count' (specify cellranger exe)
         """
@@ -1332,7 +1404,6 @@ class TestQCPipeline(unittest.TestCase):
         MockFastQC.create(os.path.join(self.bin,"fastqc"))
         MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
         MockMultiQC.create(os.path.join(self.bin,"multiqc"))
-        # Mock cellranger 5.0.1 with check on --include-introns
         MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
                                  version="6.0.0",
                                  assert_include_introns=True)
@@ -1392,6 +1463,78 @@ class TestQCPipeline(unittest.TestCase):
                   "cellranger_count/6.0.0/refdata-gex-GRCh38-2020-A/PJB2/_cmdline",
                   "cellranger_count/6.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/web_summary.html",
                   "cellranger_count/6.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    def test_qcpipeline_with_cellranger_count_snRNA_seq_700(self):
+        """QCPipeline: single nuclei RNA-seq QC run with 'cellranger count' (v7.0.0)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="7.0.0",
+                                 assert_include_introns=True)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v2',
+                                           'Library type': 'snRNA-seq' })
+        p.create(top_dir=self.wd)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject("PJB",
+                                          os.path.join(self.wd,"PJB")),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           cellranger_transcriptomes=
+                           { 'human': '/data/refdata-gex-GRCh38-2020-A' },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"10x_snRNAseq")
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.cellranger_version,"7.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-gex-GRCh38-2020-A")
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/_cmdline",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/web_summary.html",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/metrics_summary.csv",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/_cmdline",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/web_summary.html",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/_cmdline",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/web_summary.html",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/metrics_summary.csv",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/_cmdline",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/web_summary.html",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/metrics_summary.csv",
                   "multiqc_report.html"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),


### PR DESCRIPTION
PR which updates the QC pipeline (in `qc/pipeline.py`) to work with Cellranger 7.0.0.

Specifically the main syntactic difference is that the `--include-introns` command line option for `cellranger count` now takes a single argument (either `true` or `false`), whereas for Cellranger 6.1.2 the option took no arguments.

(Cellranger 7.0.0 has a behavioral change in that introns are included by default (i.e. `--include-introns true` is the default) however this doesn't affect the pipeline operation.)