### PR TITLE
Enable specifying Fastqs from additional projects in single library analyses

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -1115,6 +1115,9 @@ class AnalysisProject:
         """
         return bcf_utils.pretty_print_names(self.samples)
 
+    def __repr__(self):
+        return "AnalysisProject(%s)" % self.name
+
 class AnalysisSample:
     """
     Class describing an analysis sample

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -598,22 +598,6 @@ def add_run_qc_command(cmdparser):
                    "where 'pname' specifies a project (or set of "
                    "projects) and 'sname' optionally specifies a sample "
                    "(or set of samples).")
-    p.add_argument('--fastq_screen_subset',action='store',dest='subset',
-                   type=int,default=fastq_screen_subset,
-                   help="specify size of subset of total reads to use for "
-                   "fastq_screen (i.e. --subset option); (default %d, set to "
-                   "0 to use all reads)" % fastq_screen_subset)
-    p.add_argument('-t','--threads',action='store',dest="nthreads",
-                   type=int,default=default_nthreads,
-                   help="number of threads to use for QC script "
-                   "(default: %s)" % ('taken from job runner'
-                                      if not default_nthreads
-                                      else default_nthreads,))
-    p.add_argument('--max-jobs',action='store',
-                   dest='max_jobs',default=max_concurrent_jobs,type=int,
-                   help="explicitly specify maximum number of concurrent QC "
-                   "jobs to run (default %s, change in settings file)"
-                   % max_concurrent_jobs)
     p.add_argument('--qc_dir',action='store',dest='qc_dir',default='qc',
                    help="explicitly specify QC output directory (nb if "
                    "supplied then the same QC_DIR will be used for each "
@@ -622,46 +606,67 @@ def add_run_qc_command(cmdparser):
     p.add_argument('--fastq_dir',action='store',dest='fastq_dir',default=None,
                    help="explicitly specify subdirectory of DIR with "
                    "Fastq files to run the QC on.")
-    p.add_argument('--cellranger',action='store',
-                   metavar='CELLRANGER_EXE',
-                   dest='cellranger_exe',
-                   help="explicitly specify path to Cellranger "
-                   "executable to use for single library "
-                   "analysis (NB will be used for all projects)")
-    p.add_argument("--10x_chemistry",
-                   choices=sorted(CELLRANGER_ASSAY_CONFIGS.keys()),
-                   dest="cellranger_chemistry",default="auto",
-                   help="assay configuration for 10xGenomics scRNA-seq; if "
-                   "set to 'auto' (the default) then cellranger will attempt "
-                   "to determine this automatically")
-    p.add_argument("--10x_force_cells",action='store',metavar="N_CELLS",
-                   dest="cellranger_force_cells",default=None,
-                   help="force number of cells for 10xGenomics scRNA-seq and "
-                   "scATAC-seq, overriding automatic cell detection "
-                   "algorithms (default is to use built-in cell detection")
-    p.add_argument('--10x_transcriptome',action='append',
-                   metavar='ORGANISM=REFERENCE',
-                   dest='cellranger_transcriptomes',
-                   help="specify cellranger transcriptome reference datasets "
-                   "to associate with organisms (overrides references defined "
-                   "in config file)")
-    p.add_argument('--10x_premrna_reference',action='append',
-                   metavar='ORGANISM=REFERENCE',
-                   dest='cellranger_premrna_references',
-                   help="specify cellranger pre-mRNA reference datasets "
-                   "to associate with organisms (overrides references defined "
-                   "in config file)")
-    p.add_argument('--10x_extra_projects',action='store',
-                   metavar="PROJECT_DIRS",
-                   dest="cellranger_extra_projects",
-                   help="specify additional projects to include samples "
-                   "from in single library analyses, as comma-separated "
-                   "list")
-    p.add_argument('--report',action='store',dest='html_file',default=None,
-                   help="file name for output HTML QC report (default: "
-                   "<QC_DIR>_report.html)")
-    add_runner_option(p)
-    add_modulefiles_option(p)
+    # QC pipeline options
+    qc_options = p.add_argument_group('QC options')
+    qc_options.add_argument('--fastq_screen_subset',action='store',
+                            dest='subset',type=int,
+                            default=fastq_screen_subset,
+                            help="specify size of subset of total reads to "
+                            "use for fastq_screen (i.e. --subset option); "
+                            "(default %d, set to 0 to use all reads)" %
+                            fastq_screen_subset)
+    qc_options.add_argument('-t','--threads',action='store',dest="nthreads",
+                            type=int,default=default_nthreads,
+                            help="number of threads to use for QC script "
+                            "(default: %s)" % ('taken from job runner'
+                                               if not default_nthreads
+                                               else default_nthreads,))
+    # Cellranger options
+    cellranger = p.add_argument_group('Cellranger/10xGenomics options')
+    cellranger.add_argument('--cellranger',action='store',
+                            metavar='CELLRANGER_EXE',
+                            dest='cellranger_exe',
+                            help="explicitly specify path to Cellranger "
+                            "executable to use for single library "
+                            "analysis (NB will be used for all projects)")
+    cellranger.add_argument("--10x_chemistry",
+                            choices=sorted(CELLRANGER_ASSAY_CONFIGS.keys()),
+                            dest="cellranger_chemistry",default="auto",
+                            help="assay configuration for 10xGenomics "
+                            "scRNA-seq; if set to 'auto' (the default) "
+                            "then cellranger will attempt to determine "
+                            "this automatically")
+    cellranger.add_argument("--10x_force_cells",action='store',
+                            metavar="N_CELLS",
+                            dest="cellranger_force_cells",default=None,
+                            help="force number of cells for 10xGenomics "
+                            "scRNA-seq and scATAC-seq, overriding automatic "
+                            "cell detection algorithms (default is to use "
+                            "built-in cell detection)")
+    cellranger.add_argument('--10x_extra_projects',action='store',
+                            metavar="PROJECT_DIRS",
+                            dest="cellranger_extra_projects",
+                            help="specify additional projects to include "
+                            "samples from in single library analyses, as "
+                            "comma-separated list")
+    cellranger.add_argument('--10x_transcriptome',action='append',
+                            metavar='ORGANISM=REFERENCE',
+                            dest='cellranger_transcriptomes',
+                            help="specify cellranger transcriptome reference "
+                            "datasets to associate with organisms (overrides "
+                            "references defined in config file)")
+    cellranger.add_argument('--10x_premrna_reference',action='append',
+                            metavar='ORGANISM=REFERENCE',
+                            dest='cellranger_premrna_references',
+                            help="specify cellranger pre-mRNA reference "
+                            "datasets to associate with organisms (overrides "
+                            "references defined in config file)")
+    # Reporting options
+    reporting = p.add_argument_group('Output and reporting')
+    reporting.add_argument('--report',action='store',dest='html_file',
+                           default=None,
+                           help="file name for output HTML QC report "
+                           "(default: <QC_DIR>_report.html)")
     # Conda options
     conda = p.add_argument_group("Conda dependency resolution")
     conda.add_argument('--enable-conda',choices=["yes","no"],
@@ -676,6 +681,12 @@ def add_run_qc_command(cmdparser):
                                           conda_env_dir))
     # Job control options
     job_control = p.add_argument_group("Job control options")
