### PR TITLE
Refactor handling of QC protocols within pipeline

### DIFF
--- a/auto_process_ngs/cli/reportqc.py
+++ b/auto_process_ngs/cli/reportqc.py
@@ -214,13 +214,15 @@ def main():
         # QC metadata
         qc_dir = p.qc_dir
         qc_info = p.qc_info(qc_dir)
-        # Set QC protocol for verification
-        if args.qc_protocol is None:
-            protocol = qc_info.protocol
-            if protocol is None:
+        # Fetch QC protocol for verification
+        protocol = args.qc_protocol
+        if protocol is None:
+            if qc_info.protocol_specification:
+                protocol = qc_info.protocol_specification
+            elif qc_info.protocol:
+                protocol = qc_info.protocol
+            else:
                 protocol = determine_qc_protocol(p)
-        else:
-            protocol = args.qc_protocol
         print("Verifying against QC protocol '%s'" % protocol)
         # Verification step
         if len(p.fastqs) == 0:

--- a/auto_process_ngs/cli/run_qc.py
+++ b/auto_process_ngs/cli/run_qc.py
@@ -42,6 +42,7 @@ from ..fastq_utils import group_fastqs_by_name
 from ..settings import Settings
 from ..settings import fetch_reference_data
 from ..qc.pipeline import QCPipeline
+from ..qc.protocols import determine_qc_protocol
 from ..qc.protocols import fetch_protocol_definition
 from ..qc.utils import report_qc
 
@@ -955,6 +956,13 @@ def main():
     project = AnalysisProject(project_dir,fastq_attrs=fastq_attrs)
     print("Loaded project '%s'" % project.name)
 
+    # Fetch the QC protocol
+    if args.qc_protocol:
+        qc_protocol = args.qc_protocol
+    else:
+        qc_protocol = determine_qc_protocol(project)
+    protocol = fetch_protocol_definition(qc_protocol)
+
     # Set working directory for pipeline
     working_dir = args.working_dir
     if not working_dir:
