### PR TITLE
QC pipeline: fix handling of non-canonical Fastq names for grouping/BAM file generation

### DIFF
--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -356,6 +356,7 @@ class QCPipeline(Pipeline):
                 self.params.fastq_subset,
                 self.params.nthreads,
                 reads=read_numbers.seq_data,
+                fastq_attrs=project.fastq_attrs,
                 verbose=self.params.VERBOSE)
             self.add_task(get_bam_files,
                           requires=(setup_qc_dirs,),
@@ -2799,13 +2800,15 @@ class GetBAMFiles(PipelineFunctionTask):
             self.report("STAR index is not set, cannot generate BAM files")
             return
         # Remove index reads and group Fastqs
-        fq_pairs = group_fastqs_by_name(
-            remove_index_fastqs(self.args.fastqs))
-        # Filter reads
         if self.args.fastq_attrs:
             fastq_attrs = self.args.fastq_attrs
         else:
             fastq_attrs = AnalysisFastq
+        fq_pairs = group_fastqs_by_name(
+            remove_index_fastqs(self.args.fastqs,
+                                fastq_attrs=fastq_attrs),
+            fastq_attrs=fastq_attrs)
+        # Filter reads
         if self.args.reads:
             filtered_pairs = []
             for fq_pair in fq_pairs:

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -30,10 +30,10 @@ import logging
 from bcftbx.JobRunner import fetch_runner
 from bcftbx.JobRunner import SimpleJobRunner
 from auto_process_ngs.analysis import AnalysisProject
+from auto_process_ngs.analysis import AnalysisFastq
 from auto_process_ngs.analysis import locate_project_info_file
 from auto_process_ngs.metadata import AnalysisProjectInfo
 from auto_process_ngs.metadata import AnalysisProjectQCDirInfo
-from auto_process_ngs.fastq_utils import IlluminaFastqAttrs
 from auto_process_ngs.fastq_utils import group_fastqs_by_name
 import auto_process_ngs
 import auto_process_ngs.settings
@@ -362,7 +362,7 @@ if __name__ == "__main__":
     out_dir = args.out_dir
     qc_dir = args.qc_dir
     master_fastq_dir = None
-    fastq_attrs = IlluminaFastqAttrs
+    fastq_attrs = AnalysisFastq
     extra_files = set()
 
     # Deal with inputs
@@ -757,7 +757,7 @@ if __name__ == "__main__":
         atexit.register(cleanup_atexit,project_dir)
 
     # Load the project
-    project = AnalysisProject(project_dir)
+    project = AnalysisProject(project_dir,fastq_attrs=fastq_attrs)
     print("Loaded project '%s'" % project.name)
 
     # Set working directory for pipeline


### PR DESCRIPTION
Updates to the QC pipeline (`qc/pipeline.py`) and standalone QC runner (`run_qc.py`) to better handle non-canonical (i.e. non-Illumina-style) Fastq names when grouping for BAM file generation:

1. In `qc/pipeline.py`: fix the `GetBAMFiles` task to explicitly use the supplied `fastq_attrs` object (and ensure that the appropriate object is supplied when the task is set up) when removing index reads and grouping Fastqs;
2. In `run_qc.py`: switch from using the `IlluminaFastqAttrs` class to the more flexible `AnalysisFastqs` class, for handling Fastq names.