### PR TITLE
Update QC pipeline to operate based on "QC modules" defined in protocols

### DIFF
--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -1748,7 +1748,7 @@ def check_fastqc_outputs(project,qc_dir,read_numbers=None):
     return sorted(list(fastqs))
 
 def check_fastq_strand_outputs(project,qc_dir,fastq_strand_conf,
-                               qc_protocol=None):
+                               read_numbers=None):
     """
     Return Fastqs missing QC outputs from fastq_strand.py
 
@@ -1767,9 +1767,8 @@ def check_fastq_strand_outputs(project,qc_dir,fastq_strand_conf,
         included unless the path is `None` or the
         config file doesn't exist. Relative path is
         assumed to be a subdirectory of the project
-      qc_protocol (str): QC protocol to predict outputs
-        for; if not set then defaults to standard QC
-        based on ended-ness
+      read_numbers (list): read numbers to predict
+        outputs for
 
     Returns:
       List: list of Fastq file "pairs" with missing
@@ -1788,14 +1787,16 @@ def check_fastq_strand_outputs(project,qc_dir,fastq_strand_conf,
     if not os.path.exists(fastq_strand_conf):
         # No conf file, nothing to check
         return list()
-    read_numbers = get_read_numbers(qc_protocol).seq_data
     fastq_pairs = set()
     for fq_group in group_fastqs_by_name(
             remove_index_fastqs(project.fastqs,
                                 project.fastq_attrs),
             fastq_attrs=project.fastq_attrs):
         # Assemble Fastq pairs based on read numbers
-        fq_pair = tuple([fq_group[r-1] for r in read_numbers])
+        if read_numbers:
+            fq_pair = tuple([fq_group[r-1] for r in read_numbers])
+        else:
+            fq_pair = tuple([fq_group[0]])
         # Strand stats output
         output = os.path.join(qc_dir,
                               fastq_strand_output(fq_pair[0]))

--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -52,7 +52,6 @@ from .fastq_screen import Fastqscreen
 from .fastq_strand import Fastqstrand
 from .cellranger import CellrangerCount
 from .cellranger import CellrangerMulti
-from .protocols import get_read_numbers
 from .seqlens import SeqLens
 
 # Module specific logger

--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -1670,7 +1670,7 @@ def cellranger_multi_output(project,config_csv,sample_name=None,
         outputs.append(os.path.join(multi_analysis_dir,f))
     return tuple(outputs)
 
-def check_fastq_screen_outputs(project,qc_dir,screen,qc_protocol=None,
+def check_fastq_screen_outputs(project,qc_dir,screen,read_numbers=None,
                                legacy=False):
     """
     Return Fastqs missing QC outputs from FastqScreen
@@ -1686,9 +1686,9 @@ def check_fastq_screen_outputs(project,qc_dir,screen,qc_protocol=None,
         path is assumed to be a subdirectory of the
         project)
       screen (str): screen name to check
-      qc_protocol (str): QC protocol to predict outputs
-        for; if not set then defaults to standard QC
-        based on ended-ness
+      read_numbers (list): read numbers to define Fastqs
+        to predict outputs for; if not set then all
+        non-index reads will be included
       legacy (bool): if True then check for 'legacy'-style
          names (defult: False)
 
@@ -1700,8 +1700,8 @@ def check_fastq_screen_outputs(project,qc_dir,screen,qc_protocol=None,
     fastqs = set()
     for fastq in remove_index_fastqs(project.fastqs,
                                      project.fastq_attrs):
-        read_numbers = get_read_numbers(qc_protocol).seq_data
-        if project.fastq_attrs(fastq).read_number not in read_numbers:
+        if read_numbers and \
+           project.fastq_attrs(fastq).read_number not in read_numbers:
             # Ignore non-data reads
             continue
         for output in [os.path.join(qc_dir,f)

--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -1711,7 +1711,7 @@ def check_fastq_screen_outputs(project,qc_dir,screen,read_numbers=None,
                 fastqs.add(fastq)
     return sorted(list(fastqs))
 
-def check_fastqc_outputs(project,qc_dir,qc_protocol=None):
+def check_fastqc_outputs(project,qc_dir,read_numbers=None):
     """
     Return Fastqs missing QC outputs from FastQC
 
@@ -1725,9 +1725,8 @@ def check_fastqc_outputs(project,qc_dir,qc_protocol=None):
       qc_dir (str): path to the QC directory (relative
         path is assumed to be a subdirectory of the
         project)
-      qc_protocol (str): QC protocol to predict outputs
-        for; if not set then defaults to standard QC
-        based on ended-ness
+      read_numbers (list): read numbers to predict
+        outputs for
 
     Returns:
       List: list of Fastq files with missing outputs.
@@ -1737,8 +1736,8 @@ def check_fastqc_outputs(project,qc_dir,qc_protocol=None):
     fastqs = set()
     for fastq in remove_index_fastqs(project.fastqs,
                                      project.fastq_attrs):
-        read_numbers = get_read_numbers(qc_protocol).qc
-        if project.fastq_attrs(fastq).read_number not in read_numbers:
+        if read_numbers and \
+           project.fastq_attrs(fastq).read_number not in read_numbers:
             # Ignore non-QC reads
             continue
         # FastQC outputs

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -502,7 +502,7 @@ class QCPipeline(Pipeline):
                     project,
                     qc_dir,
                     setup_fastq_strand_conf.output.fastq_strand_conf,
-                    qc_protocol=qc_protocol,
+                    read_numbers=read_numbers.seq_data,
                     verbose=self.params.VERBOSE
                 )
                 self.add_task(check_fastq_strand,
@@ -1651,7 +1651,7 @@ class CheckFastqStrandOutputs(PipelineFunctionTask):
     Check the outputs from the fastq_strand.py utility
     """
     def init(self,project,qc_dir,fastq_strand_conf,
-             qc_protocol=None,verbose=False):
+             read_numbers=None,verbose=False):
         """
         Initialise the CheckFastqStrandOutputs task.
 
@@ -1662,7 +1662,8 @@ class CheckFastqStrandOutputs(PipelineFunctionTask):
             to subdirectory 'qc' of project directory)
           fastq_strand_conf (str): path to the fastq_strand
             config file
-          qc_protocol (str): QC protocol to use
+          read_numbers (list): list of read numbers to
+            include when checking outputs
           verbose (bool): if True then print additional
             information from the task
 
@@ -1685,7 +1686,7 @@ class CheckFastqStrandOutputs(PipelineFunctionTask):
                       self.args.project,
                       self.args.qc_dir,
                       fastq_strand_conf,
-                      qc_protocol=self.args.qc_protocol)
+                      read_numbers=self.args.read_numbers)
     def finish(self):
         for result in self.result():
             self.output.fastq_pairs.extend(result)

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -456,7 +456,7 @@ class QCPipeline(Pipeline):
                     project_name,
                     project,
                     qc_dir,
-                    qc_protocol=qc_protocol,
+                    read_numbers=read_numbers.qc,
                     verbose=self.params.VERBOSE
                 )
                 self.add_task(check_fastqc,
@@ -1480,7 +1480,7 @@ class CheckFastQCOutputs(PipelineFunctionTask):
     """
     Check the outputs from FastQC
     """
-    def init(self,project,qc_dir,qc_protocol,verbose=False):
+    def init(self,project,qc_dir,read_numbers,verbose=False):
         """
         Initialise the CheckFastQCOutputs task.
 
@@ -1489,6 +1489,8 @@ class CheckFastQCOutputs(PipelineFunctionTask):
             QC for
           qc_dir (str): directory for QC outputs (defaults
             to subdirectory 'qc' of project directory)
+          read_numbers (list): list of read numbers to
+            include
           qc_protocol (str): QC protocol to use
           verbose (bool): if True then print additional
             information from the task
@@ -1505,7 +1507,7 @@ class CheckFastQCOutputs(PipelineFunctionTask):
                       check_fastqc_outputs,
                       self.args.project,
                       self.args.qc_dir,
-                      self.args.qc_protocol)
+                      self.args.read_numbers)
     def finish(self):
         fastqs = set()
         for result in self.result():

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -510,6 +510,12 @@ class QCPipeline(Pipeline):
                 except KeyError:
                     set_metadata = True
 
