### PR TITLE
Fix attribute extraction from sequence length files for non-canonical Fastq names

### DIFF
--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -672,7 +672,7 @@ class QCOutputs:
         if seq_lens:
             tags.add("sequence_lengths")
             for f in seq_lens:
-                fq = self.fastq_attrs(os.path.splitext(f)[0])
+                fq = self.fastq_attrs(f[:-len("_seqlens.json")])
                 read = '%s%s' % ('i' if fq.is_index_read else 'r',
                                  fq.read_number)
                 fastqs.add(


### PR DESCRIPTION
Fixes the extraction of Fastq name attributes from the sequence length QC output files (in the `QCOutputs._collect_seq_lens` method in the `qc/outputs` module) so that attribute extraction (specifically the read number) is handled correctly for non-canonical Fastq names (such those from the SRA).