### PR TITLE
Update the 10x_multi_config.csv template from 'setup_analysis_dirs'

### DIFF
--- a/auto_process_ngs/tenx/cellplex.py
+++ b/auto_process_ngs/tenx/cellplex.py
@@ -37,6 +37,7 @@ class CellrangerMultiConfigCsv:
     - sample_names: list of multiplexed sample names
     - reference_data_path: path to the reference dataset
     - probe_set_path: path to the probe set
+    - feature_reference_path: path to the feature reference
     - gex_libraries: list of Fastq IDs associated
       with GEX data
 
@@ -63,6 +64,7 @@ class CellrangerMultiConfigCsv:
         self._samples = {}
         self._reference_data_path = None
         self._probe_set_path = None
+        self._feature_reference_path = None
         self._gex_libraries = {}
         self._fastq_dirs = {}
         self._read_config_csv()
@@ -81,6 +83,9 @@ class CellrangerMultiConfigCsv:
                     continue
                 elif line == "[gene-expression]":
                     current_section = "gene-expression"
+                    continue
+                elif line == "[feature]":
+                    current_section = "feature"
                     continue
                 elif line == "[libraries]":
                     current_section = "libraries"
@@ -118,6 +123,11 @@ class CellrangerMultiConfigCsv:
                     elif line.startswith('probe-set,'):
                         # Extract probe set
                         self._probe_set_path = ','.join(
+                            line.split(',')[1:]).strip()
+                elif current_section == "feature":
+                    if line.startswith('reference,'):
+                        # Extract feature reference file
+                        self._feature_reference_path = ','.join(
                             line.split(',')[1:]).strip()
                 elif current_section == "libraries":
                     if line.startswith('fastq_id,fastqs,'):
