### PR TITLE
Escape spaces in 'source' and 'target' for 'rsync' commands

### DIFF
--- a/auto_process_ngs/applications.py
+++ b/auto_process_ngs/applications.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     applications.py: utilities for running command line applications
-#     Copyright (C) University of Manchester 2013-2021 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2023 Peter Briggs
 #
 ########################################################################
 #
@@ -32,12 +32,6 @@ the 'run_subprocess' method of the Command object, e.g:
 
 >>> rsync.run_subprocess()
 """
-
-#######################################################################
-# Module metadata
-#######################################################################
-
-__version__ = "0.0.10"
 
 #######################################################################
 # Import modules that this module depends on

--- a/auto_process_ngs/applications.py
+++ b/auto_process_ngs/applications.py
@@ -379,6 +379,11 @@ class general:
         # Additional options
         if extra_options is not None:
             rsync_cmd.add_args(*extra_options)
+        # Escape spaces in source and target, if required
+        if ' ' in source:
+            source = source.replace(' ','\ ')
+        if ' ' in target:
+            target = target.replace(' ','\ ')
         # Make rsync command
         rsync_cmd.add_args(source,target)
         return rsync_cmd


### PR DESCRIPTION
Updates the `general.rsync` command generation in the `applications` module so that space characters in the 'source' and 'target' arguments (which specify the locations to be `rsync`ed from and to) are escaped when the command is generated.

For example: `user@example.ac.uk:/mnt/data/230109_A01234_0050_ABCDE1X2/NovaSeqRun SampleSheet.csv` becomes `user@example.ac.uk:/mnt/data/230109_A01234_0050_ABCDE1X2/NovaSeqRun\ SampleSheet.csv`