### PR TITLE
Skip single library analyses in QC for CellPlex data when config file is absent

### DIFF
--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1873,7 +1873,8 @@ class CheckCellrangerCountOutputs(PipelineFunctionTask):
         samples = set()
         for result in self.result():
             for smpl in result:
-                if not self.args.samples or smpl in self.args.samples:
+                if self.args.samples is None or \
+                   smpl in self.args.samples:
                     samples.add(smpl)
         self.output.samples.extend(sorted(list(samples)))
         if self.output.samples:


### PR DESCRIPTION
PR which addresses issue #795 by updating the QC pipeline (`qc.pipeline`) to explicitly skip single library analyses for all 10x Genomics CellPlex samples when the `10x_multi_config.csv` file is not present.

Without this fix the analyses are run using for all Fastqs i.e. both the gene expression and the multiplex capture data.