+                # Whether to set cell count
+                try:
+                    set_cell_count = qc_module_params['set_cell_count']
+                except KeyError:
+                    set_cell_count = True
+
                 # Run cellranger* count
                 run_cellranger_count = self.add_cellranger_count(
                     project_name,
@@ -537,7 +543,8 @@ class QCPipeline(Pipeline):
                         run_cellranger_count.output.cellranger_refdata
                     update_qc_metadata.requires(run_cellranger_count)
 
-                    # Set cell count
+                # Set cell count
+                if set_cell_count:
                     set_cellranger_cell_count = \
                         SetCellCountFromCellrangerCount(
                             "%s: set cell count from single library analysis" %

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -93,10 +93,12 @@ from .outputs import check_cellranger_atac_count_outputs
 from .outputs import check_cellranger_arc_count_outputs
 from .picard import CollectInsertSizeMetrics
 from .protocols import determine_qc_protocol
+from .protocols import fetch_protocol_definition
 from .protocols import get_read_numbers
 from .rseqc import InferExperiment
 from .utils import get_bam_basename
 from .utils import set_cell_count_for_project
+from .verification import parse_qc_module_spec
 from .verification import verify_project
 from .fastq_strand import build_fastq_strand_conf
 from .seqlens import get_sequence_lengths
@@ -207,6 +209,9 @@ class QCPipeline(Pipeline):
         if qc_protocol is None:
             qc_protocol = determine_qc_protocol(project)
 
+        # Fetch the QC modules and read data
+        reads,qc_modules = fetch_protocol_definition(qc_protocol)
+
         # Clone the supplied project
         project = copy_analysis_project(project,fastq_dir=fastq_dir)
 
@@ -228,13 +233,17 @@ class QCPipeline(Pipeline):
             organism = project.info.organism
 
         # Report details
-        self.report("-- Protocol  : %s" % qc_protocol)
-        self.report("-- Directory : %s" % project.dirn)
-        self.report("-- Fastqs dir: %s" % project.fastq_dir)
-        self.report("-- QC dir    : %s" % qc_dir)
-        self.report("-- Library   : %s" % project.info.library_type)
-        self.report("-- Organism  : %s" % organism)
-        self.report("-- Report    : %s" % report_html)
+        self.report("-- Protocol   : %s" % qc_protocol)
+        self.report("-- Directory  : %s" % project.dirn)
+        self.report("-- Fastqs dir : %s" % project.fastq_dir)
+        self.report("-- QC dir     : %s" % qc_dir)
+        self.report("-- Library    : %s" % project.info.library_type)
+        self.report("-- SC platform: %s" % project.info.single_cell_platform)
+        self.report("-- Organism   : %s" % organism)
+        self.report("-- Report     : %s" % report_html)
+        self.report("QC modules :")
+        for qc_module in qc_modules:
+            self.report("-- %s" % qc_module)
 
         ####################
         # Build the pipeline
@@ -302,316 +311,335 @@ class QCPipeline(Pipeline):
                       envmodules=self.envmodules['report_qc'],
                       log_dir=log_dir)
 
-        # Get Fastq sequence length statistics
-        get_seq_lengths = GetSeqLengthStats(
-            "%s: get sequence length statistics" %
-            project_name,
-            project,
-            qc_dir,
-            qc_protocol=qc_protocol,
-            fastq_attrs=project.fastq_attrs)
-        self.add_task(get_seq_lengths,
-                      requires=(setup_qc_dirs,),
-                      runner=self.runners['fastqc_runner'],
-                      log_dir=log_dir)
-        verify_qc.requires(get_seq_lengths)
+        ################
+        # Add QC modules
+        ################
 
-        # Check outputs for FastqScreen
-        check_fastq_screen = CheckFastqScreenOutputs(
-            "%s: check FastqScreen outputs" %
-            project_name,
-            project,
-            qc_dir,
-            self.params.fastq_screens,
-            qc_protocol=qc_protocol,
-            legacy=self.params.legacy_screens,
-            verbose=self.params.VERBOSE
-        )
-        self.add_task(check_fastq_screen,
-                      requires=(setup_qc_dirs,),
-                      runner=self.runners['verify_runner'],
-                      log_dir=log_dir)
+        for qc_module in qc_modules:
 
-        # Run FastqScreen
-        run_fastq_screen = RunFastqScreen(
-            "%s: FastqScreen" % project_name,
-            check_fastq_screen.output.fastqs,
-            qc_dir,
-            self.params.fastq_screens,
-            subset=self.params.fastq_subset,
-            nthreads=self.params.nthreads,
-            qc_protocol=qc_protocol,
-            fastq_attrs=project.fastq_attrs,
-            legacy=self.params.legacy_screens
-        )
-        self.add_task(run_fastq_screen,
-                      requires=(check_fastq_screen,),
-                      runner=self.runners['fastq_screen_runner'],
-                      envmodules=self.envmodules['fastq_screen'],
-                      log_dir=log_dir)
-        qc_metadata['fastq_screens'] = self.params.fastq_screens
-        qc_metadata['legacy_screens'] = self.params.legacy_screens
-        verify_qc.requires(run_fastq_screen)
+            qc_module_name,qc_module_params = parse_qc_module_spec(qc_module)
 
-        # Check outputs for FastQC
-        check_fastqc = CheckFastQCOutputs(
-            "%s: check FastQC outputs" %
-            project_name,
-            project,
-            qc_dir,
-            qc_protocol=qc_protocol,
-            verbose=self.params.VERBOSE
-        )
-        self.add_task(check_fastqc,
-                      requires=(setup_qc_dirs,),
-                      runner=self.runners['verify_runner'],
-                      log_dir=log_dir)
+            ##################################
+            # Fastq sequence length statistics
+            ##################################
+            if qc_module_name == 'sequence_lengths':
+                get_seq_lengths = GetSeqLengthStats(
+                    "%s: get sequence length statistics" %
+                    project_name,
+                    project,
+                    qc_dir,
+                    qc_protocol=qc_protocol,
+                    fastq_attrs=project.fastq_attrs)
+                self.add_task(get_seq_lengths,
+                              requires=(setup_qc_dirs,),
+                              runner=self.runners['fastqc_runner'],
+                              log_dir=log_dir)
+                verify_qc.requires(get_seq_lengths)
 
-        # Run FastqQC
-        run_fastqc = RunFastQC(
-            "%s: FastQC" % project_name,
-            check_fastqc.output.fastqs,
-            qc_dir,
-            nthreads=self.params.nthreads
-        )
-        self.add_task(run_fastqc,
-                      requires=(check_fastqc,),
-                      runner=self.runners['fastqc_runner'],
-                      envmodules=self.envmodules['fastqc'],
-                      log_dir=log_dir)
-        verify_qc.requires(run_fastqc)
+            #############
+            # FastqScreen
+            #############
+            if qc_module_name == 'fastq_screen':
+                # Check outputs for FastqScreen
+                check_fastq_screen = CheckFastqScreenOutputs(
+                    "%s: check FastqScreen outputs" %
+                    project_name,
+                    project,
+                    qc_dir,
+                    self.params.fastq_screens,
+                    qc_protocol=qc_protocol,
+                    legacy=self.params.legacy_screens,
+                    verbose=self.params.VERBOSE
+                )
+                self.add_task(check_fastq_screen,
+                              requires=(setup_qc_dirs,),
+                              runner=self.runners['verify_runner'],
+                              log_dir=log_dir)
 
-        # Set up fastq_strand.conf file
-        setup_fastq_strand_conf = SetupFastqStrandConf(
-            "%s: conf file for strandedness (fastq_strand)" %
-            project_name,
-            project,
-            qc_dir=qc_dir,
-            organism=organism,
-            star_indexes=self.params.star_indexes
-        )
-        self.add_task(setup_fastq_strand_conf,
-                      requires=(setup_qc_dirs,),
-                      log_dir=log_dir)
+                # Run FastqScreen
+                run_fastq_screen = RunFastqScreen(
+                    "%s: FastqScreen" % project_name,
+                    check_fastq_screen.output.fastqs,
+                    qc_dir,
+                    self.params.fastq_screens,
+                    subset=self.params.fastq_subset,
+                    nthreads=self.params.nthreads,
+                    qc_protocol=qc_protocol,
+                    fastq_attrs=project.fastq_attrs,
+                    legacy=self.params.legacy_screens
+                )
+                self.add_task(run_fastq_screen,
+                              requires=(check_fastq_screen,),
+                              runner=self.runners['fastq_screen_runner'],
+                              envmodules=self.envmodules['fastq_screen'],
+                              log_dir=log_dir)
+                qc_metadata['fastq_screens'] = self.params.fastq_screens
+                qc_metadata['legacy_screens'] = self.params.legacy_screens
+                verify_qc.requires(run_fastq_screen)
 
-        # Check outputs for fastq_strand.py
-        check_fastq_strand = CheckFastqStrandOutputs(
-            "%s: check strandedness outputs (fastq_strand)" %
-            project_name,
-            project,
-            qc_dir,
-            setup_fastq_strand_conf.output.fastq_strand_conf,
-            qc_protocol=qc_protocol,
-            verbose=self.params.VERBOSE
-        )
-        self.add_task(check_fastq_strand,
-                      requires=(setup_fastq_strand_conf,),
-                      runner=self.runners['verify_runner'],
-                      log_dir=log_dir)
+            ########
+            # FastQC
+            ########
+            if qc_module_name == 'fastqc':
+                # Check outputs for FastQC
+                check_fastqc = CheckFastQCOutputs(
+                    "%s: check FastQC outputs" %
+                    project_name,
+                    project,
+                    qc_dir,
+                    qc_protocol=qc_protocol,
+                    verbose=self.params.VERBOSE
+                )
+                self.add_task(check_fastqc,
+                              requires=(setup_qc_dirs,),
+                              runner=self.runners['verify_runner'],
+                              log_dir=log_dir)
 
-        # Run fastq_strand.py
-        run_fastq_strand = RunFastqStrand(
-            "%s: strandedness (fastq_strand.py)" %
-            project_name,
-            check_fastq_strand.output.fastq_pairs,
-            qc_dir,
-            setup_fastq_strand_conf.output.fastq_strand_conf,
-            fastq_strand_subset=self.params.fastq_subset,
-            nthreads=self.params.nthreads,
-            qc_protocol=qc_protocol
-        )
-        self.add_task(run_fastq_strand,
-                      requires=(check_fastq_strand,),
-                      runner=self.runners['star_runner'],
-                      envmodules=self.envmodules['fastq_strand'],
-                      log_dir=log_dir)
-        verify_qc.requires(run_fastq_strand)
+                # Run FastqQC
+                run_fastqc = RunFastQC(
+                    "%s: FastQC" % project_name,
+                    check_fastqc.output.fastqs,
+                    qc_dir,
+                    nthreads=self.params.nthreads
+                )
+                self.add_task(run_fastqc,
+                              requires=(check_fastqc,),
+                              runner=self.runners['fastqc_runner'],
+                              envmodules=self.envmodules['fastqc'],
+                              log_dir=log_dir)
+                verify_qc.requires(run_fastqc)
 
-        if qc_protocol in ("10x_scRNAseq",
-                           "10x_snRNAseq",
-                           "10x_scATAC",
-                           "10x_Multiome_ATAC",
-                           "10x_Multiome_GEX",):
-            # Run cellranger* count
-            run_cellranger_count = self.add_cellranger_count(
-                project_name,
-                project,
-                qc_dir,
-                organism,
-                fastq_dir,
-                qc_protocol,
-                chemistry=self.params.cellranger_chemistry,
-                force_cells=self.params.cellranger_force_cells,
-                reference_dataset=self.params.cellranger_reference_dataset,
-                extra_projects=self.params.cellranger_extra_projects,
-                log_dir=log_dir,
-                required_tasks=(setup_qc_dirs,))
+            ##############
+            # Fastq_strand
+            ##############
+            if qc_module_name == 'strandedness':
+                # Set up fastq_strand.conf file
+                setup_fastq_strand_conf = SetupFastqStrandConf(
+                    "%s: conf file for strandedness (fastq_strand)" %
+                    project_name,
+                    project,
+                    qc_dir=qc_dir,
+                    organism=organism,
+                    star_indexes=self.params.star_indexes
+                )
+                self.add_task(setup_fastq_strand_conf,
+                              requires=(setup_qc_dirs,),
+                              log_dir=log_dir)
 
-            # Update metadata
-            qc_metadata['cellranger_version'] = \
-                    run_cellranger_count.output.cellranger_version
-            qc_metadata['cellranger_refdata'] = \
-                    run_cellranger_count.output.cellranger_refdata
-            update_qc_metadata.requires(run_cellranger_count)
+                # Check outputs for fastq_strand.py
+                check_fastq_strand = CheckFastqStrandOutputs(
+                    "%s: check strandedness outputs (fastq_strand)" %
+                    project_name,
+                    project,
+                    qc_dir,
+                    setup_fastq_strand_conf.output.fastq_strand_conf,
+                    qc_protocol=qc_protocol,
+                    verbose=self.params.VERBOSE
+                )
+                self.add_task(check_fastq_strand,
+                              requires=(setup_fastq_strand_conf,),
+                              runner=self.runners['verify_runner'],
+                              log_dir=log_dir)
 
-            # Set cell count
-            set_cellranger_cell_count = SetCellCountFromCellrangerCount(
-                "%s: set cell count from single library analysis" %
-                project_name,
-                project,
-                qc_dir
-            )
-            self.add_task(set_cellranger_cell_count,
-                          requires=(run_cellranger_count,
-                                    update_qc_metadata),)
-            verify_qc.requires(set_cellranger_cell_count)
+                # Run fastq_strand.py
+                run_fastq_strand = RunFastqStrand(
+                    "%s: strandedness (fastq_strand.py)" %
+                    project_name,
+                    check_fastq_strand.output.fastq_pairs,
+                    qc_dir,
+                    setup_fastq_strand_conf.output.fastq_strand_conf,
+                    fastq_strand_subset=self.params.fastq_subset,
+                    nthreads=self.params.nthreads,
+                    qc_protocol=qc_protocol
+                )
+                self.add_task(run_fastq_strand,
+                              requires=(check_fastq_strand,),
+                              runner=self.runners['star_runner'],
+                              envmodules=self.envmodules['fastq_strand'],
+                              log_dir=log_dir)
+                verify_qc.requires(run_fastq_strand)
 
-            # Extra protocols for multiome
-            if qc_protocol == "10x_Multiome_ATAC":
-                # See https://kb.10xgenomics.com/hc/en-us/articles/360061165691
-                # Need to set the chemistry to indicate it's
-                # multiome ATAC data
+            #############################
+            # 10x single library analysis
+            #############################
+            if qc_module_name in ('cellranger_count',
+                                  'cellranger-atac_count',
+                                  'cellranger-arc_count',):
+                # Set library type
+                try:
+                    library_type = qc_module_params['library']
+                except KeyError:
+                    library_type = project.info.library_type
+
+                # Set chemistry
+                try:
+                    chemistry = qc_module_params['chemistry']
+                except KeyError:
+                    chemistry = self.params.cellranger_chemistry
+
+                # Locate 'cellranger multi' config.csv file
+                # if required
+                try:
+                    cellranger_use_multi_config = \
+                        qc_module_params['cellranger_use_multi_config']
+                except KeyError:
+                    cellranger_use_multi_config = False
+                if cellranger_use_multi_config:
+                    get_cellranger_multi_config = GetCellrangerMultiConfig(
+                        "%s: get config file for 'cellranger multi'" %
+                        project_name,
+                        project,
+                        qc_dir
+                    )
+                    self.add_task(get_cellranger_multi_config,
+                                  requires=(setup_qc_dirs,),
+                                  log_dir=log_dir)
+                    samples = get_cellranger_multi_config.output.gex_libraries
+                    fastq_dirs = get_cellranger_multi_config.output.fastq_dirs
+                    reference_dataset = \
+                        get_cellranger_multi_config.output.reference_data_path
+                else:
+                    samples = None
+                    fastq_dirs = None
+                    reference_dataset = \
+                        self.params.cellranger_reference_dataset
+
+                # Whether to set metadata
+                try:
+                    set_metadata = qc_module_params['set_metadata']
+                except KeyError:
+                    set_metadata = True
+
+                # Run cellranger* count
                 run_cellranger_count = self.add_cellranger_count(
                     project_name,
                     project,
                     qc_dir,
                     organism,
                     fastq_dir,
-                    qc_protocol="10x_scATAC",
-                    chemistry="ARC-v1",
+                    qc_module_name,
+                    library_type=library_type,
+                    chemistry=chemistry,
                     force_cells=self.params.cellranger_force_cells,
-                    reference_dataset=\
-                    self.params.cellranger_reference_dataset,
+                    reference_dataset=reference_dataset,
+                    samples=samples,
+                    fastq_dirs=fastq_dirs,
+                    extra_projects=self.params.cellranger_extra_projects,
                     log_dir=log_dir,
                     required_tasks=(setup_qc_dirs,))
                 verify_qc.requires(run_cellranger_count)
 
-            elif qc_protocol == "10x_Multiome_GEX":
-                # See https://kb.10xgenomics.com/hc/en-us/articles/360059656912
-                # Need to set the chemistry to indicate it's
-                # multiome snRNA-seq data
-                run_cellranger_count = self.add_cellranger_count(
+                # Update metadata
+                if set_metadata:
+                    qc_metadata['cellranger_version'] = \
+                        run_cellranger_count.output.cellranger_version
+                    qc_metadata['cellranger_refdata'] = \
+                        run_cellranger_count.output.cellranger_refdata
+                    update_qc_metadata.requires(run_cellranger_count)
+
+                    # Set cell count
+                    set_cellranger_cell_count = \
+                        SetCellCountFromCellrangerCount(
+                            "%s: set cell count from single library analysis" %
+                            project_name,
+                            project,
+                            qc_dir
+                        )
+                    self.add_task(set_cellranger_cell_count,
+                                  requires=(run_cellranger_count,
+                                            update_qc_metadata),)
+                    verify_qc.requires(set_cellranger_cell_count)
+
+            ################################
+            # 10x cell multiplexing analysis
+            ################################
+            if qc_module_name == "cellranger_multi":
+
+                # Tasks 'check_cellranger_multi' depends on
+                check_cellranger_multi_requires = []
+
+                # Locate cellranger
+                required_cellranger = DetermineRequired10xPackage(
+                    "%s: determine required 'cellranger' package" %
+                    project_name,
+                    qc_module_name,
+                    self.params.cellranger_exe)
+                self.add_task(required_cellranger)
+
+                get_cellranger = Get10xPackage(
+                    "%s: get information on cellranger" % project_name,
+                    require_package=\
+                    required_cellranger.output.require_cellranger)
+                self.add_task(get_cellranger,
+                              requires=(required_cellranger,),
+                              envmodules=self.envmodules['cellranger'])
+                check_cellranger_multi_requires.append(get_cellranger)
+                qc_metadata['cellranger_version'] = \
+                        get_cellranger.output.package_version
+                update_qc_metadata.requires(get_cellranger)
+
+                # Locate config.csv file for 'cellranger multi'
+                get_cellranger_multi_config = GetCellrangerMultiConfig(
+                    "%s: get config file for 'cellranger multi'" %
                     project_name,
                     project,
-                    qc_dir,
-                    organism,
-                    fastq_dir,
-                    qc_protocol="10x_snRNAseq",
-                    chemistry="ARC-v1",
-                    force_cells=self.params.cellranger_force_cells,
-                    reference_dataset=\
-                    self.params.cellranger_reference_dataset,
-                    log_dir=log_dir,
-                    required_tasks=(setup_qc_dirs,))
-                verify_qc.requires(run_cellranger_count)
-
-        elif qc_protocol in ("10x_CellPlex",):
-
-            # Tasks 'check_cellranger_multi' depends on
-            check_cellranger_multi_requires = []
-
-            # Locate cellranger
-            required_cellranger = DetermineRequired10xPackage(
-                "%s: determine required 'cellranger' package" %
-                project_name,
-                qc_protocol,
-                self.params.cellranger_exe)
-            self.add_task(required_cellranger)
-
-            get_cellranger = Get10xPackage(
-                "%s: get information on cellranger" % project_name,
-                require_package=\
-                required_cellranger.output.require_cellranger)
-            self.add_task(get_cellranger,
-                          requires=(required_cellranger,),
-                          envmodules=self.envmodules['cellranger'])
-            check_cellranger_multi_requires.append(get_cellranger)
-            qc_metadata['cellranger_version'] = \
-                    get_cellranger.output.package_version
-            update_qc_metadata.requires(get_cellranger)
-
-            # Locate config.csv file for 'cellranger multi'
-            get_cellranger_multi_config = GetCellrangerMultiConfig(
-                "%s: get config file for 'cellranger multi'" %
-                project_name,
-                project,
-                qc_dir
-            )
-            self.add_task(get_cellranger_multi_config,
-                          requires=(setup_qc_dirs,),
-                          log_dir=log_dir)
-            check_cellranger_multi_requires.append(
-                get_cellranger_multi_config)
-            qc_metadata['cellranger_refdata'] = \
+                    qc_dir
+                )
+                self.add_task(get_cellranger_multi_config,
+                              requires=(setup_qc_dirs,),
+                              log_dir=log_dir)
+                check_cellranger_multi_requires.append(
+                    get_cellranger_multi_config)
+                qc_metadata['cellranger_refdata'] = \
                     get_cellranger_multi_config.output.reference_data_path
-            update_qc_metadata.requires(get_cellranger_multi_config)
+                update_qc_metadata.requires(get_cellranger_multi_config)
 
-            # Parent directory for cellranger multi outputs
-            # Set to project directory unless the 'cellranger_out_dir'
-            # parameter is set
-            cellranger_out_dir = FunctionParam(
-                lambda out_dir,project_dir:
-                out_dir if out_dir is not None else project_dir,
-                self.params.cellranger_out_dir,
-                project.dirn)
+                # Parent directory for cellranger multi outputs
+                # Set to project directory unless the 'cellranger_out_dir'
+                # parameter is set
+                cellranger_out_dir = FunctionParam(
+                    lambda out_dir,project_dir:
+                    out_dir if out_dir is not None else project_dir,
+                    self.params.cellranger_out_dir,
+                    project.dirn)
 
-            # Run cellranger multi
-            run_cellranger_multi = RunCellrangerMulti(
-                "%s: analyse cell multiplexing data (cellranger multi)" %
-                project_name,
-                project,
-                get_cellranger_multi_config.output.config_csv,
-                get_cellranger_multi_config.output.samples,
-                get_cellranger_multi_config.output.reference_data_path,
-                cellranger_out_dir,
-                qc_dir=qc_dir,
-                working_dir=self.params.WORKING_DIR,
-                cellranger_exe=get_cellranger.output.package_exe,
-                cellranger_version=get_cellranger.output.package_version,
-                cellranger_jobmode=self.params.cellranger_jobmode,
-                cellranger_maxjobs=self.params.cellranger_maxjobs,
-                cellranger_mempercore=self.params.cellranger_mempercore,
-                cellranger_jobinterval=self.params.cellranger_jobinterval,
-                cellranger_localcores=self.params.cellranger_localcores,
-                cellranger_localmem=self.params.cellranger_localmem,
-                qc_protocol=qc_protocol
-            )
-            self.add_task(run_cellranger_multi,
-                          requires=(get_cellranger,
-                                    get_cellranger_multi_config,),
-                          runner=self.runners['cellranger_runner'],
-                          envmodules=self.envmodules['cellranger'],
-                          log_dir=log_dir)
+                # Run cellranger multi
+                run_cellranger_multi = RunCellrangerMulti(
+                    "%s: analyse cell multiplexing data (cellranger multi)" %
+                    project_name,
+                    project,
+                    get_cellranger_multi_config.output.config_csv,
+                    get_cellranger_multi_config.output.samples,
+                    get_cellranger_multi_config.output.reference_data_path,
+                    cellranger_out_dir,
+                    qc_dir=qc_dir,
+                    working_dir=self.params.WORKING_DIR,
+                    cellranger_exe=get_cellranger.output.package_exe,
+                    cellranger_version=get_cellranger.output.package_version,
+                    cellranger_jobmode=self.params.cellranger_jobmode,
+                    cellranger_maxjobs=self.params.cellranger_maxjobs,
+                    cellranger_mempercore=self.params.cellranger_mempercore,
+                    cellranger_jobinterval=self.params.cellranger_jobinterval,
+                    cellranger_localcores=self.params.cellranger_localcores,
+                    cellranger_localmem=self.params.cellranger_localmem,
+                )
+                self.add_task(run_cellranger_multi,
+                              requires=(get_cellranger,
+                                        get_cellranger_multi_config,),
+                              runner=self.runners['cellranger_runner'],
+                              envmodules=self.envmodules['cellranger'],
+                              log_dir=log_dir)
 
-            # Set cell count
-            set_cellranger_cell_count = SetCellCountFromCellrangerCount(
-                "%s: set cell count from cell multiplexing analysis" %
-                project_name,
-                project,
-                qc_dir
-            )
-            self.add_task(set_cellranger_cell_count,
-                          requires=(run_cellranger_multi,),)
-            verify_qc.requires(set_cellranger_cell_count)
-
-            # Extra protocol for cellplex data
-            # (NB only run on the GEX "samples")
-            run_cellranger_count = self.add_cellranger_count(
-                project_name,
-                project,
-                qc_dir,
-                organism,
-                fastq_dir,
-                qc_protocol="10x_scRNAseq",
-                chemistry=self.params.cellranger_chemistry,
-                force_cells=self.params.cellranger_force_cells,
-                log_dir=log_dir,
-                samples=get_cellranger_multi_config.output.gex_libraries,
-                fastq_dirs=get_cellranger_multi_config.output.fastq_dirs,
-                reference_dataset=\
-                get_cellranger_multi_config.output.reference_data_path,
-                required_tasks=(setup_qc_dirs,))
-            verify_qc.requires(run_cellranger_count)
+                # Set cell count
+                set_cellranger_cell_count = SetCellCountFromCellrangerCount(
+                    "%s: set cell count from cell multiplexing analysis" %
+                    project_name,
+                    project,
+                    qc_dir
+                )
+                self.add_task(set_cellranger_cell_count,
+                              requires=(run_cellranger_multi,),)
+                verify_qc.requires(set_cellranger_cell_count)
 
         # Additional QC metrics
         if organism:
@@ -625,7 +653,8 @@ class QCPipeline(Pipeline):
                                       post_tasks=(verify_qc,))
 
     def add_cellranger_count(self,project_name,project,qc_dir,
-                             organism,fastq_dir,qc_protocol,chemistry,
+                             organism,fastq_dir,qc_module_name,
+                             library_type,chemistry,
                              force_cells,log_dir,samples=None,
                              fastq_dirs=None,reference_dataset=None,
                              extra_projects=None,required_tasks=None):
