### PR TITLE
Auto-generate table of QC protocols in 'run_qc' documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docs/build
 docs/source/developers/api_docs
 docs/source/reference
 docs/source/images/auto
+docs/source/using/auto

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -94,22 +94,6 @@ QC_PROTOCOLS = {
         ]
     },
 
-    "singlecell": {
-        "description": "ICELL8 single cell RNA-seq",
-        "reads": {
-            "seq_data": ('r2',),
-            "index": ('r1',)
-        },
-        "qc_modules": [
-            'fastqc',
-            'fastq_screen',
-            'sequence_lengths',
-            'strandedness',
-            'rseqc_genebody_coverage',
-            'qualimap_rnaseq'
-        ]
-    },
-
     "10x_scRNAseq": {
         "description": "10xGenomics single cell RNA-seq",
         "reads": {
@@ -279,6 +263,22 @@ QC_PROTOCOLS = {
             'fastq_screen',
             'sequence_lengths',
             'strandedness',
+            'strandedness',
+            'rseqc_genebody_coverage',
+            'qualimap_rnaseq'
+        ]
+    },
+
+    "singlecell": {
+        "description": "ICELL8 single cell RNA-seq",
+        "reads": {
+            "seq_data": ('r2',),
+            "index": ('r1',)
+        },
+        "qc_modules": [
+            'fastqc',
+            'fastq_screen',
+            'sequence_lengths',
             'strandedness',
             'rseqc_genebody_coverage',
             'qualimap_rnaseq'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -266,21 +266,22 @@ ds_width = 26
 qc_protocols_tbl = os.path.join(auto_content_dir,"qc_protocols.rst")
 with open(qc_protocols_tbl,'wt') as fp:
     # Write table header
-    fp.write("%s %s\n" % ('='*pr_width,
-                          '='*ds_width))
-    fp.write("QC protocol%s Description\n" %
-             (' '*(pr_width-len("QC Protocol"))))
-    fp.write("%s %s\n" % ('='*pr_width,
-                          '='*ds_width))
+    fp.write("{x:=<{pr_width}} {x:=<{ds_width}}\n".format(
+        x='',pr_width=pr_width,ds_width=ds_width))
+    fp.write("{name: <{pr_width}} {desc}\n".format(name="QC protocol",
+                                                   desc="Description",
+                                                   pr_width=pr_width))
+    fp.write("{x:=<{pr_width}} {x:=<{ds_width}}\n".format(
+        x='',pr_width=pr_width,ds_width=ds_width))
     # Write protocol information
     for p in qc_protocols:
-        fp.write("``{name}``{padding} {description}\n".format(
-            name=p.name,
-            padding=' '*(pr_width-len(p.name)-4),
-            description=p.description))
+        fp.write("{name: <{pr_width}} {description}\n".format(
+            name="``{name}``".format(name=p.name),
+            description=p.description,
+            pr_width=pr_width))
     # Write table footer
-    fp.write("%s %s\n" % ('='*pr_width,
-                          '='*ds_width))
+    fp.write("{x:=<{pr_width}} {x:=<{ds_width}}\n".format(
+        x='',pr_width=pr_width,ds_width=ds_width))
 
 # -- Make example plot images for QC report -----------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -248,6 +248,40 @@ texinfo_documents = [
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
 
+# -- Make table with QC protocols ---------------------------------------------
+
+from auto_process_ngs.qc import protocols
+# Directory for auto-generated content
+auto_content_dir = os.path.join("using","auto")
+if not os.path.exists(auto_content_dir):
+    os.makedirs(auto_content_dir)
+# Get list of protocol instances
+qc_protocols = []
+for p in protocols.QC_PROTOCOLS:
+    qc_protocols.append(protocols.fetch_protocol_definition(p))
+# Get width for protocol name column
+pr_width = max([len(p.name)+4 for p in qc_protocols])
+ds_width = 26
+# Generate file with table of protocol names and descriptions
+qc_protocols_tbl = os.path.join(auto_content_dir,"qc_protocols.rst")
+with open(qc_protocols_tbl,'wt') as fp:
+    # Write table header
+    fp.write("%s %s\n" % ('='*pr_width,
+                          '='*ds_width))
+    fp.write("QC protocol%s Description\n" %
+             (' '*(pr_width-len("QC Protocol"))))
+    fp.write("%s %s\n" % ('='*pr_width,
+                          '='*ds_width))
+    # Write protocol information
+    for p in qc_protocols:
+        fp.write("``{name}``{padding} {description}\n".format(
+            name=p.name,
+            padding=' '*(pr_width-len(p.name)-4),
+            description=p.description))
+    # Write table footer
+    fp.write("%s %s\n" % ('='*pr_width,
+                          '='*ds_width))
+
 # -- Make example plot images for QC report -----------------------------------
 
 from auto_process_ngs.qc import plots

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -25,23 +25,7 @@ QC protocols
 The QC pipeline protocol used for each project will differ slightly
 depending on the nature of the data within that project:
 
-===================== ==========================
-QC protocol           Used for
-===================== ==========================
-``standardPE``        Standard paired-end data i.e. R1/R2 Fastq pairs
-``standardSE``        Standard single-end data i.e. R1 Fastqs only
-``10x_scATAC``        10xGenomics single cell & single nuclei ATAC-seq
-``10x_scRNAseq``      10xGenomics single cell RNA-seq
-``10x_snRNAseq``      10xGenomics single nuclei RNA-seq
-``10x_Visium``        10xGenomics Visium spatial RNA-seq
-``10x_Multiome_ATAC`` 10xGenomics single cell multiome ATAC-seq data
-``10x_Multiome_GEX``  10xGenomics single cell multiome gene expression data
-``10x_CellPlex``      10xGenomics CellPlex cell multiplexing data
-``10x_Flex``          10xGenomics Flex (fixed RNA profiling) data
-``ParseEvercode``     Parse Evercode single cell RNA-seq
-``singlecell``        ICELL8 single cell RNA-seq
-``ICELL8_scATAC``     ICELL8 single cell ATAC-seq
-===================== ==========================
+.. include:: auto/qc_protocols.rst
 
 The protocol is determined automatically for each project, based
 on the metadata.


### PR DESCRIPTION
Updates the documentation for the 'run_qc' command, to generate the table of QC protocol names and descriptions based on the protocols defined in the ``qc.protocols`` module.