### PR TITLE
Update QC for non-biological samples in 10xGenomics CellPlex datasets

### DIFF
--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -4070,6 +4070,7 @@ def make_mock_analysis_project(name="PJB",top_dir=None,
                                fastq_dir='fastqs',
                                fastq_names=None,
                                sample_names=None,
+                               seq_data_samples=None,
                                screens=('model_organisms',
                                         'other_organisms',
                                         'rRNA',),
@@ -4105,6 +4106,8 @@ def make_mock_analysis_project(name="PJB",top_dir=None,
         names
       sample_names (list): optional, explicit list of sample
         names
+      seq_data_samples (list): list with subset of sample
+        names which include sequence (i.e. biological) data
       screens (list): optional, list of non-standard
         FastqScreen panel names
       include_fastqc (bool): include outputs from Fastqc
@@ -4170,6 +4173,7 @@ def make_mock_analysis_project(name="PJB",top_dir=None,
                      cellranger_pipelines=cellranger_pipelines,
                      cellranger_samples=cellranger_samples,
                      cellranger_multi_samples=cellranger_multi_samples,
+                     seq_data_samples=seq_data_samples,
                      include_fastqc=include_fastqc,
                      include_fastq_screen=include_fastq_screen,
                      include_strandedness=include_strandedness,

--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -76,6 +76,9 @@ class QCOutputs:
     - reads: list of reads (e.g. 'r1', 'r2', 'i1' etc)
     - samples: sorted list of sample names extracted
       from Fastqs
+    - seq_data_samples: sorted list of samples with
+      biological data (rather than e.g. feature
+      barcodes)
     - bams: sorted list of BAM file names
     - organisms: sorted list of organism names
     - fastq_screens: sorted list of screen names
@@ -136,6 +139,7 @@ class QCOutputs:
         # Properties
         self.fastqs = set()
         self.samples = []
+        self.seq_data_samples = []
         self.bams = set()
         self.reads = []
         self.organisms = set()
@@ -174,6 +178,9 @@ class QCOutputs:
         print("Organisms:")
         for o in self.organisms:
             print("- %s" % o)
+        print("Biological samples:")
+        for s in self.seq_data_samples:
+            print("- %s" % s)
         print("Software:")
         for sw in self.software:
             print("- %s: %s" % (sw,','.join(self.software[sw])))
@@ -278,6 +285,14 @@ class QCOutputs:
             samples.add(s)
         self.samples = sorted(list(samples),
                               key=lambda s: split_sample_name(s))
+        # Samples with biological sequence data
+        if os.path.exists(os.path.join(self.qc_dir,'10x_multi_config.csv')):
+            cf = CellrangerMultiConfigCsv(os.path.join(self.qc_dir,
+                                                       '10x_multi_config.csv'))
+            self.seq_data_samples.extend([s for s in cf.gex_libraries
+                                          if s in samples])
+        else:
+            self.seq_data_samples = [s for s in self.samples]
         # Determine reads
         reads = set()
         for fastq in self.fastqs:

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -1209,6 +1209,8 @@ class QCReport(Document):
             css_classes=('sample',))
         reporter = SampleQCReporter(project,
                                     sample,
+                                    is_seq_data=(sample in
+                                                 project.seq_data_samples),
                                     qc_dir=qc_dir,
                                     fastq_attrs=project.fastq_attrs)
         reads = reporter.reads
@@ -1754,6 +1756,8 @@ class QCProject:
             set(qc_outputs.samples +
                 [s.name for s in self.project.samples])),
                 key=lambda s: split_sample_name(s))
+        # Biological samples
+        self.seq_data_samples = [s for s in qc_outputs.seq_data_samples]
         # Organisms
         self.organisms = qc_outputs.organisms
         # Fastq screens
@@ -1804,20 +1808,23 @@ class SampleQCReporter:
         'sample',
         'cellranger_count',
     )
-    def __init__(self,project,sample,qc_dir=None,
-                 fastq_attrs=AnalysisFastq):
+    def __init__(self,project,sample,is_seq_data=True,
+                 qc_dir=None,fastq_attrs=AnalysisFastq):
         """
         Create a new SampleQCReporter
 
         Arguments:
           project (QCProject): project to report
           sample (str): name of sample to report
+          is_seq_data (bool): if True then the sample
+            contains biological data
           qc_dir (str): path to the directory holding the
             QC artefacts
           fastq_attrs (BaseFastqAttrs): class for extracting
             data from Fastq names
         """
         self.sample = str(sample)
+        self.is_seq_data = bool(is_seq_data)
         self.fastq_groups = []
         self.cellranger_count = []
         self.cellranger_multi = []