@@ -641,7 +670,9 @@ class QCPipeline(Pipeline):
             to subdirectory 'qc' of project directory)
           organism (str): organism for pipeline
           fastq_dir (str): directory holding Fastq files
-          qc_protocol (str): QC protocol to use
+          qc_module (str): QC module being used
+          library_type (str): type of data being analysed (e.g.
+            'scRNA-seq')
           chemistry (str): chemistry to use in single
             library analysis
           force_cells (int): if set then bypasses
@@ -671,14 +702,14 @@ class QCPipeline(Pipeline):
         # Locate cellranger
         required_cellranger = DetermineRequired10xPackage(
             "%s: determine required 10x pipeline package (%s)" %
-            (project_name,qc_protocol),
-            qc_protocol,
+            (project_name,qc_module_name),
+            qc_module_name,
             self.params.cellranger_exe)
         self.add_task(required_cellranger)
 
         get_cellranger = Get10xPackage(
             "%s: get information on 10x pipeline package (%s)" %
-            (project_name,qc_protocol),
+            (project_name,qc_module_name),
             require_package=\
             required_cellranger.output.require_cellranger)
         self.add_task(get_cellranger,
@@ -689,7 +720,7 @@ class QCPipeline(Pipeline):
         # Get reference data for cellranger
         get_cellranger_reference_data = GetCellrangerReferenceData(
             "%s: get single library analysis reference data (%s)" %
-            (project_name,qc_protocol),
+            (project_name,qc_module_name),
             project,
             organism=organism,
             transcriptomes=self.params.cellranger_transcriptomes,
@@ -698,7 +729,6 @@ class QCPipeline(Pipeline):
             multiome_references=self.params.cellranger_arc_references,
             cellranger_exe=get_cellranger.output.package_exe,
             cellranger_version=get_cellranger.output.package_version,
-            qc_protocol=qc_protocol,
             force_reference_data=reference_dataset
         )
         self.add_task(get_cellranger_reference_data,
@@ -708,8 +738,7 @@ class QCPipeline(Pipeline):
         check_cellranger_count_requires.append(get_cellranger_reference_data)
 
         # Make libraries.csv files (cellranger-arc only)
-        if qc_protocol in ("10x_Multiome_ATAC",
-                           "10x_Multiome_GEX",):
+        if qc_module_name == "cellranger-arc_count":
             make_cellranger_libraries = MakeCellrangerArcCountLibraries(
                 "%s: make libraries files for 'cellranger-arc count'" %
                 project_name,
@@ -725,12 +754,12 @@ class QCPipeline(Pipeline):
         # Check QC outputs for cellranger count
         check_cellranger_count = CheckCellrangerCountOutputs(
             "%s: check for single library analysis outputs (%s)" %
-            (project_name,qc_protocol),
+            (project_name,qc_module_name),
             project,
             fastq_dir=fastq_dir,
             samples=samples,
             qc_dir=qc_dir,
-            qc_protocol=qc_protocol,
+            qc_module=qc_module_name,
             extra_projects=extra_projects,
             cellranger_version=get_cellranger.output.package_version,
             cellranger_ref_data=\
@@ -754,11 +783,12 @@ class QCPipeline(Pipeline):
         # Run cellranger count
         run_cellranger_count = RunCellrangerCount(
             "%s: run single library analysis (%s)" %
-            (project_name,qc_protocol),
+            (project_name,project.info.library_type),
             check_cellranger_count.output.samples,
             check_cellranger_count.output.fastq_dir,
             get_cellranger_reference_data.output.reference_data_path,
-            cellranger_out_dir,
+            library_type=library_type,
+            out_dir=cellranger_out_dir,
             qc_dir=qc_dir,
             cellranger_exe=get_cellranger.output.package_exe,
             cellranger_version=get_cellranger.output.package_version,
@@ -770,8 +800,7 @@ class QCPipeline(Pipeline):
             cellranger_mempercore=self.params.cellranger_mempercore,
             cellranger_jobinterval=self.params.cellranger_jobinterval,
             cellranger_localcores=self.params.cellranger_localcores,
-            cellranger_localmem=self.params.cellranger_localmem,
-            qc_protocol=qc_protocol
+            cellranger_localmem=self.params.cellranger_localmem
         )
         self.add_task(run_cellranger_count,
                       requires=(get_cellranger,
@@ -806,6 +835,9 @@ class QCPipeline(Pipeline):
           post_tasks (list): list of tasks that depend on
             for the extended metrics to complete
         """
+        # QC modules
+        reads,qc_modules = fetch_protocol_definition(qc_protocol)
+
         # Read numbers with sequence data (based on protocol)
         # Used to set which Fastqs should be mapped
         read_numbers = get_read_numbers(qc_protocol).seq_data
@@ -859,64 +891,87 @@ class QCPipeline(Pipeline):
         self.add_task(rseqc_infer_experiment,
                       log_dir=log_dir)
 
-        # Run RSeQC gene body coverage
-        rseqc_gene_body_coverage = RunRSeQCGenebodyCoverage(
-            "%s: calculate gene body coverage (RSeQC)" % project.name,
-            get_bam_files.output.bam_files,
-            get_reference_gene_model.output.reference_dataset,
-            os.path.join(qc_dir,'rseqc_genebody_coverage',organism_name),
-            name=project.name)
-        self.add_task(rseqc_gene_body_coverage,
-                      runner=self.runners['rseqc_runner'],
-                      log_dir=log_dir)
-        for task in post_tasks:
-            rseqc_gene_body_coverage.required_by(task)
-        qc_metadata['annotation_bed'] = \
-            get_reference_gene_model.output.reference_dataset
+        ################
+        # Add QC modules
+        ################
 
-        # Run Picard's CollectInsertSizeMetrics
-        if paired:
-            insert_size_metrics = RunPicardCollectInsertSizeMetrics(
-                "%s: Picard: collect insert size metrics" % project.name,
-                get_bam_files.output.bam_files,
-                os.path.join(qc_dir,'picard',organism_name))
-            self.add_task(insert_size_metrics,
-                          log_dir=log_dir)
+        for qc_module in qc_modules:
 
-            collate_insert_sizes = CollateInsertSizes(
-                "%s: collate insert size data" % project.name,
-                get_bam_files.output.bam_files,
-                os.path.join(qc_dir,'picard',organism_name),
-                os.path.join(qc_dir,'insert_sizes.%s.tsv' % organism_name))
-            self.add_task(collate_insert_sizes,
-                          requires=(insert_size_metrics,),
-                          log_dir=log_dir)
-            for task in post_tasks:
-                collate_insert_sizes.required_by(task)
+            qc_module_name,qc_module_params = parse_qc_module_spec(qc_module)
 
-        # Get reference gene model for Qualimap
-        get_annotation_gtf = GetReferenceDataset(
-            "%s: get GTF annotation for '%s'" % (project.name,
-                                                 organism),
-            organism,
-            self.params.annotation_gtf_files)
-        self.add_task(get_annotation_gtf,
-                      log_dir=log_dir)
+            ##########################
+            # RSeQC gene body coverage
+            ##########################
+            if qc_module_name == 'rseqc_genebody_coverage':
+                # Run RSeQC gene body coverage
+                rseqc_gene_body_coverage = RunRSeQCGenebodyCoverage(
+                    "%s: calculate gene body coverage (RSeQC)" % project.name,
+                    get_bam_files.output.bam_files,
+                    get_reference_gene_model.output.reference_dataset,
+                    os.path.join(qc_dir,
+                                 'rseqc_genebody_coverage',
+                                 organism_name),
+                    name=project.name)
+                self.add_task(rseqc_gene_body_coverage,
+                              runner=self.runners['rseqc_runner'],
+                              log_dir=log_dir)
+                for task in post_tasks:
+                    rseqc_gene_body_coverage.required_by(task)
+                qc_metadata['annotation_bed'] = \
+                    get_reference_gene_model.output.reference_dataset
 
-        # Run Qualimap RNA-seq analysis
-        qualimap_rnaseq = RunQualimapRnaseq(
-            "%s: Qualimap rnaseq: RNA-seq metrics" % project.name,
-            get_bam_files.output.bam_files,
-            get_annotation_gtf.output.reference_dataset,
-            os.path.join(qc_dir,'qualimap-rnaseq',organism_name),
-            bam_properties=rseqc_infer_experiment.output.experiments)
-        self.add_task(qualimap_rnaseq,
-                      runner=self.runners['qualimap_runner'],
-                      log_dir=log_dir)
-        for task in post_tasks:
-            qualimap_rnaseq.required_by(task)
-        qc_metadata['annotation_gtf'] = \
-            get_annotation_gtf.output.reference_dataset
+            ##########################
+            # Picard insert sizes
+            ##########################
+            if qc_module_name == 'picard_insert_size_metrics' and paired:
+                # Run Picard's CollectInsertSizeMetrics
+                insert_size_metrics = RunPicardCollectInsertSizeMetrics(
+                    "%s: Picard: collect insert size metrics" %
+                    project.name,
+                    get_bam_files.output.bam_files,
+                    os.path.join(qc_dir,'picard',organism_name))
+                self.add_task(insert_size_metrics,
+                              log_dir=log_dir)
+
+                collate_insert_sizes = CollateInsertSizes(
+                    "%s: collate insert size data" % project.name,
+                    get_bam_files.output.bam_files,
+                    os.path.join(qc_dir,'picard',organism_name),
+                    os.path.join(qc_dir,
+                                 'insert_sizes.%s.tsv' % organism_name))
+                self.add_task(collate_insert_sizes,
+                              requires=(insert_size_metrics,),
+                              log_dir=log_dir)
+                for task in post_tasks:
+                    collate_insert_sizes.required_by(task)
+
+            #################
+            # Qualimap RNASEQ
+            #################
+            if qc_module_name == 'qualimap_rnaseq':
+                # Get reference gene model for Qualimap
+                get_annotation_gtf = GetReferenceDataset(
+                    "%s: get GTF annotation for '%s'" % (project.name,
+                                                         organism),
+                    organism,
+                    self.params.annotation_gtf_files)
+                self.add_task(get_annotation_gtf,
+                              log_dir=log_dir)
+
+                # Run Qualimap RNA-seq analysis
+                qualimap_rnaseq = RunQualimapRnaseq(
+                    "%s: Qualimap rnaseq: RNA-seq metrics" % project.name,
+                    get_bam_files.output.bam_files,
+                    get_annotation_gtf.output.reference_dataset,
+                    os.path.join(qc_dir,'qualimap-rnaseq',organism_name),
+                    bam_properties=rseqc_infer_experiment.output.experiments)
+                self.add_task(qualimap_rnaseq,
+                              runner=self.runners['qualimap_runner'],
+                              log_dir=log_dir)
+                for task in post_tasks:
+                    qualimap_rnaseq.required_by(task)
+                    qc_metadata['annotation_gtf'] = \
+                        get_annotation_gtf.output.reference_dataset
 
     def run(self,nthreads=None,fastq_screens=None,star_indexes=None,
             annotation_bed_files=None,annotation_gtf_files=None,
@@ -1725,7 +1780,7 @@ class DetermineRequired10xPackage(PipelineTask):
     Determine which 10xGenomics software package is required
 
     By default determines the package name based on the
-    supplied QC protocol, but this can be overridden by
+    supplied QC module, but this can be overridden by
     explicitly supplying a required package (which can
     also be a path to an executable).
 
@@ -1733,12 +1788,12 @@ class DetermineRequired10xPackage(PipelineTask):
     supplied to the 'Get10xPackage' task, which will
     do the job of actually locating an executable.
     """
-    def init(self,qc_protocol,require_cellranger=None):
+    def init(self,qc_module,require_cellranger=None):
         """
         Initialise the DetermineRequired10xPackage task
 
         Argument:
-          qc_protocol (str): QC protocol to use
+          qc_module (str): QC module being used
           require_cellranger (str): optional package name
             or path to an executable; if supplied then
             overrides the automatic package determination
@@ -1749,22 +1804,20 @@ class DetermineRequired10xPackage(PipelineTask):
         """
         self.add_output('require_cellranger',Param(type=str))
     def setup(self):
-        protocols = {
-            "10x_scRNAseq": "cellranger",
-            "10x_snRNAseq": "cellranger",
-            "10x_scATAC": "cellranger-atac",
-            "10x_Multiome_ATAC": "cellranger-arc",
-            "10x_Multiome_GEX": "cellranger-arc",
-            "10x_CellPlex": "cellranger",
+        qc_modules = {
+            "cellranger_count": "cellranger",
+            "cellranger-atac_count": "cellranger-atac",
+            "cellranger-arc_count": "cellranger-arc",
+            "cellranger_multi": "cellranger",
         }
         require_cellranger = self.args.require_cellranger
         if require_cellranger is None:
             try:
-                require_cellranger = protocols[self.args.qc_protocol]
+                require_cellranger = qc_modules[self.args.qc_module]
             except KeyError:
                 raise Exception("Can't identify 10xGenomics package "
-                                "required for protocol '%s'" %
-                                self.args.qc_protocol)
+                                "required for QC module '%s'" %
+                                self.args.qc_module)
         print("Required 10x package: %s" % require_cellranger)
         self.output.require_cellranger.set(require_cellranger)
 
@@ -1773,9 +1826,8 @@ class GetCellrangerReferenceData(PipelineFunctionTask):
     """
     def init(self,project,organism=None,transcriptomes=None,
              premrna_references=None,atac_references=None,
-             multiome_references=None,qc_protocol=None,
-             cellranger_exe=None,cellranger_version=None,
-             force_reference_data=None):
+             multiome_references=None,cellranger_exe=None,
+             cellranger_version=None,force_reference_data=None):
         """
         Initialise the GetCellrangerReferenceData task
 
@@ -1800,7 +1852,6 @@ class GetCellrangerReferenceData(PipelineFunctionTask):
             'cellranger-atac', 'spaceranger')
           cellranger_version (str): the version string for the
             Cellranger package
-          qc_protocol (str): QC protocol to use
           force_reference_data (str): if supplied then
             will be used as the reference dataset, instead of
             trying to locate appropriate reference data
@@ -1817,7 +1868,6 @@ class GetCellrangerReferenceData(PipelineFunctionTask):
         # Report inputs
         print("Cellranger : %s" % self.args.cellranger_exe)
         print("Version    : %s" % self.args.cellranger_version)
-        print("QC protocol: %s" % self.args.qc_protocol)
         print("Organism(s): %s" % self.args.organism)
         # Check pre-determined reference dataset
         if self.args.force_reference_data:
@@ -1836,7 +1886,7 @@ class GetCellrangerReferenceData(PipelineFunctionTask):
         cellranger_pkg = os.path.basename(self.args.cellranger_exe)
         if cellranger_pkg == "cellranger":
             references = self.args.transcriptomes
-            if self.args.qc_protocol == "10x_snRNAseq" and \
+            if self.args.project.info.library_type == "snRNA-seq" and \
                int(self.args.cellranger_version.split('.')[0]) < 5:
                 references = self.args.premrna_references
         elif cellranger_pkg == "cellranger-atac":
@@ -1845,9 +1895,9 @@ class GetCellrangerReferenceData(PipelineFunctionTask):
             references = self.args.multiome_references
         else:
             self.fail(message="Don't know which reference "
-                      "dataset to use for '%s' and protocol '%s'" %
+                      "dataset to use for '%s' and library '%s'" %
                       (self.args.cellranger_exe,
-                       self.args.qc_protocol))
+                       self.args.project.info.library_type))
             return
         if references is None:
             references = {}
@@ -1975,7 +2025,7 @@ class CheckCellrangerCountOutputs(PipelineFunctionTask):
     Check the outputs from cellranger(-atac) count
     """
     def init(self,project,fastq_dir=None,samples=None,qc_dir=None,
-             qc_protocol=None,extra_projects=None,
+             qc_module=None,extra_projects=None,
              cellranger_version=None,cellranger_ref_data=None,
              verbose=False):
         """
@@ -1991,7 +2041,7 @@ class CheckCellrangerCountOutputs(PipelineFunctionTask):
           qc_dir (str): top-level QC directory to look
             for 'count' QC outputs (e.g. metrics CSV and
             summary HTML files)
-          qc_protocol (str): QC protocol to use
+          qc_module (str): QC protocol being used
           extra_projects (list): optional list of extra
             AnalysisProjects to include Fastqs from when
             running cellranger pipeline
@@ -2016,13 +2066,11 @@ class CheckCellrangerCountOutputs(PipelineFunctionTask):
             # No reference data, nothing to check
             return
         # Determine which checking function to use
-        if self.args.qc_protocol in ("10x_scRNAseq",
-                                     "10x_snRNAseq",):
+        if self.args.qc_module == "cellranger_count":
             check_outputs = check_cellranger_count_outputs
-        elif self.args.qc_protocol == "10x_scATAC":
+        elif self.args.qc_module == "cellranger-atac_count":
             check_outputs = check_cellranger_atac_count_outputs
-        elif self.args.qc_protocol in ("10x_Multiome_ATAC",
-                                       "10x_Multiome_GEX",):
+        elif self.args.qc_module == "cellranger-arc_count":
             check_outputs = check_cellranger_arc_count_outputs
         # Set the prefix for cellranger/10x outputs
         prefix = os.path.join("cellranger_count",
@@ -2076,13 +2124,13 @@ class RunCellrangerCount(PipelineTask):
     """
     Run 'cellranger count'
     """
-    def init(self,samples,fastq_dir,reference_data_path,out_dir,
-             qc_dir=None,cellranger_exe=None,cellranger_version=None,
-             chemistry='auto',fastq_dirs=None,force_cells=None,
-             cellranger_jobmode='local',cellranger_maxjobs=None,
-             cellranger_mempercore=None,cellranger_jobinterval=None,
-             cellranger_localcores=None,cellranger_localmem=None,
-             qc_protocol=None):
+    def init(self,samples,fastq_dir,reference_data_path,library_type,
+             out_dir,qc_dir=None,cellranger_exe=None,
+             cellranger_version=None,chemistry='auto',fastq_dirs=None,
+             force_cells=None,cellranger_jobmode='local',
+             cellranger_maxjobs=None,cellranger_mempercore=None,
+             cellranger_jobinterval=None,cellranger_localcores=None,
+             cellranger_localmem=None):
         """
         Initialise the RunCellrangerCount task.
 
@@ -2095,6 +2143,8 @@ class RunCellrangerCount(PipelineTask):
             Fastq files
           reference_data_path (str): path to the cellranger
             compatible reference dataset
+          library_type (str): type of data being analysed
+            (e.g. 'scRNA-seq')
           out_dir (str): top-level directory to copy all
             final 'count' outputs into. Outputs won't be
             copied if no value is supplied
@@ -2134,7 +2184,6 @@ class RunCellrangerCount(PipelineTask):
             (defaults to number of slots set in runner)
           cellranger_localmem (int): maximum memory cellranger
             can request in jobmode 'local' (default: None)
-          qc_protocol (str): QC protocol to use
         """
         # Add outputs
         self.add_output('cellranger_version',Param(type=str))
@@ -2218,7 +2267,7 @@ class RunCellrangerCount(PipelineTask):
                 if cellranger_major_version >= 5:
                     # Hard-trim the input R1 sequence to 26bp
                     cmd.add_args("--r1-length=26")
-                    if self.args.qc_protocol == "10x_snRNAseq":
+                    if self.args.library_type == "snRNA-seq":
                         # For single nuclei RNA-seq specify the
                         # --include-introns for cellranger 5.0+
                         if cellranger_major_version == 7:
@@ -2385,7 +2434,7 @@ class RunCellrangerMulti(PipelineTask):
              cellranger_jobmode='local',cellranger_maxjobs=None,
              cellranger_mempercore=None,cellranger_jobinterval=None,
              cellranger_localcores=None,cellranger_localmem=None,
-             qc_protocol=None,working_dir=None):
+             working_dir=None):
         """
         Initialise the RunCellrangerMulti task.
 
@@ -2427,7 +2476,6 @@ class RunCellrangerMulti(PipelineTask):
             (defaults to number of slots set in runner)
           cellranger_localmem (int): maximum memory cellranger
             can request in jobmode 'local' (default: None)
-          qc_protocol (str): QC protocol to use
         """
         # Internal: top-level working directory
         self._working_dir = None

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -94,7 +94,6 @@ from .outputs import check_cellranger_arc_count_outputs
 from .picard import CollectInsertSizeMetrics
 from .protocols import determine_qc_protocol
 from .protocols import fetch_protocol_definition
-from .protocols import get_read_numbers
 from .rseqc import InferExperiment
 from .utils import get_bam_basename
 from .utils import set_cell_count_for_project
@@ -209,11 +208,14 @@ class QCPipeline(Pipeline):
         if qc_protocol is None:
             qc_protocol = determine_qc_protocol(project)
 
-        # Fetch the QC modules and read data
-        reads,qc_modules = fetch_protocol_definition(qc_protocol)
+        # Fetch the QC protocol definition
+        protocol = fetch_protocol_definition(qc_protocol)
+
+        # QC modules
+        qc_modules = protocol.qc_modules
 
         # Read numbers for sequence data and QC
-        read_numbers = get_read_numbers(qc_protocol)
+        read_numbers = protocol.read_numbers
 
         # Determine whether sequence data are paired
         paired = (len(read_numbers.seq_data) > 1)

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1314,7 +1314,6 @@ class CheckFastqScreenOutputs(PipelineFunctionTask):
             to subdirectory 'qc' of project directory)
           screens (mapping): mapping of screen names to
             FastqScreen conf files
-          qc_protocol (str): QC protocol to use
           read_numbers (list): read numbers to include
           legacy (bool): if True then use 'legacy' naming
             convention for output files (default is to
@@ -1491,7 +1490,6 @@ class CheckFastQCOutputs(PipelineFunctionTask):
             to subdirectory 'qc' of project directory)
           read_numbers (list): list of read numbers to
             include
-          qc_protocol (str): QC protocol to use
           verbose (bool): if True then print additional
             information from the task
 

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -416,7 +416,7 @@ class QCPipeline(Pipeline):
                     project,
                     qc_dir,
                     self.params.fastq_screens,
-                    qc_protocol=qc_protocol,
+                    read_numbers=read_numbers.seq_data,
                     legacy=self.params.legacy_screens,
                     verbose=self.params.VERBOSE
                 )
