### PR TITLE
make_fastqs: capture NovaSeq flow cell mode

### DIFF
--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -443,6 +443,8 @@ def make_fastqs(ap,protocol='standard',platform=None,
     if status == 0:
         # Platform
         ap.metadata['platform'] = make_fastqs.output.platform
+        # Flow cell mode
+        ap.metadata['flow_cell_mode'] = make_fastqs.output.flow_cell_mode
         # Software used for processing
         try:
             processing_software = ast.literal_eval(

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -452,7 +452,11 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                        value=ap.metadata.platform)
     if ap.metadata.sequencer_model:
         params_tbl.add_row(param="Sequencer",
-                           value=ap.metadata.sequencer_model)
+                           value="%s%s" %
+                           (ap.metadata.sequencer_model,
+                            " (%s flow cell)" % ap.metadata.flow_cell_mode
+                            if ap.metadata.flow_cell_mode
+                            else ''))
     params_tbl.add_row(param="Endedness",
                        value=('Paired end' if ap.paired_end
                               else 'Single end'))

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -611,6 +611,9 @@ def fetch_value(ap,project,field):
     elif field == 'sequencer_model':
         return ('' if not ap.metadata.sequencer_model
                 else ap.metadata.sequencer_model)
+    elif field == 'flow_cell_mode':
+        return ('' if not ap.metadata.flow_cell_mode
+                else ap.metadata.flow_cell_mode)
     elif field == 'no_of_samples' or field == '#samples':
         if cellplex_config:
             # Number of multiplexed samples

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -500,8 +500,13 @@ def report_projects(ap,fields=None):
 
     Composite fields can be specified by joining two or more
     fields with '+' (e.g. 'project+run_id'); the resulting
-    value will be the values of the individual fields joined by
-    underscores.
+    value will be the values of the individual fields separated
+    by spaces (with null values simply ignored).
+
+    An alternative delimiter can be explicitly specified by
+    prefacing the composite field with a pair of square braces
+    enclosing the new delimiter, followed by a colon (e.g.
+    '[_]:user+PI' will use an underscore instead of a space).
 
     Arguments:
       ap (AutoProcessor): autoprocessor pointing to the
@@ -535,13 +540,25 @@ def report_projects(ap,fields=None):
     for project in analysis_dir.projects:
         project_line = []
         for field in fields:
+            # Default delimiter for this field
+            delimiter = ' '
+            # Check for custom delimiter (for composite
+            # fields, starts with '[...]:'
+            if field.startswith('['):
+                field_ = field.split(':')
+                if len(field_) > 1 and field_[-2].endswith(']'):
+                    delimiter = ':'.join(field_[:-1])[1:-1]
+                    field = field_[-1]
             # Deal with composite fields (multiple field names
             # joined with '+')
             value = []
             for subfield in field.split('+'):
-                value.append(fetch_value(ap,project,subfield))
+                subvalue = fetch_value(ap,project,subfield)
+                if subvalue:
+                    # Only append if there is a value
+                    value.append(subvalue)
             # Append to the output line
-            project_line.append('_'.join(value))
+            project_line.append(delimiter.join(value))
         report.append('\t'.join(project_line))
     report = '\n'.join(report)
     return report

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -352,6 +352,8 @@ class AnalysisDirMetadata(MetadataDict):
     instrument_flow_cell_id: the flow cell ID from the sequencing
       instrument
     sequencer_model: the model of the sequencing instrument
