### PR TITLE
auto-process-ngs version 0.31.0

### DIFF
--- a/auto_process_ngs/__init__.py
+++ b/auto_process_ngs/__init__.py
@@ -1,5 +1,5 @@
 # Current version of the library
-__version__ = '0.30.1'
+__version__ = '0.31.0'
 
 def get_version():
     """Returns a string with the current version of the library (e.g., "0.2.0")


### PR DESCRIPTION
PR to create version 0.31.0.

NB this fixes the version bump in PR #800, which erroneously bumped the version to `0.30.1`.