@@ -964,8 +972,8 @@ def main():
     announce("Running QC pipeline")
     runqc = QCPipeline()
     runqc.add_project(project,
+                      protocol,
                       qc_dir=qc_dir,
-                      qc_protocol=args.qc_protocol,
                       report_html=out_file,
                       multiqc=(not args.no_multiqc))
     status = runqc.run(nthreads=nthreads,

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     run_qc_cmd.py: implement auto process run_qc command
-#     Copyright (C) University of Manchester 2018-2022 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2023 Peter Briggs
 #
 #########################################################################
 
@@ -16,6 +16,7 @@ from ..command import Command
 from ..qc.pipeline import QCPipeline
 from ..qc.fastq_strand import build_fastq_strand_conf
 from ..qc.protocols import determine_qc_protocol
+from ..qc.protocols import fetch_protocol_definition
 from ..settings import fetch_reference_data
 from ..utils import get_organism_list
 
@@ -229,13 +230,14 @@ def run_qc(ap,projects=None,fastq_screens=None,
     # Set up the QC for each project
     runqc = QCPipeline()
     for project in projects:
-        # Determine the QC protocol
-        protocol = determine_qc_protocol(project)
+        # Determine and fetch the QC protocol
+        qc_protocol = determine_qc_protocol(project)
+        protocol = fetch_protocol_definition(qc_protocol)
         runqc.add_project(project,
+                          protocol,
                           qc_dir=qc_dir,
                           fastq_dir=fastq_dir,
                           organism=project.info.organism,
-                          qc_protocol=protocol,
                           sample_pattern=sample_pattern,
                           multiqc=True)
     # Collect the cellranger data and parameters

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -672,6 +672,7 @@ class AnalysisProjectQCDirInfo(MetadataDict):
     annotation_bed: BED file with gene annotation
     annotation_gtf: GTF file with gene annotation
     protocol_summary: free-text summary of the QC protocol
+    protocol_specification: full QC protocol specification
     """
     def __init__(self,filen=None):
         """Create a new AnalysisProjectQCDirInfo instance
@@ -694,6 +695,7 @@ class AnalysisProjectQCDirInfo(MetadataDict):
                 'annotation_bed': 'BED gene annotation file',
                 'annotation_gtf': 'GTF gene annotation file',
                 'protocol_summary': 'Protocol summary',
+                'protocol_specification': 'Protocol specification',
             },
             order = (
                 'fastq_dir',

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -180,8 +180,8 @@ class QCPipeline(Pipeline):
         self.add_envmodules('cellranger')
         self.add_envmodules('report_qc')
 
-    def add_project(self,project,qc_dir=None,organism=None,fastq_dir=None,
-                    qc_protocol=None,report_html=None,multiqc=False,
+    def add_project(self,project,protocol,qc_dir=None,organism=None,
+                    fastq_dir=None,report_html=None,multiqc=False,
                     sample_pattern=None,log_dir=None,convert_gtf=True):
         """
         Add a project to the QC pipeline
@@ -189,6 +189,7 @@ class QCPipeline(Pipeline):
         Arguments:
           project (AnalysisProject): project to run
             QC for
+          protocol (QCProtocol): QC protocol to use
           qc_dir (str): directory for QC outputs (defaults
             to subdirectory 'qc' of project directory)
           organism (str): organism(s) for project
@@ -196,7 +197,6 @@ class QCPipeline(Pipeline):
             metadata)
           fastq_dir (str): directory holding Fastq files
             (defaults to primary fastq_dir in project)
-          qc_protocol (str): QC protocol to use
           multiqc (bool): if True then also run MultiQC
             (default is not to run MultiQC)
           sample_pattern (str): glob-style pattern to
@@ -215,13 +215,6 @@ class QCPipeline(Pipeline):
         ###################
 
         self.report("Adding project: %s" % project.name)
-
-        # Determine QC protocol (if not set)
-        if qc_protocol is None:
-            qc_protocol = determine_qc_protocol(project)
-
-        # Fetch the QC protocol definition
-        protocol = fetch_protocol_definition(qc_protocol)
 
         # QC modules
         qc_modules = protocol.qc_modules

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -269,7 +269,10 @@ class QCPipeline(Pipeline):
         self.report("-- SC platform: %s" % project.info.single_cell_platform)
         self.report("-- Organism   : %s" % organism)
         self.report("-- Report     : %s" % report_html)
-        self.report("QC modules :")
+        self.report("Reads")
+        self.report("-- Seq data   : %s" % protocol.seq_data_reads)
+        self.report("-- Index      : %s" % protocol.index_reads)
+        self.report("QC modules")
         for qc_module in qc_modules:
             self.report("-- %s" % qc_module)
 

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -43,7 +43,7 @@ The available modifiers are the same as the parameter list for the
 This module also provides the following classes and functions:
 
 - QCProtocol: class representing a QC protocol
-- determine_qc_protocol: get QC protocol for a project
+- determine_qc_protocol: determine built-in protocol for a project
 - fetch_protocol_definition: get the definition for a QC protocol
 - parse_protocol_repr: get a QCProtocol object from a string
 """
@@ -336,7 +336,7 @@ class QCProtocol:
     - description: text description
     - reads: AttributeDictionary with elements 'seq_data',
       'index', and 'qc' (listing sequence data, index reads,
-      and all read for QC, respectively)
+      and all reads for QC, respectively)
     - read_numbers: AttributeDictionary with the same
       elements as 'reads', listing non-index read numbers
     - read_range: AttributeDictionary with normalised read
@@ -354,7 +354,7 @@ class QCProtocol:
 
     READ[:[START]-[END]]
 
-    For example: 'r1:1-50'. These can ben accessed via the
+    For example: 'r1:1-50'. These can be accessed via the
     'read_range' property as e.g. 'read_range.r1' and will
     be returned as either 'None' (if no range was supplied),
     or a tuple '(START,END)' (where either 'START' or 'END'

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -360,6 +360,9 @@ class QCProtocol:
     or a tuple '(START,END)' (where either 'START' or 'END'
     will be 'None' if no limit was supplied).
 
+    The 'seq_data_reads' and 'index_reads' properties
+    store the original read specifications.
+
     QCProtocol instances can also be created directly from
     protocol specification strings using the
     'from_specification' class method. (Specification
@@ -385,10 +388,15 @@ class QCProtocol:
                             else "")
         self.qc_modules = (sorted([m for m in qc_modules])
                            if qc_modules is not None else [])
+        # Store supplied reads
+        self.seq_data_reads = [str(r).lower() for r in seq_data_reads] \
+                              if seq_data_reads else []
+        self.index_reads = [str(r).lower() for r in index_reads] \
+                           if index_reads else []
         # Normalise and store supplied read names
         self.reads = AttributeDictionary(
-            seq_data=self.__reads(seq_data_reads),
-            index=self.__reads(index_reads))
+            seq_data=self.__reads(self.seq_data_reads),
+            index=self.__reads(self.index_reads))
         # Generate and store QC read names
         self.reads['qc'] = self.__reads(self.reads.seq_data +
                                         self.reads.index)

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -669,10 +669,8 @@ def fetch_protocol_definition(p):
         be returned for the requested protocol.
     """
     # Try protocol specification
-    try:
+    if ':' in p:
         return QCProtocol.from_specification(p)
-    except QCProtocolParseSpecError:
-        pass
     # Try looking up a built-in protocol
     if p not in QC_PROTOCOLS:
         raise KeyError("%s: not built-in QC protocol" % p)

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -639,25 +639,37 @@ def determine_qc_protocol(project):
             protocol = "10x_Multiome_GEX"
     return protocol
 
-def fetch_protocol_definition(name):
+def fetch_protocol_definition(p):
     """
     Return the definition for a QC protocol
 
+    Fetches a QCProtocol instance for the supplied
+    protocol, which can either be a protocol
+    definition string or the name of a built-in
+    QC protocol.
+
     Arguments:
-      name (str): name of the QC protocol
+      p (str): name or specification for the QC
+       protocol
 
     Returns:
       QCProtocol: QCProtocol object representing
-        the requested protocol
+        the requested protocol.
 
     Raises:
-      KeyError: when the requested protocol isn't
-        defined.
+      KeyError: when a QCProtocol instance can't
+        be returned for the requested protocol.
     """
-    if name not in QC_PROTOCOLS:
-        raise KeyError("%s: undefined QC protocol" % name)
-    protocol_defn = QC_PROTOCOLS[name]
-    return QCProtocol(name=name,
+    # Try protocol specification
+    try:
+        return QCProtocol.from_specification(p)
+    except QCProtocolParseSpecError:
+        pass
+    # Try looking up a built-in protocol
+    if p not in QC_PROTOCOLS:
+        raise KeyError("%s: not built-in QC protocol" % p)
+    protocol_defn = QC_PROTOCOLS[p]
+    return QCProtocol(name=p,
                       description=protocol_defn['description'],
                       seq_data_reads=protocol_defn['reads']['seq_data'],
                       index_reads=protocol_defn['reads']['index'],

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -693,7 +693,7 @@ def parse_protocol_spec(s):
 
     - name
     - description
-    - seq_data_reads
+    - seq_reads
     - index_reads
     - qc_modules
 
@@ -832,8 +832,6 @@ class QCProtocolParseSpecError(QCProtocolError):
 
     Arguments:
       message (str): error message
-      protocol_spec (str): specification string being
-        parsed
     """
     def __init__(self,message=None):
         if message is None:

--- a/auto_process_ngs/qc/verification.py
+++ b/auto_process_ngs/qc/verification.py
@@ -757,8 +757,8 @@ def verify_project(project,qc_dir=None,qc_protocol=None):
       qc_dir (str): path to the QC output dir; relative
         path will be treated as a subdirectory of the
         project being checked.
-      qc_protocol (str): QC protocol to verify against
-        (optional)
+      qc_protocol (str): QC protocol name or specification
+        to verify against (optional)
 
      Returns:
        Boolean: Returns True if all expected QC products
@@ -783,7 +783,10 @@ def verify_project(project,qc_dir=None,qc_protocol=None):
     if os.path.exists(qc_info_file):
         qc_info = AnalysisProjectQCDirInfo(filen=qc_info_file)
         if not qc_protocol:
-            qc_protocol = qc_info['protocol']
+            if qc_info['protocol_specification']:
+                qc_protocol = qc_info['protocol_specification']
+            else:
+                qc_protocol = qc_info['protocol']
         try:
             organism = qc_info['organism']
         except KeyError:

--- a/auto_process_ngs/qc/verification.py
+++ b/auto_process_ngs/qc/verification.py
@@ -65,7 +65,7 @@ class QCVerifier(QCOutputs):
     def __init__(self,qc_dir,fastq_attrs=None):
         QCOutputs.__init__(self,qc_dir,fastq_attrs=fastq_attrs)
 
-    def verify(self,fastqs,qc_protocol,organism=None,
+    def verify(self,protocol,fastqs,organism=None,
                fastq_screens=None,star_index=None,
                annotation_bed=None,annotation_gtf=None,
                cellranger_version=None,cellranger_refdata=None,
@@ -74,8 +74,8 @@ class QCVerifier(QCOutputs):
         Verify QC outputs for Fastqs against specified protocol
 
         Arguments:
+          protocol (QCProtocol): QC protocol to verify against
           fastqs (list): list of Fastqs to verify outputs for
-          qc_protocol (str): QC protocol to verify against
           organism (str): organism associated with outputs
           fastq_screens (list): list of panel names to verify
             FastqScreen outputs against
@@ -95,9 +95,6 @@ class QCVerifier(QCOutputs):
           Boolean: True if all expected outputs are present,
             False otherwise.
         """
-        # Look up protocol definition
-        protocol = fetch_protocol_definition(qc_protocol)
-
         # Sample names
         samples = set()
         for fq in fastqs:
@@ -161,7 +158,7 @@ class QCVerifier(QCOutputs):
         # Report parameters and status of checks
         print("-"*(10+len(self.qc_dir)))
         print("QC dir  : %s" % self.qc_dir)
-        print("Protocol: %s" % qc_protocol)
+        print("Protocol: %s" % protocol.name)
         print("-"*(10+len(self.qc_dir)))
         # Report parameters
         print("Parameters:")
@@ -822,10 +819,11 @@ def verify_project(project,qc_dir=None,qc_protocol=None):
     logger.debug("verify: cellranger reference data : %s" %
                  cellranger_refdata)
     logger.debug("verify: fastq screens : %s" % (fastq_screens,))
+    protocol = fetch_protocol_definition(qc_protocol)
     verifier = QCVerifier(qc_dir,
                           fastq_attrs=project.fastq_attrs)
-    return verifier.verify(project.fastqs,
-                           qc_protocol,
+    return verifier.verify(protocol,
+                           project.fastqs,
                            organism=organism,
                            fastq_screens=fastq_screens,
                            star_index=star_index,

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -24,6 +24,7 @@ from auto_process_ngs.mock import MockAnalysisProject
 from auto_process_ngs.mock import UpdateAnalysisProject
 from auto_process_ngs.analysis import AnalysisProject
 from auto_process_ngs.qc.pipeline import QCPipeline
+from auto_process_ngs.qc.protocols import fetch_protocol_definition
 
 # Set to False to keep test output dirs
 REMOVE_TEST_OUTPUTS = True
@@ -110,8 +111,8 @@ class TestQCPipeline(unittest.TestCase):
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -128,6 +129,8 @@ class TestQCPipeline(unittest.TestCase):
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -187,8 +190,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           multiqc=True)
         status = runqc.run(star_indexes=
                            { 'human': '/data/hg38/star_index' },
@@ -204,6 +207,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -248,8 +253,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            annotation_bed_files=
@@ -264,6 +269,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -318,8 +325,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -334,6 +341,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -388,8 +397,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -404,6 +413,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -459,8 +470,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -477,6 +488,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -523,8 +536,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           multiqc=False)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -541,6 +554,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -590,8 +605,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -608,6 +623,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -653,8 +670,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -672,6 +689,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -723,8 +742,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -741,6 +760,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -787,8 +808,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -805,6 +826,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -854,8 +877,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           fastq_dir="fastqs.cells",
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
@@ -873,6 +896,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs.cells"))
@@ -917,8 +942,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           qc_dir="qc.non_default",
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
@@ -936,6 +961,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc.non_default","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -986,8 +1013,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardSE"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -1004,6 +1031,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardSE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardSE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -1057,8 +1086,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         # Set up and run the QC
         runqc = QCPipeline()
         for p in ("AB","CD"):
-            runqc.add_project(AnalysisProject(p,
-                                              os.path.join(self.wd,p)),
+            runqc.add_project(AnalysisProject(os.path.join(self.wd,p)),
+                              fetch_protocol_definition("standardPE"),
                               multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -1078,6 +1107,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"AB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"AB","fastqs"))
@@ -1093,6 +1124,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"CD","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Mouse")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"CD","fastqs"))
@@ -1141,8 +1174,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -1159,6 +1192,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -1205,8 +1240,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -1224,6 +1259,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -1272,8 +1309,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -1291,6 +1328,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -1340,8 +1379,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
                          "Log dir '%s' already exists" % log_dir)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           multiqc=True,
                           log_dir=log_dir)
         status = runqc.run(fastq_screens=self.fastq_screens,
@@ -1359,6 +1398,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -1417,8 +1458,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_scRNAseq"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -1437,6 +1478,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_scRNAseq")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_scRNAseq")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -1504,8 +1547,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_scRNAseq"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -1524,6 +1567,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_scRNAseq")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_scRNAseq")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -1591,8 +1636,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_scRNAseq"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -1611,6 +1656,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_scRNAseq")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_scRNAseq")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -1678,8 +1725,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_scRNAseq"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -1698,6 +1745,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_scRNAseq")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_scRNAseq")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -1770,6 +1819,7 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject("PJB",
                                           os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_scRNAseq"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -1790,6 +1840,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_scRNAseq")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_scRNAseq")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -1856,8 +1908,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_scRNAseq"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -1877,6 +1929,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_scRNAseq")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_scRNAseq")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -1944,8 +1998,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_snRNAseq"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -1964,6 +2018,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_snRNAseq")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_snRNAseq")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -2041,8 +2097,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p2.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_scRNAseq"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -2064,6 +2120,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_scRNAseq")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_scRNAseq")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -2144,8 +2202,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_snRNAseq"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -2164,6 +2222,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_snRNAseq")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_snRNAseq")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -2231,8 +2291,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_snRNAseq"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -2251,6 +2311,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_snRNAseq")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_snRNAseq")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -2318,8 +2380,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_snRNAseq"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -2338,6 +2400,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_snRNAseq")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_snRNAseq")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -2406,8 +2470,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_scATAC"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -2427,6 +2491,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_scATAC")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_scATAC")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -2495,8 +2561,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_scATAC"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -2516,6 +2582,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_scATAC")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_scATAC")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -2584,8 +2652,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_scATAC"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -2606,6 +2674,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_scATAC")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_scATAC")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -2678,6 +2748,7 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         # Set up and run the QC
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB_ATAC")),
+                          fetch_protocol_definition("10x_Multiome_ATAC"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -2700,6 +2771,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB_ATAC","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_Multiome_ATAC")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_Multiome_ATAC")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB_ATAC","fastqs"))
@@ -2771,6 +2844,7 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         # Set up and run the QC
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB_GEX")),
+                          fetch_protocol_definition("10x_Multiome_GEX"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -2792,6 +2866,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB_GEX","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_Multiome_GEX")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_Multiome_GEX")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB_GEX","fastqs"))
@@ -2892,6 +2968,7 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         # Set up and run the QC
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB_ATAC")),
+                          fetch_protocol_definition("10x_Multiome_ATAC"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -2914,6 +2991,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB_ATAC","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_Multiome_ATAC")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_Multiome_ATAC")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB_ATAC","fastqs"))
@@ -3027,6 +3106,7 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         # Set up and run the QC
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB_ATAC")),
+                          fetch_protocol_definition("10x_Multiome_ATAC"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -3049,6 +3129,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB_ATAC","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_Multiome_ATAC")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_Multiome_ATAC")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB_ATAC","fastqs"))
@@ -3162,6 +3244,7 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         # Set up and run the QC
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB_GEX")),
+                          fetch_protocol_definition("10x_Multiome_GEX"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -3183,6 +3266,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB_GEX","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_Multiome_GEX")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_Multiome_GEX")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB_GEX","fastqs"))
@@ -3296,6 +3381,7 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         # Set up and run the QC
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB_GEX")),
+                          fetch_protocol_definition("10x_Multiome_GEX"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -3317,6 +3403,8 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB_GEX","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_Multiome_GEX")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_Multiome_GEX")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB_GEX","fastqs"))
@@ -3418,6 +3506,7 @@ PBB,CMO302,PBB
         # Set up and run the QC
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_CellPlex"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -3437,6 +3526,8 @@ PBB,CMO302,PBB
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_CellPlex")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_CellPlex")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -3525,6 +3616,7 @@ PBB,CMO302,PBB
         # Set up and run the QC
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_CellPlex"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -3544,6 +3636,8 @@ PBB,CMO302,PBB
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_CellPlex")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_CellPlex")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -3624,6 +3718,7 @@ PB2,BC002,PB2
         # Set up and run the QC
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_Flex"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -3640,6 +3735,8 @@ PB2,BC002,PB2
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_Flex")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_Flex")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -3714,6 +3811,7 @@ PB2,BC002,PB2
         # Set up and run the QC
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_Flex"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -3730,6 +3828,8 @@ PB2,BC002,PB2
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_Flex")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_Flex")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -3785,8 +3885,8 @@ PB2,BC002,PB2
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_Visium"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -3805,6 +3905,8 @@ PB2,BC002,PB2
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_Visium")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_Visium")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -3855,8 +3957,8 @@ PB2,BC002,PB2
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_Visium_FFPE"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -3875,6 +3977,8 @@ PB2,BC002,PB2
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_Visium_FFPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_Visium_FFPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -3924,8 +4028,8 @@ PB2,BC002,PB2
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("ParseEvercode"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -3942,6 +4046,8 @@ PB2,BC002,PB2
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"ParseEvercode")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("ParseEvercode")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -3992,10 +4098,9 @@ PB2,BC002,PB2
         os.remove(os.path.join(self.wd,"PJB","README.info"))
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_scRNAseq"),
                           multiqc=True,
-                          qc_protocol="10x_scRNAseq",
                           organism="human")
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -4014,6 +4119,8 @@ PB2,BC002,PB2
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_scRNAseq")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_scRNAseq")))
         self.assertEqual(qc_info.organism,"human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -4080,8 +4187,8 @@ PB2,BC002,PB2
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_scRNAseq"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -4098,6 +4205,8 @@ PB2,BC002,PB2
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"10x_scRNAseq")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_scRNAseq")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
@@ -4151,9 +4260,8 @@ PB2,BC002,PB2
                 include_multiqc=True)
         # Set up and run the QC
         runqc = QCPipeline()
-        runqc.add_project(AnalysisProject("PJB",
-                                          os.path.join(self.wd,"PJB")),
-                          qc_protocol="standardPE",
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -4170,6 +4278,8 @@ PB2,BC002,PB2
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
         self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -12,6 +12,7 @@ from auto_process_ngs.qc.protocols import QCProtocol
 from auto_process_ngs.qc.protocols import determine_qc_protocol
 from auto_process_ngs.qc.protocols import fetch_protocol_definition
 from auto_process_ngs.qc.protocols import parse_protocol_spec
+from auto_process_ngs.qc.protocols import QCProtocolParseSpecError
 
 # Set to False to keep test output dirs
 REMOVE_TEST_OUTPUTS = True
@@ -834,3 +835,101 @@ class TestParseProtocolSpec(unittest.TestCase):
         self.assertEqual(p.seq_data_reads,['r1','r2'])
         self.assertEqual(p.index_reads,[])
         self.assertEqual(p.qc_modules,[])
+
+    def test_parse_protocol_spec_incomplete_specification(self):
+        """
+        parse_protocol_spec: raises exception for incomplete specification
+        """
+        self.assertRaises(QCProtocolParseSpecError,
+                          parse_protocol_spec,
+                          "test")
+        self.assertRaises(QCProtocolParseSpecError,
+                          parse_protocol_spec,
+                          "test:description")
+
+    def test_parse_protocol_spec_bad_description(self):
+        """
+        parse_protocol_spec: raises exception for incorrect description
+        """
+        self.assertRaises(QCProtocolParseSpecError,
+                          parse_protocol_spec,
+                          "test:'Continues'after quotes:"
+                          "seq_reads=[r1,r2]:"
+                          "index_reads=[]:"
+                          "qc_modules=[]")
+        self.assertRaises(QCProtocolParseSpecError,
+                          parse_protocol_spec,
+                          "test:'Mismatched quotes\":"
+                          "seq_reads=[r1,r2]:"
+                          "index_reads=[]:"
+                          "qc_modules=[]")
+
+    def test_parse_protocol_spec_bad_seq_data_reads(self):
+        """
+        parse_protocol_spec: raises exception for incorrect seq data reads
+        """
+        self.assertRaises(QCProtocolParseSpecError,
+                          parse_protocol_spec,
+                          "test:Reads beyond closing brace:"
+                          "seq_reads=[r1,r2],r3:"
+                          "index_reads=[]:"
+                          "qc_modules=[]")
+        self.assertRaises(QCProtocolParseSpecError,
+                          parse_protocol_spec,
+                          "test:Closing brace missing:"
+                          "seq_reads=[r1,r2:"
+                          "index_reads=[]:"
+                          "qc_modules=[]")
+        self.assertRaises(QCProtocolParseSpecError,
+                          parse_protocol_spec,
+                          "test:Opening brace missing:"
+                          "seq_reads=r1,r2]:"
+                          "index_reads=[]:"
+                          "qc_modules=[]")
+        self.assertRaises(QCProtocolParseSpecError,
+                          parse_protocol_spec,
+                          "test:No braces:"
+                          "seq_reads=r1,r2:"
+                          "index_reads=[]:"
+                          "qc_modules=[]")
+
+    def test_parse_protocol_spec_bad_index_reads(self):
+        """
+        parse_protocol_spec: raises exception for incorrect index reads
+        """
+        self.assertRaises(QCProtocolParseSpecError,
+                          parse_protocol_spec,
+                          "test:Reads beyond closing brace:"
+                          "seq_reads=[]:"
+                          "index_reads=[r1,r2],r3:"
+                          "qc_modules=[]")
+        self.assertRaises(QCProtocolParseSpecError,
+                          parse_protocol_spec,
+                          "test:Closing brace missing:"
+                          "seq_reads=[]:"
+                          "index_reads=[r1,r2:"
+                          "qc_modules=[]")
+        self.assertRaises(QCProtocolParseSpecError,
+                          parse_protocol_spec,
+                          "test:Opening brace missing:"
+                          "seq_reads=[]:"
+                          "index_reads=r1,r2]:"
+                          "qc_modules=[]")
+        self.assertRaises(QCProtocolParseSpecError,
+                          parse_protocol_spec,
+                          "test:No braces:"
+                          "seq_reads=[]:"
+                          "index_reads=r1,r2:"
+                          "qc_modules=[]")
+
+    def test_parse_protocol_spec_unrecognised_component(self):
+        """
+        parse_protocol_spec: raises exception for unrecognised component
+        """
+        self.assertRaises(QCProtocolParseSpecError,
+                          parse_protocol_spec,
+                          "test:Unrecognised component:" \
+                          "seq_reads=[r1,r2]:" \
+                          "index_reads=[]:" \
+                          "magic_spell=True:" \
+                          "qc_modules=[fastqc]")

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -672,9 +672,28 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
 
 class TestFetchProtocolDefinition(unittest.TestCase):
 
-    def test_fetch_protocol_definition(self):
+    def test_fetch_protocol_definition_from_specification(self):
         """
-        fetch_protocol_definition: check definition is returned
+        fetch_protocol_definition: get definition from specification
+        """
+        p = fetch_protocol_definition("custom:Custom protocol:"
+                                      "seq_reads=[r1,r2]:"
+                                      "index_reads=[]:"
+                                      "qc_modules=[fastqc,"
+                                      "fastq_screen]")
+        self.assertEqual(p.name,"custom")
+        self.assertEqual(p.reads.seq_data,('r1','r2'))
+        self.assertEqual(p.reads.index,())
+        self.assertEqual(p.reads.qc,('r1','r2'))
+        self.assertEqual(p.read_numbers.seq_data,(1,2))
+        self.assertEqual(p.read_numbers.index,())
+        self.assertEqual(p.read_numbers.qc,(1,2))
+        self.assertEqual(p.qc_modules,['fastq_screen',
+                                       'fastqc'])
+
+    def test_fetch_protocol_definition_from_name(self):
+        """
+        fetch_protocol_definition: get built-in definition from name
         """
         p = fetch_protocol_definition("standardPE")
         self.assertEqual(p.name,"standardPE")
@@ -692,9 +711,9 @@ class TestFetchProtocolDefinition(unittest.TestCase):
                                        'sequence_lengths',
                                        'strandedness'])
 
-    def test_fetch_protocol_definition_unknown_protocol(self):
+    def test_fetch_protocol_definition_unknown_protocol_name(self):
         """
-        fetch_protocol_definition: raises KeyError for unknown protocol
+        fetch_protocol_definition: raises KeyError for unknown protocol name
         """
         self.assertRaises(KeyError,
                           fetch_protocol_definition,

--- a/auto_process_ngs/test/qc/test_verification.py
+++ b/auto_process_ngs/test/qc/test_verification.py
@@ -10,6 +10,7 @@ from auto_process_ngs.analysis import AnalysisProject
 from auto_process_ngs.mock import make_mock_analysis_project
 from auto_process_ngs.mockqc import make_mock_qc_dir
 from auto_process_ngs.metadata import AnalysisProjectQCDirInfo
+from auto_process_ngs.qc.protocols import fetch_protocol_definition
 from auto_process_ngs.qc.verification import QCVerifier
 from auto_process_ngs.qc.verification import parse_qc_module_spec
 from auto_process_ngs.qc.verification import filter_fastqs
@@ -783,11 +784,12 @@ class TestQCVerifier(unittest.TestCase):
                                    protocol="standardSE",
                                    fastq_names=fastq_names)
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify(fastqs=fastq_names,
-                                           qc_protocol="standardSE",
-                                           fastq_screens=('model_organisms',
-                                                          'other_organisms',
-                                                          'rRNA')))
+        self.assertTrue(qc_verifier.verify(
+            fetch_protocol_definition("standardSE"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA')))
 
     def test_qcverifier_verify_single_end_no_fastqc(self):
         """
@@ -801,11 +803,12 @@ class TestQCVerifier(unittest.TestCase):
                                    fastq_names=fastq_names,
                                    include_fastqc=False)
         qc_verifier = QCVerifier(qc_dir)
-        self.assertFalse(qc_verifier.verify(fastqs=fastq_names,
-                                            qc_protocol="standardSE",
-                                            fastq_screens=('model_organisms',
-                                                           'other_organisms',
-                                                           'rRNA')))
+        self.assertFalse(qc_verifier.verify(
+            fetch_protocol_definition("standardSE"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA')))
 
     def test_qcverifier_verify_single_end_no_screens(self):
         """
@@ -819,11 +822,12 @@ class TestQCVerifier(unittest.TestCase):
                                    fastq_names=fastq_names,
                                    include_fastq_screen=False)
         qc_verifier = QCVerifier(qc_dir)
-        self.assertFalse(qc_verifier.verify(fastqs=fastq_names,
-                                            qc_protocol="standardSE",
-                                            fastq_screens=('model_organisms',
-                                                           'other_organisms',
-                                                           'rRNA')))
+        self.assertFalse(qc_verifier.verify(
+            fetch_protocol_definition("standardSE"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA')))
 
     def test_qcverifier_verify_single_end_no_seqlens(self):
         """
@@ -837,11 +841,12 @@ class TestQCVerifier(unittest.TestCase):
                                    fastq_names=fastq_names,
                                    include_seqlens=False)
         qc_verifier = QCVerifier(qc_dir)
-        self.assertFalse(qc_verifier.verify(fastqs=fastq_names,
-                                            qc_protocol="standardSE",
-                                            fastq_screens=('model_organisms',
-                                                           'other_organisms',
-                                                           'rRNA')))
+        self.assertFalse(qc_verifier.verify(
+            fetch_protocol_definition("standardSE"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA')))
 
     def test_qcverifier_verify_single_end_no_standedness(self):
         """
@@ -857,11 +862,12 @@ class TestQCVerifier(unittest.TestCase):
         with open(os.path.join(qc_dir,"fastq_strand.conf"),'wt') as fp:
             fp.write("fastq_strand.conf\n")
         qc_verifier = QCVerifier(qc_dir)
-        self.assertFalse(qc_verifier.verify(fastqs=fastq_names,
-                                            qc_protocol="standardSE",
-                                            fastq_screens=('model_organisms',
-                                                           'other_organisms',
-                                                           'rRNA')))
+        self.assertFalse(qc_verifier.verify(
+            fetch_protocol_definition("standardSE"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA')))
 
     def test_qcverifier_verify_single_end_legacy_screen_naming(self):
         """
@@ -875,11 +881,12 @@ class TestQCVerifier(unittest.TestCase):
                                    fastq_names=fastq_names,
                                    legacy_screens=True)
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify(fastqs=fastq_names,
-                                           qc_protocol="standardSE",
-                                           fastq_screens=('model_organisms',
-                                                          'other_organisms',
-                                                          'rRNA')))
+        self.assertTrue(qc_verifier.verify(
+            fetch_protocol_definition("standardSE"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA')))
 
     def test_qcverifier_verify_paired_end(self):
         """
@@ -894,11 +901,12 @@ class TestQCVerifier(unittest.TestCase):
                                    protocol="standardPE",
                                    fastq_names=fastq_names)
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify(fastqs=fastq_names,
-                                           qc_protocol="standardPE",
-                                           fastq_screens=('model_organisms',
-                                                          'other_organisms',
-                                                          'rRNA')))
+        self.assertTrue(qc_verifier.verify(
+            fetch_protocol_definition("standardPE"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA')))
 
     def test_qcverifier_verify_paired_end_no_fastqc(self):
         """
@@ -914,11 +922,12 @@ class TestQCVerifier(unittest.TestCase):
                                    fastq_names=fastq_names,
                                    include_fastqc=False)
         qc_verifier = QCVerifier(qc_dir)
-        self.assertFalse(qc_verifier.verify(fastqs=fastq_names,
-                                            qc_protocol="standardPE",
-                                            fastq_screens=('model_organisms',
-                                                           'other_organisms',
-                                                           'rRNA')))
+        self.assertFalse(qc_verifier.verify(
+            fetch_protocol_definition("standardPE"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA')))
 
     def test_qcverifier_verify_paired_end_no_screens(self):
         """
@@ -934,11 +943,12 @@ class TestQCVerifier(unittest.TestCase):
                                    fastq_names=fastq_names,
                                    include_fastq_screen=False)
         qc_verifier = QCVerifier(qc_dir)
-        self.assertFalse(qc_verifier.verify(fastqs=fastq_names,
-                                            qc_protocol="standardPE",
-                                            fastq_screens=('model_organisms',
-                                                           'other_organisms',
-                                                           'rRNA')))
+        self.assertFalse(qc_verifier.verify(
+            fetch_protocol_definition("standardPE"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA')))
 
     def test_qcverifier_verify_paired_end_no_seqlens(self):
         """
@@ -954,11 +964,12 @@ class TestQCVerifier(unittest.TestCase):
                                    fastq_names=fastq_names,
                                    include_seqlens=False)
         qc_verifier = QCVerifier(qc_dir)
-        self.assertFalse(qc_verifier.verify(fastqs=fastq_names,
-                                            qc_protocol="standardPE",
-                                            fastq_screens=('model_organisms',
-                                                           'other_organisms',
-                                                           'rRNA')))
+        self.assertFalse(qc_verifier.verify(
+            fetch_protocol_definition("standardPE"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA')))
 
     def test_qcverifier_verify_paired_end_no_strandedness(self):
         """
@@ -974,11 +985,12 @@ class TestQCVerifier(unittest.TestCase):
                                    fastq_names=fastq_names,
                                    include_strandedness=False)
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify(fastqs=fastq_names,
-                                           qc_protocol="standardPE",
-                                           fastq_screens=('model_organisms',
-                                                          'other_organisms',
-                                                          'rRNA')))
+        self.assertTrue(qc_verifier.verify(
+            fetch_protocol_definition("standardPE"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA')))
 
     def test_qcverifier_verify_paired_end_legacy_screen_naming(self):
         """
@@ -994,11 +1006,12 @@ class TestQCVerifier(unittest.TestCase):
                                    fastq_names=fastq_names,
                                    legacy_screens=True)
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify(fastqs=fastq_names,
-                                           qc_protocol="standardPE",
-                                           fastq_screens=('model_organisms',
-                                                          'other_organisms',
-                                                          'rRNA')))
+        self.assertTrue(qc_verifier.verify(
+            fetch_protocol_definition("standardPE"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA')))
 
     def test_qcverifier_verify_paired_end_non_canonical_fastq_names(self):
         """
@@ -1013,11 +1026,12 @@ class TestQCVerifier(unittest.TestCase):
                                    protocol="standardPE",
                                    fastq_names=fastq_names)
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify(fastqs=fastq_names,
-                                           qc_protocol="standardPE",
-                                           fastq_screens=('model_organisms',
-                                                          'other_organisms',
-                                                          'rRNA')))
+        self.assertTrue(qc_verifier.verify(
+            fetch_protocol_definition("standardPE"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA')))
 
     def test_qcverifier_verify_10x_cellranger_count(self):
         """
@@ -1038,14 +1052,14 @@ class TestQCVerifier(unittest.TestCase):
                                        'PJB2',
                                    ))
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify(fastqs=fastq_names,
-                                           qc_protocol="10x_scRNAseq",
-                                           fastq_screens=('model_organisms',
-                                                          'other_organisms',
-                                                          'rRNA'),
-                                           cellranger_version="6.1.2",
-                                           cellranger_refdata=\
-                                           "/data/refdata-cellranger-2020-A"))
+        self.assertTrue(qc_verifier.verify(
+            fetch_protocol_definition("10x_scRNAseq"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA'),
+            cellranger_version="6.1.2",
+            cellranger_refdata="/data/refdata-cellranger-2020-A"))
 
     def test_qcverifier_verify_10x_cellranger_count_different_version(self):
         """
@@ -1066,14 +1080,14 @@ class TestQCVerifier(unittest.TestCase):
                                        'PJB2',
                                    ))
         qc_verifier = QCVerifier(qc_dir)
-        self.assertFalse(qc_verifier.verify(fastqs=fastq_names,
-                                            qc_protocol="10x_scRNAseq",
-                                            fastq_screens=('model_organisms',
-                                                           'other_organisms',
-                                                           'rRNA'),
-                                            cellranger_version="5.0.0",
-                                            cellranger_refdata=\
-                                            "/data/refdata-cellranger-2020-A"))
+        self.assertFalse(qc_verifier.verify(
+            fetch_protocol_definition("10x_scRNAseq"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA'),
+            cellranger_version="5.0.0",
+            cellranger_refdata="/data/refdata-cellranger-2020-A"))
 
     def test_qcverifier_verify_10x_cellranger_count_legacy(self):
         """
@@ -1095,13 +1109,14 @@ class TestQCVerifier(unittest.TestCase):
                                    ),
                                    legacy_cellranger_outs=True)
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify(fastqs=fastq_names,
-                                           qc_protocol="10x_scRNAseq",
-                                           fastq_screens=('model_organisms',
-                                                          'other_organisms',
-                                                          'rRNA'),
-                                           cellranger_version=None,
-                                           cellranger_refdata=None))
+        self.assertTrue(qc_verifier.verify(
+            fetch_protocol_definition("10x_scRNAseq"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA'),
+            cellranger_version=None,
+            cellranger_refdata=None))
 
     def test_qcverifier_10x_cellranger_atac_count(self):
         """
@@ -1124,14 +1139,14 @@ class TestQCVerifier(unittest.TestCase):
                                        'PJB2',
                                    ))
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify(fastqs=fastq_names,
-                                           qc_protocol="10x_scATAC",
-                                           fastq_screens=('model_organisms',
-                                                          'other_organisms',
-                                                          'rRNA'),
-                                           cellranger_version="2.0.0",
-                                           cellranger_refdata=\
-                                           "/data/refdata-cellranger-atac-2020-A"))
+        self.assertTrue(qc_verifier.verify(
+            fetch_protocol_definition("10x_scATAC"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA'),
+            cellranger_version="2.0.0",
+            cellranger_refdata="/data/refdata-cellranger-atac-2020-A"))
 
     def test_verify_qcverifier_10x_multiome_gex(self):
         """
@@ -1155,14 +1170,14 @@ class TestQCVerifier(unittest.TestCase):
                                        'PJB2',
                                    ))
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify(fastqs=fastq_names,
-                                           qc_protocol="10x_Multiome_GEX",
-                                           fastq_screens=('model_organisms',
-                                                          'other_organisms',
-                                                          'rRNA'),
-                                           cellranger_version="2.0.0",
-                                           cellranger_refdata=\
-                                           "refdata-cellranger-arc-2020-A"))
+        self.assertTrue(qc_verifier.verify(
+            fetch_protocol_definition("10x_Multiome_GEX"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA'),
+            cellranger_version="2.0.0",
+            cellranger_refdata="refdata-cellranger-arc-2020-A"))
 
     def test_verify_qcverifier_10x_multiome_gex_no_paired_samples(self):
         """
@@ -1185,14 +1200,14 @@ class TestQCVerifier(unittest.TestCase):
                                        'PJB2',
                                    ))
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify(fastqs=fastq_names,
-                                           qc_protocol="10x_Multiome_GEX",
-                                           fastq_screens=('model_organisms',
-                                                          'other_organisms',
-                                                          'rRNA'),
-                                           cellranger_version="2.0.0",
-                                           cellranger_refdata=\
-                                           "refdata-cellranger-arc-2020-A"))
+        self.assertTrue(qc_verifier.verify(
+            fetch_protocol_definition("10x_Multiome_GEX"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA'),
+            cellranger_version="2.0.0",
+            cellranger_refdata="refdata-cellranger-arc-2020-A"))
 
     def test_verify_qcverifier_10x_multiome_gex_missing_paired_samples(self):
         """
@@ -1218,14 +1233,14 @@ class TestQCVerifier(unittest.TestCase):
             with open(os.path.join(qc_dir,"libraries.%s.csv" % s),'wt') as fp:
                 fp.write("Placeholder\n")
         qc_verifier = QCVerifier(qc_dir)
-        self.assertFalse(qc_verifier.verify(fastqs=fastq_names,
-                                            qc_protocol="10x_Multiome_GEX",
-                                            fastq_screens=('model_organisms',
-                                                           'other_organisms',
-                                                           'rRNA'),
-                                            cellranger_version="2.0.0",
-                                            cellranger_refdata=\
-                                            "refdata-cellranger-arc-2020-A"))
+        self.assertFalse(qc_verifier.verify(
+            fetch_protocol_definition("10x_Multiome_GEX"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA'),
+            cellranger_version="2.0.0",
+            cellranger_refdata="refdata-cellranger-arc-2020-A"))
 
     def test_qcverifier_10x_multiome_atac(self):
         """
@@ -1249,14 +1264,14 @@ class TestQCVerifier(unittest.TestCase):
                                        'PJB2',
                                    ))
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify(fastqs=fastq_names,
-                                           qc_protocol="10x_Multiome_ATAC",
-                                           fastq_screens=('model_organisms',
-                                                          'other_organisms',
-                                                          'rRNA'),
-                                           cellranger_version="2.0.0",
-                                           cellranger_refdata=\
-                                           "refdata-cellranger-arc-2020-A"))
+        self.assertTrue(qc_verifier.verify(
+            fetch_protocol_definition("10x_Multiome_ATAC"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA'),
+            cellranger_version="2.0.0",
+            cellranger_refdata="refdata-cellranger-arc-2020-A"))
 
     def test_qcverifier_10x_multiome_atac_no_paired_samples(self):
         """
@@ -1279,14 +1294,14 @@ class TestQCVerifier(unittest.TestCase):
                                        'PJB2',
                                    ))
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify(fastqs=fastq_names,
-                                           qc_protocol="10x_Multiome_ATAC",
-                                           fastq_screens=('model_organisms',
-                                                          'other_organisms',
-                                                          'rRNA'),
-                                           cellranger_version="2.0.0",
-                                           cellranger_refdata=\
-                                           "refdata-cellranger-arc-2020-A"))
+        self.assertTrue(qc_verifier.verify(
+            fetch_protocol_definition("10x_Multiome_ATAC"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA'),
+            cellranger_version="2.0.0",
+            cellranger_refdata="refdata-cellranger-arc-2020-A"))
 
     def test_qcverifier_10x_multiome_atac_missing_paired_samples(self):
         """
@@ -1312,14 +1327,14 @@ class TestQCVerifier(unittest.TestCase):
             with open(os.path.join(qc_dir,"libraries.%s.csv" % s),'wt') as fp:
                 fp.write("Placeholder\n")
         qc_verifier = QCVerifier(qc_dir)
-        self.assertFalse(qc_verifier.verify(fastqs=fastq_names,
-                                            qc_protocol="10x_Multiome_ATAC",
-                                            fastq_screens=('model_organisms',
-                                                           'other_organisms',
-                                                           'rRNA'),
-                                            cellranger_version="2.0.0",
-                                            cellranger_refdata=\
-                                            "refdata-cellranger-arc-2020-A"))
+        self.assertFalse(qc_verifier.verify(
+            fetch_protocol_definition("10x_Multiome_ATAC"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA'),
+            cellranger_version="2.0.0",
+            cellranger_refdata="refdata-cellranger-arc-2020-A"))
 
     def test_qcverifier_verify_10x_visium(self):
         """
@@ -1334,11 +1349,12 @@ class TestQCVerifier(unittest.TestCase):
                                    protocol="10x_Visium",
                                    fastq_names=fastq_names)
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify(fastqs=fastq_names,
-                                           qc_protocol="10x_Visium",
-                                           fastq_screens=('model_organisms',
-                                                          'other_organisms',
-                                                          'rRNA')))
+        self.assertTrue(qc_verifier.verify(
+            fetch_protocol_definition("10x_Visium"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA')))
 
     def test_qcverifier_verify_10x_cellranger_multi(self):
         """
@@ -1369,8 +1385,8 @@ class TestQCVerifier(unittest.TestCase):
         verify_params = dict()
         qc_verifier = QCVerifier(qc_dir)
         self.assertTrue(qc_verifier.verify(
-            fastqs=fastq_names,
-            qc_protocol="10x_CellPlex",
+            fetch_protocol_definition("10x_CellPlex"),
+            fastq_names,
             organism="Human",
             fastq_screens=('model_organisms',
                            'other_organisms',
@@ -1379,8 +1395,7 @@ class TestQCVerifier(unittest.TestCase):
             annotation_bed="/data/annotation/hg38.bed",
             annotation_gtf="/data/annotation/hg38.gtf",
             cellranger_version="6.1.2",
-            cellranger_refdata=\
-            "/data/refdata-cellranger-2020-A"))
+            cellranger_refdata="/data/refdata-cellranger-2020-A"))
 
     def test_qcverifier_verify_10x_cellranger_multi_no_config(self):
         """
@@ -1397,14 +1412,14 @@ class TestQCVerifier(unittest.TestCase):
                                    include_cellranger_count=False,
                                    include_cellranger_multi=False)
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify(fastqs=fastq_names,
-                                           qc_protocol="10x_CellPlex",
-                                           fastq_screens=('model_organisms',
-                                                          'other_organisms',
-                                                          'rRNA'),
-                                           cellranger_version="6.1.2",
-                                           cellranger_refdata=\
-                                           "/data/refdata-cellranger-2020-A"))
+        self.assertTrue(qc_verifier.verify(
+            fetch_protocol_definition("10x_CellPlex"),
+            fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA'),
+            cellranger_version="6.1.2",
+            cellranger_refdata="/data/refdata-cellranger-2020-A"))
 
 class TestParseQCModuleSpec(unittest.TestCase):
 


### PR DESCRIPTION
Refactors the handling of QC protocols within the QC pipeline code so that the core pipelines take `QCProtocol` instances as input, leaving the calling subprograms to deal with protocol determination.

The principal changes are:

* `QCPipeline.add_project` now explicitly requires a `QCProtocol` instance as mandatory input
* The QC run metadata stored in `qc.info` files and handled by the `AnalysisProjectQCDirInfo` class now includes a `protocol_specification` field, which the pipeline uses to store the QC protocol specification string; this specification is used to pass protocol information to verification and reporting
* The `run_qc` command and `run_qc.py` utility now perform QC protocol determination and generate `QCProtocol` instances that they pass into the pipeline setup 