@@ -1302,7 +1302,7 @@ class CheckFastqScreenOutputs(PipelineFunctionTask):
     """
     Check the outputs from FastqScreen
     """
-    def init(self,project,qc_dir,screens,qc_protocol=None,
+    def init(self,project,qc_dir,screens,read_numbers=None,
              legacy=False,verbose=False):
         """
         Initialise the CheckFastqScreenOutputs task.
@@ -1315,6 +1315,7 @@ class CheckFastqScreenOutputs(PipelineFunctionTask):
           screens (mapping): mapping of screen names to
             FastqScreen conf files
           qc_protocol (str): QC protocol to use
+          read_numbers (list): read numbers to include
           legacy (bool): if True then use 'legacy' naming
             convention for output files (default is to
             use new format)
@@ -1342,7 +1343,7 @@ class CheckFastqScreenOutputs(PipelineFunctionTask):
                           self.args.project,
                           self.args.qc_dir,
                           screen,
-                          self.args.qc_protocol,
+                          self.args.read_numbers,
                           legacy=self.args.legacy)
     def finish(self):
         fastqs = set()

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -19,6 +19,7 @@ For example:
 ::
 
     "ExampleProtocol": {
+        "description": "Example QC protocol"
         "reads": { "seq_data": ('r1','r3'), "index": ('r2') },
         "qc_modules": ['fastqc','fastq_screen','sequence_lengths']
     }
@@ -61,6 +62,7 @@ from bcftbx.utils import AttributeDictionary
 QC_PROTOCOLS = {
 
     "standardSE": {
+        "description": "Standard single-end data (R1 Fastqs only)",
         "reads": {
             "seq_data": ('r1',),
             "index": ()
@@ -76,6 +78,7 @@ QC_PROTOCOLS = {
     },
 
     "standardPE": {
+        "description": "Standard paired-end data (R1/R2 Fastq pairs)",
         "reads": {
             "seq_data": ('r1','r2',),
             "index": ()
@@ -92,6 +95,7 @@ QC_PROTOCOLS = {
     },
 
     "singlecell": {
+        "description": "ICELL8 single cell RNA-seq",
         "reads": {
             "seq_data": ('r2',),
             "index": ('r1',)
@@ -107,6 +111,7 @@ QC_PROTOCOLS = {
     },
 
     "10x_scRNAseq": {
+        "description": "10xGenomics single cell RNA-seq",
         "reads": {
             "seq_data": ('r2',),
             "index": ('r1',)
@@ -123,6 +128,7 @@ QC_PROTOCOLS = {
     },
 
     "10x_snRNAseq": {
+        "description": "10xGenomics single nuclei RNA-seq",
         "reads": {
             "seq_data": ('r2',),
             "index": ('r1',)
@@ -139,6 +145,7 @@ QC_PROTOCOLS = {
     },
 
     "10x_scATAC": {
+        "description": "10xGenomics single cell ATAC-seq",
         "reads": {
             "seq_data": ('r1','r3',),
             "index": ()
@@ -156,6 +163,7 @@ QC_PROTOCOLS = {
     },
 
     "10x_Multiome_GEX": {
+        "description": "10xGenomics single cell multiome gene expression data",
         "reads": {
             "seq_data": ('r2',),
             "index": ('r1',)
@@ -181,6 +189,7 @@ QC_PROTOCOLS = {
     },
 
     "10x_Multiome_ATAC": {
+        "description": "10xGenomics single cell multiome ATAC-seq data",
         "reads": {
             "seq_data": ('r1','r3',),
             "index": ()
@@ -207,6 +216,7 @@ QC_PROTOCOLS = {
     },
 
     "10x_CellPlex": {
+        "description": "10xGenomics CellPlex cell multiplexing data",
         "reads": {
             "seq_data": ('r2',),
             "index": ('r1',)
@@ -219,12 +229,14 @@ QC_PROTOCOLS = {
             'rseqc_genebody_coverage',
             'qualimap_rnaseq',
             'cellranger_count(cellranger_use_multi_config=True;'
+                             'set_cell_count=false;'
                              'set_metadata=False)',
             'cellranger_multi'
         ]
     },
 
     "10x_Visium": {
+        "description": "10xGenomics Visium spatial RNA-seq",
         "reads": {
             "seq_data": ('r2',),
             "index": ('r1',)
@@ -240,6 +252,7 @@ QC_PROTOCOLS = {
     },
 
     "ParseEvercode": {
+        "description": "Parse Biosciences Evercode data",
         "reads": {
             "seq_data": ('r1',),
             "index": ('r2',)
@@ -256,6 +269,7 @@ QC_PROTOCOLS = {
     },
 
     "ICELL8_scATAC": {
+        "description": "ICELL8 single cell ATAC-seq",
         "reads": {
             "seq_data": ('r1','r2',),
             "index": ()

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -45,7 +45,6 @@ This module also provides the following classes and functions:
 - QCProtocol: class representing a QC protocol
 - determine_qc_protocol: get QC protocol for a project
 - fetch_protocol_definition: get the definition for a QC protocol
-- get_read_numbers: get the read numbers associated with a QC protocol
 """
 
 #######################################################################
@@ -440,21 +439,3 @@ def fetch_protocol_definition(name):
                       seq_data_reads=protocol_defn['reads']['seq_data'],
                       index_reads=protocol_defn['reads']['index'],
                       qc_modules=protocol_defn['qc_modules'])
