### PR TITLE
'run_qc' command: enable CellRanger executable to be specified on command line

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     cli/auto_process.py: command line interface for auto_process_ngs
-#     Copyright (C) University of Manchester 2013-2021 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2022 Peter Briggs
 #
 #########################################################################
 #
@@ -622,6 +622,12 @@ def add_run_qc_command(cmdparser):
     p.add_argument('--fastq_dir',action='store',dest='fastq_dir',default=None,
                    help="explicitly specify subdirectory of DIR with "
                    "Fastq files to run the QC on.")
+    p.add_argument('--cellranger',action='store',
+                   metavar='CELLRANGER_EXE',
+                   dest='cellranger_exe',
+                   help="explicitly specify path to Cellranger "
+                   "executable to use for single library "
+                   "analysis (NB will be used for all projects)")
     p.add_argument("--10x_chemistry",
                    choices=sorted(CELLRANGER_ASSAY_CONFIGS.keys()),
                    dest="cellranger_chemistry",default="auto",
@@ -1364,6 +1370,7 @@ def run_qc(args):
                        nthreads=args.nthreads,
                        fastq_dir=args.fastq_dir,
                        qc_dir=args.qc_dir,
+                       cellranger_exe=args.cellranger_exe,
                        cellranger_chemistry=
                        args.cellranger_chemistry,
                        cellranger_force_cells=

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 def run_qc(ap,projects=None,fastq_screens=None,
            fastq_screen_subset=100000,nthreads=None,
            runner=None,fastq_dir=None,qc_dir=None,
+           cellranger_exe=None,
            cellranger_chemistry='auto',
            cellranger_force_cells=None,
            cellranger_transcriptomes=None,
@@ -66,6 +67,9 @@ def run_qc(ap,projects=None,fastq_screens=None,
       qc_dir (str): specify a non-standard directory to write the
         QC outputs to; will be used for all projects that are
         processed (default: 'qc')
+      cellranger_exe (str): explicitly specify path to cellranger
+        executable to use for 10xGenomics projects (default:
+        determine appropriate executable automatically)
       cellranger_chemistry (str): assay configuration for
         10xGenomics scRNA-seq data (set to 'auto' to let cellranger
         determine this automatically; default: 'auto')
@@ -243,6 +247,7 @@ def run_qc(ap,projects=None,fastq_screens=None,
                        cellranger_jobinterval=cellranger_jobinterval,
                        cellranger_localcores=cellranger_localcores,
                        cellranger_localmem=cellranger_localmem,
+                       cellranger_exe=cellranger_exe,
                        log_file=log_file,
                        poll_interval=poll_interval,
                        max_jobs=max_jobs,


### PR DESCRIPTION
PR which adds a new `--cellranger` option to the `run_qc` command (essentially replicating the same option already implemented for the standalone `run_qc.py` utility). This allows the CellRanger executable to be explicitly set at run time, overriding the automatic detection that is used otherwise.