+    job_control.add_argument('-c','--maxcores',type=int,action='store',
+                             dest='max_cores',metavar='NCORES',
+                             default=max_cores,
+                             help="maximum number of cores available for "
+                             "running jobs (default: %s)"
+                             % (max_cores if max_cores else 'no limit'))
     job_control.add_argument('-j','--maxjobs',type=int,action='store',
                              dest="max_jobs",metavar='NJOBS',
                              default=max_concurrent_jobs,
@@ -683,12 +694,6 @@ def add_run_qc_command(cmdparser):
                              "concurrently (default: %s)"
                              % (max_concurrent_jobs
                                 if max_concurrent_jobs else 'no limit'))
-    job_control.add_argument('-c','--maxcores',type=int,action='store',
-                             dest='max_cores',metavar='NCORES',
-                             default=max_cores,
-                             help="maximum number of cores available for "
-                             "running jobs (default: %s)"
-                             % (max_cores if max_cores else 'no limit'))
     job_control.add_argument('-b','--maxbatches',type=int,action='store',
                              dest='max_batches',metavar='NBATCHES',
                              default=__settings.general.max_batches,
@@ -706,6 +711,8 @@ def add_run_qc_command(cmdparser):
                           dest="working_dir",default=None,
                           help="specify the working directory for the "
                           "pipeline operations")
