### PR TITLE
tenx_genomics_utils: fix broken version checking in the 'AtacSummary' class

### DIFF
--- a/auto_process_ngs/tenx_genomics_utils.py
+++ b/auto_process_ngs/tenx_genomics_utils.py
@@ -51,6 +51,7 @@ from .docwriter import Document
 from .docwriter import List
 from .docwriter import Link
 from .docwriter import Table
+from .utils import parse_version
 from .bcl2fastq.utils import get_bases_mask
 from . import css_rules
 
@@ -282,7 +283,7 @@ class AtacSummary(MetricsSummary):
         Only supported for Cellranger ATAC < 2.0.0; raises
         AttributeError otherwise.
         """
-        if self.version != "2.0.0":
+        if parse_version(self.version) < parse_version("2.0.0"):
             # Only supported for pre-2.0.0
             return self.fetch('cells_detected')
         else:
@@ -296,7 +297,7 @@ class AtacSummary(MetricsSummary):
         Only supported for Cellranger ATAC < 2.0.0; raises
         AttributeError otherwise.
         """
-        if self.version != "2.0.0":
+        if parse_version(self.version) < parse_version("2.0.0"):
             # Only supported for pre-2.0.0
             return self.fetch('annotated_cells')
         else:
@@ -310,8 +311,8 @@ class AtacSummary(MetricsSummary):
         Only supported for Cellranger ATAC < 2.0.0; raises
         AttributeError otherwise.
         """
-        if self.version == "2.0.0":
-            # Only supported for 2.0.0
+        if parse_version(self.version) >= parse_version("2.0.0"):
+            # Only supported for 2.0.0 and later
             return self.fetch('Estimated number of cells')
         else:
             # Not supported


### PR DESCRIPTION
PR which fixes the version comparisons in methods/properties of the `AtacSummary` class (in the `tenx_genomics_utils` module), when checking if the summary file was from a Cellranger ATAC version older or newer than version 2.0.0.

Previously the check did a simple-minded string comparison on the version against the string `"2.0.0"`, but this didn't work e.g for version 2.1.0. The updated code uses the `parse_version` function from the `utils` module to perform a more robust comparison.