### PR TITLE
Add 'read ranges' to QC protocols for 10x Flex data

### DIFF
--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -662,7 +662,7 @@ class AnalysisProjectQCDirInfo(MetadataDict):
     The data items are:
 
     fastq_dir: the name of the associated Fastq subdirectory
-    protocol: the QC protocol used
+    protocol: name of the QC protocol used
     organism: the organism(s) that the QC was run with
     cellranger_version: version of cellranger/10x software used
     cellranger_refdata: reference datasets used with cellranger
@@ -671,6 +671,7 @@ class AnalysisProjectQCDirInfo(MetadataDict):
     star_index: index used by STAR
     annotation_bed: BED file with gene annotation
     annotation_gtf: GTF file with gene annotation
+    protocol_summary: free-text summary of the QC protocol
     """
     def __init__(self,filen=None):
         """Create a new AnalysisProjectQCDirInfo instance
@@ -692,6 +693,7 @@ class AnalysisProjectQCDirInfo(MetadataDict):
                 'star_index': 'STAR index',
                 'annotation_bed': 'BED gene annotation file',
                 'annotation_gtf': 'GTF gene annotation file',
+                'protocol_summary': 'Protocol summary',
             },
             order = (
                 'fastq_dir',

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -39,6 +39,7 @@ the external software required for parts of the pipeline:
 - MockFastQC
 - MockFastqStrandPy
 - MockGtf2bed
+- MockSeqtk
 - MockStar
 - MockSamtools
 - MockPicard
@@ -78,6 +79,7 @@ from bcftbx.IlluminaData import IlluminaData
 from bcftbx.IlluminaData import IlluminaFastq
 from bcftbx.IlluminaData import SampleSheet
 from bcftbx.IlluminaData import SampleSheetPredictor
+from bcftbx.FASTQFile import get_fastq_file_handle
 from bcftbx.qc.report import strip_ngs_extensions
 from .analysis import AnalysisProject
 from .analysis import AnalysisFastq
@@ -2887,7 +2889,7 @@ class MockGtf2bed:
 
     This class can be used to create a mock
     gtf2bed executable, which in turn can be used
-    in place of the actual fastqc program for
+    in place of the actual gtf2bed program for
     testing purposes.
 
     To create a mock script, use the 'create' static
@@ -2983,6 +2985,122 @@ sys.exit(MockGtf2bed(version=%s,
         for line in sys.stdin:
             if not self._no_outputs:
                 print("GTF2BED: placeholder")
+        return self._exit_code
+
+class MockSeqtk:
+    """
+    Create mock 'seqtk'
+
+    This class can be used to create a mock
+    seqtk executable, which in turn can be used
+    in place of the actual seqtk program for
+    testing purposes.
+
+    To create a mock script, use the 'create' static
+    method, e.g.
+
+    >>> MockGtf2bed.create("/tmpbin/seqtk")
+
+    The resulting executable will generate mock outputs
+    when run on Fastq files (ignoring their content).
+
+    The executable can be configured on creation to
+    produce different error conditions when run:
+
+    - the exit code can be set to an arbitrary value
+      via the `exit_code` argument
+
+    The following flags can also be used:
+
+    - `no_outputs` configures the mock executable not
+      to write any output
+    """
+
+    @staticmethod
+    def create(path,version=None,no_outputs=False,
+               exit_code=0):
+        """
+        Create a mock 'seqtk' utility
+
+        Arguments:
+          path (str): path to the new executable
+            to create. The final executable must
+            not exist, however the directory it
+            will be created in must.
+          version (str): explicit version string
+          no_outputs (bool): if True then make
+            don't create mock outputs
+          exit_code (int): exit code that the
+            mock executable should complete
+            with
+        """
+        path = os.path.abspath(path)
+        print("Building mock executable: %s" % path)
+        # Don't clobber an existing executable
+        assert(os.path.exists(path) is False)
+        with open(path,'w') as fp:
+            fp.write("""#!/usr/bin/env python
+import sys
+from auto_process_ngs.mock import MockSeqtk
+sys.exit(MockSeqtk(version=%s,
+                  no_outputs=%s,
+                  exit_code=%s).main(sys.argv[1:]))
+            """ % (("\"%s\"" % version
+                    if version is not None
+                    else None),
+                   no_outputs,
+                   exit_code))
+            os.chmod(path,0o775)
+        with open(path,'r') as fp:
+            print("gtf2bed:")
+            print("%s" % fp.read())
+        return path
+
+    def __init__(self,version=None,no_outputs=False,
+                 exit_code=0):
+        """
+        Internal: configure the mock seqtk
+        """
+        if version is None:
+            version = "1.3"
+        self._version = str(version)
+        self._no_outputs = no_outputs
+        self._exit_code = exit_code
+
+    def main(self,args):
+        """
+        Internal: provides mock seqtk functionality
+        """
+        # Build top-level parser
+        p = argparse.ArgumentParser()
+        sp = p.add_subparsers(dest='command')
+
+        # 'trimfq' subparser
+        trimfq = sp.add_parser('trimfq')
+        trimfq.add_argument('-b',action='store')
+        trimfq.add_argument('-L',action='store')
+        trimfq.add_argument('fastq_in')
+
+        # Process command line
+        args = p.parse_args()
+
+        # Handle commands
+        if args.command == "trimfq":
+            # trimfq command
+            # Echo the input Fastq to stdout
+            if args.fastq_in == '-':
+                fp = sys.stdin
+            else:
+                fp = get_fastq_file_handle(args.fastq_in,'rt')
+            try:
+                sys.stdout.write(fp.read())
+            except Exception as ex:
+                sys.stderr.write("%s\n" % ex)
+                return 1
+            if args.fastq_in != '-':
+                close(fp)
+        else:
+            print("%s: not implemented" % args.command)
         return self._exit_code
 
 class MockStar:

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -3098,7 +3098,7 @@ sys.exit(MockSeqtk(version=%s,
                 sys.stderr.write("%s\n" % ex)
                 return 1
             if args.fastq_in != '-':
-                close(fp)
+                fp.close()
         else:
             print("%s: not implemented" % args.command)
         return self._exit_code

--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -269,7 +269,8 @@ class QCOutputs:
         # Cellranger multi
         cellranger_multi = self.data('cellranger_multi')
         # Multiplexed samples
-        self.multiplexed_samples = cellranger_multi.multiplexed_samples
+        self.multiplexed_samples = sorted(cellranger_multi.multiplexed_samples,
+                                          key=lambda s: split_sample_name(s))
         for reference_data in cellranger_multi.references:
             if reference_data not in self.cellranger_references:
                 self.cellranger_references.append(reference_data)

--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -1693,8 +1693,8 @@ def cellranger_multi_output(project,config_csv,sample_name=None,
         outputs.append(os.path.join(multi_analysis_dir,f))
     return tuple(outputs)
 
-def check_fastq_screen_outputs(project,qc_dir,screen,read_numbers=None,
-                               legacy=False):
+def check_fastq_screen_outputs(project,qc_dir,screen,fastqs=None,
+                               read_numbers=None,legacy=False):
     """
     Return Fastqs missing QC outputs from FastqScreen
 
@@ -1709,6 +1709,8 @@ def check_fastq_screen_outputs(project,qc_dir,screen,read_numbers=None,
         path is assumed to be a subdirectory of the
         project)
       screen (str): screen name to check
+      fastqs (list): optional list of Fastqs to check
+        against (defaults to Fastqs from the project)
       read_numbers (list): read numbers to define Fastqs
         to predict outputs for; if not set then all
         non-index reads will be included
@@ -1720,8 +1722,12 @@ def check_fastq_screen_outputs(project,qc_dir,screen,read_numbers=None,
     """
     if not os.path.isabs(qc_dir):
         qc_dir = os.path.join(project.dirn,qc_dir)
+    if not fastqs:
+        fastqs_in = project.fastqs
+    else:
+        fastqs_in = fastqs
     fastqs = set()
-    for fastq in remove_index_fastqs(project.fastqs,
+    for fastq in remove_index_fastqs(fastqs_in,
                                      project.fastq_attrs):
         if read_numbers and \
            project.fastq_attrs(fastq).read_number not in read_numbers:

--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -1777,7 +1777,7 @@ def check_fastqc_outputs(project,qc_dir,read_numbers=None):
     return sorted(list(fastqs))
 
 def check_fastq_strand_outputs(project,qc_dir,fastq_strand_conf,
-                               read_numbers=None):
+                               fastqs=None,read_numbers=None):
     """
     Return Fastqs missing QC outputs from fastq_strand.py
 
@@ -1796,6 +1796,8 @@ def check_fastq_strand_outputs(project,qc_dir,fastq_strand_conf,
         included unless the path is `None` or the
         config file doesn't exist. Relative path is
         assumed to be a subdirectory of the project
+      fastqs (list): optional list of Fastqs to check
+        against (defaults to Fastqs from the project)
       read_numbers (list): read numbers to predict
         outputs for
 
@@ -1816,9 +1818,13 @@ def check_fastq_strand_outputs(project,qc_dir,fastq_strand_conf,
     if not os.path.exists(fastq_strand_conf):
         # No conf file, nothing to check
         return list()
+    if not fastqs:
+        fastqs_in = project.fastqs
+    else:
+        fastqs_in = fastqs
     fastq_pairs = set()
     for fq_group in group_fastqs_by_name(
-            remove_index_fastqs(project.fastqs,
+            remove_index_fastqs(fastqs_in,
                                 project.fastq_attrs),
             fastq_attrs=project.fastq_attrs):
         # Assemble Fastq pairs based on read numbers

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -307,6 +307,7 @@ class QCPipeline(Pipeline):
         # Build a dictionary of QC metadata items to
         # update
         qc_metadata = dict(protocol=qc_protocol,
+                           protocol_summary=protocol.summarise(),
                            organism=organism,
                            fastq_dir=project.fastq_dir)
 

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -483,6 +483,7 @@ class QCPipeline(Pipeline):
                     project,
                     qc_dir,
                     self.params.fastq_screens,
+                    fastqs=get_seq_fastqs.output.fastqs,
                     read_numbers=read_numbers.seq_data,
                     include_samples=get_seq_data.output.seq_data_samples,
                     fastq_attrs=project.fastq_attrs,
@@ -571,6 +572,7 @@ class QCPipeline(Pipeline):
                     project,
                     qc_dir,
                     setup_fastq_strand_conf.output.fastq_strand_conf,
+                    fastqs=get_seq_fastqs.output.fastqs,
                     read_numbers=read_numbers.seq_data,
                     include_samples=get_seq_data.output.seq_data_samples,
                     verbose=self.params.VERBOSE
@@ -1512,9 +1514,9 @@ class CheckFastqScreenOutputs(PipelineFunctionTask):
     """
     Check the outputs from FastqScreen
     """
-    def init(self,project,qc_dir,screens,read_numbers=None,
-             include_samples=None,fastq_attrs=None,legacy=False,
-             verbose=False):
+    def init(self,project,qc_dir,screens,fastqs=None,
+             read_numbers=None,include_samples=None,
+             fastq_attrs=None,legacy=False,verbose=False):
         """
         Initialise the CheckFastqScreenOutputs task.
 
@@ -1525,6 +1527,9 @@ class CheckFastqScreenOutputs(PipelineFunctionTask):
             to subdirectory 'qc' of project directory)
           screens (mapping): mapping of screen names to
             FastqScreen conf files
+          fastqs (list): explicit list of Fastq files
+            to check against (default is to use Fastqs
+            from supplied analysis project)
           read_numbers (list): read numbers to include
           include_samples (list): optional, list of sample
             names to include
@@ -1557,7 +1562,8 @@ class CheckFastqScreenOutputs(PipelineFunctionTask):
                           self.args.project,
                           self.args.qc_dir,
                           screen,
-                          self.args.read_numbers,
+                          fastqs=self.args.fastqs,
+                          read_numbers=self.args.read_numbers,
                           legacy=self.args.legacy)
     def finish(self):
         fastqs = set()
@@ -1867,8 +1873,8 @@ class CheckFastqStrandOutputs(PipelineFunctionTask):
     """
     Check the outputs from the fastq_strand.py utility
     """
-    def init(self,project,qc_dir,fastq_strand_conf,read_numbers=None,
-             include_samples=None,verbose=False):
+    def init(self,project,qc_dir,fastq_strand_conf,fastqs=None,
+             read_numbers=None,include_samples=None,verbose=False):
         """
         Initialise the CheckFastqStrandOutputs task.
 
@@ -1879,6 +1885,9 @@ class CheckFastqStrandOutputs(PipelineFunctionTask):
             to subdirectory 'qc' of project directory)
           fastq_strand_conf (str): path to the fastq_strand
             config file
+          fastqs (list):  explicit list of Fastq files
+            to check against (default is to use Fastqs
+            from supplied analysis project)
           read_numbers (list): list of read numbers to
             include when checking outputs
           include_samples (list): optional, list of sample
@@ -1905,6 +1914,7 @@ class CheckFastqStrandOutputs(PipelineFunctionTask):
                       self.args.project,
                       self.args.qc_dir,
                       fastq_strand_conf,
+                      fastqs=self.args.fastqs,
                       read_numbers=self.args.read_numbers)
     def finish(self):
         for result in self.result():

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1397,7 +1397,8 @@ class GetSequenceDataFastqs(PipelineTask):
                     cmd.append("seqtk trimfq -L %d -" % length)
                 if trim_leading:
                     cmd.append("seqtk trimfq -b %d -" % trim_leading)
-                cmd.append("gzip >{fq_out}".format(fq_out=ffq))
+                cmd.append("gzip -{compression} >{fq_out}".\
+                           format(fq_out=ffq,compression=2))
                 self.add_cmd(
                     "Run SeqTK 'trimfq' on '%s'" % os.path.basename(fq),
                     """

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -238,7 +238,7 @@ QC_PROTOCOLS = {
     "10x_Flex": {
         "description": "10xGenomics fixed RNA profiling (Flex) data",
         "reads": {
-            "seq_data": ('r2',),
+            "seq_data": ('r2:1-50',),
             "index": ('r1',)
         },
         "qc_modules": [

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -385,18 +385,16 @@ class QCProtocol:
         Generate plain-text description of the protocol
         """
         summary = []
-        if self.name:
-            summary.append("'%s' protocol" % self.name)
         if self.reads.seq_data:
             summary.append("biological data in %s" %
                            self.__summarise_reads(self.reads.seq_data))
         else:
-            summary.append("no reads assigned with biological data")
+            summary.append("no reads explicitly assigned as biological data")
         if self.reads.index:
             summary.append("index data in %s" %
                            self.__summarise_reads(self.reads.index))
         else:
-            summary.append("no reads assigned with index data")
+            summary.append("no reads explicitly assigned as index data")
         if self.__mapped_metrics():
             has_ranges = False
             if self.reads.seq_data:
@@ -410,7 +408,10 @@ class QCProtocol:
             else:
                 summary.append("mapped metrics generated using only "
                                "biological data reads")
-        return '; '.join(summary)
+        summary = '; '.join(summary)
+        if self.name:
+            summary = "'%s' protocol: %s" % (self.name,summary)
+        return summary
 
     def __parse_read_defn(self,read):
         # Internal: process a read definition string of the

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -453,7 +453,7 @@ class QCProtocol:
         # Internal: generate a plain text description of the
         # sequence data and index reads and ranges
         reads = []
-        for r in self.reads.seq_data:
+        for r in rds:
             rd = r.upper()
             if r in self.read_range:
                 rng = self.read_range[r]

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -557,14 +557,19 @@ class QCReport(Document):
                     name=sanitize_name(project.id))
             else:
                 project_summary = self.summary
-            # Create a new summary table
-            project_summary.add(
+            # Add a section for notes
+            project_notes = project_summary.add_subsection()
+            project_notes.add(
                 "%d sample%s | %d fastq%s" % (
                     len(project.samples),
                     ('s' if len(project.samples) != 1 else ''),
                     len(project.fastqs),
                     ('s' if len(project.fastqs) != 1 else ''))
             )
+            # Protocol summary
+            if project.qc_info.protocol_summary:
+                project_notes.add(project.qc_info.protocol_summary)
+            # Create a new summary table
             summary_table = self.add_summary_table(project,
                                                    summary_fields_,
                                                    section=project_summary)

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -2359,6 +2359,62 @@ class TestCheckFastqScreenOutputs(unittest.TestCase):
                          [os.path.join(project.fastq_dir,
                                        "PJB1_S1_R1_001.fastq.gz")])
 
+    def test_check_fastq_screen_outputs_all_missing_specify_fastqs(self):
+        """
+        check_fastq_screen_outputs: all screen outputs missing (specify Fastqs)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # Copy Fastqs to alternative location
+        alt_fastqs_dir = os.path.join(self.wd,"alt_fastqs")
+        os.mkdir(alt_fastqs_dir)
+        project = AnalysisProject(os.path.join(self.wd,"PJB"))
+        for fq in project.fastqs:
+            shutil.copyfile(fq,os.path.join(alt_fastqs_dir,
+                                            os.path.basename(fq)))
+        alt_fastqs = [os.path.join(alt_fastqs_dir,os.path.basename(fq))
+                      for fq in project.fastqs]
+        # Check
+        self.assertEqual(check_fastq_screen_outputs(project,
+                                                    qc_dir="qc",
+                                                    screen="model_organisms",
+                                                    read_numbers=(1,2),
+                                                    fastqs=alt_fastqs),
+                         alt_fastqs)
+
+    def test_check_fastq_screen_outputs_all_present_specify_fastqs(self):
+        """
+        check_fastq_screen_outputs: all screen outputs present (specify Fastqs)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # Copy Fastqs to alternative location
+        alt_fastqs_dir = os.path.join(self.wd,"alt_fastqs")
+        os.mkdir(alt_fastqs_dir)
+        project = AnalysisProject(os.path.join(self.wd,"PJB"))
+        for fq in project.fastqs:
+            shutil.copyfile(fq,os.path.join(alt_fastqs_dir,
+                                            os.path.basename(fq)))
+        alt_fastqs = [os.path.join(alt_fastqs_dir,os.path.basename(fq))
+                      for fq in project.fastqs]
+        # Add QC artefacts
+        UpdateAnalysisProject(project).add_qc_outputs(
+            include_fastq_strand=False,
+            include_multiqc=False)
+        # Check
+        self.assertEqual(check_fastq_screen_outputs(project,
+                                                    qc_dir="qc",
+                                                    screen="model_organisms",
+                                                    read_numbers=(1,2),
+                                                    fastqs=alt_fastqs),
+                         [])
+
 class TestCheckFastQCOutputs(unittest.TestCase):
     """
     Tests for the 'check_fastqc_outputs' function

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -2797,6 +2797,72 @@ class TestCheckFastqStrandOutputs(unittest.TestCase):
                                                     read_numbers=(1,)),
                          [])
 
+    def test_check_fastq_strand_outputs_all_missing_specify_fastqs(self):
+        """
+        check_fastq_strand_outputs: fastq_strand.py output missing (specify Fastqs)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",os.path.join(self.wd,"PJB"))
+        # Make fastq_strand.conf
+        fastq_strand_conf = os.path.join(project.dirn,"fastq_strand.conf")
+        with open(fastq_strand_conf,'w') as fp:
+            fp.write("")
+        # Copy Fastqs to alternative location
+        alt_fastqs_dir = os.path.join(self.wd,"alt_fastqs")
+        os.mkdir(alt_fastqs_dir)
+        for fq in project.fastqs:
+            shutil.copyfile(fq,os.path.join(alt_fastqs_dir,
+                                            os.path.basename(fq)))
+        alt_fastqs = [os.path.join(alt_fastqs_dir,os.path.basename(fq))
+                      for fq in project.fastqs]
+        # Check the outputs
+        self.assertEqual(check_fastq_strand_outputs(project,
+                                                    "qc",
+                                                    fastq_strand_conf,
+                                                    read_numbers=(1,2),
+                                                    fastqs=alt_fastqs),
+                         [(os.path.join(alt_fastqs_dir,
+                                        "PJB1_S1_R1_001.fastq.gz"),
+                           os.path.join(alt_fastqs_dir,
+                                        "PJB1_S1_R2_001.fastq.gz")),])
+
+    def test_check_fastq_strand_outputs_all_present_specify_fastqs(self):
+        """
+        check_fastq_strand_outputs: fastq_strand.py output present (specify Fastqs)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        project = AnalysisProject(os.path.join(self.wd,"PJB"))
+        UpdateAnalysisProject(project).add_qc_outputs(
+            protocol="standardPE",
+            include_fastq_strand=True,
+            include_multiqc=False)
+        fastq_strand_conf = os.path.join(project.dirn,"fastq_strand.conf")
+        with open(fastq_strand_conf,'w') as fp:
+            fp.write("")
+        # Copy Fastqs to alternative location
+        alt_fastqs_dir = os.path.join(self.wd,"alt_fastqs")
+        os.mkdir(alt_fastqs_dir)
+        for fq in project.fastqs:
+            shutil.copyfile(fq,os.path.join(alt_fastqs_dir,
+                                            os.path.basename(fq)))
+        alt_fastqs = [os.path.join(alt_fastqs_dir,os.path.basename(fq))
+                      for fq in project.fastqs]
+        # Check the outputs
+        self.assertEqual(check_fastq_strand_outputs(project,
+                                                    "qc",
+                                                    fastq_strand_conf,
+                                                    read_numbers=(1,2),
+                                                    fastqs=alt_fastqs),
+                         [])
+
 class TestCheckCellrangerCountOutputs(unittest.TestCase):
     """
     Tests for the 'check_cellranger_count_outputs' function

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -12,6 +12,7 @@ from auto_process_ngs.mock import MockFastqScreen
 from auto_process_ngs.mock import MockFastQC
 from auto_process_ngs.mock import MockFastqStrandPy
 from auto_process_ngs.mock import MockGtf2bed
+from auto_process_ngs.mock import MockSeqtk
 from auto_process_ngs.mock import MockStar
 from auto_process_ngs.mock import MockSamtools
 from auto_process_ngs.mock import MockPicard
@@ -3581,6 +3582,7 @@ PBB,CMO302,PBB
         MockSamtools.create(os.path.join(self.bin,"samtools"))
         MockPicard.create(os.path.join(self.bin,"picard"))
         MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockSeqtk.create(os.path.join(self.bin,"seqtk"))
         MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
         MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
         MockQualimap.create(os.path.join(self.bin,"qualimap"))
@@ -3692,6 +3694,7 @@ PB2,BC002,PB2
         MockSamtools.create(os.path.join(self.bin,"samtools"))
         MockPicard.create(os.path.join(self.bin,"picard"))
         MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockSeqtk.create(os.path.join(self.bin,"seqtk"))
         MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
         MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
         MockQualimap.create(os.path.join(self.bin,"qualimap"))

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -38,9 +38,9 @@ class TestQCProtocol(unittest.TestCase):
         self.assertEqual(p.read_numbers.qc,())
         self.assertEqual(p.read_range,{})
         self.assertEqual(p.qc_modules,[])
-        self.assertEqual(p.summarise(),"'null' protocol; no reads "
-                         "assigned with biological data; no reads "
-                         "assigned with index data")
+        self.assertEqual(p.summarise(),"'null' protocol: no reads "
+                         "explicitly assigned as biological data; no "
+                         "reads explicitly assigned as index data")
 
     def test_qcprotocol_example_paired_end_protocol(self):
         """
@@ -67,10 +67,10 @@ class TestQCProtocol(unittest.TestCase):
                          ["fastq_screen",
                           "fastqc",
                           "sequence_lengths"])
-        self.assertEqual(p.summarise(),"'basicPE' protocol; biological "
-                         "data in R1 and R2; no reads assigned with index "
-                         "data; mapped metrics generated using only "
-                         "biological data reads")
+        self.assertEqual(p.summarise(),"'basicPE' protocol: biological "
+                         "data in R1 and R2; no reads explicitly assigned "
+                         "as index data; mapped metrics generated using "
+                         "only biological data reads")
 
     def test_qcprotocol_example_single_cell_protocol(self):
         """
@@ -97,7 +97,7 @@ class TestQCProtocol(unittest.TestCase):
                          ["fastq_screen",
                           "fastqc",
                           "sequence_lengths"])
-        self.assertEqual(p.summarise(),"'basicSC' protocol; biological "
+        self.assertEqual(p.summarise(),"'basicSC' protocol: biological "
                          "data in R2 only; index data in R2 only; mapped "
                          "metrics generated using only biological data "
                          "reads")
@@ -127,9 +127,9 @@ class TestQCProtocol(unittest.TestCase):
                          ["fastq_screen",
                           "fastqc",
                           "sequence_lengths"])
-        self.assertEqual(p.summarise(),"'basicPE_with_ranges' protocol; "
+        self.assertEqual(p.summarise(),"'basicPE_with_ranges' protocol: "
                          "biological data in R1 and R2 (R2 bases 1 to 50); "
-                         "no reads assigned with index data; mapped "
+                         "no reads explicitly assigned as index data; mapped "
                          "metrics generated using only subsequences of "
                          "biological data reads")
 

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -36,6 +36,7 @@ class TestQCProtocol(unittest.TestCase):
         self.assertEqual(p.read_numbers.seq_data,())
         self.assertEqual(p.read_numbers.index,())
         self.assertEqual(p.read_numbers.qc,())
+        self.assertEqual(p.read_range,{})
         self.assertEqual(p.qc_modules,[])
 
     def test_qcprotocol_example_paired_end_protocol(self):
@@ -57,6 +58,8 @@ class TestQCProtocol(unittest.TestCase):
         self.assertEqual(p.read_numbers.seq_data,(1,2))
         self.assertEqual(p.read_numbers.index,())
         self.assertEqual(p.read_numbers.qc,(1,2))
+        self.assertEqual(p.read_range.r1,None)
+        self.assertEqual(p.read_range.r2,None)
         self.assertEqual(p.qc_modules,
                          ["fastq_screen",
                           "fastqc",
@@ -81,6 +84,34 @@ class TestQCProtocol(unittest.TestCase):
         self.assertEqual(p.read_numbers.seq_data,(2,))
         self.assertEqual(p.read_numbers.index,(1,))
         self.assertEqual(p.read_numbers.qc,(1,2))
+        self.assertEqual(p.read_range.r1,None)
+        self.assertEqual(p.read_range.r2,None)
+        self.assertEqual(p.qc_modules,
+                         ["fastq_screen",
+                          "fastqc",
+                          "sequence_lengths"])
+
+    def test_qcprotocol_example_paired_end_protocol_with_ranges(self):
+        """
+        QCProtocol: check basic paired end protocol with ranges
+        """
+        p = QCProtocol(name="basicPE_with_ranges",
+                       description="Basic paired-end QC with ranges",
+                       seq_data_reads=['r1','r2:1-50'],
+                       index_reads=None,
+                       qc_modules=("fastqc",
+                                   "fastq_screen",
+                                   "sequence_lengths"))
+        self.assertEqual(p.name,"basicPE_with_ranges")
+        self.assertEqual(p.description,"Basic paired-end QC with ranges")
+        self.assertEqual(p.reads.seq_data,('r1','r2',))
+        self.assertEqual(p.reads.index,())
+        self.assertEqual(p.reads.qc,('r1','r2'))
+        self.assertEqual(p.read_numbers.seq_data,(1,2))
+        self.assertEqual(p.read_numbers.index,())
+        self.assertEqual(p.read_numbers.qc,(1,2))
+        self.assertEqual(p.read_range.r1,None)
+        self.assertEqual(p.read_range.r2,(1,50))
         self.assertEqual(p.qc_modules,
                          ["fastq_screen",
                           "fastqc",

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -98,7 +98,7 @@ class TestQCProtocol(unittest.TestCase):
                           "fastqc",
                           "sequence_lengths"])
         self.assertEqual(p.summarise(),"'basicSC' protocol: biological "
-                         "data in R2 only; index data in R2 only; mapped "
+                         "data in R2 only; index data in R1 only; mapped "
                          "metrics generated using only biological data "
                          "reads")
 

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -38,6 +38,9 @@ class TestQCProtocol(unittest.TestCase):
         self.assertEqual(p.read_numbers.qc,())
         self.assertEqual(p.read_range,{})
         self.assertEqual(p.qc_modules,[])
+        self.assertEqual(p.summarise(),"'null' protocol; no reads "
+                         "assigned with biological data; no reads "
+                         "assigned with index data")
 
     def test_qcprotocol_example_paired_end_protocol(self):
         """
@@ -64,6 +67,10 @@ class TestQCProtocol(unittest.TestCase):
                          ["fastq_screen",
                           "fastqc",
                           "sequence_lengths"])
+        self.assertEqual(p.summarise(),"'basicPE' protocol; biological "
+                         "data in R1 and R2; no reads assigned with index "
+                         "data; mapped metrics generated using only "
+                         "biological data reads")
 
     def test_qcprotocol_example_single_cell_protocol(self):
         """
@@ -90,6 +97,10 @@ class TestQCProtocol(unittest.TestCase):
                          ["fastq_screen",
                           "fastqc",
                           "sequence_lengths"])
+        self.assertEqual(p.summarise(),"'basicSC' protocol; biological "
+                         "data in R2 only; index data in R2 only; mapped "
+                         "metrics generated using only biological data "
+                         "reads")
 
     def test_qcprotocol_example_paired_end_protocol_with_ranges(self):
         """
@@ -116,6 +127,11 @@ class TestQCProtocol(unittest.TestCase):
                          ["fastq_screen",
                           "fastqc",
                           "sequence_lengths"])
+        self.assertEqual(p.summarise(),"'basicPE_with_ranges' protocol; "
+                         "biological data in R1 and R2 (R2 bases 1 to 50); "
+                         "no reads assigned with index data; mapped "
+                         "metrics generated using only subsequences of "
+                         "biological data reads")
 
 class TestDetermineQCProtocolFunction(unittest.TestCase):
     """

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -44,6 +44,7 @@ run_qc              `cellranger`_      10xGenomics Chromium single-cell RNA-seq 
 run_qc              `cellranger-atac`_ 10xGenomics single-cell ATAC-seq data only
 run_qc              `cellranger-arc`_  10xGenomics Multiome ATAC + GEX data
 run_qc (*)          `multiqc`_
+run_qc (*)          `seqtk`_           Required for protocols mapping subsequences of reads (e.g. ``10x_Flex``)
 process_icell8      `cutadapt`_
 process_icell8      `fastq_screen`_
 process_icell8      `bowtie2`_         Required by fastq_screen
@@ -65,6 +66,7 @@ process_icell8      `bowtie2`_         Required by fastq_screen
 .. _rseqc: http://rseqc.sourceforge.net/#
 .. _qualimap: http://qualimap.conesalab.org/doc_html/command_line.html#rna-seq-qc
 .. _multiqc: http://multiqc.info/
+.. _seqtk: https://github.com/lh3/seqtk
 .. _cutadapt: http://cutadapt.readthedocs.io
 
 (*) indicates packages that only need to be installed if

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -47,7 +47,9 @@ The protocol is determined automatically for each project, based
 on the metadata.
 
 In turn each protocol defines a set of "QC modules" that are run
-by the QC pipeline.
+by the QC pipeline, as well as "sequence data reads" (reads that
+contain biological data) and "index data reads" (reads that
+contain index data).
 
 ----------
 QC modules
@@ -137,6 +139,19 @@ Where these types of samples can be identified by the pipeline
 for CellPlex) only metrics that are appropriate for non-biological
 samples will be generated (e.g. screens, strandedness etc) and
 reported.
+
+-------------------------------------
+QC metric using subsequences in reads
+-------------------------------------
+
+Some metrics can be applied to subsequences within reads (rather
+than the whole sequence), if a range of bases is defined within
+the protocol.
+
+Specifically, where subsequences are specified for sequence data
+reads (i.e. reads containing biological data) then the "mapped"
+QC modules (for example, FastqScreen or strandedness) will only
+use those subsequences.
 
 ------------------
 Additional options


### PR DESCRIPTION
Add a new feature to the QC pipeline which enables 'read ranges' to be specified with the sequence data reads within QC protocols. These ranges essentially define subsequences to be cut out of the reads in the specified Fastqs for relevant QC metrics (coverage, screens, strandedness).

This is specifically requested for 10x Genomics "Flex" data (single cell fixed RNA profiling), where the requirement is to restrict the metrics to the first 50bp of R2. However the implementation should be generally applicable.

As part of the PR the QC metadata has also been updated to add a new "protocol summary" field, which is used within the QC pipeline to record an automatically generated text summary of the reads (and ranges) used by the protocol. This summary is then included in the HTML reports.