### PR TITLE
Implement run reference ID distinct from run ID

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     analysis: classes & funcs for handling analysis dirs and projects
-#     Copyright (C) University of Manchester 2018-2022 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2023 Peter Briggs
 #
 ########################################################################
 #
@@ -1229,9 +1229,9 @@ class AnalysisSample:
 # Functions
 #######################################################################
 
-def run_reference_id(run_name,platform=None,facility_run_number=None):
+def run_id(run_name,platform=None,facility_run_number=None):
     """
-    Return a run reference id e.g. 'HISEQ_140701/242#22'
+    Return a run ID e.g. 'HISEQ_140701/242#22'
 
     The run reference code is a code that identifies the sequencing
     run, and has the general form:
@@ -1319,6 +1319,14 @@ def run_reference_id(run_name,platform=None,facility_run_number=None):
     if facility_run_number is not None:
         run_id += "#%s" % facility_run_number
     return run_id
+
+def run_reference_id(*args,**kws):
+    """
+    Return a run reference id e.g. 'HISEQ_140701/242#22'
+
+    Wrapper for 'run_id' function
+    """
+    return run_id(*args,**kws)
 
 def split_sample_name(s):
     """
@@ -1464,13 +1472,13 @@ def match_run_id(run,d):
         logger.debug("%s: run name = %s" % (d,analysis_dir.run_name))
         if analysis_dir.run_name == run or run == '*':
             return d
-        # Check run reference ID
-        run_id = run_reference_id(
+        # Check run ID
+        run_id_ = run_id(
             analysis_dir.run_name,
             platform=analysis_dir.metadata.platform,
             facility_run_number=analysis_dir.metadata.run_number)
-        logger.debug("%s: run ID = %s" % (d,run_id))
-        if run_id == run:
+        logger.debug("%s: run ID = %s" % (d,run_id_))
+        if run_id_ == run:
             return True
     except Exception as ex:
         # Not an analysis directory

--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -22,7 +22,7 @@ Classes:
 
 Functions:
 
-- run_reference_id: fetch identifier for sequencing run
+- run_id: fetch run ID for sequencing run
 - split_sample_name: split sample name into components
 - split_sample_reference: split sample reference ID into components
 - match_run_id: check if directory matches run identifier
@@ -1233,8 +1233,8 @@ def run_id(run_name,platform=None,facility_run_number=None):
     """
     Return a run ID e.g. 'HISEQ_140701/242#22'
 
-    The run reference code is a code that identifies the sequencing
-    run, and has the general form:
+    The run ID is a code that identifies the sequencing run, and has
+    the general form:
 
     ``PLATFORM_DATESTAMP[/INSTRUMENT_RUN_NUMBER]#FACILITY_RUN_NUMBER``
 
@@ -1272,7 +1272,7 @@ def run_id(run_name,platform=None,facility_run_number=None):
         run number) (optional)
 
     Returns:
-      String: run reference identifier.
+      String: run ID.
     """
     # Extract information from run name
     run_name = os.path.basename(os.path.normpath(run_name))
@@ -1301,7 +1301,7 @@ def run_id(run_name,platform=None,facility_run_number=None):
             facility_run_number = None
     else:
         facility_run_number = None
-    # Construct the reference id
+    # Construct the run id
     if platform is not None:
         run_id = platform
         if datestamp is not None:
@@ -1319,14 +1319,6 @@ def run_id(run_name,platform=None,facility_run_number=None):
     if facility_run_number is not None:
         run_id += "#%s" % facility_run_number
     return run_id
-
-def run_reference_id(*args,**kws):
-    """
-    Return a run reference id e.g. 'HISEQ_140701/242#22'
-
-    Wrapper for 'run_id' function
-    """
-    return run_id(*args,**kws)
 
 def split_sample_name(s):
     """

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -31,7 +31,7 @@ from bcftbx.JobRunner import fetch_runner
 from bcftbx.FASTQFile import FastqIterator
 from . import commands
 from .analysis import AnalysisProject
-from .analysis import run_reference_id
+from .analysis import run_id
 from .decorators import add_command
 from .metadata import AnalysisDirParameters
 from .metadata import AnalysisDirMetadata
@@ -642,11 +642,11 @@ class AutoProcess:
         return None
 
     @property
-    def run_reference_id(self):
+    def run_id(self):
         """
-        Return a run reference id (e.g. 'HISEQ_140701/242#22')
+        Return the run ID (e.g. 'HISEQ_140701/242#22')
         """
-        return run_reference_id(
+        return run_id(
             self.run_name,
             platform=self.metadata.platform,
             facility_run_number=self.metadata.run_number)
@@ -707,7 +707,7 @@ class AutoProcess:
 
         """
         values = bcf_utils.OrderedDictionary()
-        values['Run reference'] = self.run_reference_id
+        values['Run ID'] = self.run_id
         for i in data:
             values[i] = data[i]
         field_width = max([len(i) for i in values])
@@ -924,4 +924,4 @@ class AutoProcess:
     def __str__(self):
         # Implement string representation
         # as the run reference id
-        return str(self.run_reference_id)
+        return str(self.run_id)

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -652,6 +652,20 @@ class AutoProcess:
             facility_run_number=self.metadata.run_number)
 
     @property
