### PR TITLE
run_qc.py: always generate HTML report

### DIFF
--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -136,10 +136,6 @@ if __name__ == "__main__":
                            "QC directory already exists in <OUT_DIR> "
                            "(default: stop if output QC directory already "
                            "exists)")
-    reporting.add_argument('--force',action='store_true',
-                           help="force generation of HTML report even if "
-                           "pipeline fails (default: don't generate HTML "
-                           "report on pipeline failure")
     # Project metadata
     metadata = p.add_argument_group('Metadata')
     metadata.add_argument('--organism',metavar='ORGANISM',
@@ -305,6 +301,10 @@ if __name__ == "__main__":
                            "temporary directory is deleted)")
     # Deprecated options
     deprecated = p.add_argument_group('Deprecated/redundant options')
+    deprecated.add_argument('--force',action='store_true',
+                            help="redundant: HTML report generation will "
+                            "always be attempted (even when pipeline "
+                            "fails)")
     deprecated.add_argument('--multiqc',action='store_true',
                             dest='run_multiqc', default=False,
                             help="redundant: MultiQC report is generated "
@@ -810,18 +810,19 @@ if __name__ == "__main__":
                        working_dir=working_dir,
                        legacy_screens=use_legacy_screen_names,
                        verbose=args.verbose)
+
+    # Report if QC pipeline failed
     if status:
         logger.critical("QC failed (see warnings above)")
-        if args.force:
-            logger.warning("Forcing generation of HTML report")
-            report_qc(project,
-                      qc_dir=qc_dir,
-                      qc_protocol=args.qc_protocol,
-                      report_html=out_file,
-                      zip_outputs=True,
-                      multiqc=(not args.no_multiqc),
-                      force=True,
-                      runner=runners['report_runner'])
+        logger.warning("Forcing generation of HTML report")
+        report_qc(project,
+                  qc_dir=qc_dir,
+                  qc_protocol=args.qc_protocol,
+                  report_html=out_file,
+                  zip_outputs=True,
+                  multiqc=(not args.no_multiqc),
+                  force=True,
+                  runner=runners['report_runner'])
 
     # Update the QC metadata
     announce("Updating QC metadata")

--- a/docs/source/using/run_qc_standalone.rst
+++ b/docs/source/using/run_qc_standalone.rst
@@ -93,14 +93,6 @@ default ``run_qc.py`` will stop without running the pipeline;
 to override this behaviour and update an existing QC output
 directory, specify the ``-u`` or ``--update`` option.
 
-Force generation of HTML reports
---------------------------------
-
-By default if ``run_qc.py`` encounters an error when running
-the pipeline then it will not generate or update the final HTML
-QC report; use the ``--force`` option to ensure that the HTML
-report is always created.
-
 Running 10xGenomics single library analyses
 -------------------------------------------
 


### PR DESCRIPTION
Update `run_qc.py` so that default behaviour is to always generate an HTML report, even if the QC pipeline fails.

Previously the `--force` option was required in order to get this behaviour, however with this change `--force` is now redundant. The option is still supported but does nothing if specified.