### PR TITLE
Enable support for pooled GEX and ATAC datasets in single 10x multiome sequencing run

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -3318,14 +3318,10 @@ class Run10xMkfastq(PipelineTask):
             mkfastq_cmd.add_args('--mask-short-adapter-reads',
                                  self.args.mask_short_adapter_reads)
         if self.pkg == "cellranger-arc":
-            if self.args.filter_single_index is not None:
-                mkfastq_cmd.add_args('--filter-single-index=%s' %
-                                     ('true' if self.args.filter_single_index
-                                      else 'false'))
-            if self.args.filter_dual_index is not None:
-                mkfastq_cmd.add_args('--filter-dual-index=%s' %
-                                     ('true' if self.args.filter_dual_index
-                                      else 'false'))
+            if self.args.filter_single_index:
+                mkfastq_cmd.add_args('--filter-single-index')
+            if self.args.filter_dual_index:
+                mkfastq_cmd.add_args('--filter-dual-index')
         add_cellranger_args(
             mkfastq_cmd,
             jobmode=self.args.jobmode,

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1777,6 +1777,8 @@ class Mock10xPackageExe:
                assert_include_introns=None,
                assert_chemistry=None,
                assert_force_cells=None,
+               assert_filter_single_index=None,
+               assert_filter_dual_index=None,
                reads=None,multiome_data=None,
                version=None):
         """
@@ -1808,6 +1810,16 @@ class Mock10xPackageExe:
           assert_force_cells (int): if set then
             check that the '--force-cells' option
             was specified with this value
+          assert_filter_single_index (bool): if
+            set to True/False then check that
+            the '--filter-single-index' option
+            was/n't supplied (ignored if set to
+            None)
+          assert_filter_dual_index (bool): if
+            set to True/False then check that
+            the '--filter-dual-index' option
+            was/n't supplied (ignored if set to
+            None)
           reads (list): list of 'reads' that
             will be created
           multiome_data (str): either 'GEX' or
@@ -1830,6 +1842,8 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
                            assert_include_introns=%s,
                            assert_chemistry=%s,
                            assert_force_cells=%s,
+                           assert_filter_single_index=%s,
+                           assert_filter_dual_index=%s,
                            reads=%s,
                            multiome_data=%s,
                            version=%s).main(sys.argv[1:]))
@@ -1845,6 +1859,8 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
                     if assert_chemistry is not None
                     else None),
                    assert_force_cells,
+                   assert_filter_single_index,
+                   assert_filter_dual_index,
                    reads,
                    ("\"%s\"" % multiome_data
                     if multiome_data is not None
@@ -1865,6 +1881,8 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
                  assert_include_introns=None,
                  assert_chemistry=None,
                  assert_force_cells=None,
+                 assert_filter_single_index=None,
+                 assert_filter_dual_index=None,
                  reads=None,
                  multiome_data=None,
                  version=None):
@@ -1890,6 +1908,8 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
         self._assert_include_introns = assert_include_introns
         self._assert_chemistry = assert_chemistry
         self._assert_force_cells = assert_force_cells
+        self._assert_filter_single_index = assert_filter_single_index
+        self._assert_filter_dual_index = assert_filter_dual_index
         self._multiome_data = str(multiome_data).upper()
         if self._package_name == 'cellranger-arc':
             assert self._multiome_data is not None
@@ -2062,6 +2082,8 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
         mkfastq.add_argument("--minimum-trimmed-read-length",action="store")
         mkfastq.add_argument("--mask-short-adapter-reads",action="store")
         mkfastq.add_argument("--ignore-dual-index",action="store_true")
+        mkfastq.add_argument("--filter-single-index",action="store_true")
+        mkfastq.add_argument("--filter-dual-index",action="store_true")
         mkfastq.add_argument("--jobmode",action="store")
         mkfastq.add_argument("--localcores",action="store")
         mkfastq.add_argument("--localmem",action="store")
@@ -2160,6 +2182,18 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
         if self._assert_force_cells:
             print("Checking --force-cells: %s" % args.force_cells)
             assert(args.force_cells == self._assert_force_cells)
+        # Check --filter-single-index
+        if self._assert_filter_single_index is not None:
+            print("Checking --filter-single-index: %s" %
+                  args.filter_single_index)
+            assert(args.filter_single_index ==
+                   self._assert_filter_single_index)
+        # Check --filter-dual-index
+        if self._assert_filter_dual_index is not None:
+            print("Checking --filter-dual-index: %s" %
+                  args.filter_dual_index)
+            assert(args.filter_dual_index ==
+                   self._assert_filter_dual_index)
         # Handle commands
         if args.command == "mkfastq":
             ##################

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -5966,6 +5966,198 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_makefastqs_10x_multiome_atac(self):
+        """
+        MakeFastqs: '10x_multiome_atac' protocol
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            bases_mask="y50,I10,I24,y90",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics indices
+        samplesheet_10x_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-GA-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_10x_indices)
+        # Create mock bcl2fastq and cellranger-arc
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,"bcl2fastq"))
+        Mock10xPackageExe.create(os.path.join(self.bin,
+                                              "cellranger-arc"),
+                                 version="2.0.0",
+                                 multiome_data="ATAC",
+                                 assert_bases_mask="Y50,I8n2,Y24,Y90",
+                                 assert_filter_single_index=True)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="10x_multiome_atac")
+        status = p.run(analysis_dir,
+                       poll_interval=POLL_INTERVAL)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_arc_info,
+                         (os.path.join(self.bin,"cellranger-arc"),
+                          "cellranger-arc",
+                          "2.0.0"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html",):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_10x_multiome_gex(self):
+        """
+        MakeFastqs: '10x_multiome_gex' protocol
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            bases_mask="y50,I10,I24,y90",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics indices
+        samplesheet_10x_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-GA-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_10x_indices)
+        # Create mock bcl2fastq and cellranger-arc
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,"bcl2fastq"))
+        Mock10xPackageExe.create(os.path.join(self.bin,
+                                              "cellranger-arc"),
+                                 version="2.0.0",
+                                 multiome_data="GEX",
+                                 assert_bases_mask="Y28n22,I10,I10n14,Y90",
+                                 assert_filter_dual_index=True)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="10x_multiome_gex")
+        status = p.run(analysis_dir,
+                       poll_interval=POLL_INTERVAL)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_arc_info,
+                         (os.path.join(self.bin,"cellranger-arc"),
+                          "cellranger-arc",
+                          "2.0.0"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html",):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
     def test_makefastqs_10x_visium_protocol_110(self):
         """
         MakeFastqs: '10x_visium' protocol (Spaceranger 1.1.0)

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -285,6 +285,58 @@ class TestGetBasesMask10xAtac(unittest.TestCase):
                           get_bases_mask_10x_atac,
                           run_info_xml)
 
