### PR TITLE
'setup' command: fix bug when supplied sample sheet is on a remote system

### DIFF
--- a/auto_process_ngs/commands/setup_cmd.py
+++ b/auto_process_ngs/commands/setup_cmd.py
@@ -151,7 +151,7 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
                 targets = (sample_sheet,)
             # Try each possibility until one sticks
             for target in targets:
-                if not Location(target).is_url:
+                if not (Location(target).is_url or Location(target).is_remote) :
                     target = os.path.join(data_dir,target)
                 print("Trying '%s'" % target)
                 try:


### PR DESCRIPTION
Fixes a bug in the 'setup' command where `abspath` was applied to the supplied sample sheet file path for remote paths (i.e. of the form `USER@HOST:/path/to/SampleSheet.csv`), resulting in mangled paths (e.g. `/path/to/run/USER@HOST:/path/to/SampleSheet.csv`).

The fix checks if the sample sheet is on a remote system and doesn't apply `abspath` in these cases.