### PR TITLE
Enable '__repr__' method on QCProtocol class & recover instances from 'repr' string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ auto_process.ini
 settings.ini
 docs/build
 docs/source/developers/api_docs
-docs/source/reference
+docs/source/reference/commands.rst
+docs/source/reference/utilities.rst
 docs/source/images/auto

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -619,15 +619,29 @@ def parse_protocol_spec(s):
 
     Parses a QC protocol specification string (such as
     one returned by the '__repr__' built-in of an
-    existing QCProtocol instance) and returns a new
-    QCProtocol instance which matches the specification.
+    existing QCProtocol instance) and returns an
+    AttributeDictionary with the following elements
+    extracted from the specification:
+
+    - name
+    - description
+    - seq_data_reads
+    - index_reads
+    - qc_modules
+
+    These can then be used to create a new QCProtocol
+    instance which matches the specification using
+    e.g.
+
+    >>> p = QCProtocol(**parse_protocol_spec("..."))
 
     Arguments:
       s (string): QC protocol specification string
 
     Returns:
-      QCProtocol: populated QCProtocol instance built
-        from the supplied specification string.
+      AttributeDictionary: AttributeDictionary with
+        keys mapped to values from the supplied
+        specification.
 
     Raises:
       Exception: if the specification string cannot be
@@ -717,6 +731,9 @@ def parse_protocol_spec(s):
         elif s:
             raise Exception("Unable to parse section starting '%s...'" %
                             s[:5])
-    # Return QCProtocol instance
-    return QCProtocol(name,description,seq_data_reads,index_reads,
-                      qc_modules)
+    # Return mapping of extracted components
+    return AttributeDictionary(name=name,
+                               description=description,
+                               seq_data_reads=seq_data_reads,
+                               index_reads=index_reads,
+                               qc_modules=qc_modules)

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -548,6 +548,11 @@ class QCProtocol:
                 index_reads=self.__repr_reads(self.reads.index),
                 qc_modules=qc_modules)
 
+    def __eq__(self,p):
+        # Check if another object is equal to this one
+        return (isinstance(p,QCProtocol) and
+                repr(self) == repr(p))
+
 #######################################################################
 # Functions
 #######################################################################

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -486,6 +486,36 @@ class QCProtocol:
                 mapped_metrics.append(qc_module)
         return mapped_metrics
 
+    def __repr_reads(self,rds):
+        # Internal: get string representation of reads
+        # for __repr__
+        reads = []
+        for rd in rds:
+            rng = self.read_range[rd]
+            if rng and (rng[0] or rng[1]):
+                if not rng[0]:
+                    reads.append("%s:1-%s" % (rd,rng[1]))
+                elif not rng[1]:
+                    reads.append("%s:%s-" % (rd,rng[0]))
+                else:
+                    reads.append("%s:%s-%s" % (rd,rng[0],rng[1]))
+            else:
+                reads.append(rd)
+        return "[%s]" % ','.join(r for r in reads)
+
+    def __repr__(self):
+        # Generate string representation
+        qc_modules = "[%s]" % ','.join(m for m in self.qc_modules)
+        return \
+            "{name}:'{descr}':seq_reads={seq_reads}:"\
+            "index_reads={index_reads}:"\
+            "qc_modules={qc_modules}".format(
+                name=self.name,
+                descr=self.description,
+                seq_reads=self.__repr_reads(self.reads.seq_data),
+                index_reads=self.__repr_reads(self.reads.index),
+                qc_modules=qc_modules)
+
 #######################################################################
 # Functions
 #######################################################################

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -344,6 +344,13 @@ class QCProtocol:
     or a tuple '(START,END)' (where either 'START' or 'END'
     will be 'None' if no limit was supplied).
 
+    QCProtocol instances can also be created directly from
+    protocol specification strings using the
+    'from_specification' class method. (Specification
+    strings are returned from 'repr' on existing QCProtocol
+    instances, or can alternatively be constructed
+    manually.)
+
     Arguments:
       name (str): name of the protocol
       description (str): protocol description
@@ -383,6 +390,25 @@ class QCProtocol:
         for r in list(seq_data_reads) + list(index_reads):
             rd,rng = self.__parse_read_defn(r)
             self.read_range[rd] = rng
+
+    @classmethod
+    def from_specification(cls,s):
+        """
+        Create new QCProtocol instance from specification
+
+        Given a specification string (such as that
+        returned by 'repr(...)'), create a new
+        QCProtocol instance initialised from that
+        specification.
+
+        Example usage:
+
+        >>> p = QCProtocol.from_specification("custom:...")
+
+        Arguments:
+          s (str): QC protocol specification string
+        """
+        return cls(**parse_protocol_spec(s))
 
     def summarise(self):
         """

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -613,24 +613,24 @@ def fetch_protocol_definition(name):
                       index_reads=protocol_defn['reads']['index'],
                       qc_modules=protocol_defn['qc_modules'])
 
-def parse_protocol_repr(s):
+def parse_protocol_spec(s):
     """
-    Parse QC protocol definition string
+    Parse QC protocol specification string
 
-    Parses a QC protocol definition string (such as one
-    returned by the '__repr__' built-in of an existing
-    QCProtocol instance) and returns a new QCProtocol
-    instance which matches the definition.
+    Parses a QC protocol specification string (such as
+    one returned by the '__repr__' built-in of an
+    existing QCProtocol instance) and returns a new
+    QCProtocol instance which matches the specification.
 
     Arguments:
-      s (string): QC protocol definition string
+      s (string): QC protocol specification string
 
     Returns:
       QCProtocol: populated QCProtocol instance built
-        from the supplied definition string.
+        from the supplied specification string.
 
     Raises:
-      Exception: if the definition string cannot be
+      Exception: if the specification string cannot be
         parsed correctly.
     """
     # Initialise

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -45,6 +45,8 @@ class TestQCProtocol(unittest.TestCase):
         self.assertEqual(repr(p),
                          "null:'':seq_reads=[]:index_reads=[]:"
                          "qc_modules=[]")
+        self.assertEqual(repr(p),
+                         repr(QCProtocol.from_specification(repr(p))))
 
     def test_qcprotocol_example_paired_end_protocol(self):
         """
@@ -79,6 +81,8 @@ class TestQCProtocol(unittest.TestCase):
                          "basicPE:'Basic paired-end QC':"
                          "seq_reads=[r1,r2]:index_reads=[]:"
                          "qc_modules=[fastq_screen,fastqc,sequence_lengths]")
