### PR TITLE
run_qc.py: allow STAR index to be specified explicitly

### DIFF
--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -157,6 +157,7 @@ class QCPipeline(Pipeline):
         self.add_param('fastq_screens',type=dict)
         self.add_param('star_indexes',type=dict)
         self.add_param('force_star_index',type=str)
+        self.add_param('force_gtf_annotation',type=str)
         self.add_param('legacy_screens',type=bool,value=False)
 
         # Define runners
@@ -398,7 +399,8 @@ class QCPipeline(Pipeline):
                 "%s: get GTF annotation for '%s'" % (project.name,
                                                      organism),
                 organism,
-                self.params.annotation_gtf_files)
+                self.params.annotation_gtf_files,
+                force_reference=self.params.force_gtf_annotation)
             self.add_task(get_annotation_gtf,
                           log_dir=log_dir)
             qc_metadata['annotation_gtf'] = \
@@ -1002,7 +1004,8 @@ class QCPipeline(Pipeline):
             cellranger_jobinterval=None,cellranger_localcores=None,
             cellranger_localmem=None,cellranger_exe=None,
             cellranger_extra_projects=None,cellranger_reference_dataset=None,
-            cellranger_out_dir=None,force_star_index=None,working_dir=None,
+            cellranger_out_dir=None,force_star_index=None,
+            force_gtf_annotation=None,working_dir=None,
             log_file=None,batch_size=None,batch_limit=None,max_jobs=1,
             max_slots=None,poll_interval=5,runners=None,default_runner=None,
             enable_conda=False,conda=None,conda_env_dir=None,
@@ -1078,6 +1081,9 @@ class QCPipeline(Pipeline):
           force_star_index (str): explicitly specify STAR
             index to use (default: index is determined
             automatically)
+          force_gtf_annotation (str): explicitly specify
+            GTF annotation to use (default: annotation
+            file is determined automatically)
           working_dir (str): optional path to a working
             directory (defaults to temporary directory in
             the current directory)
@@ -1185,6 +1191,7 @@ class QCPipeline(Pipeline):
                                   'fastq_screens': fastq_screens,
                                   'star_indexes': star_indexes,
                                   'force_star_index': force_star_index,
