### PR TITLE
New functionality for the 'samplesheet' command

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -61,6 +61,7 @@ from . import get_version
 @add_command("update_fastq_stats",commands.update_fastq_stats)
 @add_command("import_project",commands.import_project)
 @add_command("clone",commands.clone)
+@add_command("samplesheet",commands.samplesheet)
 class AutoProcess:
     """
     Class implementing an automatic fastq generation and QC
@@ -300,20 +301,6 @@ class AutoProcess:
                 except KeyError:
                     print("Unable to get sequencer model for "
                           "instrument '%s'" % instrument_name)
-
-    def edit_samplesheet(self):
-        """
-        Bring up SampleSheet in an editor
-        """
-        # Fetch the sample sheet
-        sample_sheet_file = self.params.sample_sheet
-        if sample_sheet_file is None:
-            logging.error("No sample sheet file to edit")
-            return
-        edit_file(sample_sheet_file)
-        # Check updated sample sheet and issue warnings
-        if check_and_warn(sample_sheet_file=sample_sheet_file):
-            logging.error("Sample sheet may have problems, see warnings above")
 
     def init_readme(self):
         """

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -222,21 +222,22 @@ def add_samplesheet_command(cmdparser):
     mutex.add_argument('--set-sample-id',
                        metavar="[LANES:][COL=PATTERN:]NEW_ID",
                        action='store',dest='set_sample_id',
-                       help="update the sample ID field for the "
-                       "lines matching the supplied set of lanes "
-                       "(specified as e.g. '1', '1,2,3', '1-3', "
-                       "'1,3-5' etc) and/or columns with the supplied "
-                       "glob-stype pattern. NEW_ID can be either "
+                       help="update the sample ID field."
+                       "Optional LANES specifies one or more lanes "
+                       "(e.g. '1', '1,2,3', '1-3', '1,3-5') to update; "
+                       "optional COL=PATTERN specifies a glob-style "
+                       "pattern to match to an arbitrary column (e.g. "
+                       "'Sample_Name=ITS*'); NEW_ID can be either "
                        "'SAMPLE_NAME' or an arbitrary string")
     mutex.add_argument('--set-sample-name',metavar="NEW_NAME",
                        action='store',dest='set_sample_name',
-                       help="update the sample name field; "
-                       "NEW_NAME should be of the form "
-                       "'[<lanes>:]<name>'; optional <lanes> specifies "
-                       "which lanes to update. If no lanes are specified "
-                       "then all samples will have their name set to "
-                       "<name>, which can be either 'SAMPLE_ID', "
-                       "or an arbitrary string")
+                       help="update the sample name field."
+                       "Optional LANES specifies one or more lanes "
+                       "(e.g. '1', '1,2,3', '1-3', '1,3-5') to update; "
+                       "optional COL=PATTERN specifies a glob-style "
+                       "pattern to match to an arbitrary column (e.g. "
+                       "'Sample_Name=ITS*'); NEW_NAME can be either "
+                       "'SAMPLE_ID' or an arbitrary string")
     mutex.add_argument('-e','--edit',action='store_true',dest='edit',
                        default=False,
                        help="bring up sample sheet file in an editor "

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -238,6 +238,13 @@ def add_samplesheet_command(cmdparser):
                        "pattern to match to an arbitrary column (e.g. "
                        "'Sample_Name=ITS*'); NEW_NAME can be either "
                        "'SAMPLE_ID' or an arbitrary string")