-
-def get_read_numbers(protocol):
-    """
-    Return the read numbers for a QC protocol definition
-
-    Given a QC protocol, returns the integer read numbers
-    for sequence data reads, index reads, and QC reads
-    associated with that protocol.
-
-    Arguments:
-      protocol (str): name of the QC protocol
-
-    Returns:
-      AttributeDictionary: dictionary with keys 'seq_data',
-        'index' and 'qc', mapping to lists of read numbers
-        for each type of read data.
-    """
-    return fetch_protocol_definition(protocol).read_numbers

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -167,9 +167,15 @@ QC_PROTOCOLS = {
             'strandedness',
             'rseqc_genebody_coverage',
             'qualimap_rnaseq',
-            'cellranger_count(cellranger_version=*;'
-                             'cellranger_refdata=*)',
-            'cellranger-arc_count'
+            'cellranger-arc_count',
+            # Also run Cellranger
+            # Set the chemistry to 'ARC-v1' and library to 'snRNA-seq'
+            # See https://kb.10xgenomics.com/hc/en-us/articles/360059656912
+            'cellranger_count(chemistry=ARC-v1;'
+                             'library=snRNA-seq;'
+                             'cellranger_version=*;'
+                             'cellranger_refdata=*;'
+                             'set_metadata=False)'
         ]
     },
 
