### PR TITLE
'cellranger mkfastq' needs additional files for NovaSeq data

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -2018,6 +2018,7 @@ class FetchPrimaryData(PipelineTask):
             extra_options=('--copy-links',
                            '--include=*/',
                            '--include=Data/**',
+                           '--include=Recipe/**',
                            '--include=RunInfo.xml',
                            '--include=SampleSheet.csv',
                            '--include=RTAComplete.txt',


### PR DESCRIPTION
PR which fixes a bug in the Fastq generation pipeline (`bcl2fastq/pipeline.py`) when `cellranger mkfastq` is used to handle data from a NovaSeq sequencer.

The fix is to include the `Recipe` subdirectory of the NovaSeq run directory when fetching the primary data (`FetchPrimaryData` task), as CellRanger needs the XML file to handle NovaSeq data,