### PR TITLE
Fix bug in TSV with collated insert sizes in QC pipeline

### DIFF
--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -3472,7 +3472,7 @@ class CollateInsertSizes(PipelineTask):
                                    "Standard deviation",
                                    "Median insert size",
                                    "Median absolute deviation"))
-        metrics_files = []
+        metrics_files = {}
         for bam in self.args.bam_files:
             # Get metrics file associated with this BAM file
             outputs = list(filter(lambda f:
@@ -3488,7 +3488,7 @@ class CollateInsertSizes(PipelineTask):
                       (bam,
                        self.args.picard_out_dir))
                 continue
-            metrics_files.append(outputs[0])
+            metrics_files[os.path.basename(bam)] = outputs[0]
         # Check there is data to collate
         if not metrics_files:
             print("no insert size metrics files recovered")
@@ -3499,8 +3499,9 @@ class CollateInsertSizes(PipelineTask):
                                    "Standard deviation",
                                    "Median insert size",
                                    "Median absolute deviation"))
-        for metrics_file in metrics_files:
+        for bam in sorted(list(metrics_files.keys())):
             # Get mean and median insert sizes
+            metrics_file = metrics_files[bam]
             insert_size_metrics = CollectInsertSizeMetrics(metrics_file)
             tf.append(data=(
                 os.path.basename(bam),

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -145,6 +145,19 @@ class TestQCPipeline(unittest.TestCase):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
                             "Missing %s" % f)
+        # Check collated Picard insert sizes
+        collated_insert_sizes = os.path.join(self.wd,
+                                             "PJB",
+                                             "qc",
+                                             "insert_sizes.human.tsv")
+        self.assertTrue(os.path.exists(collated_insert_sizes),
+                        "Missing collated insert sizes TSV")
+        with open(collated_insert_sizes,'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """#Bam file	Mean insert size	Standard deviation	Median insert size	Median absolute deviation
+PJB1_S1_001.bam	153.754829	69.675347	139	37
+PJB2_S2_001.bam	153.754829	69.675347	139	37
+""")
 
     def test_qcpipeline_with_no_screens(self):
         """QCPipeline: standard QC run with no screens defined


### PR DESCRIPTION
Fixes a bug in the QC pipeline (`qc/pipeline.py`) when collating the insert sizes from Picard's `collectInsertSizeMetrics` function, where the TSV file produced by the pipeline didn't use the correct BAM file names (in fact the same name was used for all metrics). 