@@ -187,8 +193,14 @@ QC_PROTOCOLS = {
             'rseqc_genebody_coverage',
             'qualimap_rnaseq',
             'cellranger-arc_count',
-            'cellranger-atac_count(cellranger_version=*;'
-                                  'cellranger_refdata=*)'
+            # Also run Cellranger ATAC
+            # Set the chemistry to 'ARC-v1' and library to 'scATAC-seq'
+            # See https://kb.10xgenomics.com/hc/en-us/articles/360061165691
+            'cellranger-atac_count(chemistry=ARC-v1;'
+                                  'library=scATAC-seq;'
+                                  'cellranger_version=*;'
+                                  'cellranger_refdata=*;'
+                                  'set_metadata=False)'
         ]
     },
 
@@ -204,7 +216,8 @@ QC_PROTOCOLS = {
             'strandedness',
             'rseqc_genebody_coverage',
             'qualimap_rnaseq',
-            'cellranger_count(cellranger_use_multi_config=True)',
+            'cellranger_count(cellranger_use_multi_config=True;'
+                             'set_metadata=False)',
             'cellranger_multi'
         ]
     },

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -175,6 +175,7 @@ QC_PROTOCOLS = {
                              'library=snRNA-seq;'
                              'cellranger_version=*;'
                              'cellranger_refdata=*;'
+                             'set_cell_count=false;'
                              'set_metadata=False)'
         ]
     },
@@ -200,6 +201,7 @@ QC_PROTOCOLS = {
                                   'library=scATAC-seq;'
                                   'cellranger_version=*;'
                                   'cellranger_refdata=*;'
+                                  'set_cell_count=false;'
                                   'set_metadata=False)'
         ]
     },

--- a/auto_process_ngs/qc/verification.py
+++ b/auto_process_ngs/qc/verification.py
@@ -226,7 +226,8 @@ class QCVerifier(QCOutputs):
                          annotation_gtf=None,
                          cellranger_version=None,
                          cellranger_refdata=None,