@@ -1839,7 +1846,8 @@ class SampleQCReporter:
                 qc_dir=qc_dir,
                 project=project,
                 project_id=project.id,
-                fastq_attrs=fastq_attrs))
+                fastq_attrs=fastq_attrs,
+                is_seq_data=self.is_seq_data))
         # Reads associated with the sample
         if self.fastq_groups:
             self.reads = [r for r in self.fastq_groups[0].reads]
@@ -2314,9 +2322,11 @@ class FastqGroupQCReporter:
       project_id (str): identifier for the project
       fastq_attrs (BaseFastqAttrs): class for extracting
         data from Fastq names
+      is_seq_data (bool): if True then indicates that the
+        group contains biological data
     """
     def __init__(self,fastqs,qc_dir,project,project_id=None,
-                 fastq_attrs=AnalysisFastq):
+                 fastq_attrs=AnalysisFastq,is_seq_data=True):
         """
         Create a new FastqGroupQCReporter
         """
@@ -2324,6 +2334,7 @@ class FastqGroupQCReporter:
         self.project = project
         self.project_id = project_id
         self.fastq_attrs = fastq_attrs
+        self.is_seq_data = bool(is_seq_data)
         # Assign fastqs to reads
         self.fastqs = defaultdict(lambda: None)
         self.reporters = defaultdict(lambda: None)
@@ -2704,6 +2715,9 @@ class FastqGroupQCReporter:
             except Exception as ex:
                 # Encountered an exception trying to acquire the value
                 # for the field
+                if not self.is_seq_data:
+                    summary_table.set_value(idx,field,"&nbsp;")
+                    continue
                 fastqs = ", ".join([self.reporters[r].name
                                     for r in self.reads])
                 logger.warning("Exception setting '%s' in summary table "

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -282,6 +282,18 @@ SUMMARY_FIELD_DESCRIPTIONS = {
                       'Corresponding sample for single cell multiome analysis')
 }
 
+# Fields that are only applicable for biological data
+SEQ_DATA_SUMMARY_FIELDS = (
+    'bam_file',
+    'screens_.*',
+    'strandedness',
+    'strandedness_.*',
+    'insert_size_histogram',
+    'coverage_profile_along_genes',
+    'reads_genomic_origin',
+    'strand_specificity',
+)
+
 #######################################################################
 # Classes
 #######################################################################
@@ -2716,8 +2728,13 @@ class FastqGroupQCReporter:
                 # Encountered an exception trying to acquire the value
                 # for the field
                 if not self.is_seq_data:
-                    summary_table.set_value(idx,field,"&nbsp;")
-                    continue
+                    is_seq_data_field = any([bool(re.match('^%s$' % f,field))
+                                             for f in SEQ_DATA_SUMMARY_FIELDS])
+                    if is_seq_data_field:
+                        # Field not valid for non-biological
+                        # data so missing value is OK
+                        summary_table.set_value(idx,field,"&nbsp;")
+                        continue
                 fastqs = ", ".join([self.reporters[r].name
                                     for r in self.reads])
                 logger.warning("Exception setting '%s' in summary table "

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -107,6 +107,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R1_001'])
         self.assertEqual(qc_outputs.samples,
                          ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
         self.assertEqual(qc_outputs.fastq_screens,
@@ -154,6 +156,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R1_001'])
         self.assertEqual(qc_outputs.samples,
                          ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
         self.assertEqual(qc_outputs.fastq_screens,
@@ -200,6 +204,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R1_001'])
         self.assertEqual(qc_outputs.samples,
                          ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
         self.assertEqual(qc_outputs.fastq_screens,[])
@@ -242,6 +248,8 @@ class TestQCOutputs(unittest.TestCase):
                          ['PJB1_S1_R1_001',
                           'PJB2_S2_R1_001'])
         self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
                          ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
@@ -288,6 +296,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R1_001'])
         self.assertEqual(qc_outputs.samples,
                          ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
         self.assertEqual(qc_outputs.fastq_screens,
@@ -332,6 +342,8 @@ class TestQCOutputs(unittest.TestCase):
                          ['PJB1_S1_R1_001',
                           'PJB2_S2_R1_001'])
         self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
                          ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
@@ -379,6 +391,8 @@ class TestQCOutputs(unittest.TestCase):
                          ['PJB1_S1_R1_001',
                           'PJB2_S2_R1_001'])
         self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
                          ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
@@ -433,6 +447,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R2_001'])
         self.assertEqual(qc_outputs.samples,
                          ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
         self.assertEqual(qc_outputs.fastq_screens,
@@ -486,6 +502,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R1_001',
                           'PJB2_S2_R2_001'])
         self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
                          ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
@@ -542,6 +560,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R1_001',
                           'PJB2_S2_R2_001'])
         self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
                          ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,['PJB1_S1_001',
                                           'PJB2_S2_001'])
@@ -602,6 +622,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R2_001'])
         self.assertEqual(qc_outputs.samples,
                          ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,['human'])
         self.assertEqual(qc_outputs.fastq_screens,
@@ -660,6 +682,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R1_001',
                           'PJB2_S2_R2_001'])
         self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
                          ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,['PJB1_S1_001',
                                           'PJB2_S2_001'])
@@ -720,6 +744,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R2_001'])
         self.assertEqual(qc_outputs.samples,
                          ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,['PJB1_S1_001',
                                           'PJB2_S2_001'])
         self.assertEqual(qc_outputs.organisms,['human'])
@@ -776,6 +802,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R2_001'])
         self.assertEqual(qc_outputs.samples,
                          ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
         self.assertEqual(qc_outputs.fastq_screens,[])
@@ -827,6 +855,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R2_001'])
         self.assertEqual(qc_outputs.samples,
                          ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
         self.assertEqual(qc_outputs.fastq_screens,
@@ -877,6 +907,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R2_001'])
         self.assertEqual(qc_outputs.samples,
                          ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
@@ -924,6 +956,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R1_001',
                           'PJB2_S2_R2_001'])
         self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
                          ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
@@ -979,6 +1013,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R1_001',
                           'PJB2_S2_R2_001'])
         self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
                          ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
@@ -1041,6 +1077,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R1_001',
                           'PJB2_S2_R2_001'])
         self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
                          ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
@@ -1107,6 +1145,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R2_001'])
         self.assertEqual(qc_outputs.samples,
                          ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
         self.assertEqual(qc_outputs.fastq_screens,
@@ -1170,6 +1210,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R1_001',
                           'PJB2_S2_R3_001'])
         self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
                          ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
@@ -1236,6 +1278,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R1_001',
                           'PJB2_S2_R2_001'])
         self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
                          ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
@@ -1306,6 +1350,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R1_001',
                           'PJB2_S2_R3_001'])
         self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
                          ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
@@ -1379,6 +1425,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_MC_S2_R2_001'])
         self.assertEqual(qc_outputs.samples,
                          ['PJB1_GEX','PJB2_MC'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1_GEX'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
         self.assertEqual(qc_outputs.fastq_screens,
@@ -1451,6 +1499,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_MC_S2_R2_001'])
         self.assertEqual(qc_outputs.samples,
                          ['PJB1_GEX','PJB2_MC'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1_GEX'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
         self.assertEqual(qc_outputs.fastq_screens,
@@ -1510,6 +1560,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R2_001'])
         self.assertEqual(qc_outputs.samples,
                          ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
         self.assertEqual(qc_outputs.fastq_screens,
@@ -1564,6 +1616,8 @@ class TestQCOutputs(unittest.TestCase):
                           'PJB2_S2_R1_001_paired',
                           'PJB2_S2_R2_001_paired'])
         self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
                          ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -3423,6 +3423,17 @@ PBB,CMO302,PBB
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
                             "Missing %s" % f)
+        # Verify missing outputs for multiplex capture samples
+        for f in ("PJB2_MC_S2_R2_001_fastq_strand.txt",
+                  "PJB2_MC_S2_R2_001_screen_model_organisms.txt",
+                  "PJB2_MC_S2_R2_001_screen_other_organisms.txt",
+                  "PJB2_MC_S2_R2_001_screen_rRNA.txt",
+                  "qualimap-rnaseq/human/PJB2_MC_S2_001",):
+            self.assertFalse(os.path.exists(os.path.join(self.wd,
+                                                         "PJB",
+                                                         "qc",
+                                                         f)),
+                             "Found %s (shouldn't exist)" % f)
 
     #@unittest.skip("Skipped")
     def test_qcpipeline_cellplex_no_10x_multi_config_file(self):

--- a/auto_process_ngs/test/qc/test_verification.py
+++ b/auto_process_ngs/test/qc/test_verification.py
@@ -45,6 +45,7 @@ class TestQCVerifier(unittest.TestCase):
                      cellranger_pipelines=('cellranger',),
                      cellranger_samples=None,
                      cellranger_multi_samples=None,
+                     seq_data_samples=None,
                      include_fastqc=True,
                      include_fastq_screen=True,
                      include_strandedness=True,
@@ -68,6 +69,7 @@ class TestQCVerifier(unittest.TestCase):
             cellranger_pipelines=cellranger_pipelines,
             cellranger_samples=cellranger_samples,
             cellranger_multi_samples=cellranger_multi_samples,
+            seq_data_samples=seq_data_samples,
             include_fastqc=include_fastqc,
             include_fastq_screen=include_fastq_screen,
             include_strandedness=include_strandedness,
@@ -1312,6 +1314,9 @@ class TestQCVerifier(unittest.TestCase):
         qc_dir = self._make_qc_dir('qc',
                                    protocol="10x_CellPlex",
                                    fastq_names=fastq_names,
+                                   seq_data_samples=("PJB1_GEX",),
+                                   include_rseqc_genebody_coverage=True,
+                                   include_qualimap_rnaseq=True,
                                    include_cellranger_count=True,
                                    include_cellranger_multi=True,
                                    cellranger_pipelines=('cellranger',),
@@ -1323,15 +1328,21 @@ class TestQCVerifier(unittest.TestCase):
                                        'PJB_CML1',
                                        'PJB_CML2',
                                    ))
+        verify_params = dict()
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify(fastqs=fastq_names,
-                                           qc_protocol="10x_CellPlex",
-                                           fastq_screens=('model_organisms',
-                                                          'other_organisms',
-                                                          'rRNA'),
-                                           cellranger_version="6.1.2",
-                                           cellranger_refdata=\
-                                           "/data/refdata-cellranger-2020-A"))
+        self.assertTrue(qc_verifier.verify(
+            fastqs=fastq_names,
+            qc_protocol="10x_CellPlex",
+            organism="Human",
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA'),
+            star_index="/data/star/hg38",
+            annotation_bed="/data/annotation/hg38.bed",
+            annotation_gtf="/data/annotation/hg38.gtf",
+            cellranger_version="6.1.2",
+            cellranger_refdata=\
+            "/data/refdata-cellranger-2020-A"))
 
     def test_qcverifier_verify_10x_cellranger_multi_no_config(self):
         """