+    add_runner_option(advanced)
+    add_modulefiles_option(advanced)
     add_debug_option(advanced)
     p.add_argument('analysis_dir',metavar="ANALYSIS_DIR",nargs="?",
                    help="auto_process analysis directory (optional: defaults "

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -651,6 +651,12 @@ def add_run_qc_command(cmdparser):
                    help="specify cellranger pre-mRNA reference datasets "
                    "to associate with organisms (overrides references defined "
                    "in config file)")
+    p.add_argument('--10x_extra_projects',action='store',
+                   metavar="PROJECT_DIRS",
+                   dest="cellranger_extra_projects",
+                   help="specify additional projects to include samples "
+                   "from in single library analyses, as comma-separated "
+                   "list")
     p.add_argument('--report',action='store',dest='html_file',default=None,
                    help="file name for output HTML QC report (default: "
                    "<QC_DIR>_report.html)")
@@ -1379,6 +1385,8 @@ def run_qc(args):
                        cellranger_transcriptomes,
                        cellranger_premrna_references=
                        cellranger_premrna_references,
+                       cellranger_extra_projects=
+                       args.cellranger_extra_projects,
                        report_html=args.html_file,
                        runner=runner,
                        max_jobs=args.max_jobs,

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1385,7 +1385,7 @@ def run_qc(args):
                        cellranger_transcriptomes,
                        cellranger_premrna_references=
                        cellranger_premrna_references,
-                       cellranger_extra_projects=
+                       cellranger_extra_project_dirs=
                        args.cellranger_extra_projects,
                        report_html=args.html_file,
                        runner=runner,

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -11,6 +11,7 @@
 
 import os
 import logging
+from ..analysis import AnalysisProject
 from ..command import Command
 from ..qc.pipeline import QCPipeline
 from ..qc.fastq_strand import build_fastq_strand_conf