-                         cellranger_use_multi_config=None):
+                         cellranger_use_multi_config=None,
+                         **extra_params):
         """
         Verify QC outputs for specific QC module
 
@@ -252,6 +253,8 @@ class QCVerifier(QCOutputs):
             cellranger count verification will attempt to
             use data (GEX samples and reference dataset) from
             the '10x_multi_config.csv' file
+          extra_params (mapping): any additional parameters
+            not required for verification
 
         Returns:
           Boolean: True if all outputs are present, False

--- a/auto_process_ngs/qc/verification.py
+++ b/auto_process_ngs/qc/verification.py
@@ -95,7 +95,7 @@ class QCVerifier(QCOutputs):
             False otherwise.
         """
         # Look up protocol definition
-        reads,qc_modules = fetch_protocol_definition(qc_protocol)
+        protocol = fetch_protocol_definition(qc_protocol)
 
         # Sample names
         samples = set()
@@ -107,8 +107,8 @@ class QCVerifier(QCOutputs):
         default_params = dict(
             fastqs=fastqs,
             samples=samples,
-            seq_data_reads=reads.seq_data,
-            qc_reads=reads.qc,
+            seq_data_reads=protocol.reads.seq_data,
+            qc_reads=protocol.reads.qc,
             organism=organism,
             fastq_screens=fastq_screens,
             star_index=star_index,
@@ -123,7 +123,7 @@ class QCVerifier(QCOutputs):
         verified = dict()
         params_for_module = dict()
 
-        for qc_module in qc_modules:
+        for qc_module in protocol.qc_modules:
 
             # Handle QC module specification
             qc_module,module_params = parse_qc_module_spec(qc_module)
@@ -144,7 +144,7 @@ class QCVerifier(QCOutputs):
                                                         **params)
         # Make templates for parameter and status
         field_width = 21
-        for qc_module in qc_modules:
+        for qc_module in protocol.qc_modules:
             field_width = max(len(qc_module),field_width)
         parameter_template_str = "{parameter:%ss}: {value}" % field_width
         qc_module_template_str = "{name:%ss}: {status:4s}{params}" % field_width

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -2438,9 +2438,9 @@ class TestCheckFastqStrandOutputs(unittest.TestCase):
         if REMOVE_TEST_OUTPUTS:
             shutil.rmtree(self.wd)
 
-    def test_check_fastq_strand_outputs_standardPE_missing(self):
+    def test_check_fastq_strand_outputs_paired_end_missing(self):
         """
-        check_fastq_strand_outputs: fastq_strand.py output missing (standardPE)
+        check_fastq_strand_outputs: fastq_strand.py output missing (paired end)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -2456,15 +2456,15 @@ class TestCheckFastqStrandOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_strand_outputs(project,
                                                     "qc",
                                                     fastq_strand_conf,
-                                                    qc_protocol="standardPE"),
+                                                    read_numbers=(1,2)),
                          [(os.path.join(project.fastq_dir,
                                         "PJB1_S1_R1_001.fastq.gz"),
                            os.path.join(project.fastq_dir,
                                         "PJB1_S1_R2_001.fastq.gz")),])
 
-    def test_check_fastq_strand_outputs_standardPE_present(self):
+    def test_check_fastq_strand_outputs_paired_end_present(self):
         """
-        check_fastq_strand_outputs: fastq_strand.py output present (standardPE)
+        check_fastq_strand_outputs: fastq_strand.py output present (paired end)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -2481,12 +2481,12 @@ class TestCheckFastqStrandOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_strand_outputs(project,
                                                     "qc",
                                                     fastq_strand_conf,
-                                                    qc_protocol="standardPE"),
+                                                    read_numbers=(1,2)),
                          [])
 
-    def test_check_fastq_strand_outputs_standardSE_missing(self):
+    def test_check_fastq_strand_outputs_single_end_missing(self):
         """
-        check_fastq_strand_outputs: fastq_strand.py output missing (standardSE)
+        check_fastq_strand_outputs: fastq_strand.py output missing (single end)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",),
@@ -2501,13 +2501,13 @@ class TestCheckFastqStrandOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_strand_outputs(project,
                                                     "qc",
                                                     fastq_strand_conf,
-                                                    qc_protocol="standardSE"),
+                                                    read_numbers=(1,)),
                          [(os.path.join(project.fastq_dir,
                                         "PJB1_S1_R1_001.fastq.gz"),),])
 
-    def test_check_fastq_strand_outputs_standardSE_present(self):
+    def test_check_fastq_strand_outputs_single_end_present(self):
         """
-        check_fastq_strand_outputs: fastq_strand.py output present (standardSE)
+        check_fastq_strand_outputs: fastq_strand.py output present (single end)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",),
@@ -2523,12 +2523,12 @@ class TestCheckFastqStrandOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_strand_outputs(project,
                                                     "qc",
                                                     fastq_strand_conf,
-                                                    qc_protocol="standardSE"),
+                                                    read_numbers=(1,)),
                          [])
 
-    def test_check_fastq_strand_outputs_singlecell_missing(self):
+    def test_check_fastq_strand_outputs_single_cell_missing(self):
         """
-        check_fastq_strand_outputs: fastq_strand.py output missing (singlecell)
+        check_fastq_strand_outputs: fastq_strand.py output missing (single cell)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -2544,13 +2544,13 @@ class TestCheckFastqStrandOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_strand_outputs(project,
                                                     "qc",
                                                     fastq_strand_conf,
-                                                    qc_protocol="singlecell"),
+                                                    read_numbers=(2,)),
                          [(os.path.join(project.fastq_dir,
                                         "PJB1_S1_R2_001.fastq.gz"),),])
 
-    def test_check_fastq_strand_outputs_singlecell_present(self):
+    def test_check_fastq_strand_outputs_single_cell_present(self):
         """
-        check_fastq_strand_outputs: fastq_strand.py output present (singlecell)
+        check_fastq_strand_outputs: fastq_strand.py output present (single cell)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -2567,7 +2567,7 @@ class TestCheckFastqStrandOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_strand_outputs(project,
                                                     "qc",
                                                     fastq_strand_conf,
-                                                    qc_protocol="singlecell"),
+                                                    read_numbers=(2,)),
                          [])
 
     def test_check_fastq_strand_outputs_parseevercode_missing(self):
@@ -2588,7 +2588,7 @@ class TestCheckFastqStrandOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_strand_outputs(project,
                                                     "qc",
                                                     fastq_strand_conf,
-                                                    qc_protocol="ParseEvercode"),
+                                                    read_numbers=(1,)),
                          [(os.path.join(project.fastq_dir,
                                         "PJB1_S1_R1_001.fastq.gz"),),])
 
@@ -2611,7 +2611,7 @@ class TestCheckFastqStrandOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_strand_outputs(project,
                                                     "qc",
                                                     fastq_strand_conf,
-                                                    qc_protocol="ParseEvercode"),
+                                                    read_numbers=(1,)),
                          [])
 
 class TestCheckCellrangerCountOutputs(unittest.TestCase):

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -1946,9 +1946,9 @@ class TestCheckFastqScreenOutputs(unittest.TestCase):
         if REMOVE_TEST_OUTPUTS:
             shutil.rmtree(self.wd)
 
-    def test_check_fastq_screen_outputs_standardPE_all_missing(self):
+    def test_check_fastq_screen_outputs_paired_end_all_missing(self):
         """
-        check_fastq_screen_outputs: all screen outputs missing (standardPE)
+        check_fastq_screen_outputs: all screen outputs missing (paired end)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -1961,12 +1961,12 @@ class TestCheckFastqScreenOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_screen_outputs(project,
                                                     qc_dir="qc",
                                                     screen="model_organisms",
-                                                    qc_protocol="standardPE"),
+                                                    read_numbers=(1,2)),
                          project.fastqs)
 
-    def test_check_fastq_screen_outputs_standardPE_all_present(self):
+    def test_check_fastq_screen_outputs_paired_end_all_present(self):
         """
-        check_fastq_screen_outputs: all screen outputs present (standardPE)
+        check_fastq_screen_outputs: all screen outputs present (paired end)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -1982,12 +1982,12 @@ class TestCheckFastqScreenOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_screen_outputs(project,
                                                     qc_dir="qc",
                                                     screen="model_organisms",
-                                                    qc_protocol="standardPE"),
+                                                    read_numbers=(1,2)),
                          [])
 
-    def test_check_fastq_screen_outputs_standardPE_some_missing(self):
+    def test_check_fastq_screen_outputs_paired_end_some_missing(self):
         """
-        check_fastq_screen_outputs: some screen outputs missing (standardPE)
+        check_fastq_screen_outputs: some screen outputs missing (paired end)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -2007,13 +2007,13 @@ class TestCheckFastqScreenOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_screen_outputs(project,
                                                     qc_dir="qc",
                                                     screen="model_organisms",
-                                                    qc_protocol="standardPE"),
+                                                    read_numbers=(1,2)),
                          [os.path.join(project.fastq_dir,
                                        "PJB1_S1_R1_001.fastq.gz")])
 
-    def test_check_fastq_screen_outputs_standardPE_legacy(self):
+    def test_check_fastq_screen_outputs_paired_end_legacy(self):
         """
-        check_fastq_screen_outputs: all screen outputs present (standardPE)
+        check_fastq_screen_outputs: all screen outputs present (paired, legacy)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -2030,13 +2030,13 @@ class TestCheckFastqScreenOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_screen_outputs(project,
                                                     qc_dir="qc",
                                                     screen="model_organisms",
-                                                    qc_protocol="standardPE",
+                                                    read_numbers=(1,2),
                                                     legacy=True),
                          [])
 
-    def test_check_fastq_screen_outputs_standardSE_all_missing(self):
+    def test_check_fastq_screen_outputs_single_end_all_missing(self):
         """
-        check_fastq_screen_outputs: all screen outputs missing (standardSE)
+        check_fastq_screen_outputs: all screen outputs missing (single end)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",),
@@ -2048,12 +2048,12 @@ class TestCheckFastqScreenOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_screen_outputs(project,
                                                     qc_dir="qc",
                                                     screen="model_organisms",
-                                                    qc_protocol="standardSE"),
+                                                    read_numbers=(1,2)),
                          project.fastqs)
 
-    def test_check_fastq_screen_outputs_standardSE_all_present(self):
+    def test_check_fastq_screen_outputs_single_end_all_present(self):
         """
-        check_fastq_screen_outputs: all screen outputs present (standardSE)
+        check_fastq_screen_outputs: all screen outputs present (single end)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",),
@@ -2068,12 +2068,12 @@ class TestCheckFastqScreenOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_screen_outputs(project,
                                                     qc_dir="qc",
                                                     screen="model_organisms",
-                                                    qc_protocol="standardSE"),
+                                                    read_numbers=(1,)),
                          [])
 
-    def test_check_fastq_screen_outputs_standardSE_some_missing(self):
+    def test_check_fastq_screen_outputs_single_end_some_missing(self):
         """
-        check_fastq_screen_outputs: some screen outputs missing (standardSE)
+        check_fastq_screen_outputs: some screen outputs missing (single end)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",),
@@ -2092,13 +2092,13 @@ class TestCheckFastqScreenOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_screen_outputs(project,
                                                     qc_dir="qc",
                                                     screen="model_organisms",
-                                                    qc_protocol="standardSE"),
+                                                    read_numbers=(1,)),
                          [os.path.join(project.fastq_dir,
                                        "PJB1_S1_R1_001.fastq.gz")])
 
-    def test_check_fastq_screen_outputs_singlecell_all_missing(self):
+    def test_check_fastq_screen_outputs_single_cell_all_missing(self):
         """