+        self.assertEqual(repr(p),
+                         repr(QCProtocol.from_specification(repr(p))))
 
     def test_qcprotocol_example_single_cell_protocol(self):
         """
@@ -113,6 +117,8 @@ class TestQCProtocol(unittest.TestCase):
                          "basicSC:'Basic single cell QC':"
                          "seq_reads=[r2]:index_reads=[r1]:"
                          "qc_modules=[fastq_screen,fastqc,sequence_lengths]")
+        self.assertEqual(repr(p),
+                         repr(QCProtocol.from_specification(repr(p))))
 
     def test_qcprotocol_example_paired_end_protocol_with_ranges(self):
         """
@@ -149,6 +155,8 @@ class TestQCProtocol(unittest.TestCase):
                          "'Basic paired-end QC with ranges':"
                          "seq_reads=[r1,r2:1-50]:index_reads=[]:"
                          "qc_modules=[fastq_screen,fastqc,sequence_lengths]")
+        self.assertEqual(repr(p),
+                         repr(QCProtocol.from_specification(repr(p))))
 
 class TestDetermineQCProtocolFunction(unittest.TestCase):
     """

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -11,7 +11,7 @@ from auto_process_ngs.mock import MockAnalysisProject
 from auto_process_ngs.qc.protocols import QCProtocol
 from auto_process_ngs.qc.protocols import determine_qc_protocol
 from auto_process_ngs.qc.protocols import fetch_protocol_definition
-from auto_process_ngs.qc.protocols import parse_protocol_repr
+from auto_process_ngs.qc.protocols import parse_protocol_spec
 
 # Set to False to keep test output dirs
 REMOVE_TEST_OUTPUTS = True
@@ -617,15 +617,15 @@ class TestFetchProtocolDefinition(unittest.TestCase):
                           fetch_protocol_definition,
                           "whazzdis?")
 
-class TestParseProtocolRepr(unittest.TestCase):
-    def test_parse_protocol_repr(self):
+class TestParseProtocolSpec(unittest.TestCase):
+    def test_parse_protocol_spec(self):
         """
-        parse_protocol_repr: simple protocol definition
+        parse_protocol_spec: simple protocol specification
         """
         s = "simple_pe_qc:'Simple PE QC protocol':" \
             "seq_reads=[r1,r2]:index_reads=[]:" \
             "qc_modules=[fastq_screen,fastqc]"
-        p = parse_protocol_repr(s)
+        p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_pe_qc")
         self.assertEqual(p.description,"Simple PE QC protocol")
         self.assertEqual(p.reads.seq_data,('r1','r2'))
@@ -639,14 +639,14 @@ class TestParseProtocolRepr(unittest.TestCase):
         self.assertEqual(p.qc_modules,['fastq_screen','fastqc'])
         self.assertEqual(repr(p),s)
 
-    def test_parse_protocol_repr_10x(self):
+    def test_parse_protocol_spec_10x(self):
         """
-        parse_protocol_repr: 10x single cell-style protocol definition
+        parse_protocol_spec: 10x single cell-style protocol specification
         """
         s = "simple_10x_qc:'Simple 10x single cell QC protocol':" \
             "seq_reads=[r2]:index_reads=[r1]:" \
             "qc_modules=[cellranger_count,fastqc]"
-        p = parse_protocol_repr(s)
+        p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_10x_qc")
         self.assertEqual(p.description,"Simple 10x single cell QC protocol")
         self.assertEqual(p.reads.seq_data,('r2',))
@@ -660,14 +660,14 @@ class TestParseProtocolRepr(unittest.TestCase):
         self.assertEqual(p.qc_modules,['cellranger_count','fastqc'])
         self.assertEqual(repr(p),s)
 
-    def test_parse_protocol_repr_simple_10x_flex(self):
+    def test_parse_protocol_spec_simple_10x_flex(self):
         """
-        parse_protocol_repr: 10x Flex-style protocol definition
+        parse_protocol_spec: 10x Flex-style protocol specification
         """
         s = "simple_flex_qc:'Simple 10x Flex QC protocol':" \
             "seq_reads=[r2:1-50]:index_reads=[r1]:" \
             "qc_modules=[cellranger_count,fastqc]"
-        p = parse_protocol_repr(s)
+        p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_flex_qc")
         self.assertEqual(p.description,"Simple 10x Flex QC protocol")
         self.assertEqual(p.reads.seq_data,('r2',))
@@ -681,9 +681,9 @@ class TestParseProtocolRepr(unittest.TestCase):
         self.assertEqual(p.qc_modules,['cellranger_count','fastqc'])
         self.assertEqual(repr(p),s)
 
-    def test_parse_protocol_repr_simple_10x_gex_multiome(self):
+    def test_parse_protocol_spec_simple_10x_gex_multiome(self):
         """
-        parse_protocol_repr: 10x GEX multiome-style protocol definition
+        parse_protocol_spec: 10x GEX multiome-style protocol specification
         """
         s = "simple_multiome_gex_qc:'Simple 10x multiome GEX QC protocol':" \
             "seq_reads=[r2]:index_reads=[r1]:" \
@@ -691,7 +691,7 @@ class TestParseProtocolRepr(unittest.TestCase):
             "cellranger_count(chemistry=ARC-v1;library=snRNA-seq;" \
             "cellranger_version=*;cellranger_refdata=*;" \
             "set_cell_count=false;set_metadata=False)]"
-        p = parse_protocol_repr(s)
+        p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_multiome_gex_qc")
         self.assertEqual(p.description,"Simple 10x multiome GEX QC protocol")
         self.assertEqual(p.reads.seq_data,('r2',))
@@ -709,14 +709,14 @@ class TestParseProtocolRepr(unittest.TestCase):
             'set_cell_count=false;set_metadata=False)'])
         self.assertEqual(repr(p),s)
 
-    def test_parse_protocol_repr_no_index_reads(self):
+    def test_parse_protocol_spec_no_index_reads(self):
         """
-        parse_protocol_repr: handles missing index reads definition
+        parse_protocol_spec: handles missing index reads specification
         """
         s = "simple_pe_qc:'Simple PE QC protocol':" \
             "seq_reads=[r1,r2]:" \
             "qc_modules=[fastq_screen,fastqc]"
-        p = parse_protocol_repr(s)
+        p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_pe_qc")
         self.assertEqual(p.description,"Simple PE QC protocol")
         self.assertEqual(p.reads.seq_data,('r1','r2'))
@@ -734,14 +734,14 @@ class TestParseProtocolRepr(unittest.TestCase):
                          "index_reads=[]:" \
                          "qc_modules=[fastq_screen,fastqc]")
 
-    def test_parse_protocol_repr_no_seq_data_reads(self):
+    def test_parse_protocol_spec_no_seq_data_reads(self):
         """