@@ -174,6 +184,13 @@ class CellrangerMultiConfigCsv:
         Return the path to the probe set file from config.csv
         """
         return self._probe_set_path
+
+    @property
+    def feature_reference_path(self):
+        """
+        Return the path to the feature reference file from config.csv
+        """
+        return self._feature_reference_path
 
     @property
     def gex_libraries(self):

--- a/auto_process_ngs/tenx/utils.py
+++ b/auto_process_ngs/tenx/utils.py
@@ -586,10 +586,15 @@ def make_multi_config_template(f,reference=None,probe_set=None,
         fp.write("[libraries]\n"
                  "fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate\n")
         if samples:
+            if library_type == "CellPlex":
+                tenx_library_type = "[Gene Expression|Multiplexing Capture|Antibody Capture]"
+            elif library_type == "Flex":
+                tenx_library_type = "[Gene Expression|Antibody Capture]"
             for sample in samples:
-                fp.write("{sample},{fastqs_dir},any,{sample},[Gene Expression|Multiplexing Capture],\n".format(
+                fp.write("{sample},{fastqs_dir},any,{sample},{tenx_library_type},\n".format(
                     sample=sample,
-                    fastqs_dir=(fastq_dir if fastq_dir else "/path/to/fastqs")))
+                    fastqs_dir=(fastq_dir if fastq_dir else "/path/to/fastqs"),
+                    tenx_library_type=tenx_library_type))
         fp.write("\n")
         # Samples section
         fp.write("[samples]\n")

--- a/auto_process_ngs/tenx/utils.py
+++ b/auto_process_ngs/tenx/utils.py
@@ -582,6 +582,10 @@ def make_multi_config_template(f,reference=None,probe_set=None,
         else:
             fp.write("#no-bam,true|false\n")
         fp.write("\n")
+        # Feature section
+        fp.write("#[feature]\n"
+                 "#reference,/path/to/feature/reference\n")
+        fp.write("\n")
         # Libraries section
         fp.write("[libraries]\n"
                  "fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate\n")

--- a/auto_process_ngs/test/tenx/test_cellplex.py
+++ b/auto_process_ngs/test/tenx/test_cellplex.py
@@ -48,6 +48,7 @@ PBB,CMO302,PBB
         self.assertEqual(config_csv.reference_data_path,
                          "/data/refdata-cellranger-gex-GRCh38-2020-A")
         self.assertEqual(config_csv.probe_set_path,None)
+        self.assertEqual(config_csv.feature_reference_path,None)
         self.assertEqual(config_csv.gex_libraries,
                          ['PJB1_GEX',])
         self.assertEqual(config_csv.gex_library('PJB1_GEX'),
@@ -91,6 +92,7 @@ PB2,BC002,PB2
                          "/data/refdata-cellranger-gex-GRCh38-2020-A")
         self.assertEqual(config_csv.probe_set_path,
                          "/data/Probe_Set_v1.0_GRCh38-2020-A.csv")
+        self.assertEqual(config_csv.feature_reference_path,None)
         self.assertEqual(config_csv.gex_libraries,
                          ['PJB1_Flex',])
         self.assertEqual(config_csv.gex_library('PJB1_Flex'),
@@ -106,6 +108,52 @@ PB2,BC002,PB2
                          })
         self.assertEqual(config_csv.pretty_print_samples(),
                          "PB1-2")
+
+    def test_cellranger_multi_config_csv_feature_ref(self):
+        """
+        CellrangerMultiConfigCsv: check feature reference is extracted from config.csv
+        """
+        with open(os.path.join(self.wd,"10x_multi_config.csv"),'wt') as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[feature]
+reference,/data/feature_ref.csv
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,/data/runs/fastqs_gex,any,PJB1,Gene Expression,
+PJB2_MC,/data/runs/fastqs_mc,any,PJB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+PBA,CMO301,PBA
+PBB,CMO302,PBB
+""")
+        config_csv = CellrangerMultiConfigCsv(
+            os.path.join(self.wd,
+                         "10x_multi_config.csv"))
+        self.assertEqual(config_csv.sample_names,['PBA','PBB'])
+        self.assertEqual(config_csv.reference_data_path,
+                         "/data/refdata-cellranger-gex-GRCh38-2020-A")
+        self.assertEqual(config_csv.probe_set_path,None)
+        self.assertEqual(config_csv.feature_reference_path,
+                         "/data/feature_ref.csv")
+        self.assertEqual(config_csv.gex_libraries,
+                         ['PJB1_GEX',])
+        self.assertEqual(config_csv.gex_library('PJB1_GEX'),
+                         { 'fastqs': '/data/runs/fastqs_gex',
+                           'lanes': 'any',
+                           'library_id': 'PJB1',
+                           'feature_type': 'Gene Expression',
+                           'subsample_rate': ''
+                         })
+        self.assertEqual(config_csv.fastq_dirs,
+                         { 'PJB1_GEX': '/data/runs/fastqs_gex',
+                           'PJB2_MC': '/data/runs/fastqs_mc'
+                         })
+        self.assertEqual(config_csv.pretty_print_samples(),
+                         "PBA, PBB")
 
     def test_cellranger_multi_config_csv_reduced_fields(self):
         """
@@ -131,6 +179,8 @@ PBB,CMO302
         self.assertEqual(config_csv.sample_names,['PBA','PBB'])
         self.assertEqual(config_csv.reference_data_path,
                          "/data/refdata-cellranger-gex-GRCh38-2020-A")
+        self.assertEqual(config_csv.probe_set_path,None)
+        self.assertEqual(config_csv.feature_reference_path,None)
         self.assertEqual(config_csv.gex_libraries,
                          ['PJB1_GEX',])
         self.assertEqual(config_csv.gex_library('PJB1_GEX'),

--- a/auto_process_ngs/test/tenx/test_utils.py
+++ b/auto_process_ngs/test/tenx/test_utils.py
@@ -587,6 +587,11 @@ class TestMakeMultiConfigTemplate(unittest.TestCase):
         """
         expected_content = """[gene-expression]
 reference,/path/to/transcriptome
+#force-cells,n
+#no-bam,true|false
+
+#[feature]
+#reference,/path/to/feature/reference
 
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
@@ -600,7 +605,7 @@ MULTIPLEXED_SAMPLE,CMO1|CMO2|...,DESCRIPTION
         self.assertTrue(os.path.exists(out_file))
         with open(out_file,'rt') as fp:
             actual_content = '\n'.join([line for line in fp.read().split('\n')
-                                        if not line.startswith('#')])
+                                        if not line.startswith('##')])
         self.assertEqual(expected_content,actual_content)
 
     def test_make_multi_config_template_flex(self):
@@ -610,7 +615,11 @@ MULTIPLEXED_SAMPLE,CMO1|CMO2|...,DESCRIPTION
         expected_content = """[gene-expression]
 reference,/data/mm10_transcriptome
 probe-set,/data/mm10_probe_set.csv