-        check_fastq_screen_outputs: all screen outputs missing (singlecell)
+        check_fastq_screen_outputs: all screen outputs missing (single cell)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -2112,13 +2112,13 @@ class TestCheckFastqScreenOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_screen_outputs(project,
                                                     qc_dir="qc",
                                                     screen="model_organisms",
-                                                    qc_protocol="singlecell"),
+                                                    read_numbers=(2,)),
                          [os.path.join(project.fastq_dir,
                                        "PJB1_S1_R2_001.fastq.gz")])
 
-    def test_check_fastq_screen_outputs_singlecell_all_present(self):
+    def test_check_fastq_screen_outputs_single_cell_all_present(self):
         """
-        check_fastq_screen_outputs: all screen outputs present (singlecell)
+        check_fastq_screen_outputs: all screen outputs present (single cell)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -2134,12 +2134,12 @@ class TestCheckFastqScreenOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_screen_outputs(project,
                                                     qc_dir="qc",
                                                     screen="model_organisms",
-                                                    qc_protocol="singlecell"),
+                                                    read_numbers=(2,)),
                          [])
 
-    def test_check_fastq_screen_outputs_singlecell_some_missing(self):
+    def test_check_fastq_screen_outputs_single_cell_some_missing(self):
         """
-        check_fastq_screen_outputs: some screen outputs missing (singlecell)
+        check_fastq_screen_outputs: some screen outputs missing (single cell)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -2159,7 +2159,7 @@ class TestCheckFastqScreenOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_screen_outputs(project,
                                                     qc_dir="qc",
                                                     screen="model_organisms",
-                                                    qc_protocol="singlecell"),
+                                                    read_numbers=(2,)),
                          [os.path.join(project.fastq_dir,
                                        "PJB1_S1_R2_001.fastq.gz")])
 
@@ -2179,7 +2179,7 @@ class TestCheckFastqScreenOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_screen_outputs(project,
                                                     qc_dir="qc",
                                                     screen="model_organisms",
-                                                    qc_protocol="ParseEvercode"),
+                                                    read_numbers=(1,)),
                          [os.path.join(project.fastq_dir,
                                        "PJB1_S1_R1_001.fastq.gz")])
 
@@ -2202,7 +2202,7 @@ class TestCheckFastqScreenOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_screen_outputs(project,
                                                     qc_dir="qc",
                                                     screen="model_organisms",
-                                                    qc_protocol="ParseEvercode"),
+                                                    read_numbers=(1,)),
                          [])
 
     def test_check_fastq_screen_outputs_parseevercode_some_missing(self):
@@ -2228,7 +2228,7 @@ class TestCheckFastqScreenOutputs(unittest.TestCase):
         self.assertEqual(check_fastq_screen_outputs(project,
                                                     qc_dir="qc",
                                                     screen="model_organisms",
-                                                    qc_protocol="ParseEvercode"),
+                                                    read_numbers=(1,)),
                          [os.path.join(project.fastq_dir,
                                        "PJB1_S1_R1_001.fastq.gz")])
 

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -2245,9 +2245,9 @@ class TestCheckFastQCOutputs(unittest.TestCase):
         if REMOVE_TEST_OUTPUTS:
             shutil.rmtree(self.wd)
 
-    def test_check_fastqc_outputs_standardPE_all_missing(self):
+    def test_check_fastqc_outputs_paired_end_all_missing(self):
         """
-        check_fastqc_outputs: all FastQC outputs missing (standardPE)
+        check_fastqc_outputs: all FastQC outputs missing (paired end)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -2259,12 +2259,12 @@ class TestCheckFastQCOutputs(unittest.TestCase):
         # Check
         self.assertEqual(check_fastqc_outputs(project,
                                               qc_dir="qc",
-                                              qc_protocol="standardPE"),
+                                              read_numbers=(1,2)),
                          project.fastqs)
 
-    def test_check_fastqc_outputs_standardPE_all_present(self):
+    def test_check_fastqc_outputs_paired_end_all_present(self):
         """
-        check_fastqc_outputs: all FastQC outputs present (standardPE)
+        check_fastqc_outputs: all FastQC outputs present (paired end)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -2279,12 +2279,12 @@ class TestCheckFastQCOutputs(unittest.TestCase):
         # Check
         self.assertEqual(check_fastqc_outputs(project,
                                               qc_dir="qc",
-                                              qc_protocol="standardPE"),
+                                              read_numbers=(1,2)),
                          [])
 
-    def test_check_fastqc_outputs_standardPE_some_missing(self):
+    def test_check_fastqc_outputs_paired_end_some_missing(self):
         """
-        check_fastqc_outputs: some FastQC outputs missing (standardPE)
+        check_fastqc_outputs: some FastQC outputs missing (paired end)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -2302,13 +2302,13 @@ class TestCheckFastQCOutputs(unittest.TestCase):
         # Check
         self.assertEqual(check_fastqc_outputs(project,
                                               qc_dir="qc",
-                                              qc_protocol="standardPE"),
+                                              read_numbers=(1,2)),
                          [os.path.join(project.fastq_dir,
                                        "PJB1_S1_R1_001.fastq.gz")])
 
-    def test_check_fastqc_outputs_standardSE_all_missing(self):
+    def test_check_fastqc_outputs_single_end_all_missing(self):
         """
-        check_fastqc_outputs: all FastQC outputs missing (standardSE)
+        check_fastqc_outputs: all FastQC outputs missing (single end)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",),
@@ -2319,12 +2319,12 @@ class TestCheckFastQCOutputs(unittest.TestCase):
         # Check
         self.assertEqual(check_fastqc_outputs(project,
                                               qc_dir="qc",
-                                              qc_protocol="standardSE"),
+                                              read_numbers=(1,)),
                          project.fastqs)
 
-    def test_check_fastqc_outputs_standardSE_all_present(self):
+    def test_check_fastqc_outputs_single_end_all_present(self):
         """
-        check_fastqc_outputs: all FastQC outputs present (standardSE)
+        check_fastqc_outputs: all FastQC outputs present (single end)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",),
@@ -2338,12 +2338,12 @@ class TestCheckFastQCOutputs(unittest.TestCase):
         # Check
         self.assertEqual(check_fastqc_outputs(project,
                                               qc_dir="qc",
-                                              qc_protocol="standardSE"),
+                                              read_numbers=(1,)),
                          [])
 
-    def test_check_fastqc_outputs_standardSE_some_missing(self):
+    def test_check_fastqc_outputs_single_end_some_missing(self):
         """
-        check_fastqc_outputs: some FastQC outputs missing (standardSE)
+        check_fastqc_outputs: some FastQC outputs missing (single end)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",),
@@ -2360,13 +2360,13 @@ class TestCheckFastQCOutputs(unittest.TestCase):
         # Check
         self.assertEqual(check_fastqc_outputs(project,
                                               qc_dir="qc",
-                                              qc_protocol="standardSE"),
+                                              read_numbers=(1,)),
                          [os.path.join(project.fastq_dir,
                                        "PJB1_S1_R1_001.fastq.gz")])
 
-    def test_check_fastqc_outputs_singlecell_all_missing(self):
+    def test_check_fastqc_outputs_single_cell_all_missing(self):
         """
-        check_fastqc_outputs: all FastQC outputs missing (singlecell)
+        check_fastqc_outputs: all FastQC outputs missing (single cell)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -2378,12 +2378,12 @@ class TestCheckFastQCOutputs(unittest.TestCase):
         # Check
         self.assertEqual(check_fastqc_outputs(project,
                                               qc_dir="qc",
-                                              qc_protocol="singlecell"),
+                                              read_numbers=(1,2,)),
                          project.fastqs)
 
-    def test_check_fastqc_outputs_singlecell_all_present(self):
+    def test_check_fastqc_outputs_single_cell_all_present(self):
         """
-        check_fastqc_outputs: all FastQC outputs present (singlecell)
+        check_fastqc_outputs: all FastQC outputs present (single cell)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -2398,12 +2398,12 @@ class TestCheckFastQCOutputs(unittest.TestCase):
         # Check
         self.assertEqual(check_fastqc_outputs(project,
                                               qc_dir="qc",
-                                              qc_protocol="singlecell"),
+                                              read_numbers=(1,2,)),
                          [])
 
-    def test_check_fastqc_outputs_singlecell_some_missing(self):
+    def test_check_fastqc_outputs_single_cell_some_missing(self):
         """
-        check_fastqc_outputs: some FastQC outputs missing (singlecell)
+        check_fastqc_outputs: some FastQC outputs missing (single cell)
         """
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
@@ -2421,7 +2421,7 @@ class TestCheckFastQCOutputs(unittest.TestCase):
         # Check
         self.assertEqual(check_fastqc_outputs(project,
                                               qc_dir="qc",
-                                              qc_protocol="singlecell"),
+                                              read_numbers=(1,2,)),
                          [os.path.join(project.fastq_dir,
                                        "PJB1_S1_R1_001.fastq.gz")])
 

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -11,7 +11,6 @@ from auto_process_ngs.mock import MockAnalysisProject
 from auto_process_ngs.qc.protocols import QCProtocol
 from auto_process_ngs.qc.protocols import determine_qc_protocol
 from auto_process_ngs.qc.protocols import fetch_protocol_definition
-from auto_process_ngs.qc.protocols import get_read_numbers
 
 # Set to False to keep test output dirs
 REMOVE_TEST_OUTPUTS = True
@@ -515,25 +514,3 @@ class TestFetchProtocolDefinition(unittest.TestCase):
         self.assertRaises(KeyError,
                           fetch_protocol_definition,
                           "whazzdis?")
-
-class TestGetReadNumbers(unittest.TestCase):
-
-    def test_get_read_numbers(self):
-        """
-        get_read_numbers: check for sample protocol definitions
-        """
-        # Standard PE
-        read_numbers = get_read_numbers("standardPE")
-        self.assertEqual(read_numbers.seq_data,(1,2))
-        self.assertEqual(read_numbers.index,())
-        self.assertEqual(read_numbers.qc,(1,2))
-        # 10x single cell RNA-seq
-        read_numbers = get_read_numbers("10x_scRNAseq")
-        self.assertEqual(read_numbers.seq_data,(2,))
-        self.assertEqual(read_numbers.index,(1,))
-        self.assertEqual(read_numbers.qc,(1,2))
-        # 10x single cell ATAC
-        read_numbers = get_read_numbers("10x_scATAC")
-        self.assertEqual(read_numbers.seq_data,(1,3))
-        self.assertEqual(read_numbers.index,())
-        self.assertEqual(read_numbers.qc,(1,3))


### PR DESCRIPTION
PR which updates the QC pipeline in `qc/pipeline.py` to use the "QC modules" that are defined in `qc/protocols.py`, to determine which tasks to run.

Previously the QC modules have only been used for verification, with the protocols hard-coded in various places outside the pipeline. With these changes new protocols can be created more easily from the existing QC modules, without recoding the pipeline.