-        parse_protocol_repr: handles missing seq data reads definition
+        parse_protocol_spec: handles missing seq data reads specification
         """
         s = "simple_pe_qc:'Simple PE QC protocol':" \
             "index_reads=[r1,r2]:" \
             "qc_modules=[fastq_screen,fastqc]"
-        p = parse_protocol_repr(s)
+        p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_pe_qc")
         self.assertEqual(p.description,"Simple PE QC protocol")
         self.assertEqual(p.reads.seq_data,())
@@ -759,14 +759,14 @@ class TestParseProtocolRepr(unittest.TestCase):
                          "index_reads=[r1,r2]:" \
                          "qc_modules=[fastq_screen,fastqc]")
 
-    def test_parse_protocol_repr_no_qc_modules(self):
+    def test_parse_protocol_spec_no_qc_modules(self):
         """
-        parse_protocol_repr: handles missing QC modules definition
+        parse_protocol_spec: handles missing QC modules specification
         """
         s = "simple_pe_qc:'Simple PE QC protocol':" \
             "seq_reads=[r1,r2]:" \
             "index_reads=[]"
-        p = parse_protocol_repr(s)
+        p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_pe_qc")
         self.assertEqual(p.description,"Simple PE QC protocol")
         self.assertEqual(p.reads.seq_data,('r1','r2'))
@@ -784,15 +784,15 @@ class TestParseProtocolRepr(unittest.TestCase):
                          "index_reads=[]:" \
                          "qc_modules=[]")
 
-    def test_parse_protocol_repr_empty_qc_modules(self):
+    def test_parse_protocol_spec_empty_qc_modules(self):
         """
-        parse_protocol_repr: handles trailing colon in definition
+        parse_protocol_spec: handles trailing colon in specification
         """
         s = "simple_pe_qc:'Simple PE QC protocol':" \
             "seq_reads=[r1,r2]:" \
             "index_reads=[]:" \
             "qc_modules=[fastqc]:"
-        p = parse_protocol_repr(s)
+        p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_pe_qc")
         self.assertEqual(p.description,"Simple PE QC protocol")
         self.assertEqual(p.reads.seq_data,('r1','r2'))
@@ -806,15 +806,15 @@ class TestParseProtocolRepr(unittest.TestCase):
         self.assertEqual(p.qc_modules,['fastqc'])
         self.assertEqual(repr(p),s[:-1])
 
-    def test_parse_protocol_repr_trailing_colon(self):
+    def test_parse_protocol_spec_trailing_colon(self):
         """
-        parse_protocol_repr: handles empty QC modules definition
+        parse_protocol_spec: handles empty QC modules specification
         """
         s = "simple_pe_qc:'Simple PE QC protocol':" \
             "seq_reads=[r1,r2]:" \
             "index_reads=[]:" \
             "qc_modules=[]"
-        p = parse_protocol_repr(s)
+        p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_pe_qc")
         self.assertEqual(p.description,"Simple PE QC protocol")
         self.assertEqual(p.reads.seq_data,('r1','r2'))

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -41,6 +41,9 @@ class TestQCProtocol(unittest.TestCase):
         self.assertEqual(p.summarise(),"'null' protocol: no reads "
                          "explicitly assigned as biological data; no "
                          "reads explicitly assigned as index data")
+        self.assertEqual(repr(p),
+                         "null:'':seq_reads=[]:index_reads=[]:"
+                         "qc_modules=[]")
 
     def test_qcprotocol_example_paired_end_protocol(self):
         """
@@ -71,6 +74,10 @@ class TestQCProtocol(unittest.TestCase):
                          "data in R1 and R2; no reads explicitly assigned "
                          "as index data; mapped metrics generated using "
                          "only biological data reads")
+        self.assertEqual(repr(p),
+                         "basicPE:'Basic paired-end QC':"
+                         "seq_reads=[r1,r2]:index_reads=[]:"
+                         "qc_modules=[fastq_screen,fastqc,sequence_lengths]")
 
     def test_qcprotocol_example_single_cell_protocol(self):
         """
@@ -101,6 +108,10 @@ class TestQCProtocol(unittest.TestCase):
                          "data in R2 only; index data in R1 only; mapped "
                          "metrics generated using only biological data "
                          "reads")
+        self.assertEqual(repr(p),
+                         "basicSC:'Basic single cell QC':"
+                         "seq_reads=[r2]:index_reads=[r1]:"
+                         "qc_modules=[fastq_screen,fastqc,sequence_lengths]")
 
     def test_qcprotocol_example_paired_end_protocol_with_ranges(self):
         """
@@ -132,6 +143,11 @@ class TestQCProtocol(unittest.TestCase):
                          "no reads explicitly assigned as index data; mapped "
                          "metrics generated using only subsequences of "
                          "biological data reads")
