### PR TITLE
Update pipelines for CellRanger 7.1.0

### DIFF
--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1,5 +1,5 @@
 #     mock.py: module providing mock Illumina data for testing
-#     Copyright (C) University of Manchester 2012-2022 Peter Briggs
+#     Copyright (C) University of Manchester 2012-2023 Peter Briggs
 #
 ########################################################################
 
@@ -2320,9 +2320,13 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
             outs_dir = os.path.join(top_dir,"outs")
             os.mkdir(outs_dir)
             if self._package_name == "cellranger":
+                if version[0] < 7:
+                    metrics_data = mock10xdata.METRICS_SUMMARY
+                else:
+                    metrics_data = mock10xdata.METRICS_SUMMARY_7_1_0
                 metrics_file = os.path.join(outs_dir,"metrics_summary.csv")
                 with open(metrics_file,'w') as fp:
-                    fp.write(mock10xdata.METRICS_SUMMARY)
+                    fp.write(metrics_data)
             elif self._package_name in "cellranger-atac":
                 summary_file = os.path.join(outs_dir,"summary.csv")
                 with open(summary_file,'w') as fp:
@@ -2373,6 +2377,10 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
                       "multi/multiplexing_analysis",):
                 os.mkdir(os.path.join(outs_dir,d))
             # Per sample outs