@@ -1542,6 +1553,7 @@ class TestVerifyProject(unittest.TestCase):
                                fastq_dir="fastqs",qc_dir="qc",
                                fastq_names=None,
                                sample_names=None,
+                               seq_data_samples=None,
                                screens=('model_organisms',
                                         'other_organisms',
                                         'rRNA',),
@@ -1571,6 +1583,7 @@ class TestVerifyProject(unittest.TestCase):
             qc_dir=qc_dir,
             fastq_names=fastq_names,
             sample_names=sample_names,
+            seq_data_samples=seq_data_samples,
             screens=screens,
             include_fastqc=include_fastqc,
             include_fastq_screen=include_fastq_screen,
@@ -1633,6 +1646,8 @@ class TestVerifyProject(unittest.TestCase):
         """
         analysis_dir = self._make_analysis_project(
             protocol='10x_CellPlex',
+            sample_names=('PJB1_GEX','PJB2_CML',),
+            seq_data_samples=('PJB1_GEX',),
             include_cellranger_multi=True,
             cellranger_multi_samples=('PJB_CML1','PJB_CML2',))
         project = AnalysisProject(analysis_dir)
@@ -1644,6 +1659,8 @@ class TestVerifyProject(unittest.TestCase):
         """
         analysis_dir = self._make_analysis_project(
             protocol='10x_CellPlex',
+            sample_names=('PJB1_GEX','PJB2_CML',),
+            seq_data_samples=('PJB1_GEX',),
             include_cellranger_multi=True,
             include_cellranger_count=True,
             cellranger_pipelines=('cellranger',),

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -121,6 +121,21 @@ reports can be copied there for sharing using the
    pipeline by using the ``run_qc.py`` utility; see the
    section on :doc:`running the QC standalone <run_qc_standalone>`.
 
+--------------------------------
+Samples with non-biological data
+--------------------------------
+
+For some types of dataset (e.g. 10x Genomics CellPlex data), not
+all samples in the dataset contain biological data (for example,
+CellPlex datasets also have "multiplexing capture" samples which
+contain feature barcodes).
+
+Where these types of samples can be identified by the pipeline
+(for example, information in the ``10x_multi_config.csv`` file
+for CellPlex) only metrics that are appropriate for non-biological
+samples will be generated (e.g. screens, strandedness etc) and
+reported.
+
 ------------------
 Additional options
 ------------------


### PR DESCRIPTION
PR which updates the QC pipeline, verification and reporting to accommodate non-biological samples in 10xGenomics CellPlex datasets.

In these cases the dataset contains samples with biological data (the `GEX` samples) and samples with "metadata" (i.e. feature barcode data, in the multiplexing capture samples). As certain metrics are only valid for biological data (specifically strandedness, gene body coverage, genomic origin of reads, and Fastq screens), these changes update the QC so that the metrics are not applied to non-biological data (and are not reported as errors when missing from the QC verification or reports).