+        self.assertEqual(repr(p),
+                         "basicPE_with_ranges:"
+                         "'Basic paired-end QC with ranges':"
+                         "seq_reads=[r1,r2:1-50]:index_reads=[]:"
+                         "qc_modules=[fastq_screen,fastqc,sequence_lengths]")
 
 class TestDetermineQCProtocolFunction(unittest.TestCase):
     """

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -11,6 +11,7 @@ from auto_process_ngs.mock import MockAnalysisProject
 from auto_process_ngs.qc.protocols import QCProtocol
 from auto_process_ngs.qc.protocols import determine_qc_protocol
 from auto_process_ngs.qc.protocols import fetch_protocol_definition
+from auto_process_ngs.qc.protocols import parse_protocol_repr
 
 # Set to False to keep test output dirs
 REMOVE_TEST_OUTPUTS = True
@@ -615,3 +616,214 @@ class TestFetchProtocolDefinition(unittest.TestCase):
         self.assertRaises(KeyError,
                           fetch_protocol_definition,
                           "whazzdis?")
+
+class TestParseProtocolRepr(unittest.TestCase):
+    def test_parse_protocol_repr(self):
+        """
+        parse_protocol_repr: simple protocol definition
+        """
+        s = "simple_pe_qc:'Simple PE QC protocol':" \
+            "seq_reads=[r1,r2]:index_reads=[]:" \
+            "qc_modules=[fastq_screen,fastqc]"
+        p = parse_protocol_repr(s)
+        self.assertEqual(p.name,"simple_pe_qc")
+        self.assertEqual(p.description,"Simple PE QC protocol")
+        self.assertEqual(p.reads.seq_data,('r1','r2'))
+        self.assertEqual(p.reads.index,())
+        self.assertEqual(p.reads.qc,('r1','r2'))
+        self.assertEqual(p.read_numbers.seq_data,(1,2))
+        self.assertEqual(p.read_numbers.index,())
+        self.assertEqual(p.read_numbers.qc,(1,2))
+        self.assertEqual(p.read_range.r1,None)
+        self.assertEqual(p.read_range.r2,None)
+        self.assertEqual(p.qc_modules,['fastq_screen','fastqc'])
+        self.assertEqual(repr(p),s)
+
+    def test_parse_protocol_repr_10x(self):
+        """
+        parse_protocol_repr: 10x single cell-style protocol definition
+        """
+        s = "simple_10x_qc:'Simple 10x single cell QC protocol':" \
+            "seq_reads=[r2]:index_reads=[r1]:" \
+            "qc_modules=[cellranger_count,fastqc]"
+        p = parse_protocol_repr(s)
+        self.assertEqual(p.name,"simple_10x_qc")
+        self.assertEqual(p.description,"Simple 10x single cell QC protocol")
+        self.assertEqual(p.reads.seq_data,('r2',))
+        self.assertEqual(p.reads.index,('r1',))
+        self.assertEqual(p.reads.qc,('r1','r2'))
+        self.assertEqual(p.read_numbers.seq_data,(2,))
+        self.assertEqual(p.read_numbers.index,(1,))
+        self.assertEqual(p.read_numbers.qc,(1,2))
+        self.assertEqual(p.read_range.r1,None)
+        self.assertEqual(p.read_range.r2,None)
+        self.assertEqual(p.qc_modules,['cellranger_count','fastqc'])
+        self.assertEqual(repr(p),s)
+
+    def test_parse_protocol_repr_simple_10x_flex(self):
+        """
+        parse_protocol_repr: 10x Flex-style protocol definition
+        """
+        s = "simple_flex_qc:'Simple 10x Flex QC protocol':" \
+            "seq_reads=[r2:1-50]:index_reads=[r1]:" \
+            "qc_modules=[cellranger_count,fastqc]"
+        p = parse_protocol_repr(s)
+        self.assertEqual(p.name,"simple_flex_qc")
+        self.assertEqual(p.description,"Simple 10x Flex QC protocol")
+        self.assertEqual(p.reads.seq_data,('r2',))
+        self.assertEqual(p.reads.index,('r1',))
+        self.assertEqual(p.reads.qc,('r1','r2'))
+        self.assertEqual(p.read_numbers.seq_data,(2,))
+        self.assertEqual(p.read_numbers.index,(1,))
+        self.assertEqual(p.read_numbers.qc,(1,2))
+        self.assertEqual(p.read_range.r1,None)
+        self.assertEqual(p.read_range.r2,(1,50))
+        self.assertEqual(p.qc_modules,['cellranger_count','fastqc'])
+        self.assertEqual(repr(p),s)
+
+    def test_parse_protocol_repr_simple_10x_gex_multiome(self):
+        """
+        parse_protocol_repr: 10x GEX multiome-style protocol definition
+        """
+        s = "simple_multiome_gex_qc:'Simple 10x multiome GEX QC protocol':" \
+            "seq_reads=[r2]:index_reads=[r1]:" \
+            "qc_modules=[cellranger-arc_count," \
+            "cellranger_count(chemistry=ARC-v1;library=snRNA-seq;" \
+            "cellranger_version=*;cellranger_refdata=*;" \
+            "set_cell_count=false;set_metadata=False)]"
+        p = parse_protocol_repr(s)
+        self.assertEqual(p.name,"simple_multiome_gex_qc")
+        self.assertEqual(p.description,"Simple 10x multiome GEX QC protocol")
+        self.assertEqual(p.reads.seq_data,('r2',))
+        self.assertEqual(p.reads.index,('r1',))
+        self.assertEqual(p.reads.qc,('r1','r2'))
+        self.assertEqual(p.read_numbers.seq_data,(2,))
+        self.assertEqual(p.read_numbers.index,(1,))
+        self.assertEqual(p.read_numbers.qc,(1,2))
+        self.assertEqual(p.read_range.r1,None)
+        self.assertEqual(p.read_range.r2,None)
+        self.assertEqual(p.qc_modules,[
+            'cellranger-arc_count',
+            'cellranger_count(chemistry=ARC-v1;library=snRNA-seq;' \
+            'cellranger_version=*;cellranger_refdata=*;' \
+            'set_cell_count=false;set_metadata=False)'])
+        self.assertEqual(repr(p),s)
+
+    def test_parse_protocol_repr_no_index_reads(self):
+        """
+        parse_protocol_repr: handles missing index reads definition
+        """
+        s = "simple_pe_qc:'Simple PE QC protocol':" \
+            "seq_reads=[r1,r2]:" \
+            "qc_modules=[fastq_screen,fastqc]"
+        p = parse_protocol_repr(s)
+        self.assertEqual(p.name,"simple_pe_qc")
+        self.assertEqual(p.description,"Simple PE QC protocol")
+        self.assertEqual(p.reads.seq_data,('r1','r2'))
+        self.assertEqual(p.reads.index,())
+        self.assertEqual(p.reads.qc,('r1','r2'))
+        self.assertEqual(p.read_numbers.seq_data,(1,2))
+        self.assertEqual(p.read_numbers.index,())
+        self.assertEqual(p.read_numbers.qc,(1,2))
+        self.assertEqual(p.read_range.r1,None)
+        self.assertEqual(p.read_range.r2,None)
+        self.assertEqual(p.qc_modules,['fastq_screen','fastqc'])
+        self.assertEqual(repr(p),
+                         "simple_pe_qc:'Simple PE QC protocol':" \
+                         "seq_reads=[r1,r2]:" \
+                         "index_reads=[]:" \
+                         "qc_modules=[fastq_screen,fastqc]")
+
+    def test_parse_protocol_repr_no_seq_data_reads(self):
+        """
+        parse_protocol_repr: handles missing seq data reads definition
+        """
+        s = "simple_pe_qc:'Simple PE QC protocol':" \
+            "index_reads=[r1,r2]:" \
+            "qc_modules=[fastq_screen,fastqc]"
+        p = parse_protocol_repr(s)
+        self.assertEqual(p.name,"simple_pe_qc")
+        self.assertEqual(p.description,"Simple PE QC protocol")
+        self.assertEqual(p.reads.seq_data,())
+        self.assertEqual(p.reads.index,('r1','r2'))
+        self.assertEqual(p.reads.qc,('r1','r2'))
+        self.assertEqual(p.read_numbers.seq_data,())
+        self.assertEqual(p.read_numbers.index,(1,2))
+        self.assertEqual(p.read_numbers.qc,(1,2))
+        self.assertEqual(p.read_range.r1,None)
+        self.assertEqual(p.read_range.r2,None)
+        self.assertEqual(p.qc_modules,['fastq_screen','fastqc'])
+        self.assertEqual(repr(p),
+                         "simple_pe_qc:'Simple PE QC protocol':" \
+                         "seq_reads=[]:" \
+                         "index_reads=[r1,r2]:" \
+                         "qc_modules=[fastq_screen,fastqc]")
+
+    def test_parse_protocol_repr_no_qc_modules(self):
+        """
+        parse_protocol_repr: handles missing QC modules definition
+        """
+        s = "simple_pe_qc:'Simple PE QC protocol':" \
+            "seq_reads=[r1,r2]:" \
+            "index_reads=[]"
+        p = parse_protocol_repr(s)
+        self.assertEqual(p.name,"simple_pe_qc")
+        self.assertEqual(p.description,"Simple PE QC protocol")
+        self.assertEqual(p.reads.seq_data,('r1','r2'))
+        self.assertEqual(p.reads.index,())
+        self.assertEqual(p.reads.qc,('r1','r2'))
+        self.assertEqual(p.read_numbers.seq_data,(1,2))
+        self.assertEqual(p.read_numbers.index,())
+        self.assertEqual(p.read_numbers.qc,(1,2))
+        self.assertEqual(p.read_range.r1,None)
+        self.assertEqual(p.read_range.r2,None)
+        self.assertEqual(p.qc_modules,[])
+        self.assertEqual(repr(p),
+                         "simple_pe_qc:'Simple PE QC protocol':" \
+                         "seq_reads=[r1,r2]:" \
+                         "index_reads=[]:" \
+                         "qc_modules=[]")
+
+    def test_parse_protocol_repr_empty_qc_modules(self):
+        """
+        parse_protocol_repr: handles trailing colon in definition
+        """
+        s = "simple_pe_qc:'Simple PE QC protocol':" \
+            "seq_reads=[r1,r2]:" \
+            "index_reads=[]:" \
+            "qc_modules=[fastqc]:"
+        p = parse_protocol_repr(s)
+        self.assertEqual(p.name,"simple_pe_qc")
+        self.assertEqual(p.description,"Simple PE QC protocol")
+        self.assertEqual(p.reads.seq_data,('r1','r2'))
+        self.assertEqual(p.reads.index,())
+        self.assertEqual(p.reads.qc,('r1','r2'))
+        self.assertEqual(p.read_numbers.seq_data,(1,2))
+        self.assertEqual(p.read_numbers.index,())
+        self.assertEqual(p.read_numbers.qc,(1,2))
+        self.assertEqual(p.read_range.r1,None)
+        self.assertEqual(p.read_range.r2,None)
+        self.assertEqual(p.qc_modules,['fastqc'])
+        self.assertEqual(repr(p),s[:-1])
+
+    def test_parse_protocol_repr_trailing_colon(self):
+        """
+        parse_protocol_repr: handles empty QC modules definition
+        """
+        s = "simple_pe_qc:'Simple PE QC protocol':" \
+            "seq_reads=[r1,r2]:" \
+            "index_reads=[]:" \
+            "qc_modules=[]"
+        p = parse_protocol_repr(s)
+        self.assertEqual(p.name,"simple_pe_qc")
+        self.assertEqual(p.description,"Simple PE QC protocol")
+        self.assertEqual(p.reads.seq_data,('r1','r2'))
+        self.assertEqual(p.reads.index,())
+        self.assertEqual(p.reads.qc,('r1','r2'))
+        self.assertEqual(p.read_numbers.seq_data,(1,2))
+        self.assertEqual(p.read_numbers.index,())
+        self.assertEqual(p.read_numbers.qc,(1,2))
+        self.assertEqual(p.read_range.r1,None)
+        self.assertEqual(p.read_range.r2,None)
+        self.assertEqual(p.qc_modules,[])
+        self.assertEqual(repr(p),s)

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -20,6 +20,66 @@ class TestQCProtocol(unittest.TestCase):
     """
     Tests for the QCProtocol class
     """
+    def test_qcprotocol_eq(self):
+        """
+        QCProtocol: check equality operations
+        """
+        p = QCProtocol(name="example",
+                       description="Example protocol",
+                       seq_data_reads=['r1','r2'],
+                       index_reads=None,
+                       qc_modules=("fastqc",
+                                    "fastq_screen",
+                                    "sequence_lengths"))
+        q = QCProtocol(name="example",
+                       description="Example protocol",
+                       seq_data_reads=['r1','r3'],
+                       index_reads=None,
+                       qc_modules=("fastqc",
+                                   "fastq_screen",
+                                   "sequence_lengths"))
+        self.assertEqual(p,p)
+        self.assertEqual(q,q)
+        self.assertNotEqual(p,q)
+        self.assertNotEqual(q,p)
+        self.assertNotEqual(p,repr(p))
+
+    def test_qcprotocol_repr(self):
+        """
+        QCProtocol: check 'repr' output
+        """
+        p = QCProtocol(name="example",
+                       description="Example protocol",
+                       seq_data_reads=['r1','r2'],
+                       index_reads=None,
+                       qc_modules=("fastqc",
+                                   "fastq_screen",
+                                   "sequence_lengths"))
+        self.assertEqual(repr(p),
+                         "example:'Example protocol':"
+                         "seq_reads=[r1,r2]:"
+                         "index_reads=[]:"
+                         "qc_modules=[fastq_screen,"
+                         "fastqc,sequence_lengths]")
+
+    def test_qcprotocol_from_specification(self):
+        """
+        QCProtocol: check instantiating using 'from_specification'
+        """
+        p = QCProtocol(name="example",
+                       description="Example protocol",
+                       seq_data_reads=['r1','r2'],
+                       index_reads=None,
+                       qc_modules=("fastqc",
+                                   "fastq_screen",
+                                   "sequence_lengths"))
+        q = QCProtocol.from_specification("example:'Example protocol':"
+                                          "seq_reads=[r1,r2]:"
+                                          "index_reads=[]:"
+                                          "qc_modules=[fastq_screen,"
+                                          "fastqc,sequence_lengths]")
+        self.assertEqual(p,q)
+
     def test_qcprotocol_null_protocol(self):
         """
         QCProtocol: check 'null' protocol