+            if version[0] < 7:
+                metrics_data = mock10xdata.CELLPLEX_METRICS_SUMMARY
+            else:
+                metrics_data = mock10xdata.CELLPLEX_METRICS_SUMMARY_7_1_0
             for sample in config.sample_names:
                 sample_dir = os.path.join(outs_dir,
                                           "per_sample_outs",
@@ -2381,7 +2389,7 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
                 metrics_file = os.path.join(sample_dir,
                                             "metrics_summary.csv")
                 with open(metrics_file,'wt') as fp:
-                    fp.write(mock10xdata.CELLPLEX_METRICS_SUMMARY)
+                    fp.write(metrics_data)
                 web_summary_file = os.path.join(sample_dir,
                                                 "web_summary.html")
                 with open(web_summary_file,'wt') as fp:

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -2064,6 +2064,8 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
         elif self._package_name == 'cellranger':
             header = "%s %s-%s" % (self._package_name,self._package_name,
                                    self._version)
+            if version[0] > 6:
+                header += '\n'
         elif self._package_name == 'cellranger-arc':
             header = "%s %s-%s" % (self._package_name,self._package_name,
                                    self._version)

--- a/auto_process_ngs/mock10xdata.py
+++ b/auto_process_ngs/mock10xdata.py
@@ -204,8 +204,14 @@ td { text-align: right; }</style>
 </html>
 """
 
+# CellRanger
 METRICS_SUMMARY = """Estimated Number of Cells,Mean Reads per Cell,Median Genes per Cell,Number of Reads,Valid Barcodes,Reads Mapped Confidently to Transcriptome,Reads Mapped Confidently to Exonic Regions,Reads Mapped Confidently to Intronic Regions,Reads Mapped Confidently to Intergenic Regions,Reads Mapped Antisense to Gene,Sequencing Saturation,Q30 Bases in Barcode,Q30 Bases in RNA Read,Q30 Bases in Sample Index,Q30 Bases in UMI,Fraction Reads in Cells,Total Genes Detected,Median UMI Counts per Cell
 "2,272","107,875","1,282","245,093,084",98.3%,69.6%,71.9%,6.1%,3.2%,4.4%,51.3%,98.5%,79.2%,93.6%,98.5%,12.0%,"16,437","2,934"
+"""
+
+# CellRanger 7.1.0
+METRICS_SUMMARY_7_1_0 = """Estimated Number of Cells,Mean Reads per Cell,Median Genes per Cell,Number of Reads,Valid Barcodes,Sequencing Saturation,Q30 Bases in Barcode,Q30 Bases in RNA Read,Q30 Bases in UMI,Reads Mapped to Genome,Reads Mapped Confidently to Genome,Reads Mapped Confidently to Intergenic Regions,Reads Mapped Confidently to Intronic Regions,Reads Mapped Confidently to Exonic Regions,Reads Mapped Confidently to Transcriptome,Reads Mapped Antisense to Gene,Fraction Reads in Cells,Total Genes Detected,Median UMI Counts per Cell
+"5,529",551,267,"3,045,784",97.6%,1.7%,97.4%,89.4%,97.1%,94.3%,89.0%,3.9%,30.6%,54.5%,76.5%,8.0%,88.5%,"17,781",331
 """
 
 # Cellranger ATAC < 2.0.0

--- a/auto_process_ngs/mock10xdata.py
+++ b/auto_process_ngs/mock10xdata.py
@@ -312,6 +312,90 @@ Sample,Gene Expression,Physical library ID,JR_10K_gex,Cells assigned to other sa
 Sample,Gene Expression,Physical library ID,JR_10K_gex,Cells assigned to this sample,5175 (38.09%)
 """
 
+CELLPLEX_METRICS_SUMMARY_7_1_0 = """Category,Library Type,Grouped By,Group Name,Metric Name,Metric Value
+Cells,Gene Expression,,,Cells,"1,569"
+Cells,Gene Expression,,,Confidently mapped antisense,3.66%
+Cells,Gene Expression,,,Confidently mapped to exonic regions,65.79%
+Cells,Gene Expression,,,Confidently mapped to genome,92.83%
+Cells,Gene Expression,,,Confidently mapped to intergenic regions,4.66%
+Cells,Gene Expression,,,Confidently mapped to intronic regions,22.39%
+Cells,Gene Expression,,,Confidently mapped to transcriptome,84.16%
+Cells,Gene Expression,,,Mapped to genome,96.27%
+Cells,Gene Expression,,,Median UMI counts per cell,"6,685"
+Cells,Gene Expression,,,Median genes per cell,"2,468"
+Cells,Gene Expression,,,Median reads per cell,"26,198"
+Cells,Gene Expression,,,Number of reads from cells called from this sample,"61,845,367"
+Cells,Gene Expression,,,Total genes detected,"20,942"
+Cells,Gene Expression,Physical library ID,SC_GE,Cell-associated barcodes identified as multiplets,"1,222 (8.31%)"
+Cells,Gene Expression,Physical library ID,SC_GE,Cell-associated barcodes not assigned any CMOs,"4,359 (29.65%)"
+Cells,Gene Expression,Physical library ID,SC_GE,Cells assigned to other samples,"7,553 (51.37%)"
+Cells,Gene Expression,Physical library ID,SC_GE,Cells assigned to this sample,"1,569 (10.67%)"
+Library,Gene Expression,Fastq ID,SC_GE,Number of reads,"771,660,546"
+Library,Gene Expression,Fastq ID,SC_GE,Number of short reads skipped,0
+Library,Gene Expression,Fastq ID,SC_GE,Q30 RNA read,92.8%
+Library,Gene Expression,Fastq ID,SC_GE,Q30 UMI,95.7%
+Library,Gene Expression,Fastq ID,SC_GE,Q30 barcodes,96.2%
+Library,Gene Expression,Physical library ID,SC_GE,Cell-associated barcodes identified as multiplets,"1,222 (8.31%)"
+Library,Gene Expression,Physical library ID,SC_GE,Cell-associated barcodes not assigned any CMOs,"4,359 (29.65%)"
+Library,Gene Expression,Physical library ID,SC_GE,Cells assigned to a sample,"9,122 (62.04%)"
+Library,Gene Expression,Physical library ID,SC_GE,Confidently mapped antisense,3.41%
+Library,Gene Expression,Physical library ID,SC_GE,Confidently mapped reads in cells,96.92%
+Library,Gene Expression,Physical library ID,SC_GE,Confidently mapped to exonic regions,68.96%
+Library,Gene Expression,Physical library ID,SC_GE,Confidently mapped to genome,91.86%
+Library,Gene Expression,Physical library ID,SC_GE,Confidently mapped to intergenic regions,4.04%
+Library,Gene Expression,Physical library ID,SC_GE,Confidently mapped to intronic regions,18.87%
+Library,Gene Expression,Physical library ID,SC_GE,Confidently mapped to transcriptome,84.09%
+Library,Gene Expression,Physical library ID,SC_GE,Estimated number of cells,"14,703"
+Library,Gene Expression,Physical library ID,SC_GE,Mapped to genome,95.29%
+Library,Gene Expression,Physical library ID,SC_GE,Mean reads per cell,"52,483"
+Library,Gene Expression,Physical library ID,SC_GE,Number of reads,"771,660,546"
+Library,Gene Expression,Physical library ID,SC_GE,Number of reads in the library,"771,660,546"
+Library,Gene Expression,Physical library ID,SC_GE,Sequencing saturation,69.03%
+Library,Gene Expression,Physical library ID,SC_GE,Valid UMIs,99.93%
+Library,Gene Expression,Physical library ID,SC_GE,Valid barcodes,97.62%
+Library,Multiplexing Capture,,,Cell-associated barcodes identified as multiplets,"1,222 (8.31%)"
+Library,Multiplexing Capture,,,Cells assigned to a sample,"9,122 (62.04%)"
+Library,Multiplexing Capture,,,Estimated number of cell-associated barcodes,"14,703"
+Library,Multiplexing Capture,,,Median CMO UMIs per cell,"2,987"
+Library,Multiplexing Capture,,,Number of samples assigned at least one cell,5
+Library,Multiplexing Capture,,,Singlet capture ratio,0.69
+Library,Multiplexing Capture,CMO Name,CMO301,CMO signal-to-noise ratio,4.25
+Library,Multiplexing Capture,CMO Name,CMO301,Cells assigned to CMO,17.20%Library,Multiplexing Capture,CMO Name,CMO301,Fraction reads in cell-associated barcodes,72.63%
+Library,Multiplexing Capture,CMO Name,CMO302,CMO signal-to-noise ratio,2.70
+Library,Multiplexing Capture,CMO Name,CMO302,Cells assigned to CMO,13.24%
+Library,Multiplexing Capture,CMO Name,CMO302,Fraction reads in cell-associated barcodes,49.82%
+Library,Multiplexing Capture,CMO Name,CMO303,CMO signal-to-noise ratio,3.50
+Library,Multiplexing Capture,CMO Name,CMO303,Cells assigned to CMO,27.26%
+Library,Multiplexing Capture,CMO Name,CMO303,Fraction reads in cell-associated barcodes,71.93%
+Library,Multiplexing Capture,CMO Name,CMO304,CMO signal-to-noise ratio,4.60
+Library,Multiplexing Capture,CMO Name,CMO304,Cells assigned to CMO,14.42%
+Library,Multiplexing Capture,CMO Name,CMO304,Fraction reads in cell-associated barcodes,66.88%
+Library,Multiplexing Capture,CMO Name,CMO305,CMO signal-to-noise ratio,3.34
+Library,Multiplexing Capture,CMO Name,CMO305,Cells assigned to CMO,27.88%
+Library,Multiplexing Capture,CMO Name,CMO305,Fraction reads in cell-associated barcodes,73.27%
+Library,Multiplexing Capture,Fastq ID,SC_CML,Number of reads,"204,261,166"
+Library,Multiplexing Capture,Fastq ID,SC_CML,Number of short reads skipped,0
+Library,Multiplexing Capture,Fastq ID,SC_CML,Q30 RNA read,96.9%
+Library,Multiplexing Capture,Fastq ID,SC_CML,Q30 UMI,96.4%
+Library,Multiplexing Capture,Fastq ID,SC_CML,Q30 barcodes,96.3%
+Library,Multiplexing Capture,Physical library ID,SC_CML,Cell-associated barcodes identified as multiplets,"1,222 (8.31%)"
+Library,Multiplexing Capture,Physical library ID,SC_CML,Cell-associated barcodes not assigned any CMOs,"4,359 (29.65%)"
+Library,Multiplexing Capture,Physical library ID,SC_CML,Cells assigned to a sample,"9,122 (62.04%)"
+Library,Multiplexing Capture,Physical library ID,SC_CML,Estimated number of cell-associated barcodes,"14,703"
+Library,Multiplexing Capture,Physical library ID,SC_CML,Fraction CMO reads,97.66%
+Library,Multiplexing Capture,Physical library ID,SC_CML,Fraction CMO reads usable,65.16%
+Library,Multiplexing Capture,Physical library ID,SC_CML,Fraction reads from multiplets,0.00%
+Library,Multiplexing Capture,Physical library ID,SC_CML,Fraction reads in cell-associated barcodes,67.12%
+Library,Multiplexing Capture,Physical library ID,SC_CML,Fraction unrecognized CMO,2.34%
+Library,Multiplexing Capture,Physical library ID,SC_CML,Mean reads per cell-associated barcode,"13,892"
+Library,Multiplexing Capture,Physical library ID,SC_CML,Median CMO UMIs per cell-associated barcode,"2,814"
+Library,Multiplexing Capture,Physical library ID,SC_CML,Number of reads,"204,261,166"
+Library,Multiplexing Capture,Physical library ID,SC_CML,Samples assigned at least one cell,5
+Library,Multiplexing Capture,Physical library ID,SC_CML,Sequencing saturation,29.48%
+Library,Multiplexing Capture,Physical library ID,SC_CML,Valid UMIs,99.99%
+Library,Multiplexing Capture,Physical library ID,SC_CML,Valid barcodes,99.17%
+"""
+
 MULTIOME_LIBRARIES = """#Local sample\tLinked sample
 PB2_ATAC\tNEXTSEQ_210111/12:PB_GEX/PB2_GEX
 PB1_ATAC\tNEXTSEQ_210111/12:PB_GEX/PB1_GEX

--- a/auto_process_ngs/test/tenx/test_metrics.py
+++ b/auto_process_ngs/test/tenx/test_metrics.py
@@ -11,6 +11,7 @@ from auto_process_ngs.mock10xdata import METRICS_SUMMARY_7_1_0
 from auto_process_ngs.mock10xdata import ATAC_SUMMARY
 from auto_process_ngs.mock10xdata import ATAC_SUMMARY_2_0_0
 from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY
+from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY_7_1_0
 from auto_process_ngs.mock10xdata import MULTIOME_SUMMARY
 from auto_process_ngs.mock10xdata import MULTIOME_SUMMARY_2_0_0
 from auto_process_ngs.tenx.metrics import *
@@ -172,3 +173,16 @@ class TestMultiplexSummary(unittest.TestCase):
         self.assertEqual(m.median_genes_per_cell,3086)
         self.assertEqual(m.total_genes_detected,21260)
         self.assertEqual(m.median_umi_counts_per_cell,10515)
+
+    def test_multiplex_summary_cellranger_7_1_0(self):
+        """MultiplexSummary: check metrics are extracted from CSV file (Cellranger 7.1.0)
+        """
+        summary_csv = os.path.join(self.wd,"metrics_summary.csv")
+        with open(summary_csv,'w') as fp:
+            fp.write(CELLPLEX_METRICS_SUMMARY_7_1_0)
+        m = MultiplexSummary(summary_csv)
+        self.assertEqual(m.cells,1569)
+        self.assertEqual(m.median_reads_per_cell,26198)
+        self.assertEqual(m.median_genes_per_cell,2468)
+        self.assertEqual(m.total_genes_detected,20942)
+        self.assertEqual(m.median_umi_counts_per_cell,6685)

--- a/auto_process_ngs/test/tenx/test_metrics.py
+++ b/auto_process_ngs/test/tenx/test_metrics.py
@@ -7,6 +7,7 @@ import tempfile
 import os
 import shutil
 from auto_process_ngs.mock10xdata import METRICS_SUMMARY
+from auto_process_ngs.mock10xdata import METRICS_SUMMARY_7_1_0
 from auto_process_ngs.mock10xdata import ATAC_SUMMARY
 from auto_process_ngs.mock10xdata import ATAC_SUMMARY_2_0_0
 from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY
@@ -40,6 +41,19 @@ class TestGexSummary(unittest.TestCase):
         self.assertEqual(m.estimated_number_of_cells,2272)
         self.assertEqual(m.mean_reads_per_cell,107875)
         self.assertEqual(m.median_genes_per_cell,1282)
+        self.assertEqual(m.frac_reads_in_cells,"12.0%")
+
+    def test_gex_summary_cellranger_7_1_0(self):
+        """GexSummary: check metrics are extracted from CSV file (CellRanger 7.1.0)
+        """
+        summary_csv = os.path.join(self.wd,"metrics_summary.csv")
+        with open(summary_csv,'w') as fp:
+            fp.write(METRICS_SUMMARY_7_1_0)
+        m = GexSummary(summary_csv)
+        self.assertEqual(m.estimated_number_of_cells,5529)
+        self.assertEqual(m.mean_reads_per_cell,551)
+        self.assertEqual(m.median_genes_per_cell,267)
+        self.assertEqual(m.frac_reads_in_cells,"88.5%")
 
 class TestAtacSummary(unittest.TestCase):
     """

--- a/auto_process_ngs/test/tenx/test_utils.py
+++ b/auto_process_ngs/test/tenx/test_utils.py
@@ -360,6 +360,13 @@ class TestCellrangerInfo(unittest.TestCase):
             fp.write("#!/bin/bash\necho -n cellranger cellranger-6.0.0")
         os.chmod(cellranger_600,0o775)
         return cellranger_600
+    def _make_mock_cellranger_710(self):
+        # Make a fake cellranger 7.1.0 executable
+        cellranger_710 = os.path.join(self.wd,"cellranger")
+        with open(cellranger_710,'w') as fp:
+            fp.write("#!/bin/bash\necho cellranger cellranger-7.1.0")
+        os.chmod(cellranger_710,0o775)
+        return cellranger_710
     def _make_mock_cellranger_atac_101(self):
         # Make a fake cellranger-atac 1.0.1 executable
         cellranger_atac_101 = os.path.join(self.wd,"cellranger-atac")
@@ -420,6 +427,13 @@ class TestCellrangerInfo(unittest.TestCase):
         cellranger = self._make_mock_cellranger_600()
         self.assertEqual(cellranger_info(path=cellranger),
                          (cellranger,'cellranger','6.0.0'))
+
+    def test_cellranger_710(self):
+        """cellranger_info: collect info for cellranger 7.1.0
+        """
+        cellranger = self._make_mock_cellranger_710()
+        self.assertEqual(cellranger_info(path=cellranger),
+                         (cellranger,'cellranger','7.1.0'))
 
     def test_cellranger_atac_101(self):
         """cellranger_info: collect info for cellranger-atac 1.0.1

--- a/docs/source/developers/update_cellranger.rst
+++ b/docs/source/developers/update_cellranger.rst
@@ -1,0 +1,73 @@
+===================
+Updating CellRanger
+===================
+
+This is an overview of updates that need to be made to the code to
+add support for new versions of 10x Genomics ``cellranger`` family
+of pipelines, and a suggested procedure for doing this.
+
+It is also recommended to scan the release notes for the new
+version to see if any significant changes to existing options or
+outputs are flagged up.
+
+**Step 1: Check and update version detection**
+
+Run ``cellranger --version`` to see what the version string output
+looks like, for example for CellRanger 7.1.0:
+
+::
+
+   $ cellranger --version
+   cellranger cellranger-7.1.0
+
+If the format differs from the previous version then the
+``cellranger_info`` function in ``auto_process_ngs.tenx.utils``)
+will need to be updated; add a new to ``TestCellrangerInfo`` and
+update ``cellranger_info`` so that the test passes.
+
+The version returned by the ``Mock10xPackageExe`` class in the
+``mock`` module should also be updated in this case; the default
+version should also be updated.
+
+**Step 2: Run Fastq generation**
+
+Next, update the configuration to use the new version for Fastq
+generation, then run the pipeline on a test dataset and look
+for errors.
+
+Any failures will flag up issues with changes to the command line
+for the ``mkfastq`` command; once the differences are identified
+then the appropriate parts of the ``Mock10xPackageExe`` class in
+the ``mock`` module should be updated, to mimick the behaviour for
+new, modified or removed command line options (the CellRanger
+documentation can help here).
+
+A new version-specific unit test case for the ``MakeFastqs``
+pipeline should also be added (e.g.
+``test_makefastqs_10x_chromium_sc_protocol_710``).
+
+**Step 3: Run single library analysis (count)**
+
+Once any issues with the Fastq generation have been addressed,
+run the QC pipeline to perform the single library analyses.
+Again, any failures will flag up issues with changes to both
+the command line and the outputs from ``count``: depending on
+what has changed, these may require updates to:
+
+* The ``Mock10xPackageExe`` implementation of ``count``
+* CellRanger-specific elements of ``qc.pipeline``
+* Code for identification and handling of output files and
+  metrics (in ``tenx.metrics`` and ``qc.cellranger``).
+
+Even if the pipeline runs without issues, it is recommended to
+check the contents of the metric files in case the format has
+changed; if so then example versions of the new contents can
+be added to ``mock10xdata`` and new test cases created to
+check that the appropriate classes handle it correctly.
+
+(The ``Mock10xPackageExe`` should also be updated to use any
+new example output data for its mock outputs.)
+
+**Step 4: Run multiplexing analysis (multi)**
+
+This essentially repeats step 3, with the ``multi`` command.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -97,4 +97,5 @@ at the `University of Manchester <https://www.manchester.ac.uk/>`_.
    :maxdepth: 2
    :caption: Developer Documentation
 
+   developers/update_cellranger
    developers/api_docs/index


### PR DESCRIPTION
Updates to ensure that the Fastq generation and QC pipelines work with the latest version of CellRanger 7.1.0.

Release notes: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/release-notes