### PR TITLE
Update and fix Fastq read subsetting in 'run_qc'

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -583,7 +583,7 @@ def add_run_qc_command(cmdparser):
                               "projects in ANALYSIS_DIR.")
     # Defaults
     default_nthreads = __settings.qc.nprocessors
-    fastq_screen_subset = __settings.qc.fastq_screen_subset
+    fastq_subset_size = __settings.qc.fastq_subset_size
     max_concurrent_jobs = __settings.general.max_concurrent_jobs
     max_cores = __settings.general.max_cores
     max_batches = __settings.general.max_batches
@@ -608,13 +608,13 @@ def add_run_qc_command(cmdparser):
                    "Fastq files to run the QC on.")
     # QC pipeline options
     qc_options = p.add_argument_group('QC options')
-    qc_options.add_argument('--fastq_screen_subset',action='store',
+    qc_options.add_argument('--fastq_subset',action='store',
                             dest='subset',type=int,
-                            default=fastq_screen_subset,
+                            default=fastq_subset_size,
                             help="specify size of subset of total reads to "
-                            "use for fastq_screen (i.e. --subset option); "
+                            "use for fastq_screen, BAM file generation etc "
                             "(default %d, set to 0 to use all reads)" %
-                            fastq_screen_subset)
+                            fastq_subset_size)
     qc_options.add_argument('-t','--threads',action='store',dest="nthreads",
                             type=int,default=default_nthreads,
                             help="number of threads to use for QC script "
@@ -1379,7 +1379,7 @@ def run_qc(args):
     # Do the run_qc step
     retcode = d.run_qc(projects=args.project_pattern,
                        fastq_screens=fastq_screens,
-                       fastq_screen_subset=args.subset,
+                       fastq_subset=args.subset,
                        nthreads=args.nthreads,
                        fastq_dir=args.fastq_dir,
                        qc_dir=args.qc_dir,

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 #######################################################################
 
 def run_qc(ap,projects=None,fastq_screens=None,
-           fastq_screen_subset=100000,nthreads=None,
+           fastq_subset=100000,nthreads=None,
            runner=None,fastq_dir=None,qc_dir=None,
            cellranger_exe=None,
            cellranger_chemistry='auto',
@@ -56,9 +56,9 @@ def run_qc(ap,projects=None,fastq_screens=None,
         projects)
       fastq_screens (dict): mapping of Fastq screen names to
         corresponding conf files, to use for contaminant screens
-      fastq_screen_subset (int): subset of reads to use in
-        FastQScreen, set to zero or None to use all reads
-        (default: 100000)
+      fastq_subset (int): maximum size of subset of reads to use
+        for FastQScreen, BAM file generation etc; set to zero or
+        None to use all reads (default: 100000)
       nthreads (int): specify number of threads to run the QC jobs
         with (default: 1)
       runner (JobRunner): specify a non-default job runner to use
@@ -260,6 +260,7 @@ def run_qc(ap,projects=None,fastq_screens=None,
     # Run the QC
     status = runqc.run(nthreads=nthreads,
                        fastq_screens=fastq_screens,
+                       fastq_subset=fastq_subset,
                        star_indexes=star_indexes,
                        annotation_bed_files=annotation_bed_files,
                        annotation_gtf_files=annotation_gtf_files,

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -192,11 +192,14 @@ class Settings:
         self.qc['fastq_screen_subset'] = config.getint('qc',
                                                        'fastq_screen_subset',
                                                        100000)
-        self.qc['use_legacy_screen_names'] = \
-                                             config.getboolean(
-                                                 'qc',
-                                                 'use_legacy_screen_names',
-                                                 False)
+        self.qc['fastq_subset_size'] = config.getint(
+            'qc',
+            'subset_size',
+            self.qc.fastq_screen_subset)
+        self.qc['use_legacy_screen_names'] = config.getboolean(
+            'qc',
+            'use_legacy_screen_names',
+            False)
         # Fastq screens
         self.add_section('screens')
         for section in filter(lambda x: x.startswith('screen:'),

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -165,7 +165,7 @@ if __name__ == "__main__":
                             ", ".join(["'%s'" % x for x in PROTOCOLS]))
     qc_options.add_argument('--fastq_screen_subset',metavar='SUBSET',
                             action='store',dest='fastq_screen_subset',
-                            default=__settings.qc.fastq_screen_subset,
+                            default=__settings.qc.fastq_subset_size,
                             type=int,
                             help="specify size of subset of total reads "
                             "to use for fastq_screen (i.e. --subset "

--- a/config/auto_process.ini.sample
+++ b/config/auto_process.ini.sample
@@ -79,7 +79,7 @@ create_empty_fastqs = False
 # Comma-separated list of panel names
 # Each panel needs to be defined in its own 'screen:...' section
 #fastq_screens = model_organisms,other_organisms,rRNA
-fastq_screen_subset = 100000
+fastq_subset_size = 100000
 # By default nprocessors taken from runner
 #nprocessors = 1
 # Whether to use 'legacy' naming convention for FastqScreen

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -541,14 +541,25 @@ Additionally the ``[qc]`` section allows other aspects of the
 QC pipeline operation to be explicitly specified.
 
 The default size of the subset of reads used by FastqScreen
-when generating the screens can be set using the
-``fastq_screen_subset`` parameter, e.g.:
+when generating the screens, generating BAM files and so on
+can be set using the ``fastq_subset_size`` parameter, e.g.:
 
 ::
 
    [qc]
-   fastq_screen_subset = 10000
+   fastq_subset_size = 10000
    ...
+
+Setting this to 0 will force all reads to be used for the
+appropriate QC stages (note that this can result in extended
+run time for the QC pipeline, and larger intermediate and
+final output files).
+
+.. note::
+
+   ``fastq_subset_size`` replaces the deprecated legacy
+   ``fastq_screen_subset`` parameter (which will however be
+   used as a fallback if ``subset_size`` is not present).
 
 By default the QC pipeline creates FastqScreen outputs using
 the following naming convention:


### PR DESCRIPTION
Updates the config parameter for specifying the size of Fastq read subsetting in the QC pipeline when invoked from the `run_qc` command and the `run_qc.py` utility, to use `fastq_subset_size` (instead of `fastq_screen_subset`). This new parameter should be used to set the size of read subsets for Fastq Screen, BAM file generation and so on within the QC pipeline.

The PR also fixes a bug in the `run_qc` command which meant that the size of the subset was never passed to the pipeline (meaning that all reads were being used for BAM file generation, and resulting in larger files and longer run times),