+#force-cells,n
 no-bam,true
+
+#[feature]
+#reference,/path/to/feature/reference
 
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
@@ -631,7 +640,7 @@ MULTIPLEXED_SAMPLE,BC001|BC002|...,DESCRIPTION
         self.assertTrue(os.path.exists(out_file))
         with open(out_file,'rt') as fp:
             actual_content = '\n'.join([line for line in fp.read().split('\n')
-                                        if not line.startswith('#')])
+                                        if not line.startswith('##')])
         self.assertEqual(expected_content,actual_content)
 
     def test_make_multi_config_template_cellplex(self):
@@ -640,6 +649,11 @@ MULTIPLEXED_SAMPLE,BC001|BC002|...,DESCRIPTION
         """
         expected_content = """[gene-expression]
 reference,/data/mm10_transcriptome
+#force-cells,n
+#no-bam,true|false
+
+#[feature]
+#reference,/path/to/feature/reference
 
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
@@ -659,5 +673,5 @@ MULTIPLEXED_SAMPLE,CMO1|CMO2|...,DESCRIPTION
         self.assertTrue(os.path.exists(out_file))
         with open(out_file,'rt') as fp:
             actual_content = '\n'.join([line for line in fp.read().split('\n')
-                                        if not line.startswith('#')])
+                                        if not line.startswith('##')])
         self.assertEqual(expected_content,actual_content)

--- a/auto_process_ngs/test/tenx/test_utils.py
+++ b/auto_process_ngs/test/tenx/test_utils.py
@@ -614,7 +614,7 @@ no-bam,true
 
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
-PJB_Flex,/runs/novaseq_50/fastqs,any,PJB_Flex,[Gene Expression|Multiplexing Capture],
+PJB_Flex,/runs/novaseq_50/fastqs,any,PJB_Flex,[Gene Expression|Antibody Capture],
 
 [samples]
 sample_id,probe_barcode_ids,description
@@ -643,8 +643,8 @@ reference,/data/mm10_transcriptome
 
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
-PJB_CML,/runs/novaseq_50/fastqs,any,PJB_CML,[Gene Expression|Multiplexing Capture],
-PJB_GEX,/runs/novaseq_50/fastqs,any,PJB_GEX,[Gene Expression|Multiplexing Capture],
+PJB_CML,/runs/novaseq_50/fastqs,any,PJB_CML,[Gene Expression|Multiplexing Capture|Antibody Capture],
+PJB_GEX,/runs/novaseq_50/fastqs,any,PJB_GEX,[Gene Expression|Multiplexing Capture|Antibody Capture],
 
 [samples]
 sample_id,cmo_ids,description


### PR DESCRIPTION
Updates the `make_multi_config_template` function in `tenx/utils` (used by the `setup_analysis_dirs` command), to add `Antibody Capture` as an option for CellPlex and Flex samples (and also removes the `Multiplexing Capture` option for Flex samples).

Also updates the `CellrangerMultiConfig` class in `tenx/cellplex` so that the value of the feature reference file can be extracted.