@@ -45,8 +105,7 @@ class TestQCProtocol(unittest.TestCase):
         self.assertEqual(repr(p),
                          "null:'':seq_reads=[]:index_reads=[]:"
                          "qc_modules=[]")
-        self.assertEqual(repr(p),
-                         repr(QCProtocol.from_specification(repr(p))))
+        self.assertEqual(p,QCProtocol.from_specification(repr(p)))
 
     def test_qcprotocol_example_paired_end_protocol(self):
         """
@@ -81,8 +140,7 @@ class TestQCProtocol(unittest.TestCase):
                          "basicPE:'Basic paired-end QC':"
                          "seq_reads=[r1,r2]:index_reads=[]:"
                          "qc_modules=[fastq_screen,fastqc,sequence_lengths]")
-        self.assertEqual(repr(p),
-                         repr(QCProtocol.from_specification(repr(p))))
+        self.assertEqual(p,QCProtocol.from_specification(repr(p)))
 
     def test_qcprotocol_example_single_cell_protocol(self):
         """
@@ -117,8 +175,7 @@ class TestQCProtocol(unittest.TestCase):
                          "basicSC:'Basic single cell QC':"
                          "seq_reads=[r2]:index_reads=[r1]:"
                          "qc_modules=[fastq_screen,fastqc,sequence_lengths]")
