### PR TITLE
'setup': allow facility run number to be set from command line

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -105,8 +105,8 @@ def add_setup_command(cmdparser):
                               help="Set up a new analysis directory",
                               description="Set up automatic processing of "
                               "Illumina sequencing data from RUN_DIR.")
-    p.add_argument('--sample-sheet',action='store',dest='sample_sheet',
-                   default=None,
+    p.add_argument('-s','--samplesheet','--sample-sheet',
+                   action='store',dest='sample_sheet',default=None,
                    help="Copy sample sheet file from name and location "
                    "SAMPLE_SHEET (default is to look for SampleSheet.csv "
                    "inside DIR). SAMPLE_SHEET can be a local or remote "

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     cli/auto_process.py: command line interface for auto_process_ngs
-#     Copyright (C) University of Manchester 2013-2022 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2023 Peter Briggs
 #
 #########################################################################
 #
@@ -111,6 +111,9 @@ def add_setup_command(cmdparser):
                    "SAMPLE_SHEET (default is to look for SampleSheet.csv "
                    "inside DIR). SAMPLE_SHEET can be a local or remote "
                    "file, or a URL")
+    p.add_argument('-r','--run-number',action='store',dest='run_number',
+                   metavar="RUN_NUMBER",default=None,
+                   help="Set facility run number")
     p.add_argument('-f','--file',action='append',dest='extra_files',
                    metavar="FILE",default=None,
                    help="Additional file(s) to copy into new analysis "
@@ -1128,6 +1131,7 @@ def setup(args):
         d.setup(args.run_dir,
                 analysis_dir=args.analysis_dir,
                 sample_sheet=args.sample_sheet,
+                run_number=args.run_number,
                 extra_files=args.extra_files,
                 unaligned_dir=args.unaligned_dir)
 

--- a/auto_process_ngs/commands/setup_cmd.py
+++ b/auto_process_ngs/commands/setup_cmd.py
@@ -5,6 +5,10 @@
 #
 #########################################################################
 
+#######################################################################
+# Imports
+#######################################################################
+
 import os
 import uuid
 import shutil
@@ -21,10 +25,6 @@ from bcftbx.IlluminaData import IlluminaData
 from bcftbx.IlluminaData import IlluminaDataError
 from bcftbx.IlluminaData import SampleSheet
 from bcftbx.IlluminaData import split_run_name_full
-
-#######################################################################
-# Imports
-#######################################################################
 
 # Module specific logger
 logger = logging.getLogger(__name__)

--- a/auto_process_ngs/commands/setup_cmd.py
+++ b/auto_process_ngs/commands/setup_cmd.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 #######################################################################
 
 def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
-          extra_files=None,unaligned_dir=None):
+          run_number=None,extra_files=None,unaligned_dir=None):
     """
     Set up the initial analysis directory
 
@@ -50,6 +50,7 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
         sample sheet file; can be a local or remote file, or
         a URL (optional, will use sample sheet from the
         source data directory if present)
+      run_number (str): facility run number
       extra_files (list): arbitrary additional files to copy
         into the new analysis directory; each file can be a
         local or remote file or a URL
@@ -96,31 +97,35 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
                            ap.analysis_dir)
     # Run datestamp, instrument name and instrument run number
     try:
-        datestamp,instrument,run_number,flow_cell_prefix,flow_cell_id = \
-                                    split_run_name_full(run_name)
-        run_number = run_number.lstrip('0')
+        datestamp,\
+            instrument_name,\
+            instrument_run_number,\
+            flow_cell_prefix,\
+            flow_cell_id = \
+                split_run_name_full(run_name)
+        instrument_run_number = instrument_run_number.lstrip('0')
         flow_cell = flow_cell_prefix + flow_cell_id
     except Exception as ex:
         logger.warning("Unable to extract information from run name '%s'" \
                        % run_name)
         logger.warning("Exception: %s" % ex)
         datestamp = None
-        instrument= None
-        run_number = None
+        instrument_name = None
+        instrument_run_number = None
         flow_cell = None
     # Identify missing data and attempt to acquire
     # Sequencing platform
     platform = ap.metadata.platform
     if platform is None:
         platform = get_sequencer_platform(data_dir,
-                                          instrument=instrument,
+                                          instrument=instrument_name,
                                           settings=ap.settings)
     print("Platform identified as '%s'" % platform)
     # Sequencer model
     model = ap.metadata.sequencer_model
     if model is None:
         try:
-            model = ap.settings.sequencers[instrument]['model']
+            model = ap.settings.sequencers[instrument_name]['model']
         except KeyError:
             pass
     if model:
@@ -247,12 +252,13 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
     # Store the metadata
     ap.metadata['run_name'] = ap.run_name
     ap.metadata['platform'] = platform
-    ap.metadata['instrument_name'] = instrument
+    ap.metadata['instrument_name'] = instrument_name
     ap.metadata['instrument_datestamp'] = datestamp
-    ap.metadata['instrument_run_number'] = run_number
+    ap.metadata['instrument_run_number'] = instrument_run_number
     ap.metadata['instrument_flow_cell_id'] = flow_cell
     ap.metadata['sequencer_model'] = model
     ap.metadata['source'] = data_source
+    ap.metadata['run_number'] = run_number
     # Make a 'projects.info' metadata file
     if not ap.params.project_metadata:
         if unaligned_dir is not None:

--- a/auto_process_ngs/test/commands/test_setup_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_cmd.py
@@ -137,6 +137,61 @@ model = {model}
                                                        subdirn)),
                             "Missing subdir: %s" % subdirn)
 
+    def test_autoprocess_setup_specify_facility_run_number(self):
+        """setup: specify facility run number
+        """
+        # Create mock Illumina run directory
+        mock_illumina_run = MockIlluminaRun(
+            '151125_M00879_0001_000000000-ABCDE1',
+            'miseq',
+            top_dir=self.dirn)
+        mock_illumina_run.create()
+        # Set up autoprocessor
+        ap = AutoProcess(settings=self.settings())
+        setup_(ap,mock_illumina_run.dirn,run_number='1')
+        analysis_dirn = "%s_analysis" % mock_illumina_run.name
+        # Check parameters
+        self.assertEqual(ap.analysis_dir,
+                         os.path.join(self.dirn,analysis_dirn))
+        self.assertEqual(ap.params.data_dir,mock_illumina_run.dirn)
+        self.assertEqual(ap.params.sample_sheet,
+                         os.path.join(self.dirn,analysis_dirn,
+                                      'custom_SampleSheet.csv'))
+        self.assertEqual(ap.params.bases_mask,'auto')
+        # Check metadata
+        self.assertEqual(ap.metadata.run_name,
+                         "151125_M00879_0001_000000000-ABCDE1")
+        self.assertEqual(ap.metadata.run_number,'1')
+        self.assertEqual(ap.metadata.source,None)
+        self.assertEqual(ap.metadata.platform,"miseq")
+        self.assertEqual(ap.metadata.bcl2fastq_software,None)
+        self.assertEqual(ap.metadata.cellranger_software,None)
+        self.assertEqual(ap.metadata.cellranger_software,None)
+        self.assertEqual(ap.metadata.instrument_name,"M00879")
+        self.assertEqual(ap.metadata.instrument_datestamp,"151125")
+        self.assertEqual(ap.metadata.instrument_run_number,"1")
+        self.assertEqual(ap.metadata.instrument_flow_cell_id,
+                         "000000000-ABCDE1")
+        self.assertEqual(ap.metadata.sequencer_model,None)
+        # Delete to force write of data to disk
+        del(ap)
+        # Check directory exists
+        self.assertTrue(os.path.isdir(analysis_dirn))
+        # Check files exists
+        for filen in ('SampleSheet.orig.csv',
+                      'custom_SampleSheet.csv',
+                      'auto_process.info',
+                      'metadata.info',):
+            self.assertTrue(os.path.exists(os.path.join(analysis_dirn,
+                                                        filen)),
+                            "Missing file: %s" % filen)
+        # Check subdirs have been created
+        for subdirn in ('ScriptCode',
+                        'logs',):
+            self.assertTrue(os.path.isdir(os.path.join(analysis_dirn,
+                                                       subdirn)),
+                            "Missing subdir: %s" % subdirn)
+
     def test_autoprocess_setup_non_canonical_run_name(self):
         """setup: handle run name with non-canonical run name
         """


### PR DESCRIPTION
Updates the `setup` command so that the facility run number can be explicitly specified on the command line using a new `-r` or `--run-number` option.

E.g.:

   auto_process.py setup -r 24 ...

(Also updates the CLI so that `-s` and `--samplesheet` are acceptable aliases for the existing `--sample-sheet` option.)