+class TestGetBasesMask10xMultiome(unittest.TestCase):
+    """
+    Tests for the 'get_bases_mask_10x_multiome' function
+    """
+    def setUp(self):
+        # Create a temporary working dir
+        self.wd = tempfile.mkdtemp()
+
+    def tearDown(self):
+        # Remove working dir
+        if self.wd is not None:
+            shutil.rmtree(self.wd)
+
+    def test_get_bases_mask_10x_multiome_atac(self):
+        """get_bases_mask_10x_multiome: update bases mask for 'atac'
+        """
+        # Make a single index RunInfo.xml file
+        run_info_xml = os.path.join(self.wd,"RunInfo.xml")
+        with open(run_info_xml,'w') as fp:
+            fp.write(RunInfoXml.create("171020_NB500968_00002_AHGXXXX",
+                                       "y50,I10,I24,y90",4,12))
+        self.assertEqual(get_bases_mask_10x_multiome(run_info_xml,'ATAC'),
+                         "Y50,I8n2,Y24,Y90")
+
+    def test_get_bases_mask_10x_multiome_gex(self):
+        """get_bases_mask_10x_multiome: update bases mask for 'gex'
+        """
+        # Make a single index RunInfo.xml file
+        run_info_xml = os.path.join(self.wd,"RunInfo.xml")
+        with open(run_info_xml,'w') as fp:
+            fp.write(RunInfoXml.create("171020_NB500968_00002_AHGXXXX",
+                                       "y50,I10,I24,y90",4,12))
+        self.assertEqual(get_bases_mask_10x_multiome(run_info_xml,'GEX'),
+                         "Y28n22,I10,I10n14,Y90")
+
+    def test_get_bases_mask_10x_multiome_too_few_reads(self):
+        """get_bases_mask_10x_multiome: exception if not enough reads
+        """
+        # Make a single index RunInfo.xml file
+        run_info_xml = os.path.join(self.wd,"RunInfo.xml")
+        with open(run_info_xml,'w') as fp:
+            fp.write(RunInfoXml.create("171020_NB500968_00002_AHGXXXX",
+                                       "y50,I10,y90",4,12))
+        self.assertRaises(Exception,
+                          get_bases_mask_10x_multiome,
+                          run_info_xml,
+                          'ATAC')
+        self.assertRaises(Exception,
+                          get_bases_mask_10x_multiome,
+                          run_info_xml,
+                          'GEX')
+
 class TestCellrangerInfo(unittest.TestCase):
     """
     Tests for the cellranger_info function

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -484,6 +484,10 @@ Option                                Description
 ``minimum_trimmed_read_length=N``     Set minimum trimmed read length
 ``mask_short_adapter_reads=N``        Set minimum read length below
                                       which sequences are masked
+``tenx_filter_single_index=yes|no``   Set ``--filter-single-index``
+                                      option for ``cellranger-arc``
+``tenx_filter_dual_index=yes|no``     Set ``--filter-dual-index``
+                                      option for ``cellranger-arc``
 ``icell8_well_list=FILE``             Well list file (``icell8`` and
                                       ``icell8_atac`` protocols only)
 ``icell8_atac_swap_i1_and_i2=yes|no`` Turn I1/I2 swapping on or off

--- a/docs/source/using/troubleshooting.rst
+++ b/docs/source/using/troubleshooting.rst
@@ -12,7 +12,6 @@ with suggestions on how to address them:
  * :ref:`troubleshooting-no-adapter-trimming`
  * :ref:`troubleshooting-missing-fastqs-after-demultiplexing`
  * :ref:`troubleshooting-10x-single-index-data-in-dual-index-flowcell`
- * :ref:`troubleshooting-10x-multiome-atac-and-gex-in-same-run`
 
 .. _troubleshooting-incomplete-run:
 
@@ -191,45 +190,3 @@ HISeq instrument alongside standard libraries in other lanes), then
 
 Use the ``--ignore-dual-index`` option to force ``cellranger`` to process
 the data in this case.
-
-.. _troubleshooting-10x-multiome-atac-and-gex-in-same-run:
-
-10xGenomics: Fastq generation for single cell multiome ATAC and GEX in same run
-*******************************************************************************
-
-If Multiome ATAC and Multiome GEX libraries are sequenced together in the
-same run then the standard ``10x_multiome`` protocol of the ``make_fastqs``
-command is unable to correctly process this without additional options.
-
-While this is not a standard configuration and is not officially supported
-by 10x Genomics, they provide information on how to handle this in a
-knowledge base article here:
-
-https://kb.10xgenomics.com/hc/en-us/articles/360049373331-Can-Multiome-ATAC-and-Multiome-GEX-libraries-be-sequenced-together-
-
-Based on this, the following procedure to handle this configuration
-within ``auto-process-ngs`` is suggested:
-
- 1. Ensure that ATAC and GEX data are assigned to separate projects
-    in the input sample sheet
- 2. Use the ``--lanes`` option to explicitly specify the appropriate
-    protocol, bases mask and CellRanger index filter parameters
-    separately for the lanes with the ATAC and GEX samples
-
-For example:
-
-::
-
-   auto_process.py make_fastqs \
-      --lanes=1:10x_multiome:bases_mask=Y50,I8n2,Y24,Y90:tenx_filter_single_index=yes \
-      --lanes=2:10x_multiome:bases_mask=Y28,I10,I10n14,Y90:tenx_filter_dual_index=yes
-
-The exact bases masks strings for each type of data will vary depending
-on the read information in the ``RunInfo.xml`` file for the specific
-run. As a guide:
-
- * For ATAC data bases mask will look like ``Y*,I8n*,Y24,Y*``
- * For GEX data bases mask will look like ``Y28n*,I10,I10n*,Y*``
-
-where ``*`` should be replaced by exact values to ensure that all bases
-in the matching read in ``RunInfo.xml`` are accounted for.


### PR DESCRIPTION
PR which adds support for the `--filter-single-index` and `--filter-dual-index` options of `cellranger-arc`, in order to enable processing of pooled GEX and ATAC 10xGenomics single cell multiome datasets in a single sequencing run.

The issues with pooling these data (along with the workaround) are described in this knowledge base article:
https://kb.10xgenomics.com/hc/en-us/articles/360049373331-Can-Multiome-ATAC-and-Multiome-GEX-libraries-be-sequenced-together-

The options are only available via the `--lanes` option of the `make_fastqs` command, for example:

    auto_process.py make_fastqs --lanes=1:10x_multiome:filter_single_index=yes:bases_mask=Y45,I8,Y24,Y89 ...