+    mutex.add_argument('--import',action='store',metavar="SAMPLE_SHEET",
+                       dest='import_sample_sheet',
+                       default=None,
+                       help="replace existing sample sheet file with "
+                       "version copied from the specified location; "
+                       "SAMPLE_SHEET can be a local or remote "
+                       "file, or a URL")
     mutex.add_argument('-e','--edit',action='store_true',dest='edit',
                        default=False,
                        help="bring up sample sheet file in an editor "
@@ -1257,6 +1264,10 @@ def samplesheet(args):
     elif args.predict:
         # Predict the outputs
         d.samplesheet(SampleSheetOperation.PREDICT)
+    elif args.import_sample_sheet:
+        # Import new sample sheet file
+        d.samplesheet(SampleSheetOperation.IMPORT,
+                      args.import_sample_sheet)
     else:
         # Show raw sample sheet
         d.samplesheet(SampleSheetOperation.VIEW)

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -78,11 +78,13 @@ from ..bcl2fastq.pipeline import PROTOCOLS
 from ..bcl2fastq.pipeline import subset
 from ..commands.make_fastqs_cmd import BCL2FASTQ_DEFAULTS
 from ..commands.report_cmd import ReportingMode
+from ..commands.samplesheet_cmd import SampleSheetOperation
 from ..samplesheet_utils import predict_outputs
 from ..settings import Settings
 from ..settings import locate_settings_file
 from ..tenx import CELLRANGER_ASSAY_CONFIGS
 from ..utils import paginate
+from ..utils import parse_samplesheet_spec
 
 # Module specific logger
 logger = logging.getLogger(__name__)
@@ -204,12 +206,46 @@ def add_samplesheet_command(cmdparser):
     """
     p = cmdparser.add_command('samplesheet',
                               help="Sample sheet manipulation",
-                              description="Query and manipulate sample sheets")
-    p.add_argument('-e','--edit',action='store_true',dest='edit',
-                   default=False,
-                   help="bring up sample sheet file in an editor to make "
-                   "changes manually")
-    add_debug_option(p)
+                              description="Query and manipulate sample "
+                              "sheets")
+    mutex = p.add_mutually_exclusive_group()
+    mutex.add_argument('--set-project',
+                       metavar="[LANES:][COL=PATTERN:]NEW_PROJECT",
+                       action='store',dest='set_project',
+                       help="update the sample project field. "
+                       "Optional LANES specifies one or more lanes "
+                       "(e.g. '1', '1,2,3', '1-3', '1,3-5') to update; "
+                       "optional COL=PATTERN specifies a glob-style "
+                       "pattern to match to an arbitrary column (e.g. "
+                       "'Sample_Name=ITS*'); NEW_PROJECT is the new "
+                       "project name")
+    mutex.add_argument('--set-sample-id',
+                       metavar="[LANES:][COL=PATTERN:]NEW_ID",
+                       action='store',dest='set_sample_id',
+                       help="update the sample ID field for the "
+                       "lines matching the supplied set of lanes "
+                       "(specified as e.g. '1', '1,2,3', '1-3', "
+                       "'1,3-5' etc) and/or columns with the supplied "
+                       "glob-stype pattern. NEW_ID can be either "
+                       "'SAMPLE_NAME' or an arbitrary string")
+    mutex.add_argument('--set-sample-name',metavar="NEW_NAME",
+                       action='store',dest='set_sample_name',
+                       help="update the sample name field; "
+                       "NEW_NAME should be of the form "
+                       "'[<lanes>:]<name>'; optional <lanes> specifies "
+                       "which lanes to update. If no lanes are specified "
+                       "then all samples will have their name set to "
+                       "<name>, which can be either 'SAMPLE_ID', "
+                       "or an arbitrary string")
+    mutex.add_argument('-e','--edit',action='store_true',dest='edit',
+                       default=False,
+                       help="bring up sample sheet file in an editor "
+                       "to make changes manually")
+    mutex.add_argument('-p','--predict',action='store_true',dest='predict',
+                       default=False,
+                       help="show predicted outputs from sample sheet")
+    advanced = p.add_argument_group("Advanced options")
+    add_debug_option(advanced)
     p.add_argument('analysis_dir',metavar="ANALYSIS_DIR",nargs="?",
                    help="auto_process analysis directory (optional: defaults "
                    "to the current directory)")
@@ -1190,14 +1226,39 @@ def samplesheet(args):
     if not analysis_dir:
         analysis_dir = os.getcwd()
     d = AutoProcess(analysis_dir)
-    # Sample sheet operations
-    if args.edit:
+    if args.set_project:
+        # Set the sample project
+        name,lanes,fnmatch_col,pattern = \
+            parse_samplesheet_spec(args.set_project)
+        d.samplesheet(SampleSheetOperation.SET_PROJECT,
+                      name,
+                      lanes=lanes,
+                      where=(fnmatch_col,pattern))
+    elif args.set_sample_name:
+        # Set the sample name
+        name,lanes,fnmatch_col,pattern = \
+            parse_samplesheet_spec(args.set_project)
+        d.samplesheet(SampleSheetOperation.SET_SAMPLE_NAME,
+                      name,
+                      lanes=lanes,
+                      where=(fnmatch_col,pattern))
+    elif args.set_sample_id:
+        # Set the sample ID
+        name,lanes,fnmatch_col,pattern = \
+            parse_samplesheet_spec(args.set_project)
+        d.samplesheet(SampleSheetOperation.SET_SAMPLE_ID,
+                      name,
+                      lanes=lanes,
+                      where=(fnmatch_col,pattern))
+    elif args.edit:
         # Manually edit the sample sheet
-        d.edit_samplesheet()
-    else:
+        d.samplesheet(SampleSheetOperation.EDIT)
+    elif args.predict:
         # Predict the outputs
-        paginate(predict_outputs(
-            sample_sheet_file=d.params.sample_sheet))
+        d.samplesheet(SampleSheetOperation.PREDICT)
+    else:
+        # Show raw sample sheet
+        d.samplesheet(SampleSheetOperation.VIEW)
 
 def make_fastqs(args):
     """

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -238,7 +238,7 @@ def add_samplesheet_command(cmdparser):
                        "pattern to match to an arbitrary column (e.g. "
                        "'Sample_Name=ITS*'); NEW_NAME can be either "
                        "'SAMPLE_ID' or an arbitrary string")
