### PR TITLE
Fix broken utility documentation generation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -608,7 +608,7 @@ are available:
 for utility in ("analyse_barcodes.py",
                 "assign_barcodes.py",
                 "audit_projects.py",
-                "build_indexes.py",
+                "build_index.py",
                 "concat_fastqs.py",
                 "barcode_splitter.py",
                 "download_fastqs.py",


### PR DESCRIPTION
Fixes the broken utility documentation generation by correcting the name of the ``build_index.py`` in the Sphinx `conf.py` file.