-        self.assertEqual(repr(p),
-                         repr(QCProtocol.from_specification(repr(p))))
+        self.assertEqual(p,QCProtocol.from_specification(repr(p)))
 
     def test_qcprotocol_example_paired_end_protocol_with_ranges(self):
         """
@@ -155,8 +212,7 @@ class TestQCProtocol(unittest.TestCase):
                          "'Basic paired-end QC with ranges':"
                          "seq_reads=[r1,r2:1-50]:index_reads=[]:"
                          "qc_modules=[fastq_screen,fastqc,sequence_lengths]")
-        self.assertEqual(repr(p),
-                         repr(QCProtocol.from_specification(repr(p))))
+        self.assertEqual(p,QCProtocol.from_specification(repr(p)))
 
 class TestDetermineQCProtocolFunction(unittest.TestCase):
     """

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -628,16 +628,9 @@ class TestParseProtocolSpec(unittest.TestCase):
         p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_pe_qc")
         self.assertEqual(p.description,"Simple PE QC protocol")
-        self.assertEqual(p.reads.seq_data,('r1','r2'))
-        self.assertEqual(p.reads.index,())
-        self.assertEqual(p.reads.qc,('r1','r2'))
-        self.assertEqual(p.read_numbers.seq_data,(1,2))
-        self.assertEqual(p.read_numbers.index,())
-        self.assertEqual(p.read_numbers.qc,(1,2))
-        self.assertEqual(p.read_range.r1,None)
-        self.assertEqual(p.read_range.r2,None)
+        self.assertEqual(p.seq_data_reads,['r1','r2'])
+        self.assertEqual(p.index_reads,[])
         self.assertEqual(p.qc_modules,['fastq_screen','fastqc'])
-        self.assertEqual(repr(p),s)
 
     def test_parse_protocol_spec_10x(self):
         """
@@ -649,16 +642,9 @@ class TestParseProtocolSpec(unittest.TestCase):
         p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_10x_qc")
         self.assertEqual(p.description,"Simple 10x single cell QC protocol")
-        self.assertEqual(p.reads.seq_data,('r2',))
-        self.assertEqual(p.reads.index,('r1',))
-        self.assertEqual(p.reads.qc,('r1','r2'))
-        self.assertEqual(p.read_numbers.seq_data,(2,))
-        self.assertEqual(p.read_numbers.index,(1,))
-        self.assertEqual(p.read_numbers.qc,(1,2))
-        self.assertEqual(p.read_range.r1,None)
-        self.assertEqual(p.read_range.r2,None)
+        self.assertEqual(p.seq_data_reads,['r2',])
+        self.assertEqual(p.index_reads,['r1',])
         self.assertEqual(p.qc_modules,['cellranger_count','fastqc'])
-        self.assertEqual(repr(p),s)
 
     def test_parse_protocol_spec_simple_10x_flex(self):
         """
@@ -670,16 +656,9 @@ class TestParseProtocolSpec(unittest.TestCase):
         p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_flex_qc")
         self.assertEqual(p.description,"Simple 10x Flex QC protocol")
-        self.assertEqual(p.reads.seq_data,('r2',))
-        self.assertEqual(p.reads.index,('r1',))
-        self.assertEqual(p.reads.qc,('r1','r2'))
-        self.assertEqual(p.read_numbers.seq_data,(2,))
-        self.assertEqual(p.read_numbers.index,(1,))
-        self.assertEqual(p.read_numbers.qc,(1,2))
-        self.assertEqual(p.read_range.r1,None)
-        self.assertEqual(p.read_range.r2,(1,50))
+        self.assertEqual(p.seq_data_reads,['r2:1-50',])
+        self.assertEqual(p.index_reads,['r1',])
         self.assertEqual(p.qc_modules,['cellranger_count','fastqc'])
-        self.assertEqual(repr(p),s)
 
     def test_parse_protocol_spec_simple_10x_gex_multiome(self):
         """
@@ -694,20 +673,13 @@ class TestParseProtocolSpec(unittest.TestCase):
         p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_multiome_gex_qc")
         self.assertEqual(p.description,"Simple 10x multiome GEX QC protocol")
-        self.assertEqual(p.reads.seq_data,('r2',))
-        self.assertEqual(p.reads.index,('r1',))
-        self.assertEqual(p.reads.qc,('r1','r2'))
-        self.assertEqual(p.read_numbers.seq_data,(2,))
-        self.assertEqual(p.read_numbers.index,(1,))
-        self.assertEqual(p.read_numbers.qc,(1,2))
-        self.assertEqual(p.read_range.r1,None)
-        self.assertEqual(p.read_range.r2,None)
+        self.assertEqual(p.seq_data_reads,['r2',])
+        self.assertEqual(p.index_reads,['r1',])
         self.assertEqual(p.qc_modules,[
             'cellranger-arc_count',
             'cellranger_count(chemistry=ARC-v1;library=snRNA-seq;' \
             'cellranger_version=*;cellranger_refdata=*;' \
             'set_cell_count=false;set_metadata=False)'])
-        self.assertEqual(repr(p),s)
 
     def test_parse_protocol_spec_no_index_reads(self):
         """