+    flow_cell_mode: the flow cell configuration (if present in the
+      run parameters)
 
     """
     def __init__(self,filen=None):
@@ -376,6 +378,7 @@ class AnalysisDirMetadata(MetadataDict):
                                   'instrument_flow_cell_id': 'instrument_flow_cell_id',
                                   'instrument_run_number': 'instrument_run_number',
                                   'sequencer_model': 'sequencer_model',
+                                  'flow_cell_mode': 'flow_cell_mode',
                               },
                               order=('run_name',
                                      'platform',

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -119,6 +119,7 @@ class TestMakeFastqs(unittest.TestCase):
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -191,6 +192,7 @@ class TestMakeFastqs(unittest.TestCase):
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -264,6 +266,7 @@ class TestMakeFastqs(unittest.TestCase):
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -350,6 +353,7 @@ class TestMakeFastqs(unittest.TestCase):
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -440,6 +444,7 @@ class TestMakeFastqs(unittest.TestCase):
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -508,6 +513,7 @@ class TestMakeFastqs(unittest.TestCase):
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -584,6 +590,7 @@ class TestMakeFastqs(unittest.TestCase):
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -658,6 +665,7 @@ class TestMakeFastqs(unittest.TestCase):
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -730,6 +738,7 @@ class TestMakeFastqs(unittest.TestCase):
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -798,6 +807,7 @@ class TestMakeFastqs(unittest.TestCase):
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -876,6 +886,7 @@ class TestMakeFastqs(unittest.TestCase):
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -953,6 +964,7 @@ class TestMakeFastqs(unittest.TestCase):
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -1045,6 +1057,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -1137,6 +1150,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -1221,6 +1235,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -1296,6 +1311,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -1380,6 +1396,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -1455,6 +1472,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -1544,6 +1562,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -1622,6 +1641,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -1704,6 +1724,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -1779,6 +1800,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -1862,6 +1884,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -1935,6 +1958,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -2018,6 +2042,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(status,1)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -2085,6 +2110,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(status,1)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -2150,6 +2176,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -2223,6 +2250,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -2295,6 +2323,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -2386,6 +2415,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -2534,6 +2564,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -2661,6 +2692,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -2811,6 +2843,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -2916,6 +2949,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -3021,6 +3055,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -3117,6 +3152,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -3199,6 +3235,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                        poll_interval=POLL_INTERVAL)
         # Check outputs
         self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -3317,6 +3354,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -3440,6 +3478,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -3559,6 +3598,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -3679,6 +3719,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -3791,6 +3832,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                        poll_interval=POLL_INTERVAL)
         # Check outputs
         self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -3927,6 +3969,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -4073,6 +4116,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -4185,6 +4229,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                        poll_interval=POLL_INTERVAL)
         # Check outputs
         self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -4262,6 +4307,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                        poll_interval=POLL_INTERVAL)
         # Check outputs
         self.assertEqual(p.output.platform,"hiseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -4358,6 +4404,7 @@ AB1,AB1,,,,,AB,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -4433,6 +4480,7 @@ AB1,AB1,,,,,AB,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -4533,6 +4581,7 @@ AB1,AB1,,,,,AB,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -4628,6 +4677,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,ICELL8_ATAC,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -4755,6 +4805,7 @@ Unassigned-Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,ICELL8_ATAC,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -4844,6 +4895,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -4938,6 +4990,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -5031,6 +5084,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -5125,6 +5179,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"illumina")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -5240,6 +5295,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -5334,6 +5390,7 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -5429,6 +5486,7 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -5544,6 +5602,7 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -5638,6 +5697,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -5733,6 +5793,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -5828,6 +5889,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -5922,6 +5984,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -6018,6 +6081,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -6114,6 +6178,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -6207,6 +6272,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -6301,6 +6367,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -6380,6 +6447,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -6458,6 +6526,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -6563,6 +6632,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(status,1)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -6637,6 +6707,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -6705,6 +6776,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(status,1)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -6771,6 +6843,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(status,1)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -6840,6 +6913,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"illumina")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -6912,6 +6986,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(status,0)
         # Check outputs
         self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
         self.assertEqual(p.output.primary_data_dir,
                          os.path.join(analysis_dir,
                                       "primary_data"))
@@ -7361,6 +7436,81 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
                               subset(lanes=[1,]),
                               subset(lanes=[2,3,4])
                           ))
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_novaseq(self):
+        """
+        MakeFastqs: standard protocol/bcl2fastq: NovaSeq data
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "221206_A7001250_00042_AHGXXXX",
+            "novaseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.novaseq)
+        # Create mock bcl2fastq
+        # Check that bases mask is as expected
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,
+                       sample_sheet,
+                       protocol="standard",
+                       platform="novaseq")
+        status = p.run(analysis_dir,
+                       poll_interval=POLL_INTERVAL)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"novaseq")
+        self.assertEqual(p.output.flow_cell_mode,"SP")
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "221206_A7001250_00042_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "221206_A7001250_00042_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
 
 class TestSubsetFunction(unittest.TestCase):
     """

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -863,6 +863,42 @@ MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\t
                        expected.split('\n')):
             self.assertEqual(o,e)
 
+    def test_report_projects_novaseq_flow_cell_mode(self):
+        """report: report run in 'projects' mode with NovaSeq flow cell mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '221216_A00879_0047_000000000-AGEW9',
+            'novaseq',
+            metadata={ "source": "testing",
+                       "run_number": 47,
+                       "sequencer_model": "NovaSeq 6000",
+                       "flow_cell_mode": "SP" },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "RNA-seq",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Sequencer model": "NovaSeq 6000" },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "NovaSeq 6000" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Make autoprocess instance and set required metadata
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate projects report
+        expected = """221216\tNOVASEQ_221216#47\t47\tSP\ttesting\t\tAB\tAlison Bell\tAudrey Bower\tRNA-seq\t\tHuman\tNOVASEQ\tNovaSeq 6000\t2\t\tyes\tAB1-2\t%s
+221216\tNOVASEQ_221216#47\t47\tSP\ttesting\t\tCDE\tCharles David Edwards\tColin Delaney Eccleston\tChIP-seq\t\tMouse\tNOVASEQ\tNovaSeq 6000\t2\t\tyes\tCDE3-4\t%s
+""" % (ap.params.analysis_dir,ap.params.analysis_dir)
+        custom_fields = ['datestamp','run_id','run_number','flow_cell_mode','source','null','project','user','PI','library_type','single_cell_platform','organism','platform','sequencer_model','#samples','#cells','paired_end','samples','path']
+        for o,e in zip(report_projects(ap,fields=custom_fields).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
     def test_report_projects_single_cell(self):
         """report: report single-cell run in 'projects' mode
         """

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -325,6 +325,7 @@ class TestAnalysisDirMetadata(unittest.TestCase):
         self.assertEqual(metadata.instrument_run_number,None)
         self.assertEqual(metadata.instrument_flow_cell_id,None)
         self.assertEqual(metadata.sequencer_model,None)
+        self.assertEqual(metadata.flow_cell_mode,None)
 
 class TestProjectMetadataFile(unittest.TestCase):
     """Tests for the ProjectMetadataFile class

--- a/docs/source/using/report.rst
+++ b/docs/source/using/report.rst
@@ -115,6 +115,8 @@ Field name                Associated value
 ``single_cell_platform``  Name of the single-cell platform
                           (e.g. ``ICELL8``), or empty field
 			  if not a single-cell project
+``flow_cell_mode``        The flow cell mode stored in the
+                          run metadata
 ``organism``              Organism(s) associated with the
                           project
 ``no_of_samples``         Number of samples in the project

--- a/docs/source/using/report.rst
+++ b/docs/source/using/report.rst
@@ -139,9 +139,13 @@ Field name                Associated value
 ========================= ========================
 
 Composite fields can be specified by joining two or more fields
-with the ``+`` character (for example, ``project+run_id``); the
-resulting value will be the values of the individual fields
-joined by underscores.
+with the ``+`` character (for example, ``organism+library_type``);
+the resulting value will be the (non-null) values of the individual
+fields separated by spaces.
+
+To specify an alternative separator for a composite field, prefix
+the field with ``[...]:`` where ``...`` is the desired delimiter
+(for example, ``[_]:project+run_id`` will use an underscore).
 
 Commonly used sets of fields can be made into "templates", which
 can be defined in the ``reporting_templates`` section of the


### PR DESCRIPTION
Updates the Fastq generation pipeline to extract the NovaSeq flow cell mode (located in the `RunParameters.xml` file of the raw sequencer output), and store in a new metadata item `flow_cell_mode`.

(For other platforms which don't report a flow cell mode, a null value is stored in the metadata.)