+                                  'force_gtf_annotation': force_gtf_annotation,
                                   'legacy_screens': legacy_screens,
                               },
                               poll_interval=poll_interval,

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -3530,7 +3530,7 @@ class CollateInsertSizes(PipelineTask):
             metrics_file = metrics_files[bam]
             insert_size_metrics = CollectInsertSizeMetrics(metrics_file)
             tf.append(data=(
-                os.path.basename(bam),
+                bam,
                 insert_size_metrics.metrics['MEAN_INSERT_SIZE'],
                 insert_size_metrics.metrics['STANDARD_DEVIATION'],
                 insert_size_metrics.metrics['MEDIAN_INSERT_SIZE'],

--- a/auto_process_ngs/qc/verification.py
+++ b/auto_process_ngs/qc/verification.py
@@ -411,9 +411,7 @@ class QCVerifier(QCOutputs):
             if not organism:
                 # No organism specified
                 return None
-            if not star_index or \
-               not annotation_gtf or \
-               not annotation_bed:
+            if not star_index or not annotation_gtf:
                 # No STAR index or annotation
                 return None
             if "qualimap_rnaseq" not in self.outputs:

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     run_qc.py: run QC pipeline on arbitrary fastq files
-#     Copyright (C) University of Manchester 2017-2022 Peter Briggs
+#     Copyright (C) University of Manchester 2017-2023 Peter Briggs
 #
 #########################################################################
 #
@@ -178,9 +178,9 @@ if __name__ == "__main__":
                             "(default: %s)" % ('taken from job runner'
                                                if not default_nthreads
                                                else default_nthreads,))
-    # Mapping options
-    mapping = p.add_argument_group('STAR options')
-    mapping.add_argument('--star-index',action='store',
+    # Reference data options
+    refdata = p.add_argument_group('Reference data')
+    refdata.add_argument('--star-index',action='store',
                          metavar="INDEX",
                          dest='star_index',
                          help="specify the path to the STAR genome index "
@@ -188,6 +188,13 @@ if __name__ == "__main__":
                          "strandedness etc (overrides the "
                          "organism-specific indexes defined in the config "
                          "file)")
+    refdata.add_argument('--gtf',action='store',
+                         metavar="GTF",
+                         dest='gtf_annotation',
+                         help="specify the path to the GTF annotation "
+                         "file to use for metrics such as 'qualimap "
+                         "rnaseq' (overrides the organism-specific GTF "
+                         "files defined in the config file)")
     # Cellranger options
     cellranger = p.add_argument_group('Cellranger/10xGenomics options')
     cellranger.add_argument('--cellranger',action='store',
@@ -524,6 +531,9 @@ if __name__ == "__main__":
         annotation_gtf_file = __settings.organisms[organism].annotation_gtf
         if annotation_gtf_file:
             annotation_gtf_files[organism] = annotation_gtf_file
+    force_gtf_annotation = args.gtf_annotation
+    if force_gtf_annotation:
+        force_gtf_annotation = os.path.abspath(force_gtf_annotation)
 
     # Cellranger settings
     cellranger_settings = __settings['10xgenomics']
@@ -827,6 +837,7 @@ if __name__ == "__main__":
                        conda_env_dir=args.conda_env_dir,
                        working_dir=working_dir,
                        force_star_index=force_star_index,
+                       force_gtf_annotation=force_gtf_annotation,
                        legacy_screens=use_legacy_screen_names,
                        verbose=args.verbose)
 

--- a/bin/run_qc.py
+++ b/bin/run_qc.py
@@ -178,6 +178,16 @@ if __name__ == "__main__":
                             "(default: %s)" % ('taken from job runner'
                                                if not default_nthreads
                                                else default_nthreads,))
+    # Mapping options
+    mapping = p.add_argument_group('STAR options')
+    mapping.add_argument('--star-index',action='store',
+                         metavar="INDEX",
+                         dest='star_index',
+                         help="specify the path to the STAR genome index "
+                         "to use when mapping reads for metrics such as "
+                         "strandedness etc (overrides the "
+                         "organism-specific indexes defined in the config "
+                         "file)")
     # Cellranger options
     cellranger = p.add_argument_group('Cellranger/10xGenomics options')
     cellranger.add_argument('--cellranger',action='store',
@@ -499,6 +509,9 @@ if __name__ == "__main__":
         star_index = __settings.organisms[organism].star_index
         if star_index:
             star_indexes[organism] = star_index
+    force_star_index = args.star_index
+    if force_star_index:
+        force_star_index = os.path.abspath(force_star_index)
 
     # Annotation files
     annotation_bed_files = dict()
@@ -813,6 +826,7 @@ if __name__ == "__main__":
                        enable_conda=enable_conda,
                        conda_env_dir=args.conda_env_dir,
                        working_dir=working_dir,
+                       force_star_index=force_star_index,
                        legacy_screens=use_legacy_screen_names,
                        verbose=args.verbose)
 

--- a/docs/source/using/run_qc_standalone.rst
+++ b/docs/source/using/run_qc_standalone.rst
@@ -93,6 +93,25 @@ default ``run_qc.py`` will stop without running the pipeline;
 to override this behaviour and update an existing QC output
 directory, specify the ``-u`` or ``--update`` option.
 
+Specifying reference data
+-------------------------
+
+By default the reference data used in the QC pipeline (for
+example the ``STAR`` index or the genome annotation) are
+determined from the configuration file according to the
+organism associated with the dataset.
+
+If no matching reference data are found then the following
+options are available:
+
+* ``--star-index``: sets the path to the ``STAR`` index
+  to use
+* ``--gtf``: sets the path to the genome annotation in
+  GTF format
+
+Note that these options will also override the reference data
+which are set in the configuration.
+
 Running 10xGenomics single library analyses
 -------------------------------------------
 


### PR DESCRIPTION
Update the standalone QC pipeline utility `run_qc.py` by adding a new option `--star-index` which allows the STAR index used for mapping to be explicitly specified (similar to the existing options for 10x reference datasets).

This also includes an update to the underlying pipeline in `qc/pipeline` to enable a specific STAR index to be passed to the QC for a project.