@@ -719,20 +691,9 @@ class TestParseProtocolSpec(unittest.TestCase):
         p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_pe_qc")
         self.assertEqual(p.description,"Simple PE QC protocol")
-        self.assertEqual(p.reads.seq_data,('r1','r2'))
-        self.assertEqual(p.reads.index,())
-        self.assertEqual(p.reads.qc,('r1','r2'))
-        self.assertEqual(p.read_numbers.seq_data,(1,2))
-        self.assertEqual(p.read_numbers.index,())
-        self.assertEqual(p.read_numbers.qc,(1,2))
-        self.assertEqual(p.read_range.r1,None)
-        self.assertEqual(p.read_range.r2,None)
+        self.assertEqual(p.seq_data_reads,['r1','r2'])
+        self.assertEqual(p.index_reads,None)
         self.assertEqual(p.qc_modules,['fastq_screen','fastqc'])
-        self.assertEqual(repr(p),
-                         "simple_pe_qc:'Simple PE QC protocol':" \
-                         "seq_reads=[r1,r2]:" \
-                         "index_reads=[]:" \
-                         "qc_modules=[fastq_screen,fastqc]")
 
     def test_parse_protocol_spec_no_seq_data_reads(self):
         """
@@ -744,20 +705,9 @@ class TestParseProtocolSpec(unittest.TestCase):
         p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_pe_qc")
         self.assertEqual(p.description,"Simple PE QC protocol")
-        self.assertEqual(p.reads.seq_data,())
-        self.assertEqual(p.reads.index,('r1','r2'))
-        self.assertEqual(p.reads.qc,('r1','r2'))
-        self.assertEqual(p.read_numbers.seq_data,())
-        self.assertEqual(p.read_numbers.index,(1,2))
-        self.assertEqual(p.read_numbers.qc,(1,2))
-        self.assertEqual(p.read_range.r1,None)
-        self.assertEqual(p.read_range.r2,None)
+        self.assertEqual(p.seq_data_reads,None)
+        self.assertEqual(p.index_reads,['r1','r2'])
         self.assertEqual(p.qc_modules,['fastq_screen','fastqc'])
-        self.assertEqual(repr(p),
-                         "simple_pe_qc:'Simple PE QC protocol':" \
-                         "seq_reads=[]:" \
-                         "index_reads=[r1,r2]:" \
-                         "qc_modules=[fastq_screen,fastqc]")
 
     def test_parse_protocol_spec_no_qc_modules(self):
         """
@@ -769,20 +719,9 @@ class TestParseProtocolSpec(unittest.TestCase):
         p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_pe_qc")
         self.assertEqual(p.description,"Simple PE QC protocol")
-        self.assertEqual(p.reads.seq_data,('r1','r2'))
-        self.assertEqual(p.reads.index,())
-        self.assertEqual(p.reads.qc,('r1','r2'))
-        self.assertEqual(p.read_numbers.seq_data,(1,2))
-        self.assertEqual(p.read_numbers.index,())
-        self.assertEqual(p.read_numbers.qc,(1,2))
-        self.assertEqual(p.read_range.r1,None)
-        self.assertEqual(p.read_range.r2,None)
-        self.assertEqual(p.qc_modules,[])
-        self.assertEqual(repr(p),
-                         "simple_pe_qc:'Simple PE QC protocol':" \
-                         "seq_reads=[r1,r2]:" \
-                         "index_reads=[]:" \
-                         "qc_modules=[]")
+        self.assertEqual(p.seq_data_reads,['r1','r2'])
+        self.assertEqual(p.index_reads,[])
+        self.assertEqual(p.qc_modules,None)
 
     def test_parse_protocol_spec_empty_qc_modules(self):
         """
@@ -795,16 +734,9 @@ class TestParseProtocolSpec(unittest.TestCase):
         p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_pe_qc")
         self.assertEqual(p.description,"Simple PE QC protocol")
-        self.assertEqual(p.reads.seq_data,('r1','r2'))
-        self.assertEqual(p.reads.index,())
-        self.assertEqual(p.reads.qc,('r1','r2'))
-        self.assertEqual(p.read_numbers.seq_data,(1,2))
-        self.assertEqual(p.read_numbers.index,())
-        self.assertEqual(p.read_numbers.qc,(1,2))
-        self.assertEqual(p.read_range.r1,None)
-        self.assertEqual(p.read_range.r2,None)
+        self.assertEqual(p.seq_data_reads,['r1','r2'])
+        self.assertEqual(p.index_reads,[])
         self.assertEqual(p.qc_modules,['fastqc'])
-        self.assertEqual(repr(p),s[:-1])
 
     def test_parse_protocol_spec_trailing_colon(self):
         """
@@ -817,13 +749,6 @@ class TestParseProtocolSpec(unittest.TestCase):
         p = parse_protocol_spec(s)
         self.assertEqual(p.name,"simple_pe_qc")
         self.assertEqual(p.description,"Simple PE QC protocol")
-        self.assertEqual(p.reads.seq_data,('r1','r2'))
-        self.assertEqual(p.reads.index,())
-        self.assertEqual(p.reads.qc,('r1','r2'))
-        self.assertEqual(p.read_numbers.seq_data,(1,2))
-        self.assertEqual(p.read_numbers.index,())
-        self.assertEqual(p.read_numbers.qc,(1,2))
-        self.assertEqual(p.read_range.r1,None)
-        self.assertEqual(p.read_range.r2,None)
+        self.assertEqual(p.seq_data_reads,['r1','r2'])
+        self.assertEqual(p.index_reads,[])
         self.assertEqual(p.qc_modules,[])
-        self.assertEqual(repr(p),s)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -96,6 +96,7 @@ at the `University of Manchester <https://www.manchester.ac.uk/>`_.
 
    reference/commands
    reference/utilities
+   reference/qc_protocol_specification
 
 .. _developers-docs:
 