+    def run_reference_id(self):
+        """
+        Return the run reference (e.g. 'NOVASEQ6000_230419/74#22_SP'
+
+        The run reference is the run ID plus the
+        following additional items (if defined):
+
+        - flow cell mode
+        """
+        return "%s%s" % (self.run_id,
+                         '' if not self.metadata.flow_cell_mode
+                         else "_%s" % self.metadata.flow_cell_mode)
+
+    @property
     def parameter_file(self):
         """
         Return name of parameter file ('auto_process.info')
@@ -923,5 +937,5 @@ class AutoProcess:
 
     def __str__(self):
         # Implement string representation
-        # as the run reference id
+        # as the run ID
         return str(self.run_id)

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     publish_qc_cmd.py: implement auto process publish_qc command
-#     Copyright (C) University of Manchester 2017-2022 Peter Briggs
+#     Copyright (C) University of Manchester 2017-2023 Peter Briggs
 #
 #########################################################################
 
@@ -492,8 +492,8 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
             params_tbl.add_row(param=pkg.title(),
                                value="%s %s" % (package_info[1],
                                                 package_info[2]))
-    params_tbl.add_row(param="Reference",
-                       value=ap.run_reference_id)
+    params_tbl.add_row(param="Run ID",
+                       value=ap.run_id)
     general_info.add(params_tbl)
     # Processing QC reports
     if processing_qc_reports:

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     report_cmd.py: implement auto process 'report' command
-#     Copyright (C) University of Manchester 2018-2022 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2023 Peter Briggs
 #
 #########################################################################
 
@@ -119,7 +119,7 @@ def report_info(ap):
       String with the report text.
     """
     report = []
-    report.append("Run reference: %s" % ap.run_reference_id)
+    report.append("Run ID       : %s" % ap.run_id)
     report.append("Directory    : %s" % ap.analysis_dir)
     report.append("Platform     : %s" % ap.metadata.platform)
     report.append("Unaligned dir: %s" % ap.params.unaligned_dir)

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -271,7 +271,8 @@ def report_summary(ap):
 
     - Platform
     - Run name
-    - Run reference id
+    - Run ID
+    - Run reference
     - Sequencer model
     - Processing software
 
@@ -355,6 +356,8 @@ def report_summary(ap):
         # Get the value for each item
         if item == 'Run name':
             value = run_name
+        elif item == 'Run ID':
+            value = ap.run_id
         elif item == 'Reference':
             value = ap.run_reference_id
         elif item == 'Platform':
@@ -599,6 +602,8 @@ def fetch_value(ap,project,field):
     if field == 'datestamp':
         return IlluminaData.split_run_name(ap.run_name)[0]
     elif field == 'run_id':
