### PR TITLE
Fix bug in QC verification when organism name contains spaces

### DIFF
--- a/auto_process_ngs/mockqc.py
+++ b/auto_process_ngs/mockqc.py
@@ -1,5 +1,5 @@
 #     mockqc.py: module providing mock Illumina QC data for testing
-#     Copyright (C) University of Manchester 2016-2022 Peter Briggs
+#     Copyright (C) University of Manchester 2016-2023 Peter Briggs
 #
 ########################################################################
 
@@ -36,6 +36,7 @@ from .analysis import AnalysisFastq
 from .fastq_utils import group_fastqs_by_name
 from .metadata import AnalysisProjectQCDirInfo
 from .tenx_genomics_utils import CellrangerMultiConfigCsv
+from .utils import normalise_organism_name
 from . import mockqcdata
 from . import mock10xdata
 
@@ -482,6 +483,8 @@ def make_mock_qc_dir(qc_dir,fastq_names,fastq_dir=None,
     qc_info['protocol'] = protocol
     if organisms:
         qc_info['organism'] = ','.join(organisms)
+    # Normalise organism names
+    organisms_ = [normalise_organism_name(x) for x in organisms]
     # Populate with fake QC products
     for fq in fastq_names:
         # Sequence lengths
@@ -518,21 +521,21 @@ def make_mock_qc_dir(qc_dir,fastq_names,fastq_dir=None,
             MockQCOutputs.fastq_strand_v0_0_4(fq,qc_dir)
         # RSeQC infer_experiment.py
         if include_rseqc_infer_experiment:
-            for organism in organisms:
+            for organism in organisms_:
                 MockQCOutputs.rseqc_infer_experiment(
                     fq,organism,qc_dir)
         # Picard insert size metrics
         if include_picard_insert_size_metrics:
-            for organism in organisms:
+            for organism in organisms_:
                 MockQCOutputs.picard_collect_insert_size_metrics(
                     fq,organism,qc_dir)
         # Qualimap rnaseq
         if include_qualimap_rnaseq:
-            for organism in organisms:
+            for organism in organisms_:
                 MockQCOutputs.qualimap_rnaseq(fq,organism,qc_dir)
     # Version file for RSeQC infer_experiment.py
     if include_rseqc_infer_experiment:
-        for organism in organisms:
+        for organism in organisms_:
             with open(os.path.join(qc_dir,
                                    "rseqc_infer_experiment",
                                    organism,
@@ -541,13 +544,13 @@ def make_mock_qc_dir(qc_dir,fastq_names,fastq_dir=None,
     # Extra files for insert sizes
     if include_picard_insert_size_metrics:
         # Collated insert sizes
-        for organism in organisms:
+        for organism in organisms_:
             with open(os.path.join(
                     qc_dir,
-                    "insert_sizes.%s.tsv" % organisms),'wt') as fp:
+                    "insert_sizes.%s.tsv" % organism),'wt') as fp:
                 fp.write("Placeholder\n")
         # Picard version
-        for organism in organisms:
+        for organism in organisms_:
             with open(os.path.join(qc_dir,
                                    "picard",
                                    organism,
@@ -555,7 +558,7 @@ def make_mock_qc_dir(qc_dir,fastq_names,fastq_dir=None,
                 fp.write("picard\t2.27.1\n")
     # Version file for Qualimap rnaseq
     if include_qualimap_rnaseq:
-        for organism in organisms:
+        for organism in organisms_:
             with open(os.path.join(qc_dir,
                                    "qualimap-rnaseq",
                                    organism,
@@ -568,7 +571,7 @@ def make_mock_qc_dir(qc_dir,fastq_names,fastq_dir=None,
             fp.write("Placeholder\n")
     # RSeQC gene body coverage
     if include_rseqc_genebody_coverage:
-        for organism in organisms:
+        for organism in organisms_:
             MockQCOutputs.rseqc_genebody_coverage(project_name,
                                                   organism,
                                                   qc_dir)

--- a/auto_process_ngs/qc/verification.py
+++ b/auto_process_ngs/qc/verification.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     verification: utilities for verification of QC outputs
-#     Copyright (C) University of Manchester 2022 Peter Briggs
+#     Copyright (C) University of Manchester 2022-2023 Peter Briggs
 #
 
 """
@@ -33,6 +33,7 @@ from .protocols import fetch_protocol_definition
 from .outputs import QCOutputs
 from .utils import get_bam_basename
 from ..tenx_genomics_utils import CellrangerMultiConfigCsv
+from ..utils import normalise_organism_name
 
 # Module specific logger
 logger = logging.getLogger(__name__)
@@ -371,7 +372,7 @@ class QCVerifier(QCOutputs):
             if "rseqc_genebody_coverage" not in self.outputs:
                 # No RSeQC gene body coverage present
                 return False
-            if organism.lower() not in \
+            if normalise_organism_name(organism) not in \
                self.data('rseqc_genebody_coverage').organisms:
                 return False
             return True
@@ -389,7 +390,7 @@ class QCVerifier(QCOutputs):
             if "picard_insert_size_metrics" not in self.outputs:
                 # No insert size metrics present
                 return False
-            if organism.lower() not in \
+            if normalise_organism_name(organism) not in \
                self.data('picard_collect_insert_size_metrics').organisms:
                 return False
             # Filter Fastq names and convert to BAM names
@@ -418,7 +419,8 @@ class QCVerifier(QCOutputs):
             if "qualimap_rnaseq" not in self.outputs:
                 # No Qualimap 'rnaseq' outputs present
                 return False
-            if organism.lower() not in self.data('qualimap_rnaseq').organisms:
+            if normalise_organism_name(organism) not in \
+               self.data('qualimap_rnaseq').organisms:
                 return False
             # Filter Fastq names and convert to BAM names
             bams = [get_bam_basename(fq)

--- a/auto_process_ngs/test/qc/test_verification.py
+++ b/auto_process_ngs/test/qc/test_verification.py
@@ -298,6 +298,18 @@ class TestQCVerifier(unittest.TestCase):
                              fastqs=fastq_names,
                              organism="Human",
                              star_index="/data/indexes/STAR"))
+        # Organism name contains spaces
+        qc_dir = self._make_qc_dir('qc.homo_sapiens',
+                                   fastq_names=fastq_names[:-2],
+                                   organisms=('Homo sapiens',),
+                                   include_rseqc_genebody_coverage=True)
+        qc_verifier = QCVerifier(qc_dir)
+        self.assertTrue(qc_verifier.verify_qc_module(
+            'rseqc_genebody_coverage',
+            fastqs=fastq_names,
+            organism="Homo sapiens",
+            star_index="/data/indexes/STAR",
+            annotation_bed="/data/annot/human.bed"))
         # Empty QC directory
         qc_dir = self._make_qc_dir('qc.empty',
                                    fastq_names=fastq_names,
@@ -355,6 +367,18 @@ class TestQCVerifier(unittest.TestCase):
             fastqs=fastq_names,
             seq_data_reads=('r1','r2'),
             organism="Human",
+            star_index="/data/indexes/STAR"))
+        # Organism name contains spaces
+        qc_dir = self._make_qc_dir('qc.homo_sapiens',
+                                   fastq_names=fastq_names,
+                                   organisms=('Homo sapiens',),
+                                   include_picard_insert_size_metrics=True)
+        qc_verifier = QCVerifier(qc_dir)
+        self.assertTrue(qc_verifier.verify_qc_module(
+            'picard_insert_size_metrics',
+            fastqs=fastq_names,
+            seq_data_reads=('r1','r2'),
+            organism="Homo sapiens",
             star_index="/data/indexes/STAR"))
         # Empty QC directory
         qc_dir = self._make_qc_dir('qc.empty',
@@ -415,6 +439,20 @@ class TestQCVerifier(unittest.TestCase):
                              seq_data_reads=('r1','r2'),
                              organism="Human",
                              star_index="/data/indexes/STAR"))
+        # Organism name contains spaces
+        qc_dir = self._make_qc_dir('qc.homo_sapiens',
+                                   fastq_names=fastq_names,
+                                   organisms=('Homo sapiens',),
+                                   include_qualimap_rnaseq=True)
+        qc_verifier = QCVerifier(qc_dir)
+        self.assertTrue(qc_verifier.verify_qc_module(
+            'qualimap_rnaseq',
+            fastqs=fastq_names,
+            seq_data_reads=('r1','r2'),
+            organism="Homo sapiens",
+            star_index="/data/indexes/STAR",
+            annotation_gtf="/data/annot/human.gtf",
+            annotation_bed="/data/annot/human.bed"))
         # Empty QC directory
         qc_dir = self._make_qc_dir('qc.empty',
                                    fastq_names=fastq_names,

--- a/auto_process_ngs/test/test_utils.py
+++ b/auto_process_ngs/test/test_utils.py
@@ -563,6 +563,20 @@ class TestGetOrganismList(unittest.TestCase):
         self.assertEqual(get_organism_list("Homo sapiens, Mus  musculus "),
                          ["homo_sapiens","mus_musculus"])
 
+class TestNormaliseOrganismName(unittest.TestCase):
+    """Tests for the normalise_organism_name function
+    """
+
+    def test_normalise_organism_name(self):
+        """normalise_organism_name: check normalisation
+        """
+        self.assertEqual(normalise_organism_name("Mouse"),"mouse")
+        self.assertEqual(normalise_organism_name("mouse"),"mouse")
+        self.assertEqual(normalise_organism_name("Mus musculus"),
+                         "mus_musculus")
+        self.assertEqual(normalise_organism_name(" Mus  musculus "),
+                         "mus_musculus")
+
 class TestSplitUserHostDir(unittest.TestCase):
     """Tests for the split_user_host_dir function
 

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     utils: utility classes & funcs for auto_process_ngs module
-#     Copyright (C) University of Manchester 2013-2022 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2023 Peter Briggs
 #
 ########################################################################
 #
@@ -25,6 +25,7 @@ Functions:
 
 - bases_mask_is_paired_end:
 - get_organism_list:
+- normalise_organism_name:
 - split_user_host_dir:
 - get_numbered_subdir:
 - find_executables:
@@ -650,11 +651,31 @@ def get_organism_list(organisms):
     """
     if not organisms:
         return []
+    return [normalise_organism_name(x)
+            for x in str(organisms).split(',')]
+
+def normalise_organism_name(name):
+    """
+    Return normalised organism name
+
+    Normalisation consists of converting names to
+    lower case and spaces to underscores.
+
+    E.g.
+
+    "Human" -> 'human'
+    "Xenopus tropicalis" -> 'xenopus_tropicalis'
+
+    Arguments:
+      name (str): organism name
+
+    Returns:
+      String: normalised organism name
+    """
     # Make lowercase, split on commas and replace whitespace
     # with single underscore, then strip leading/trailing
     # underscores
-    return [re.sub(r'\s+','_',x).strip('_')
-            for x in str(organisms).lower().split(',')]
+    return re.sub(r'\s+','_',str(name).lower()).strip('_')
 
 def split_user_host_dir(location):
     # Split a location of the form [[user@]host:]dir into its


### PR DESCRIPTION
Fixes a bug in the QC verification (`verify_qc_module` method of the `QCVerifier` class in the `qc.verification` module) which failed when organism names contained spaces (e.g. `homo sapiens`).

The bug affected the verification of Picard insert sizes, RSeQC gene body coverage and Qualimap `rnaseq` outputs.