### PR TITLE
Fix reporting of sample names for 10x Genomics CellPlex datasets

### DIFF
--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -413,8 +413,20 @@ def report_summary(ap):
             library = project_data['library_type']
             if project_data['single_cell_platform'] is not None:
                 library += " (%s)" % project_data['single_cell_platform']
-            samples = "%d sample%s" % (len(project.samples),
-                                       's' if len(project.samples) != 1 else '')
+            if project.info.library_type == "CellPlex":
+                # Multiplexed samples
+                try:
+                    cellplex_config = CellrangerMultiConfigCsv(
+                        os.path.join(project.dirn,
+                                     "10x_multi_config.csv"))
+                    number_of_samples = len(cellplex_config.sample_names)
+                except FileNotFoundError:
+                    number_of_samples = len(project.samples)
+            else:
+                # Physical samples
+                number_of_samples = len(project.samples)
+            samples = "%d sample%s" % (number_of_samples,
+                                       's' if number_of_samples != 1 else '')
             if project_data['number_of_cells'] is not None:
                 samples += "/%d cell%s" % (
                     int(project_data['number_of_cells']),

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -207,8 +207,20 @@ def report_concise(ap):
     analysis_dir = analysis.AnalysisDir(ap.analysis_dir)
     if analysis_dir.projects:
         for p in analysis_dir.projects:
-            samples = "%d sample%s" % (len(p.samples),
-                                       's' if len(p.samples) != 1
+            if p.info.library_type == "CellPlex":
+                # Multiplexed samples
+                try:
+                    cellplex_config = CellrangerMultiConfigCsv(
+                        os.path.join(p.dirn,
+                                     "10x_multi_config.csv"))
+                    number_of_samples = len(cellplex_config.sample_names)
+                except FileNotFoundError:
+                    number_of_samples = len(p.samples)
+            else:
+                # Physical samples
+                number_of_samples = len(p.samples)
+            samples = "%d sample%s" % (number_of_samples,
+                                       's' if number_of_samples != 1
                                        else '')
             if p.info.number_of_cells is not None:
                 samples += "/%d cell%s" % (p.info.number_of_cells,

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -645,6 +645,8 @@ class CellrangerMultiConfigCsv:
       library
     - fastq_dirs: returns mapping of library names to the
       associated Fastq directory paths
+    - pretty_print_samples: returns a string with a 'nice'
+      description of the multiplexed sample names
     """
     def __init__(self,filen):
         """

--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -41,6 +41,7 @@ from bcftbx.IlluminaData import IlluminaDataError
 from bcftbx.IlluminaData import split_run_name_full
 from bcftbx.TabFile import TabFile
 from bcftbx.utils import find_program
+from bcftbx.utils import pretty_print_names
 from .analysis import locate_project
 from .analysis import split_sample_reference
 from .command import Command
@@ -803,6 +804,17 @@ class CellrangerMultiConfigCsv:
           sample_name (str): name of the sample of interest
         """
         return self._gex_libraries[name]
+
+    def pretty_print_samples(self):
+        """
+        Return string describing the multiplexed sample names
+
+        Wraps a call to 'pretty_print_names' function.
+
+        Returns:
+          String: pretty description of multiplexed sample names.
+        """
+        return pretty_print_names(self.sample_names)
 
 #######################################################################
 # Functions

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -505,7 +505,7 @@ ABM4,CMO304,ABM4
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Generate concise report
         self.assertEqual(report_concise(ap),
-                         "Paired end: 'AB': Alison Bell, Human 10xGenomics Chromium 3'v3 CellPlex (PI: Audrey Bower) (2 samples/1311 cells); 'CDE': Charles David Edwards, Mouse ChIP-seq (PI: Colin Delaney Eccleston) (2 samples)")
+                         "Paired end: 'AB': Alison Bell, Human 10xGenomics Chromium 3'v3 CellPlex (PI: Audrey Bower) (4 samples/1311 cells); 'CDE': Charles David Edwards, Mouse ChIP-seq (PI: Colin Delaney Eccleston) (2 samples)")
 
     def test_report_concise_no_projects(self):
         """report: report run with no projects in 'concise' mode

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -307,9 +307,9 @@ Summary of data in 'bcl2fastq' dir:
   SC Plat.: 10xGenomics Chromium 3'v3
   Organism: Human
   Dir     : AB
-  #samples: 2
+  #samples: 4 multiplexed (2 physical)
   #cells  : 1311
-  Samples : AB1-2
+  Samples : ABM1-4 (AB1-2)
   QC      : not verified
   Comments: None
 

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -717,7 +717,7 @@ Bcl2fastq : bcl2fastq 2.17.1.14
 Cellranger: cellranger 3.0.1
 
 2 projects:
-- 'AB':  Alison Bell           Human CellPlex (10xGenomics Chromium 3'v3) 2 samples/1311 cells (PI Audrey Bower)           
+- 'AB':  Alison Bell           Human CellPlex (10xGenomics Chromium 3'v3) 4 samples/1311 cells (PI Audrey Bower)           
 - 'CDE': Charles David Edwards Mouse ChIP-seq                             2 samples            (PI Colin Delaney Eccleston)
 
 Additional notes/comments:

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -950,7 +950,7 @@ ABM4,CMO304,ABM4
         # Make autoprocess instance and set required metadata
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Generate projects report
-        expected = """MISEQ_170901#87\t87\ttesting\t\tAlison Bell\tAudrey Bower\tCellPlex\t10xGenomics Chromium 3'v3\tHuman\tMISEQ\t2\t1311\tyes\tAB1-2
+        expected = """MISEQ_170901#87\t87\ttesting\t\tAlison Bell\tAudrey Bower\tCellPlex\t10xGenomics Chromium 3'v3\tHuman\tMISEQ\t4\t1311\tyes\tABM1-4
 MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\tChIP-seq\t\tMouse\tMISEQ\t2\t\tyes\tCDE3-4
 """
         for o,e in zip(report_projects(ap).split('\n'),

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -321,6 +321,57 @@ class TestReportConcise(unittest.TestCase):
         self.assertEqual(report_concise(ap),
                          "Paired end: 'AB': Alison Bell, Human ICELL8 scRNA-seq (PI: Audrey Bower) (2 samples/1311 cells); 'CDE': Charles David Edwards, Mouse ChIP-seq (PI: Colin Delaney Eccleston) (2 samples)")
 
+    def test_report_concise_10x_cellplex(self):
+        """report: report 10xGenomics CellPlex run in 'concise' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87, },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "CellPlex",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Single cell platform": "10xGenomics Chromium 3'v3",
+                        "Number of cells": 1311 },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add a cellranger multi config.csv file
+        with open(os.path.join(mockdir.dirn,
+                               "AB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(mockdir.dirn,
+                                     "AB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+AB1,%s,any,AB1,gene expression,
+AB2,%s,any,AB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+ABM1,CMO301,ABM1
+ABM2,CMO302,ABM2
+ABM3,CMO303,ABM3
+ABM4,CMO304,ABM4
+""" % (fastq_dir,fastq_dir))
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate concise report
+        self.assertEqual(report_concise(ap),
+                         "Paired end: 'AB': Alison Bell, Human 10xGenomics Chromium 3'v3 CellPlex (PI: Audrey Bower) (2 samples/1311 cells); 'CDE': Charles David Edwards, Mouse ChIP-seq (PI: Colin Delaney Eccleston) (2 samples)")
+
     def test_report_concise_no_projects(self):
         """report: report run with no projects in 'concise' mode
         """
@@ -457,6 +508,82 @@ Cellranger: cellranger 3.0.1
 2 projects:
 - 'AB':  Alison Bell           Human scRNA-seq (ICELL8) 2 samples/1311 cells (PI Audrey Bower)           
 - 'CDE': Charles David Edwards Mouse ChIP-seq           2 samples            (PI Colin Delaney Eccleston)
+
+Additional notes/comments:
+- CDE: Repeat of previous run
+""" % mockdir.dirn
+        for o,e in zip(report_summary(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
+    def test_report_summary_10x_cellplex(self):
+        """report: report 10xGenomics CellPlex run in 'summary' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "bcl2fastq_software":
+                       "('/usr/bin/bcl2fastq', 'bcl2fastq', '2.17.1.14')",
+                       "cellranger_software":
+                       "('/usr/bin/cellranger', 'cellranger', '3.0.1')",
+                       "sequencer_model": "MiSeq" },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "CellPlex",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Single cell platform": "10xGenomics Chromium 3'v3",
+                        "Number of cells": 1311 },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston",
+                         "Comments": "Repeat of previous run" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add a cellranger multi config.csv file
+        with open(os.path.join(mockdir.dirn,
+                               "AB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(mockdir.dirn,
+                                     "AB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+AB1,%s,any,AB1,gene expression,
+AB2,%s,any,AB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+ABM1,CMO301,ABM1
+ABM2,CMO302,ABM2
+ABM3,CMO303,ABM3
+ABM4,CMO304,ABM4
+""" % (fastq_dir,fastq_dir))
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate summary report
+        expected = """MISEQ run #87 datestamped 170901
+================================
+Run name  : 170901_M00879_0087_000000000-AGEW9
+Reference : MISEQ_170901#87
+Platform  : MISEQ
+Sequencer : MiSeq
+Directory : %s
+Endedness : Paired end
+Bcl2fastq : bcl2fastq 2.17.1.14
+Cellranger: cellranger 3.0.1
+
+2 projects:
+- 'AB':  Alison Bell           Human CellPlex (10xGenomics Chromium 3'v3) 2 samples/1311 cells (PI Audrey Bower)           
+- 'CDE': Charles David Edwards Mouse ChIP-seq                             2 samples            (PI Colin Delaney Eccleston)
 
 Additional notes/comments:
 - CDE: Repeat of previous run
@@ -631,6 +758,64 @@ MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\t
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Generate projects report
         expected = """MISEQ_170901#87\t87\ttesting\t\tAlison Bell\tAudrey Bower\tscRNA-seq\tICELL8\tHuman\tMISEQ\t2\t1311\tyes\tAB1-2
+MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\tChIP-seq\t\tMouse\tMISEQ\t2\t\tyes\tCDE3-4
+"""
+        for o,e in zip(report_projects(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
+    def test_report_projects_10x_cellplex(self):
+        """report: report 10xGenomics CellPlex run in 'projects' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "sequencer_model": "MiSeq" },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "CellPlex",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Single cell platform": "10xGenomics Chromium 3'v3",
+                        "Number of cells": 1311,
+                        "Sequencer model": "MiSeq" },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "MiSeq" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add a cellranger multi config.csv file
+        with open(os.path.join(mockdir.dirn,
+                               "AB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(mockdir.dirn,
+                                     "AB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+AB1,%s,any,AB1,gene expression,
+AB2,%s,any,AB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+ABM1,CMO301,ABM1
+ABM2,CMO302,ABM2
+ABM3,CMO303,ABM3
+ABM4,CMO304,ABM4
+""" % (fastq_dir,fastq_dir))
+        # Make autoprocess instance and set required metadata
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate projects report
+        expected = """MISEQ_170901#87\t87\ttesting\t\tAlison Bell\tAudrey Bower\tCellPlex\t10xGenomics Chromium 3'v3\tHuman\tMISEQ\t2\t1311\tyes\tAB1-2
 MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\tChIP-seq\t\tMouse\tMISEQ\t2\t\tyes\tCDE3-4
 """
         for o,e in zip(report_projects(ap).split('\n'),

--- a/auto_process_ngs/test/test_tenx_genomics.py
+++ b/auto_process_ngs/test/test_tenx_genomics.py
@@ -802,6 +802,8 @@ PBB,CMO302,PBB
                          { 'PJB1_GEX': '/data/runs/fastqs_gex',
                            'PJB2_MC': '/data/runs/fastqs_mc'
                          })
+        self.assertEqual(config_csv.pretty_print_samples(),
+                         "PBA, PBB")
 
     def test_cellranger_multi_config_csv_reduced_fields(self):
         """
@@ -840,3 +842,5 @@ PBB,CMO302
                          { 'PJB1_GEX': '/data/runs/fastqs_gex',
                            'PJB2_MC': '/data/runs/fastqs_mc'
                          })
+        self.assertEqual(config_csv.pretty_print_samples(),
+                         "PBA, PBB")

--- a/docs/source/using/report.rst
+++ b/docs/source/using/report.rst
@@ -118,6 +118,9 @@ Field name                Associated value
 ``organism``              Organism(s) associated with the
                           project
 ``no_of_samples``         Number of samples in the project
+                          (for 10x Genomics CellPlex data
+                          this will be the number of
+                          multiplexed samples)
 ``#samples``              Alias for ``no_of_samples``
 ``no_of_cells``           Number of cells in the project,
                           for single-cell projects
@@ -126,6 +129,9 @@ Field name                Associated value
                           ``no`` if it was single-end
 ``sample_names``          Comma-separated list of sample
                           names associated with the project
+                          (for 10x Genomics CellPlex data
+                          this will be the names of the
+                          multiplexed samples)
 ``samples``               Alias for ``sample_names``
 ``null``                  Writes an empty field
 ========================= ========================


### PR DESCRIPTION
PR which addresses issue #796 by updating the `report` command to report multiplexed samples from 10x Genomics CellPlex data.

For these data, the number and names of the multiplexed samples (rather than of the "physical" samples) from the `10x_multi_config.csv` file will be reported. If this file is absent then the fallback is to report the physical samples instead.