### PR TITLE
Fix bug setting 10x Genomics cell count from 'cellranger multi' in QC

### DIFF
--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -315,15 +315,21 @@ def get_seq_data_samples(project_dir,fastq_attrs=None):
                                   if s in samples])
     return samples
 
-def set_cell_count_for_project(project_dir,qc_dir=None):
+def set_cell_count_for_project(project_dir,qc_dir=None,
+                               source="count"):
     """
     Set the total number of cells for a project
 
-    Sums the number of cells for each sample in a project
-    (as determined from 'cellranger count' and extracted
-    from the 'metrics_summary.csv' file for scRNA-seq, or
-    from 'cellranger-atac count' and extracted from the
-    'summary.csv' file for scATAC-seq).
+    Depending on the specified 'source', sums the number
+    of cells for each sample in a project as determined
+    from either 'cellranger* count' or 'cellranger multi'.
+
+    Depending the 10x Genomics package and analysis type
+    the cell count for individual samples is extracted
+    from the 'metrics_summary.csv' file for scRNA-seq
+    (i.e. 'cellranger count' or 'cellranger multi'), or
+    from the 'summary.csv' file for scATAC (ie.
+    'cellranger-atac count').
 
     The final count is written to the 'number_of_cells'
     metadata item for the project.
@@ -332,6 +338,8 @@ def set_cell_count_for_project(project_dir,qc_dir=None):
       project_dir (str): path to the project directory
       qc_dir (str): path to QC directory (if not the default
         QC directory for the project)
+      source (str): either 'count' or 'multi' (default is
+        'count')
 
     Returns:
       Integer: exit code, non-zero values indicate problems
@@ -375,9 +383,12 @@ def set_cell_count_for_project(project_dir,qc_dir=None):
         print("%s: not found" % qc_info_file)
     # Determine whether we're handling output from 'multi'
     # or from 'count'
-    if os.path.exists(os.path.join(qc_dir,"cellranger_multi")):
-        # Handle outputs from 'multi'
+    if source == "multi":
         print("Looking for '%s multi' outputs" % pipeline)
+        if not os.path.exists(os.path.join(qc_dir,"cellranger_multi")):
+            logger.warning("Unable to set cell count: no data found")
+            return
+        # Handle outputs from 'multi'
         number_of_cells = 0
         try:
             multi_outs = CellrangerMulti(
@@ -405,9 +416,12 @@ def set_cell_count_for_project(project_dir,qc_dir=None):
             logger.warning("Unable to set cell count from data in "
                            "%s: %s" %
                            (os.path.join(qc_dir,"cellranger_multi"),ex))
-    elif os.path.exists(os.path.join(qc_dir,"cellranger_count")):
-        # Handle outputs from 'count'
+    elif source == "count":
         print("Looking for '%s count' outputs" % pipeline)
+        if not os.path.exists(os.path.join(qc_dir,"cellranger_count")):
+            logger.warning("Unable to set cell count: no data found")
+            return
+        # Handle outputs from 'count'
         # Determine possible locations for outputs
         count_dirs = []
         # New-style with 'version' and 'reference' subdirectories
@@ -422,6 +436,7 @@ def set_cell_count_for_project(project_dir,qc_dir=None):
                                        "cellranger_count"))
         # Check each putative output location in turn
         for count_dir in count_dirs:
+            print("Examining %s" % count_dir)
             # Check that the directory exists
             if os.path.exists(count_dir):
                 number_of_cells = 0
@@ -458,7 +473,7 @@ def set_cell_count_for_project(project_dir,qc_dir=None):
                                    % (count_dir,ex))
     else:
         # No known outputs to get cell counts from
-        raise Exception("No 10xGenomics analysis subdirectories found?")
+        raise Exception("Unknown source type: '%s'" % source)
     if number_of_cells is not None:
         # Report
         print("Total number of cells: %d" % number_of_cells)

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -578,6 +578,68 @@ Cellranger version\t6.0.0
                                          project_dir).info.number_of_cells,
                          10350)
 
+    def test_set_cell_count_for_cellplex_project_with_count(self):
+        """
+        set_cell_count_for_project: test for multiplexed data (CellPlex) with count output
+        """
+        # Set up mock project
+        project_dir = self._make_mock_analysis_project(
+            "10xGenomics Chromium 3'v3",
+            "CellPlex")
+        # Build mock cellranger multi output directory
+        multi_dir = os.path.join(project_dir,
+                                 "qc",
+                                 "cellranger_multi",
+                                 "6.0.0",
+                                 "refdata-cellranger-gex-GRCh38-2020-A",
+                                 "outs")
+        mkdirs(multi_dir)
+        for sample in ("PBA","PBB",):
+            sample_dir = os.path.join(multi_dir,
+                                      "per_sample_outs",
+                                      sample)
+            mkdirs(sample_dir)
+            summary_file = os.path.join(sample_dir,
+                                        "metrics_summary.csv")
+            with open(summary_file,'wt') as fp:
+                fp.write(CELLPLEX_METRICS_SUMMARY)
+            web_summary = os.path.join(sample_dir,
+                                       "web_summary.html")
+            with open(web_summary,'wt') as fp:
+                fp.write("Placeholder for web_summary.html\n")
+        # Build mock cellranger count output directory in parallel
+        counts_dir = os.path.join(project_dir,
+                                  "qc",
+                                  "cellranger_count",
+                                  "6.0.0",
+                                  "refdata-cellranger-gex-GRCh38-2020-A",
+                                  "PJB1",
+                                  "outs")
+        mkdirs(counts_dir)
+        metrics_summary_file = os.path.join(counts_dir,
+                                            "metrics_summary.csv")
+        with open(metrics_summary_file,'wt') as fp:
+            fp.write(METRICS_SUMMARY)
+        web_summary = os.path.join(counts_dir,
+                                   "web_summary.html")
+        with open(web_summary,'wt') as fp:
+            fp.write("Placeholder for web_summary.html\n")
+        # Add QC info file
+        with open(os.path.join(project_dir,"qc","qc.info"),'wt') as fp:
+            fp.write("""Cellranger reference datasets\t/data/refdata-cellranger-gex-GRCh38-2020-A
+Cellranger version\t6.0.0
+""")
+        # Check initial cell count
+        print("Checking number of cells")
+        self.assertEqual(AnalysisProject(project_dir).info.number_of_cells,
+                         None)
+        # Update the cell counts
+        print("Updating number of cells")
+        set_cell_count_for_project(project_dir)
+        # Check updated cell count
+        self.assertEqual(AnalysisProject(project_dir).info.number_of_cells,
+                         10350)
+
     def test_set_cell_count_project_missing_library_type(self):
         """
         set_cell_count_for_project: test for scRNA-seq when library not set

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -572,7 +572,7 @@ Cellranger version\t6.0.0
                          None)
         # Update the cell counts
         print("Updating number of cells")
