### PR TITLE
QC pipeline: explicitly disable DISPLAY env variable in Qualimap task

### DIFF
--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -3459,6 +3459,11 @@ class RunQualimapRnaseq(PipelineTask):
                          os.path.basename(bam),
                          """
                          export _JAVA_OPTIONS="-XX:ParallelGCThreads={nthreads} -Xmx{java_mem_size}"
+                         if [ ! -z "$DISPLAY" ] ; then
+                             echo "DISPLAY set to $DISPLAY"
+                             echo "Unsetting to disable interactive window"
+                             export DISPLAY=
+                         fi
                          qualimap rnaseq \\
                              -bam {bam} \\
                              -gtf {feature_file} \\


### PR DESCRIPTION
Update to the QC pipeline code (`qc/pipeline.py`) to explicitly unset the `DISPLAY` environment variable in the Qualimap task, to prevent the program from attempting to start an interactive window (instead of running on the command line).