--- a/docs/source/reference/qc_protocol_specification.rst
+++ b/docs/source/reference/qc_protocol_specification.rst
@@ -1,0 +1,148 @@
+QC protocol specification
+=========================
+
+--------
+Overview
+--------
+
+Different QC protocol definitions within ``auto_process``
+are used to run the appropriate metrics for different
+types of data within the QC pipeline, by specifying
+which metrics should be used on which reads within
+a dataset.
+
+Each protocol is defined by the following attributes:
+
+=================== ============================
+Attribute           Description
+=================== ============================
+Name                Short name for the protocol
+Description         Longer free-text description 
+Sequence data reads Reads with biological data
+Index data reads    Reads with index data
+QC modules          List of QC modules and arguments
+=================== ============================
+
+-----------------------
+Protocol specifications
+-----------------------
+
+The attributes for a protocol can be specified using a
+string of the form:
+
+::
+
+   NAME:DESCRIPTION:seq_reads=SEQ_READS:index_reads=INDEX_READS:qc_modules=QC_MODULES
+
+where:
+
+=============== ================== ======================
+Field           Description        Example
+=============== ================== ======================
+``NAME``        Protocol name      ``standardPE``
+``DESCRIPTION`` Description text   ``Standard paired-end data``
+``SEQ_READS``   List of reads      ``[r1,r2]``
+``INDEX_READS`` List of reads      ``[r1]``
+``QC_MODULES``  List of QC modules ``[fastqc,fastq_screen]``
+=============== ================== ======================
+
+For example:
+
+::
+
+   basicQC:'Basic QC protocol':seq_reads=[r1,r2]:index_reads=[]:qc_modules=[sequence_lengths,fastqc]
+
+The name and description must always be the first two fields
+of a protocol specification. The ``seq_reads``, ``index_reads``
+and ``qc_modules`` fields can appear in any order and can be
+omitted if empty. The same read ID should not appear in both
+``seq_reads`` and ``index_reads``.
+
+-------------------------------
+Protocol names and descriptions
+-------------------------------
+
+Names cannot contain spaces or colons; descriptions can
+contain any characters (including spaces).
+
+Optionally, descriptions can be enclosed in matching quotes
+(either single or double); these should be used if the
+description includes special characters such as colons or
+quotes.
+
+-----------------------------
+Sequence data and index reads
+-----------------------------
+
+QC protocols distinguish between "sequence data" and "index"
+reads as follows:
+
+* Sequence data reads are those reads containing biologically
+  significant data, and are used for mapped metrics;
+* Index reads contain non-biologically significant data (e.g.
+  feature barcodes). Non-mapped metrics are run on both
+  sequence data and index data reads.
+
+Reads can optionally also specify subsequences to use for
+QC, for example for 10x Genomics Flex data only the first
+50 bases of R1 contains the biologically significant data.
+Subsequences can be specified by ranges attached to reads,
+for example in this case ``seq_reads=[r2:1-50]``, and tell
+the pipeline to only use these portions of the the reads
+when running the mapped metrics.
+
+----------
+QC modules
+----------
+
+QC modules specific which software will be run and which
+metrics will be produced.
+
+The following QC modules are available:
+
+============================== =============================== ==========
+QC module                      Software                        Metrics
+============================== =============================== ==========
+``fastqc``                     FastQC                          General stats and quality information
+``fastq_screen``               FastqQScreen                    Screens against panels of organisms
+``picard_insert_size_metrics`` Picard CollectInsertSizeMetrics Insert sizes
+``qualimap_rnaseq``            Qualimap 'rnaseq'               Coverage and genomic origin of reads
+``rseqc_genebody_coverage``    RSeQC geneBody_coverage.py      Coverage
+``sequence_lengths``           Built-in                        Sequence length and masking stats
+``strandedness``               fastq_strand.py                 Strandedness information
+``cellranger_count``           CellRanger 'count'              Single library analysis
+``cellranger-atac_count``      CellRanger-ATAC 'count'         Single library analysis
+``cellranger-arc_count``       Cellranger-ARC 'count'          Single library analysis
+``cellranger_multi``           CellRanger 'multi'              Multiplexing analysis
+============================== =============================== ==========
+
+Some QC modules allow additional optional arguments to be
+specified, to modify either the metric or pipeline behaviour,
+or how the metric validation is performed.
+
+Arguments are specified using the general syntax:
+
+::
+
+   QC_MODULE(ARG1=VALUE1;ARG2=VALUE2;...)
+
+For example:
+
+::
+
+   cellranger_count(set_cell_count=false;set_metadata=false)
+
+The following options are recognised:
+
+========================================== =================== ===========
+Option                                     QC modules          Description
+========================================== =================== ===========
+``chemistry=CHEMISTRY``                    cellranger[*]_count Explicitly set chemistry when running CellRanger 'count' (e.g. ``ARC-v1``)
+``library=LIBRARY_TYPE``                   cellranger[*]_count Explicitly set library type in pipeline tasks (e.g. ``snRNA-seq``)
+``cellranger_version=VERSION``             cellranger[*]_count Set expected CellRanger version for validation (default is the version identified by the pipeline; use ``*`` to match any version)
+``cellranger_refdata=REFDATA``             cellranger[*]_count Set expected CellRanger reference dataset for validation (default is the reference identified by the pipeline; use ``*`` to match any reference dataset)                             
+``set_cell_count=true|false``              cellranger[*]_count Whether to use outputs to set the cell count (default is ``true``)
+``set_metadata=true|false``                cellranger[*]_count Whether to set metadata from this module (default is ``true``)
+``cellranger_use_multi_config=true|false`` cellranger_count    If ``true`` then use CellRanger 'multi' config file to identify samples with biological data (default is ``false``)
+========================================== =================== ===========
+


### PR DESCRIPTION
Implements the `__repr__` built-in on the `QCProtocol` class in `qc/protocols`, to produce a specification string.

A new function `parse_protocol_spec` can break down the specification string to provide the arguments required to recover the parent instance, for example:

    >>> p = QCProtocol(...)
    >>> args = parse_protocol_spec(repr(p))
    >>> q = QCProtocol(**args)

Alternatively a new classmethod `from_specification` of the `QCProtocol` class can create an instance directly from a protocol specification string, for example:

    >>> p = QCProtocol(...)
    >>> q = QCProtocol.from_specification(repr(p))

The PR also implements the `__eq__` built-in on `QCProtocol`, so it's possible to check if two instances are equivalent.