### PR TITLE
applications: enable ssh/scp to handle empty remote user arguments

### DIFF
--- a/auto_process_ngs/applications.py
+++ b/auto_process_ngs/applications.py
@@ -449,5 +449,6 @@ class general:
         if recursive:
             scp_command.add_args('-r')
         scp_command.add_args(source,
-                             '%s@%s:%s' % (user,server,target))
+                             '%s%s:%s' % ('%s@' % user if user else '',
+                                          server,target))
         return scp_command

--- a/auto_process_ngs/applications.py
+++ b/auto_process_ngs/applications.py
@@ -422,7 +422,8 @@ class general:
           Command object.
 
         """
-        ssh_command = Command('ssh','%s@%s' % (user,server))
+        ssh_command = Command('ssh','%s%s' % ('%s@' % user if user else '',
+                                              server))
         ssh_command.add_args(*cmd)
         return ssh_command
 

--- a/auto_process_ngs/test/test_applications.py
+++ b/auto_process_ngs/test/test_applications.py
@@ -163,6 +163,12 @@ class TestGeneral(unittest.TestCase):
         self.assertEqual(general.ssh_command('user','example.com',('ls','-l')).command_line,
                          ['ssh','user@example.com','ls','-l'])
 
+    def test_ssh_cmd_no_user(self):
+        """Construct 'ssh' command lines with no remote user
+        """
+        self.assertEqual(general.ssh_command(None,'example.com',('ls','-l')).command_line,
+                         ['ssh','example.com','ls','-l'])
+
     def test_scp(self):
         """Construct 'scp' command lines
         """

--- a/auto_process_ngs/test/test_applications.py
+++ b/auto_process_ngs/test/test_applications.py
@@ -184,3 +184,9 @@ class TestGeneral(unittest.TestCase):
                         recursive=True).command_line,
             ['scp','-r','my_dir','user@example.com:remotedir'])
 
+    def test_scp_no_user(self):
+        """Construct 'scp' command lines with no remote user
+        """
+        self.assertEqual(
+            general.scp(None,'example.com','my_file','remotedir').command_line,
+            ['scp','my_file','example.com:remotedir'])


### PR DESCRIPTION
Fixes a minor bug with the `general.ssh_command` and `general.scp` functions, to handle the case where `None` or an empty string is supplied as the remote user.