### PR TITLE
Update QC pipeline to use STAR 2.7.7a from conda

### DIFF
--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1489,7 +1489,7 @@ class RunFastqStrand(PipelineTask):
             runner)
           qc_protocol (str): QC protocol to use
         """
-        self.conda("star=2.4.2a",
+        self.conda("star=2.7.7a",
                    "future")
     def setup(self):
         if not self.args.fastq_pairs:


### PR DESCRIPTION
PR which updates the `RunFastqStrand` task in the QC pipeline (in `qc.pipeline`) to require `STAR` version 2.7.7a (previously 2.4.2a was specified) when using `conda` to resolve dependencies.