-    mutex.add_argument('--import',action='store',metavar="SAMPLE_SHEET",
+    mutex.add_argument('-i','--import',action='store',metavar="SAMPLE_SHEET",
                        dest='import_sample_sheet',
                        default=None,
                        help="replace existing sample sheet file with "

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -209,6 +209,11 @@ def add_samplesheet_command(cmdparser):
                               description="Query and manipulate sample "
                               "sheets")
     mutex = p.add_mutually_exclusive_group()
+    mutex.add_argument('--use',metavar="SAMPLE_SHEET",action='store',
+                       dest='use_samplesheet',
+                       help="update the default sample sheet file to "
+                       "SAMPLE_SHEET (must be a file on the local file "
+                       "system)")
     mutex.add_argument('--set-project',
                        metavar="[LANES:][COL=PATTERN:]NEW_PROJECT",
                        action='store',dest='set_project',
@@ -1234,7 +1239,15 @@ def samplesheet(args):
     if not analysis_dir:
         analysis_dir = os.getcwd()
     d = AutoProcess(analysis_dir)
-    if args.set_project:
+    if args.use_samplesheet:
+        # Update the sample sheet in the config
+        sample_sheet_file = os.path.abspath(args.use_samplesheet)
+        if not os.path.exists(sample_sheet_file):
+            raise Exception("samplesheet: '%s' not found" %
+                            sample_sheet_file)
+        d.params['sample_sheet'] = sample_sheet_file
+        print("samplesheet: updated to use '%s'" % d.params.sample_sheet)
+    elif args.set_project:
         # Set the sample project
         name,lanes,fnmatch_col,pattern = \
             parse_samplesheet_spec(args.set_project)

--- a/auto_process_ngs/commands/__init__.py
+++ b/auto_process_ngs/commands/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     commands/__init__.py: core functions for autoprocess commands
-#     Copyright (C) University of Manchester 2017-2019 Peter Briggs
+#     Copyright (C) University of Manchester 2017-2022 Peter Briggs
 #
 #######################################################################
 # Imports
@@ -19,3 +19,4 @@ from .merge_fastq_dirs_cmd import merge_fastq_dirs
 from .update_fastq_stats_cmd import update_fastq_stats
 from .import_project_cmd import import_project
 from .clone_cmd import clone
+from .samplesheet_cmd import samplesheet

--- a/auto_process_ngs/commands/samplesheet_cmd.py
+++ b/auto_process_ngs/commands/samplesheet_cmd.py
@@ -152,7 +152,10 @@ def view_samplesheet(ap):
         analysis directory to operate on
     """
     with open(ap.params.sample_sheet,'rt') as fp:
-        paginate(fp.read())
+        content = "Current samplesheet '%s'\n\n%s" % (
+            ap.params.sample_sheet,
+            fp.read())
+        paginate(content)
 
 def predict_samplesheet_outputs(ap):
     """
@@ -162,8 +165,10 @@ def predict_samplesheet_outputs(ap):
       ap (AutoProcessor): autoprocessor pointing to the
         analysis directory to operate on
     """
-    paginate(predict_outputs(
-        sample_sheet_file=ap.params.sample_sheet))
+    content = "Current samplesheet '%s'\n\n%s" % (
+        ap.params.sample_sheet,
+        predict_outputs(sample_sheet_file=ap.params.sample_sheet))
+    paginate(content)
 
 def edit_samplesheet(ap):
     """

--- a/auto_process_ngs/commands/samplesheet_cmd.py
+++ b/auto_process_ngs/commands/samplesheet_cmd.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+#
+#     samplesheet_cmd.py: implement 'samplesheet' command
+#     Copyright (C) University of Manchester 2022 Peter Briggs
+#
+#########################################################################
+
+#######################################################################
+# Imports
+#######################################################################
+
+import os
+import shutil
+import json
+import logging
+from bcftbx.IlluminaData import SampleSheet
+from ..samplesheet_utils import check_and_warn
+from ..samplesheet_utils import predict_outputs
+from ..samplesheet_utils import set_samplesheet_column
+from ..utils import edit_file
+from ..utils import paginate
+
+# Module specific logger
+logger = logging.getLogger(__name__)
+
+#######################################################################
+# Constants
+#######################################################################
+
+class SampleSheetOperation:
+    SET_PROJECT = 0
+    SET_SAMPLE_NAME = 1
+    SET_SAMPLE_ID = 2
+    VIEW = 4
+    PREDICT = 5
+    EDIT = 6
+
+#######################################################################
+# Command functions
+#######################################################################
+
+def samplesheet(ap,cmd,*args,**kws):
+    """
+    Various sample sheet manipulations
+
+    Arguments:
+      ap (AutoProcessor): autoprocessor pointing to the
+        analysis directory to operate on
+      cmd (int): sample sheet operation to perform
+      args (list): positional arguments specific to the
+        command
+      kws (mapping): keyword arguments specific to the
+        command
+    """
+    if cmd == SampleSheetOperation.SET_PROJECT:
+        # Set the sample project
+        set_project(ap,*args,**kws)
+    elif cmd == SampleSheetOperation.SET_SAMPLE_NAME:
+        # Set the sample names
+        set_sample_name(ap,*args,**kws)
+    elif cmd == SampleSheetOperation.SET_SAMPLE_ID:
+        # Set the sample IDs
+        set_sample_id(ap,*args,**kws)
+    elif cmd == SampleSheetOperation.VIEW:
+        # Show raw sample sheet
+        view_samplesheet(ap)
+    elif cmd == SampleSheetOperation.PREDICT:
+        # Predict the outputs
+        predict_samplesheet_outputs(ap)
+    elif cmd == SampleSheetOperation.EDIT:
+        # Show raw sample sheet
+        edit_samplesheet(ap)
+
+def set_project(ap,new_project,lanes=None,where=None):
+    """
+    Update the project names in the SampleSheet
+
+    Arguments:
+      ap (AutoProcessor): autoprocessor pointing to the
+        analysis directory to operate on
+      new_project (str): new project name
+      lanes (list): optional list of lane numbers to
+        apply project name update to
+      where (tuple): optional tuple '(COLUMN,PATTERN)'
+        to only apply update to lines where value in
+        COLUMN matches glob-style PATTERN
+    """
+    s = set_samplesheet_column(
+        sample_sheet=ap.params.sample_sheet,
+        column='SAMPLE_PROJECT',
+        new_value=new_project,
+        lanes=lanes,
+        where=where)
+    s.write(ap.params.sample_sheet)
+
+def set_sample_name(ap,new_name,lanes=None,where=None):
+    """
+    Update the sample names in the SampleSheet
+
+    Arguments:
+      ap (AutoProcessor): autoprocessor pointing to the
+        analysis directory to operate on
+      new_name (str): new sample name
+      lanes (list): optional list of lane numbers to
+        apply project name update to
+      where (tuple): optional tuple '(COLUMN,PATTERN)'
+        to only apply update to lines where value in
+        COLUMN matches glob-style PATTERN
+    """
+    s = set_samplesheet_column(
+        sample_sheet=ap.params.sample_sheet,
+        column='SAMPLE_NAME',
+        new_value=new_name,
+        lanes=lanes,
+        where=where)
+    s.write(ap.params.sample_sheet)
+
+def set_sample_id(ap,new_id,lanes=None,where=None):
+    """
+    Update the sample IDs in the SampleSheet
+
+    Arguments:
+      ap (AutoProcessor): autoprocessor pointing to the
+        analysis directory to operate on
+      new_id (str): new sample ID
+      lanes (list): optional list of lane numbers to
+        apply project name update to
+      where (tuple): optional tuple '(COLUMN,PATTERN)'
+        to only apply update to lines where value in
+        COLUMN matches glob-style PATTERN
+    """
+    s = set_samplesheet_column(
+        sample_sheet=ap.params.sample_sheet,
+        column='SAMPLE_ID',
+        new_value=new_id,
+        lanes=lanes,
+        where=where)
+    s.write(ap.params.sample_sheet)
+
+def view_samplesheet(ap):
+    """
+    Show the raw SampleSheet content
+
+    Arguments:
+      ap (AutoProcessor): autoprocessor pointing to the
+        analysis directory to operate on
+    """
+    with open(ap.params.sample_sheet,'rt') as fp:
+        paginate(fp.read())
+
+def predict_samplesheet_outputs(ap):
+    """
+    Predict the outputs from the SampleSheet
+
+    Arguments:
+      ap (AutoProcessor): autoprocessor pointing to the
+        analysis directory to operate on
+    """
+    paginate(predict_outputs(
+        sample_sheet_file=ap.params.sample_sheet))
+
+def edit_samplesheet(ap):
+    """
+    Bring up SampleSheet in an editor
+
+    Arguments:
+      ap (AutoProcessor): autoprocessor pointing to the
+        analysis directory to operate on
+    """
+    # Fetch the sample sheet
+    sample_sheet_file = ap.params.sample_sheet
+    if sample_sheet_file is None:
+        logging.error("No sample sheet file to edit")
+        return
+    edit_file(sample_sheet_file)
+    # Check updated sample sheet and issue warnings
+    if check_and_warn(sample_sheet_file=sample_sheet_file):
+        logger.error("Sample sheet may have problems, see warnings above")
+        return 1
+    return 0
+

--- a/auto_process_ngs/commands/samplesheet_cmd.py
+++ b/auto_process_ngs/commands/samplesheet_cmd.py
@@ -200,7 +200,7 @@ def import_samplesheet(ap,new_sample_sheet):
         fetch_file(new_sample_sheet,tmp_sample_sheet)
     except Exception as ex:
         raise Exception("Error importing sample sheet data "
-                        "from '%s': %s" % (sample_sheet,ex))
+                        "from '%s': %s" % (new_sample_sheet,ex))
     # Keep a copy of the imported sample sheet
     imported_sample_sheet = os.path.join(ap.analysis_dir,
                                          'SampleSheet.imported.csv')

--- a/auto_process_ngs/test/commands/test_samplesheet_cmd.py
+++ b/auto_process_ngs/test/commands/test_samplesheet_cmd.py
@@ -1,0 +1,212 @@
+#######################################################################
+# Tests for samplesheet_cmd.py module
+#######################################################################
+
+import unittest
+import tempfile
+import shutil
+import os
+from bcftbx.IlluminaData import SampleSheet
+from auto_process_ngs.auto_processor import AutoProcess
+from auto_process_ngs.mock import MockAnalysisDir
+from auto_process_ngs.commands.samplesheet_cmd import SampleSheetOperation
+from auto_process_ngs.commands.samplesheet_cmd import samplesheet
+
+# Unit tests
+
+class TestSampleSheetSetProject(unittest.TestCase):
+    """
+    Test the 'set_project' functionality of the 'samplesheet' command
+    """
+    def setUp(self):
+        # Create a temp working dir
+        self.dirn = tempfile.mkdtemp(suffix='TestSampleSheetSetProject')
+        # Store original location so we can get back at the end
+        self.pwd = os.getcwd()
+        # Move to working dir
+        os.chdir(self.dirn)
+
+    def tearDown(self):
+        # Return to original dir
+        os.chdir(self.pwd)
+        # Remove the temporary test directory
+        def del_rw(action,name,excinfo):
+            # Explicitly remove read only files/
+            # dirs
+            os.chmod(os.path.dirname(name),0o755)
+            os.chmod(name,0o655)
+            os.remove(name)
+        shutil.rmtree(self.dirn,onerror=del_rw)
+
+    def test_samplesheet_set_project(self):
+        """
+        samplesheet: set project names
+        """
+        # Make an empty mock auto-process directory
+        mockdir = MockAnalysisDir(
+            '221219_SN00879_0087_000000000-AGEW9',
+            'hiseq',
+            no_undetermined=True,
+            top_dir=self.dirn)
+        mockdir.create()
+        # Update content for sample sheet
+        sample_sheet_data = u"""[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,Sample_AB1,,,N701,CGATGTAT,N501,TCTTTCCC,AB1,
+2,AB2,Sample_AB2,,,N702,TGACCAAT,N502,TCTTTCCC,AB2,
+3,CD1,Sample_CD1,,,N701,CGATGTAT,N501,TCTTTCCC,CD1,
+4,FG2,Sample_FG2,,,N702,TGACCAAT,N502,TCTTTCCC,FG2,
+"""
+        sample_sheet_file = os.path.join(mockdir.dirn,
+                                         "custom_SampleSheet.csv")
+        with open(sample_sheet_file,'wt') as fp:
+            fp.write(sample_sheet_data)
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Update sample sheet project for lane 3
+        ap.samplesheet(SampleSheetOperation.SET_PROJECT,
+                       "CarlDewey",
+                       lanes=[3])
+        for line in SampleSheet(sample_sheet_file):
+            if line['Lane'] == 3:
+                self.assertEqual(line["Sample_Project"],"CarlDewey")
+        # Update sample sheet project matching on sample ID
+        ap.samplesheet(SampleSheetOperation.SET_PROJECT,
+                       "AndrewBloggs",
+                       where=("SAMPLE_ID",
+                              "AB*"))
+        for line in SampleSheet(sample_sheet_file):
+            if line['Lane'] in (1,2):
+                self.assertEqual(line["Sample_Project"],"AndrewBloggs")
+
+class TestSampleSheetSetSampleName(unittest.TestCase):
+    """
+    Test the 'set_sample_name' functionality of the 'samplesheet' command
+    """
+    def setUp(self):
+        # Create a temp working dir
+        self.dirn = tempfile.mkdtemp(suffix='TestSampleSheetSetProject')
+        # Store original location so we can get back at the end
+        self.pwd = os.getcwd()
+        # Move to working dir
+        os.chdir(self.dirn)
+
+    def tearDown(self):
+        # Return to original dir
+        os.chdir(self.pwd)
+        # Remove the temporary test directory
+        def del_rw(action,name,excinfo):
+            # Explicitly remove read only files/
+            # dirs
+            os.chmod(os.path.dirname(name),0o755)
+            os.chmod(name,0o655)
+            os.remove(name)
+        shutil.rmtree(self.dirn,onerror=del_rw)
+
+    def test_samplesheet_set_sample_name(self):
+        """
+        samplesheet: set sample names
+        """
+        # Make an empty mock auto-process directory
+        mockdir = MockAnalysisDir(
+            '221219_SN00879_0087_000000000-AGEW9',
+            'hiseq',
+            no_undetermined=True,
+            top_dir=self.dirn)
+        mockdir.create()
+        # Update content for sample sheet
+        sample_sheet_data = u"""[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,Sample_AB1,,,N701,CGATGTAT,N501,TCTTTCCC,AndrewBloggs,
+2,AB2,Sample_AB2,,,N702,TGACCAAT,N502,TCTTTCCC,AndrewBloggs,
+3,CD1,Sample_CD1,,,N701,CGATGTAT,N501,TCTTTCCC,CarlDewey,
+4,FG2,Sample_FG2,,,N702,TGACCAAT,N502,TCTTTCCC,FilipeGreer,
+"""
+        sample_sheet_file = os.path.join(mockdir.dirn,
+                                         "custom_SampleSheet.csv")
+        with open(sample_sheet_file,'wt') as fp:
+            fp.write(sample_sheet_data)
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Update sample sheet name for lane 3
+        ap.samplesheet(SampleSheetOperation.SET_SAMPLE_NAME,
+                       "SAMPLE_ID",
+                       lanes=[3])
+        for line in SampleSheet(sample_sheet_file):
+            if line['Lane'] == 3:
+                self.assertEqual(line["Sample_Name"],"CD1")
+        # Update sample sheet name matching on project name
+        ap.samplesheet(SampleSheetOperation.SET_SAMPLE_NAME,
+                       "SAMPLE_ID",
+                       where=("SAMPLE_PROJECT",
+                              "AndrewBloggs"))
+        for line in SampleSheet(sample_sheet_file):
+            if line['Lane'] in (1,2):
+                self.assertEqual(line["Sample_Name"],
+                                 line["Sample_ID"])
+
+class TestSampleSheetSetSampleID(unittest.TestCase):
+    """
+    Test the 'set_sample_id' functionality of the 'samplesheet' command
+    """
+    def setUp(self):
+        # Create a temp working dir
+        self.dirn = tempfile.mkdtemp(suffix='TestSampleSheetSetProject')
+        # Store original location so we can get back at the end
+        self.pwd = os.getcwd()
+        # Move to working dir
+        os.chdir(self.dirn)
+
+    def tearDown(self):
+        # Return to original dir
+        os.chdir(self.pwd)
+        # Remove the temporary test directory
+        def del_rw(action,name,excinfo):
+            # Explicitly remove read only files/
+            # dirs
+            os.chmod(os.path.dirname(name),0o755)
+            os.chmod(name,0o655)
+            os.remove(name)
+        shutil.rmtree(self.dirn,onerror=del_rw)
+
+    def test_samplesheet_set_sample_id(self):
+        """
+        samplesheet: set sample IDs
+        """
+        # Make an empty mock auto-process directory
+        mockdir = MockAnalysisDir(
+            '221219_SN00879_0087_000000000-AGEW9',
+            'hiseq',
+            no_undetermined=True,
+            top_dir=self.dirn)
+        mockdir.create()
+        # Update content for sample sheet
+        sample_sheet_data = u"""[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,Sample_AB1,AB1,,,N701,CGATGTAT,N501,TCTTTCCC,AndrewBloggs,
+2,Sample_AB2,AB2,,,N702,TGACCAAT,N502,TCTTTCCC,AndrewBloggs,
+3,Sample_CD1,CD1,,,N701,CGATGTAT,N501,TCTTTCCC,CarlDewey,
+4,Sample_FG2,FG2,,,N702,TGACCAAT,N502,TCTTTCCC,FilipeGreer,
+"""
+        sample_sheet_file = os.path.join(mockdir.dirn,
+                                         "custom_SampleSheet.csv")
+        with open(sample_sheet_file,'wt') as fp:
+            fp.write(sample_sheet_data)
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Update sample sheet name for lane 3
+        ap.samplesheet(SampleSheetOperation.SET_SAMPLE_ID,
+                       "SAMPLE_NAME",
+                       lanes=[3])
+        for line in SampleSheet(sample_sheet_file):
+            if line['Lane'] == 3:
+                self.assertEqual(line["Sample_ID"],"CD1")
+        # Update sample sheet name matching on project name
+        ap.samplesheet(SampleSheetOperation.SET_SAMPLE_ID,
+                       "SAMPLE_NAME",
+                       where=("SAMPLE_PROJECT",
+                              "AndrewBloggs"))
+        for line in SampleSheet(sample_sheet_file):
+            if line['Lane'] in (1,2):
+                self.assertEqual(line["Sample_Name"],
+                                 line["Sample_ID"])

--- a/auto_process_ngs/test/commands/test_samplesheet_cmd.py
+++ b/auto_process_ngs/test/commands/test_samplesheet_cmd.py
@@ -11,6 +11,7 @@ from auto_process_ngs.auto_processor import AutoProcess
 from auto_process_ngs.mock import MockAnalysisDir
 from auto_process_ngs.commands.samplesheet_cmd import SampleSheetOperation
 from auto_process_ngs.commands.samplesheet_cmd import samplesheet
+from auto_process_ngs.commands.samplesheet_cmd import import_samplesheet
 
 # Unit tests
 
@@ -210,3 +211,88 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
             if line['Lane'] in (1,2):
                 self.assertEqual(line["Sample_Name"],
                                  line["Sample_ID"])
+
+class TestSampleSheetImport(unittest.TestCase):
+    """
+    Test the 'import_samplesheet' functionality of the 'samplesheet' command
+    """
+    def setUp(self):
+        # Create a temp working dir
+        self.dirn = tempfile.mkdtemp(suffix='TestSampleSheetImport')
+        # Store original location so we can get back at the end
+        self.pwd = os.getcwd()
+        # Move to working dir
+        os.chdir(self.dirn)
+
+    def tearDown(self):
+        # Return to original dir
+        os.chdir(self.pwd)
+        # Remove the temporary test directory
+        def del_rw(action,name,excinfo):
+            # Explicitly remove read only files/
+            # dirs
+            os.chmod(os.path.dirname(name),0o755)
+            os.chmod(name,0o655)
+            os.remove(name)
+        shutil.rmtree(self.dirn,onerror=del_rw)
+
+    def test_import_samplesheet(self):
+        """
+        samplesheet: import sample sheet data
+        """
+        # Make an empty mock auto-process directory
+        mockdir = MockAnalysisDir(
+            '221219_SN00879_0087_000000000-AGEW9',
+            'hiseq',
+            no_undetermined=True,
+            top_dir=self.dirn)
+        mockdir.create()
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Check initial status
+        self.assertTrue(os.path.exists(
+            os.path.join(mockdir.dirn,
+                         "SampleSheet.orig.csv")))
+        self.assertTrue(os.path.exists(
+            os.path.join(mockdir.dirn,
+                         "custom_SampleSheet.csv")))
+        self.assertEqual(ap.params.sample_sheet,
+                         os.path.join(mockdir.dirn,"custom_SampleSheet.csv"))
+        self.assertFalse(os.path.exists(
+            os.path.join(mockdir.dirn,
+                         "SampleSheet.imported.csv")))
+        self.assertFalse(os.path.exists(
+            os.path.join(mockdir.dirn,
+                         "custom_SampleSheet.imported.csv")))
+        # Make new sample sheet to import
+        sample_sheet_data = u"""[Header]
+
+[Reads]
+
+[Settings]
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,Sample_AB1,,,N701,CGATGTAT,N501,TCTTTCCC,AndrewBloggs,
+2,AB2,Sample_AB2,,,N702,TGACCAAT,N502,TCTTTCCC,AndrewBloggs,
+3,CD1,Sample_CD1,,,N701,CGATGTAT,N501,TCTTTCCC,CarlDewey,
+4,FG2,Sample_FG2,,,N702,TGACCAAT,N502,TCTTTCCC,FilipeGreer,
+"""
+        new_sample_sheet = os.path.join(self.dirn,"new_sample_sheet")
+        with open(new_sample_sheet,'wt') as fp:
+            fp.write(sample_sheet_data)
+        # Import the new sample sheet
+        import_samplesheet(ap,new_sample_sheet)
+        # Check expected state after import
+        self.assertTrue(os.path.exists(
+            os.path.join(mockdir.dirn,
+                         "SampleSheet.imported.csv")))
+        self.assertTrue(os.path.exists(
+            os.path.join(mockdir.dirn,
+                         "custom_SampleSheet.imported.csv")))
+        self.assertEqual(ap.params.sample_sheet,
+                         os.path.join(mockdir.dirn,
+                                      "custom_SampleSheet.imported.csv"))
+        with open(ap.params.sample_sheet,'rt') as fp:
+            self.assertEqual(fp.read(),
+                             sample_sheet_data)

--- a/auto_process_ngs/test/test_samplesheet_utils.py
+++ b/auto_process_ngs/test/test_samplesheet_utils.py
@@ -14,6 +14,7 @@ from auto_process_ngs.samplesheet_utils import has_invalid_characters
 from auto_process_ngs.samplesheet_utils import barcode_is_valid
 from auto_process_ngs.samplesheet_utils import barcode_is_10xgenomics
 from auto_process_ngs.samplesheet_utils import get_close_names
+from auto_process_ngs.samplesheet_utils import set_samplesheet_column
 
 sample_sheet_header = """[Header]
 IEMFileVersion,4
@@ -345,4 +346,99 @@ class TestCloseNamesFunction(unittest.TestCase):
                                           "Filipe Greer",)),
                          { "Andrew Bloggs": ["Andrew Blogs"],
                            "Andrew Blogs": ["Andrew Bloggs"] })
-        
+
+class TestSetSampleSheetSetColumn(unittest.TestCase):
+    def test_set_samplesheet_column_project_to_name(self):
+        """
+        set_samplesheet_column: set project to sample name
+        """
+        sample_sheet_data = u"""[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,Sample_AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
+1,AB2,Sample_AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
+2,CD1,Sample_CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
+2,FG2,Sample_FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
+"""
+        s = SampleSheet(fp=StringIO(sample_sheet_data))
+        s1 = set_samplesheet_column(s,"SAMPLE_PROJECT","SAMPLE_NAME")
+        for line in s1:
+            self.assertEqual(line['Sample_Project'],line['Sample_Name'])
+    def test_set_samplesheet_column_project_to_id(self):
+        """
+        set_samplesheet_column: set project to sample ID
+        """
+        sample_sheet_data = u"""[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,Sample_AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
+1,AB2,Sample_AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
+2,CD1,Sample_CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
+2,FG2,Sample_FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
+"""
+        s = SampleSheet(fp=StringIO(sample_sheet_data))
+        s1 = set_samplesheet_column(s,"SAMPLE_PROJECT","SAMPLE_ID")
+        for line in s1:
+            self.assertEqual(line['Sample_Project'],line['Sample_ID'])
+    def test_set_samplesheet_column_project_to_value(self):
+        """
+        set_samplesheet_column: set project to a specific value
+        """
+        sample_sheet_data = u"""[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,Sample_AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
+1,AB2,Sample_AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
+2,CD1,Sample_CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
+2,FG2,Sample_FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
+"""
+        s = SampleSheet(fp=StringIO(sample_sheet_data))
+        s1 = set_samplesheet_column(s,"SAMPLE_PROJECT","Project1")
+        for line in s1:
+            self.assertEqual(line['Sample_Project'],"Project1")
+    def test_set_samplesheet_column_project_to_value_for_lane(self):
+        """
+        set_samplesheet_column: set project to specific value for a lane
+        """
+        sample_sheet_data = u"""[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,Sample_AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
+1,AB2,Sample_AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
+2,CD1,Sample_CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
+2,FG2,Sample_FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
+"""
+        s = SampleSheet(fp=StringIO(sample_sheet_data))
+        s1 = set_samplesheet_column(s,"SAMPLE_PROJECT","Project1",
+                                    lanes=[1])
+        for line in s1:
+            if line['Lane'] == 1:
+                self.assertEqual(line['Sample_Project'],"Project1")
+            else:
+                self.assertNotEqual(line['Sample_Project'],"Project1")
+    def test_set_samplesheet_column_names_to_ids(self):
+        """
+        set_samplesheet_column: set sample names to sample IDs
+        """
+        sample_sheet_data = u"""[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,Sample_AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
+1,AB2,Sample_AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
+2,CD1,Sample_CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
+2,FG2,Sample_FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
+"""
+        s = SampleSheet(fp=StringIO(sample_sheet_data))
+        s1 = set_samplesheet_column(s,"SAMPLE_NAME","SAMPLE_ID")
+        for line in s1:
+            self.assertEqual(line['Sample_Name'],line['Sample_ID'])
+    def test_set_samplesheet_column_ids_to_names(self):
+        """
+        set_samplesheet_column: set sample IDs to sample names
+        """
+        sample_sheet_data = u"""[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,AB1,Sample_AB1,,,N701,CGATGTAT,N501,TCTTTCCC,Andrew_Bloggs,
+1,AB2,Sample_AB2,,,N702,TGACCAAT,N502,TCTTTCCC,Andrew_Bloggs,
+2,CD1,Sample_CD1,,,N701,CGATGTAT,N501,TCTTTCCC,Carl_Dewey,
+2,FG2,Sample_FG2,,,N702,TGACCAAT,N502,TCTTTCCC,Filipe_Greer,
+"""
+        s = SampleSheet(fp=StringIO(sample_sheet_data))
+        s1 = set_samplesheet_column(s,"SAMPLE_ID","SAMPLE_NAME")
+        for line in s1:
+            self.assertEqual(line['Sample_Name'],line['Sample_ID'])

--- a/auto_process_ngs/test/test_utils.py
+++ b/auto_process_ngs/test/test_utils.py
@@ -1055,6 +1055,34 @@ class TestParseVersion(unittest.TestCase):
         self.assertTrue(
             parse_version("") < parse_version("1.8.4"))
 
+class TestParseSampleSheetSpec(unittest.TestCase):
+    """Tests for the parse_samplesheet_spec function
+    """
+    def test_parse_samplesheet_spec_value_only(self):
+        """parse_samplesheet_spec: value only
+        """
+        self.assertEqual(parse_samplesheet_spec("Value"),
+                         ("Value",None,None,None))
+
+    def test_parse_samplesheet_spec_value_and_lanes(self):
+        """parse_samplesheet_spec: value and lanes
+        """
+        self.assertEqual(parse_samplesheet_spec("1-2,3,4:Value"),
+                         ("Value",[1,2,3,4],None,None))
+
+    def test_parse_samplesheet_spec_value_and_pattern(self):
+        """parse_samplesheet_spec: value and column pattern
+        """
+        self.assertEqual(parse_samplesheet_spec("SAMPLE_ID=*:Value"),
+                         ("Value",None,"SAMPLE_ID","*"))
+
+    def test_parse_samplesheet_spec_value_lanes_and_pattern(self):
+        """parse_samplesheet_spec: value, lanes and and column pattern
+        """
+        self.assertEqual(parse_samplesheet_spec(
+            "1-2,3,4:SAMPLE_ID=*:Value"),
+                         ("Value",[1,2,3,4],"SAMPLE_ID","*"))
+
 class TestPrettyPrintRows(unittest.TestCase):
     """Tests for the pretty_print_rows function
 

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -32,6 +32,7 @@ Functions:
 - get_numbered_subdir:
 - find_executables:
 - parse_version:
+- parse_samplesheet_spec:
 - pretty_print_rows:
 - write_script_file:
 - edit_file:
@@ -1099,6 +1100,50 @@ def parse_version(s):
             pass
         items.append(i)
     return tuple(items)
+
+def parse_samplesheet_spec(s):
+    """
+    Split sample sheet line specification into components
+
+    Given a sample sheet line specification of the form
+    "[LANES:][COL=PATTERN:]VALUE", split into the
+    component parts and return as a tuple:
+
+    (VALUE,LANES,COL,PATTERN)
+
+    where 'LANES' is a list of lanes (or 'None', if not
+    present), and the others will be strings (or 'None',
+    if not present).
+
+    Arguments:
+      s (str): specification string
+
+    Returns:
+      Tuple: the extracted components as
+        (VALUE,LANES,COL,PATTERN).
+    """
+    # Initialise
+    value = None
+    lanes = None
+    column = None
+    pattern = None
+    # Split input string
+    items = s.split(':')
+    # Value is at the end
+    value = items[-1]
+    items = items[:-1]
+    # Optional column matching
+    if items:
+        if '=' in items[-1]:
+            # Pattern to match
+            column,pattern = items[-1].split('=')
+            items = items[:-1]
+    # Optional lanes
+    if items:
+        # Lane specification
+        lanes = bcf_utils.parse_lanes(items[0])
+    # Return as tuple
+    return (value,lanes,column,pattern)
 
 def pretty_print_rows(data,prepend=False):
     """Format row-wise data into 'pretty' lines

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -54,6 +54,12 @@ at the `University of Manchester <https://www.manchester.ac.uk/>`_.
    Importing projects </using/import_project>
    Running QC stand-alone <using/run_qc_standalone>
 
+.. toctree::
+   :maxdepth: 2
+   :caption: Helpers
+
+   Sample sheet manipulations <using/samplesheet>
+
 .. _control-files:
 
 .. toctree::

--- a/docs/source/using/samplesheet.rst
+++ b/docs/source/using/samplesheet.rst
@@ -4,11 +4,36 @@ Sample sheet manipulation using ``auto_process samplesheet``
 The ``samplesheet`` command provides functionality for interrogating
 and manipulating the Illumina sample sheet control file.
 
-When the command is invoked without arguments then the contents
-of the sample sheet are displayed.
+--------------------
+Default sample sheet
+--------------------
+
+The default sample sheet file is set in the parameters of the
+current analysis directory; all operations will be performed
+using this sample sheet.
+
+When the ``samplesheet`` command is invoked without arguments
+then the path and contents of the default sample sheet are
+displayed.
+
+The default sample sheet file can be updated with the ``--use``
+option, for example:
+
+::
+
+   auto_process.py samplesheet --use new_samplesheet.csv
+
+
+------------------
+Predicting outputs
+------------------
 
 The ``-p``/``--predict`` argument shows the predicted outputs from
 the sample sheet.
+
+------------------------------------------
+Updating project and sample names in batch
+------------------------------------------
 
 The following arguments enable key data in the sample sheet to be
 updated in batch:
@@ -36,9 +61,31 @@ name of a column in the sample sheet where lines will be selected
 only if the value in that column matches the glob-style
 ``PATTERN`` (for example: ``Sample_Name=ITS*``).
 
+---------------------------------
+Manually editing the sample sheet
+---------------------------------
+
 The ``-e``/``--edit`` argument brings up the sample sheet in an
 editor to allow changes to be made manually.
 
-The ``-i``/``--import`` argument enables content from an external
-sample sheet file to be imported and used as the new default
+---------------------------------
+Importing a new sample sheet file
+---------------------------------
+
+The ``-i``/``--import`` argument enables content from a new file to
+be imported into the analysis directory and used as the new default
 sample sheet.
+
+The imported file can be a local or remote file, or a URL, for
+example:
+
+::
+
+   auto_process.py samplesheet -i user@remote.com:/Data/new_samplesheet.csv
+
+.. note::
+
+   Importing differs from the ``--use`` argument in that a copy
+   of the imported file is made within the analysis directory
+   (whereas ``--use`` simply changes the location that the default
+   sample sheet parameter points to).

--- a/docs/source/using/samplesheet.rst
+++ b/docs/source/using/samplesheet.rst
@@ -38,3 +38,7 @@ only if the value in that column matches the glob-style
 
 The ``-e``/``--edit`` argument brings up the sample sheet in an
 editor to allow changes to be made manually.
+
+The ``-i``/``--import`` argument enables content from an external
+sample sheet file to be imported and used as the new default
+sample sheet.

--- a/docs/source/using/samplesheet.rst
+++ b/docs/source/using/samplesheet.rst
@@ -1,0 +1,40 @@
+Sample sheet manipulation using ``auto_process samplesheet``
+============================================================
+
+The ``samplesheet`` command provides functionality for interrogating
+and manipulating the Illumina sample sheet control file.
+
+When the command is invoked without arguments then the contents
+of the sample sheet are displayed.
+
+The ``-p``/``--predict`` argument shows the predicted outputs from
+the sample sheet.
+
+The following arguments enable key data in the sample sheet to be
+updated in batch:
+
+* ``--set-project``: set the sample project for some or all lines
+  in the file;
+* ``--set-sample-id``: set the sample ID for some or all lines
+  in the file (typically to synchronise the IDs with the sample
+  names);
+* ``--set-sample-name``: set the sample project for some or all
+  lines in the file (typically to synchronise the names with the
+  sample IDs).
+
+The same syntax is used for the ``--set-*`` functions to specify
+the new values and to optionally select subsets of lines to
+apply the updates to:
+
+::
+
+   [LANES:][COL=PATTERN:]NEW_VALUE
+
+where ``LANES`` specifies one or more lane numbers (for example:
+``1``, ``1,2,3``, ``1-3``, ``1,3-5`` etc), and ``COL`` specifies the
+name of a column in the sample sheet where lines will be selected
+only if the value in that column matches the glob-style
+``PATTERN`` (for example: ``Sample_Name=ITS*``).
+
+The ``-e``/``--edit`` argument brings up the sample sheet in an
+editor to allow changes to be made manually.


### PR DESCRIPTION
Updates the `samplesheet` command to add new functionality:

* Update sample project
* Update sample names and IDs
* Import replacement sample sheet from arbitrary locations

The functionality enables data to be updated for all lines in the sample sheet, or for subsets of lines to be selected based on lane numbers and/or matching values in arbitrary columns.