+        return ap.run_id
+    elif field == 'run_reference_id':
         return ap.run_reference_id
     elif field == 'run_number':
         return ('' if not ap.metadata.run_number

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -86,7 +86,7 @@ from bcftbx.utils import extract_prefix
 from bcftbx.utils import extract_index
 from bcftbx.utils import walk
 from ..analysis import AnalysisFastq
-from ..analysis import run_reference_id
+from ..analysis import run_id
 from ..analysis import split_sample_name
 from ..analysis import split_sample_reference
 from ..docwriter import Document
@@ -1730,10 +1730,10 @@ class QCProject:
         ``None`` is returned.
         """
         try:
-            return run_reference_id(self.info['run'],
-                                    platform=self.info['platform'],
-                                    facility_run_number=
-                                    self.run_metadata['run_number'])
+            return run_id(self.info['run'],
+                          platform=self.info['platform'],
+                          facility_run_number=
+                          self.run_metadata['run_number'])
         except (AttributeError,TypeError) as ex:
             logger.warning("Run reference ID can't be "
                            "determined: %s (ignored)" % ex)

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -68,7 +68,7 @@ class TestReportInfo(unittest.TestCase):
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Generate concise report
-        expected = """Run reference: MISEQ_170901#87
+        expected = """Run ID       : MISEQ_170901#87
 Directory    : %s
 Platform     : miseq
 Unaligned dir: bcl2fastq
@@ -152,7 +152,7 @@ Summary of data in 'bcl2fastq' dir:
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Generate concise report
-        expected = """Run reference: MISEQ_170901#87
+        expected = """Run ID       : MISEQ_170901#87
 Directory    : %s
 Platform     : miseq
 Unaligned dir: bcl2fastq
@@ -223,7 +223,7 @@ Summary of data in 'bcl2fastq' dir:
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Generate concise report
-        expected = """Run reference: MISEQ_170901#87
+        expected = """Run ID       : MISEQ_170901#87
 Directory    : %s
 Platform     : miseq
 Unaligned dir: bcl2fastq
@@ -287,7 +287,7 @@ ABM4,CMO304,ABM4
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Generate concise report
-        expected = """Run reference: MISEQ_170901#87
+        expected = """Run ID       : MISEQ_170901#87
 Directory    : %s
 Platform     : miseq
 Unaligned dir: bcl2fastq
@@ -358,7 +358,7 @@ Summary of data in 'bcl2fastq' dir:
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Generate concise report
-        expected = """Run reference: MISEQ_170901#87
+        expected = """Run ID       : MISEQ_170901#87
 Directory    : %s
 Platform     : miseq
 Unaligned dir: bcl2fastq

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -1315,84 +1315,98 @@ class TestAnalysisSample(unittest.TestCase):
         self.assertTrue(sample.paired_end)
         self.assertEqual(str(sample),'PJB1-B')
 
-class TestRunReferenceIdFunction(unittest.TestCase):
+class TestRunIdFunction(unittest.TestCase):
     """
-    Tests for the 'run_reference_id' function
+    Tests for the 'run_id' function
     """
-    def test_run_reference_id(self):
-        """run_reference_id: run name, platform and facility run number
+    def test_run_id(self):
         """
-        self.assertEqual(run_reference_id("160621_M00879_0087_000000000-AGEW9",
-                                          platform="miseq",
-                                          facility_run_number=87),
-                         "MISEQ_160621#87")
-        self.assertEqual(run_reference_id("/data/160621_M00879_0087_000000000-AGEW9/",
-                                          platform="miseq",
-                                          facility_run_number=87),
-                         "MISEQ_160621#87")
+        run_id: run name, platform and facility run number
+        """
+        self.assertEqual(
+            run_id("160621_M00879_0087_000000000-AGEW9",
+                   platform="miseq",
+                   facility_run_number=87),
+            "MISEQ_160621#87")
+        self.assertEqual(
+            run_id("/data/160621_M00879_0087_000000000-AGEW9/",
+                   platform="miseq",
+                   facility_run_number=87),
+            "MISEQ_160621#87")
 
-    def test_run_reference_id_no_platform(self):
-        """run_reference_id: run name and facility run number (no platform)
+    def test_run_id_no_platform(self):
         """
-        self.assertEqual(run_reference_id("160621_M00879_0087_000000000-AGEW9",
-                                          platform=None,
-                                          facility_run_number=87),
-                         "M00879_160621#87")
-        self.assertEqual(run_reference_id("160621_M00879_0087_000000000-AGEW9",
-                                          platform=None,
-                                          facility_run_number=88),
-                         "M00879_160621/87#88")
-        self.assertEqual(run_reference_id("/data/160621_M00879_0087_000000000-AGEW9/",
-                                          platform=None,
-                                          facility_run_number=87),
-                         "M00879_160621#87")
+        run_id: run name and facility run number (no platform)
+        """
+        self.assertEqual(
+            run_id("160621_M00879_0087_000000000-AGEW9",
+                   platform=None,
+                   facility_run_number=87),
+            "M00879_160621#87")
+        self.assertEqual(
+            run_id("160621_M00879_0087_000000000-AGEW9",
+                   platform=None,
+                   facility_run_number=88),
+            "M00879_160621/87#88")
+        self.assertEqual(
+            run_id("/data/160621_M00879_0087_000000000-AGEW9/",
+                   platform=None,
+                   facility_run_number=87),
+            "M00879_160621#87")
 
-    def test_run_reference_id_no_facility_run_number(self):
-        """run_reference_id: run name and platform (no facility run number)
+    def test_run_id_no_facility_run_number(self):
         """
-        self.assertEqual(run_reference_id("160621_M00879_0087_000000000-AGEW9",
-                                          platform="miseq",
-                                          facility_run_number=None),
-                         "MISEQ_160621/87")
+        run_id: run name and platform (no facility run number)
+        """
+        self.assertEqual(
+            run_id("160621_M00879_0087_000000000-AGEW9",
+                   platform="miseq",
+                   facility_run_number=None),
+            "MISEQ_160621/87")
 
-    def test_run_reference_id_facility_run_number_differs(self):
-        """run_reference_id: instrument and facility run numbers differ
+    def test_run_id_facility_run_number_differs(self):
         """
-        self.assertEqual(run_reference_id("160621_M00879_0087_000000000-AGEW9",
-                                          platform="miseq",
-                                          facility_run_number=90),
-                         "MISEQ_160621/87#90")
-        self.assertEqual(run_reference_id("/data/160621_M00879_0087_000000000-AGEW9/",
-                                          platform="miseq",
-                                          facility_run_number=90),
-                         "MISEQ_160621/87#90")
+        run_id: instrument and facility run numbers differ
+        """
+        self.assertEqual(
+            run_id("160621_M00879_0087_000000000-AGEW9",
+                   platform="miseq",
+                   facility_run_number=90),
+            "MISEQ_160621/87#90")
+        self.assertEqual(
+            run_id("/data/160621_M00879_0087_000000000-AGEW9/",
+                   platform="miseq",
+                   facility_run_number=90),
+            "MISEQ_160621/87#90")
 
-    def test_run_reference_id_bad_run_name(self):
-        """run_reference_id: handle 'bad' run name (cannot be split)
+    def test_run_id_bad_run_name(self):
         """
-        self.assertEqual(run_reference_id("rag_05_2017",
-                                          platform=None,
-                                          facility_run_number=None),
+        run_id: handle 'bad' run name (cannot be split)
+        """
+        self.assertEqual(run_id("rag_05_2017",
+                                platform=None,
+                                facility_run_number=None),
                          "rag_05_2017")
-        self.assertEqual(run_reference_id("rag_05_2017",
-                                          platform="miseq",
-                                          facility_run_number=None),
+        self.assertEqual(run_id("rag_05_2017",
+                                platform="miseq",
+                                facility_run_number=None),
                          "MISEQ_rag_05_2017")
-        self.assertEqual(run_reference_id("rag_05_2017",
-                                          platform=None,
-                                          facility_run_number=90),
+        self.assertEqual(run_id("rag_05_2017",
+                                platform=None,
+                                facility_run_number=90),
                          "rag_05_2017#90")
-        self.assertEqual(run_reference_id("rag_05_2017",
-                                          platform="miseq",
-                                          facility_run_number=90),
+        self.assertEqual(run_id("rag_05_2017",
+                                platform="miseq",
+                                facility_run_number=90),
                          "MISEQ_rag_05_2017#90")
 
-    def test_run_reference_id_handle_non_numeric_run_number(self):
-        """run_reference_id: handle non-numeric facility run number
+    def test_run_id_handle_non_numeric_run_number(self):
         """
-        self.assertEqual(run_reference_id("RAG_10x_BCLFiles_Download",
-                                          platform=None,
-                                          facility_run_number="BCLFiles"),
+        run_id: handle non-numeric facility run number
+        """
+        self.assertEqual(run_id("RAG_10x_BCLFiles_Download",
+                                platform=None,
+                                facility_run_number="BCLFiles"),
                          "RAG_10x_BCLFiles_Download")
 
 class TestSplitSampleNameFunction(unittest.TestCase):

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -114,6 +114,7 @@ Supported sequencer platforms
 The pipeline is currently used for output from the following
 Illumina sequencers:
 
+* NovaSeq 6000
 * HISeq 4000
 * MISeq
 * NextSeq
@@ -152,7 +153,7 @@ For example:
    181026_NB100234_0021_ABCDYHBGX7
 
 * ``181026`` is the datestamp (i.e. 26th October 2018). Some
-  sequencers now use a four-digit year in the datestamp (e.g.
+  sequencers may use a four-digit year in the datestamp (e.g.
   ``20181026``)
 * ``NB100234`` is the instrument ID, which uniquely identifies
   the sequencing instrument which produced the data
@@ -187,3 +188,72 @@ reads from all lanes the sample was run in; for example:
 ::
 
    SK1-control_S11_R1_001.fastq.gz
+
+=============================
+Run IDs and run reference IDs
+=============================
+
+Within the ``auto_process`` package runs can be identified by
+automatically generated run IDs of the general form:
+
+::
+
+   PLATFORM_DATESTAMP[/INSTRUMENT_RUN_NUMBER]#FACILITY_RUN_NUMBER
+
+where:
+
+* ``PLATFORM`` identifies the sequencer platform and is always
+  uppercased (e.g. ``NOVASEQ6000``, ``MISEQ``, etc)
+* ``DATESTAMP`` is the ``YYMMDD`` datestamp from the run name
+  (e.g. ``140701``)
+* ``INSTRUMENT_RUN_NUMBER`` is the run number that forms part of
+  the run name directory (e.g. for
+  ``140701_SN0123_0045_000000000-A1BCD`` it would be ``45``)
+* ``FACILITY_RUN_NUMBER`` is the run number that has been
+  assigned by the facility
+
+For example:
+
+::
+
+   NOVASEQ6000_230419/73#22
+
+is a NovaSeq 6000 sequencer run with datestamp ``230419``,
+instrument run number ``73`` and facility run number ``22``.
+
+Typically the instrument run number for a run is the same as
+the number assigned by the facility; in these cases
+conventionally it is omitted and only the facility run number
+is used, for example:
+
+::
+
+   NOVASEQ6000_230419#22
+
+The special cases are handled as follows:
+
+* If the platform isn't recognised supplied then the instrument
+  name is used instead (e.g. ``SN0123_140701/242#22``)
+* If the run name can't be split into components then the
+  general form will be ``[PLATFORM_]RUN_NAME[#FACILITY_RUN_NUMBER]``
+  depending on whether platform and/or facility run number have
+  been supplied (e.g. for a run called ``rag_05_2017`` the run ID
+  might look like ``rag_05_2017#90`` or ``MISEQ_rag_05_2017#90``)
+
+Run reference IDs are based on the run ID with additional
+arbitrary elements appended, i.e.:
+
+::
+
+   RUNID[_EXTRAINFO]
+
+Currently the following additional elements may appear if
+defined for the run:
+
+* Flow cell mode
+
+For example:
+
+::
+
+   NOVASEQ6000_230419#73_SP

--- a/docs/source/using/report.rst
+++ b/docs/source/using/report.rst
@@ -92,6 +92,8 @@ The available fields are:
 Field name                Associated value
 ========================= ========================
 ``run_id``                Run ID (e.g. ``MISEQ_150729#88``)
+``run_reference_id``      Run reference ID (e.g.
+                          ``NOVASEQ6000_230419#73_SP``)
 ``run_number``            Facility run number (e.g. ``88``)
 ``sequencer_platform``    Sequencer platform for the run
                           (e.g. ``MISEQ``)


### PR DESCRIPTION
Implements run reference IDs which are similar to but distinct from the existing run IDs, and makes the distinction more explicit in the code and documentation.

Run IDs (previously also called run references or run reference IDs interchangeably) are IDs of the form e.g.

    NOVASEQ6000_230419#74

These are now always referred to as run IDs. They are generated by the `run_id` function in the `analysis` module and returned by the `run_id` method of the `AutoProcess` class in the `auto_processor` module. Run IDs are used within the library to locate other runs for example when looking for paired 10x single cell multiome datasets.

Run reference IDs are based on the run ID with arbitrary additional data items appended (currently only the flow cell mode, if set), e.g.

    NOVASEQ6000_230419#74_SP

These are returned by the `run_reference_id` method of the `AutoProcess` class. Reference IDs are externally facing IDs and are reported e.g. in the "summary" output from the `report` command.