@@ -32,6 +33,7 @@ def run_qc(ap,projects=None,fastq_screens=None,
            cellranger_force_cells=None,
            cellranger_transcriptomes=None,
            cellranger_premrna_references=None,
+           cellranger_extra_project_dirs=None,
            report_html=None,run_multiqc=True,
            working_dir=None,verbose=None,
            max_jobs=None,max_cores=None,
@@ -81,6 +83,8 @@ def run_qc(ap,projects=None,fastq_screens=None,
         to cellranger transcriptome reference data
       cellranger_premrna_references (dict): mapping of organism
         names to cellranger pre-mRNA reference data
+      cellranger_extra_project_dirs (str): optional list of
+        additional project dirs to use in single library analyses
       report_html (str): specify the name for the output HTML QC
         report (default: '<QC_DIR>_report.html')
       run_multiqc (bool): if True then run MultiQC at the end of
@@ -161,6 +165,11 @@ def run_qc(ap,projects=None,fastq_screens=None,
         if cellranger_arc_reference:
             cellranger_multiome_references[organism] = \
                 cellranger_arc_reference
+    # Extra cellranger projects
+    if cellranger_extra_project_dirs:
+        cellranger_extra_projects = [AnalysisProject(d.strip())
+                                     for d in
+                                     cellranger_extra_project_dirs.split(',')]
     # Legacy FastqScreen naming convention
     legacy_screens = bool(ap.settings.qc.use_legacy_screen_names)
     # Set up runners
@@ -247,6 +256,7 @@ def run_qc(ap,projects=None,fastq_screens=None,
                        cellranger_jobinterval=cellranger_jobinterval,
                        cellranger_localcores=cellranger_localcores,
                        cellranger_localmem=cellranger_localmem,
+                       cellranger_extra_projects=cellranger_extra_projects,
                        cellranger_exe=cellranger_exe,
                        log_file=log_file,
                        poll_interval=poll_interval,

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -170,6 +170,8 @@ def run_qc(ap,projects=None,fastq_screens=None,
         cellranger_extra_projects = [AnalysisProject(d.strip())
                                      for d in
                                      cellranger_extra_project_dirs.split(',')]
+    else:
+        cellranger_extra_projects = None
     # Legacy FastqScreen naming convention
     legacy_screens = bool(ap.settings.qc.use_legacy_screen_names)
     # Set up runners

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1870,10 +1870,12 @@ class CheckCellrangerCountOutputs(PipelineFunctionTask):
             print("No reference data to check against")
             return
         # Collect the sample names with missing outputs
+        samples = set()
         for result in self.result():
             for smpl in result:
                 if not self.args.samples or smpl in self.args.samples:
-                    self.output.samples.append(smpl)
+                    samples.add(smpl)
+        self.output.samples.extend(list(samples))
         if self.output.samples:
             if self.args.verbose:
                 print("Samples with missing outputs from "

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1875,7 +1875,7 @@ class CheckCellrangerCountOutputs(PipelineFunctionTask):
             for smpl in result:
                 if not self.args.samples or smpl in self.args.samples:
                     samples.add(smpl)
-        self.output.samples.extend(list(samples))
+        self.output.samples.extend(sorted(list(samples)))
         if self.output.samples:
             if self.args.verbose:
                 print("Samples with missing outputs from "

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -1395,6 +1395,103 @@ class TestQCPipeline(unittest.TestCase):
                                                         "PJB",f)),
                             "Missing %s" % f)
 
+    def test_qcpipeline_with_cellranger_count_with_extra_project(self):
+        """QCPipeline: single cell RNA-seq QC run with extra project
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="7.0.0",
+                                 assert_include_introns=True)
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v2',
+                                           'Library type': 'scRNA-seq' })
+        p.create(top_dir=self.wd)
+        # Make second mock 10x analysis project
+        p2 = MockAnalysisProject("PJB2",("PJB3_S3_R1_001.fastq.gz",
+                                         "PJB3_S3_R2_001.fastq.gz",
+                                         "PJB4_S4_R1_001.fastq.gz",
+                                         "PJB4_S4_R2_001.fastq.gz",),
+                                 metadata={ 'Organism': 'Human',
+                                            'Single cell platform':
+                                            '10xGenomics Chromium 3\'v2',
+                                            'Library type': 'scRNA-seq' })
+        p2.create(top_dir=self.wd)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject("PJB",
+                                          os.path.join(self.wd,"PJB")),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           cellranger_transcriptomes=
+                           { 'human': '/data/refdata-gex-GRCh38-2020-A' },
+                           cellranger_extra_projects=[
+                               AnalysisProject("PJB2",
+                                               os.path.join(self.wd,"PJB2"))],
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"10x_scRNAseq")
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.cellranger_version,"7.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-gex-GRCh38-2020-A")
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/_cmdline",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/web_summary.html",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/metrics_summary.csv",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/_cmdline",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/web_summary.html",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/metrics_summary.csv",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB3/_cmdline",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB3/outs/web_summary.html",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB3/outs/metrics_summary.csv",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB4/_cmdline",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB4/outs/web_summary.html",
+                  "qc/cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB4/outs/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/_cmdline",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/web_summary.html",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/metrics_summary.csv",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/_cmdline",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/web_summary.html",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/metrics_summary.csv",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB3/_cmdline",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB3/outs/web_summary.html",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB3/outs/metrics_summary.csv",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB4/_cmdline",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB4/outs/web_summary.html",
+                  "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB4/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
     def test_qcpipeline_with_cellranger_count_snRNA_seq_501(self):
         """QCPipeline: single nuclei RNA-seq QC run with 'cellranger count' (v5.0.1)
         """

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -109,3 +109,20 @@ reports can be copied there for sharing using the
    The QC pipeline can be run outside of the ``auto_process``
    pipeline by using the ``run_qc.py`` utility; see the
    section on :doc:`running the QC standalone <run_qc_standalone>`.
+
+------------------
+Additional options
+------------------
+
+For 10xGenomics datasets, the following options can be used to
+override the defaults defined in the configuration:
+
+* ``--cellranger``: explicitly sets the path to the ``cellranger``
+  (or other appropriate 10xGenomics package)
+* ``--10x_force_cells``: explicitly specify the number of cells,
+  overriding automatic cell detection algorithms (i.e. set the
+  ``--force-cells`` option for CellRanger)
+* ``--10x_extra_projects``: specify additional project directories
+  to fetch Fastqs from when running single library analyses (i.e.
+  add the Fastq directory paths for each project to the
+  ``--fastqs`` option for CellRanger)


### PR DESCRIPTION
PR which updates the QC pipeline to allow additional projects to be specified for inclusion in 10x Genomics single library analyses (essentially allowing multiple Fastq directories to be supplied to the `--fastq-dir` option of CellRanger and CellRanger-ATAC).

The PR exposes this functionality to the `run_qc` command via a new `--10x_extra_projects` argument.