### PR TITLE
Expose 'cellranger count' --force-cells option in QC pipeline

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -628,6 +628,11 @@ def add_run_qc_command(cmdparser):
                    help="assay configuration for 10xGenomics scRNA-seq; if "
                    "set to 'auto' (the default) then cellranger will attempt "
                    "to determine this automatically")
+    p.add_argument("--10x_force_cells",action='store',metavar="N_CELLS",
+                   dest="cellranger_force_cells",default=None,
+                   help="force number of cells for 10xGenomics scRNA-seq and "
+                   "scATAC-seq, overriding automatic cell detection "
+                   "algorithms (default is to use built-in cell detection")
     p.add_argument('--10x_transcriptome',action='append',
                    metavar='ORGANISM=REFERENCE',
                    dest='cellranger_transcriptomes',
@@ -1361,6 +1366,8 @@ def run_qc(args):
                        qc_dir=args.qc_dir,
                        cellranger_chemistry=
                        args.cellranger_chemistry,
+                       cellranger_force_cells=
+                       args.cellranger_force_cells,
                        cellranger_transcriptomes=
                        cellranger_transcriptomes,
                        cellranger_premrna_references=

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -28,6 +28,7 @@ def run_qc(ap,projects=None,fastq_screens=None,
            fastq_screen_subset=100000,nthreads=None,
            runner=None,fastq_dir=None,qc_dir=None,
            cellranger_chemistry='auto',
+           cellranger_force_cells=None,
            cellranger_transcriptomes=None,
            cellranger_premrna_references=None,
            report_html=None,run_multiqc=True,
@@ -67,7 +68,11 @@ def run_qc(ap,projects=None,fastq_screens=None,
         processed (default: 'qc')
       cellranger_chemistry (str): assay configuration for
         10xGenomics scRNA-seq data (set to 'auto' to let cellranger
-        determine this automatically (default: 'auto')
+        determine this automatically; default: 'auto')
+      cellranger_force_cells (int): override cell detection
+        algorithm and set number of cells in 'cellranger' and
+        'cellranger-atac' (set to 'None' to use built-in cell
+        detection; default: 'None')
       cellranger_transcriptomes (dict): mapping of organism names
         to cellranger transcriptome reference data
       cellranger_premrna_references (dict): mapping of organism
@@ -231,6 +236,7 @@ def run_qc(ap,projects=None,fastq_screens=None,
                        cellranger_atac_references=cellranger_atac_references,
                        cellranger_arc_references=cellranger_multiome_references,
                        cellranger_chemistry=cellranger_chemistry,
+                       cellranger_force_cells=cellranger_force_cells,
                        cellranger_jobmode=cellranger_jobmode,
                        cellranger_maxjobs=cellranger_maxjobs,
                        cellranger_mempercore=cellranger_mempercore,

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1776,6 +1776,7 @@ class Mock10xPackageExe:
                platform=None,assert_bases_mask=None,
                assert_include_introns=None,
                assert_chemistry=None,
+               assert_force_cells=None,
                reads=None,multiome_data=None,
                version=None):
         """
@@ -1804,6 +1805,9 @@ class Mock10xPackageExe:
           assert_chemistry (str): if set then
             check that the supplied chemistry
             specification matches this value
+          assert_force_cells (int): if set then
+            check that the '--force-cells' option
+            was specified with this value
           reads (list): list of 'reads' that
             will be created
           multiome_data (str): either 'GEX' or
@@ -1825,6 +1829,7 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
                            assert_bases_mask=%s,
                            assert_include_introns=%s,
                            assert_chemistry=%s,
+                           assert_force_cells=%s,
                            reads=%s,
                            multiome_data=%s,
                            version=%s).main(sys.argv[1:]))
@@ -1839,6 +1844,7 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
                    ("\"%s\"" % assert_chemistry
                     if assert_chemistry is not None
                     else None),
+                   assert_force_cells,
                    reads,
                    ("\"%s\"" % multiome_data
                     if multiome_data is not None
@@ -1858,6 +1864,7 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
                  assert_bases_mask=None,
                  assert_include_introns=None,
                  assert_chemistry=None,
+                 assert_force_cells=None,
                  reads=None,
                  multiome_data=None,
                  version=None):
@@ -1882,6 +1889,7 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
         self._assert_bases_mask = assert_bases_mask
         self._assert_include_introns = assert_include_introns
         self._assert_chemistry = assert_chemistry
+        self._assert_force_cells = assert_force_cells
         self._multiome_data = str(multiome_data).upper()
         if self._package_name == 'cellranger-arc':
             assert self._multiome_data is not None
@@ -2085,6 +2093,7 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
         if self._package_name == "cellranger":
             count.add_argument("--transcriptome",action="store")
             count.add_argument("--chemistry",action="store")
+            count.add_argument("--force-cells",action="store",type=int)
             if version[0] == 7:
                 # Cellranger 7: include introns on by default
                 count.add_argument("--include-introns",
@@ -2102,6 +2111,7 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
             if version[0] >= 2:
                 count.add_argument("--chemistry",choices=['ATAC-v1',
                                                           'ARC-v1'])
+            count.add_argument("--force-cells",action="store",type=int)
         elif self._package_name == "cellranger-arc":
             count.add_argument("--reference",action="store")
             count.add_argument("--libraries",action="store")
@@ -2146,6 +2156,10 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
         if self._assert_chemistry:
             print("Checking chemistry: %s" % args.chemistry)
             assert(args.chemistry == self._assert_chemistry)
+        # Check --force-cells
+        if self._assert_force_cells:
+            print("Checking --force-cells: %s" % args.force_cells)
+            assert(args.force_cells == self._assert_force_cells)
         # Handle commands
         if args.command == "mkfastq":
             ##################

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -199,6 +199,13 @@ if __name__ == "__main__":
                             "scRNA-seq; if set to 'auto' (the default) then "
                             "cellranger will attempt to determine this "
                             "automatically")
+    cellranger.add_argument("--10x_force_cells",action='store',
+                            metavar="N_CELLS",
+                            dest="cellranger_force_cells",
+                            help="force number of cells for 10xGenomics "
+                            "scRNA-seq and scATAC-seq, overriding automatic "
+                            "cell detection algorithms (default is to use "
+                            "built-in cell detection")
     # Conda options
     conda = p.add_argument_group("Conda dependency resolution")
     conda.add_argument('--enable-conda',choices=["yes","no"],
@@ -735,6 +742,8 @@ if __name__ == "__main__":
                        star_indexes=star_indexes,
                        cellranger_chemistry=\
                        args.cellranger_chemistry,
+                       cellranger_force_cells=\
+                       args.cellranger_force_cells,
                        cellranger_transcriptomes=cellranger_transcriptomes,
                        cellranger_premrna_references=\
                        cellranger_premrna_references,


### PR DESCRIPTION
PR which exposes the `--force-cells` option in `cellranger count` and `cellranger-atac count` within the QC pipeline, so that it is possible to specify the number of cells when running single-library analyses (overriding the automatic cell detection algorithms in those packages).

Note that in this implementation currently the same value is applied to all samples (i.e. there is no way to apply different `--force-cells` options to individual samples).

The number of cells can be specified via the command line using the `--10x_force_cells` option in the `run_qc` command, and in the `run_qc.py` utility.