-        set_cell_count_for_project(project_dir)
+        set_cell_count_for_project(project_dir,source="multi")
         # Check updated cell count
         self.assertEqual(AnalysisProject("PJB1",
                                          project_dir).info.number_of_cells,
@@ -635,10 +635,16 @@ Cellranger version\t6.0.0
                          None)
         # Update the cell counts
         print("Updating number of cells")
-        set_cell_count_for_project(project_dir)
+        set_cell_count_for_project(project_dir,source="multi")
         # Check updated cell count
         self.assertEqual(AnalysisProject(project_dir).info.number_of_cells,
                          10350)
+        # Update the cell counts from "count" outputs
+        print("Updating number of cells")
+        set_cell_count_for_project(project_dir,source="count")
+        # Check updated cell count
+        self.assertEqual(AnalysisProject(project_dir).info.number_of_cells,
+                         2272)
 
     def test_set_cell_count_project_missing_library_type(self):
         """


### PR DESCRIPTION
Bug fix that addresses a problem with the `set_cell_count_for_project` function in `qc/utils.py` (and affects the QC pipeline where this function is wrapped by the `SetCellCountFromCellrangerCount` task) when outputs from both `cellranger count` and `cellranger multi` are present in a project.

In these cases, the bug manifested itself by defaulting to the `cellranger count` outputs to acquire the cell counts; when this failed (because only a subset of sequenced samples will have `cellranger count` run on them - the CML samples are ignored) there was no fallback to using the `cellranger multi` outputs instead.