### PR TITLE
Add 'analysis number' to analysis directory metadata and use for run ID

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -1229,14 +1229,15 @@ class AnalysisSample:
 # Functions
 #######################################################################
 
-def run_id(run_name,platform=None,facility_run_number=None):
+def run_id(run_name,platform=None,facility_run_number=None,
+           analysis_number=None):
     """
     Return a run ID e.g. 'HISEQ_140701/242#22'
 
     The run ID is a code that identifies the sequencing run, and has
     the general form:
 
-    ``PLATFORM_DATESTAMP[/INSTRUMENT_RUN_NUMBER]#FACILITY_RUN_NUMBER``
+    ``PLATFORM_DATESTAMP[/INSTRUMENT_RUN_NUMBER]#FACILITY_RUN_NUMBER[.ANALYSIS_NUMBER]``
 
     - PLATFORM is always uppercased e.g. HISEQ, MISEQ, GA2X
     - DATESTAMP is the YYMMDD code e.g. 140701
@@ -1245,6 +1246,9 @@ def run_id(run_name,platform=None,facility_run_number=None):
       it is '45'
     - FACILITY_RUN_NUMBER is the run number that has been assigned
       by the facility
+    - ANALYSIS_NUMBER is an optional number assigned to the analysis
+      to distinguish it from other analysis attempts (for example, if
+      a run is reprocessed at a later date with updated software)
 
     Note that the instrument run number is only used if it differs
     from the facility run number.
@@ -1270,6 +1274,9 @@ def run_id(run_name,platform=None,facility_run_number=None):
       facility_run_number (int): the run number assigned by the
         local facility (can be different from the instrument
         run number) (optional)
+      analysis_number (int): number assigned to this analysis
+        to distinguish it from other analysis attempts
+        (optional)
 
     Returns:
       String: run ID.
@@ -1318,6 +1325,8 @@ def run_id(run_name,platform=None,facility_run_number=None):
             run_id += "/%s" % run_number
     if facility_run_number is not None:
         run_id += "#%s" % facility_run_number
+    if analysis_number is not None:
+        run_id += ".%s" % analysis_number
     return run_id
 
 def split_sample_name(s):

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -649,7 +649,8 @@ class AutoProcess:
         return run_id(
             self.run_name,
             platform=self.metadata.platform,
-            facility_run_number=self.metadata.run_number)
+            facility_run_number=self.metadata.run_number,
+            analysis_number=self.metadata.analysis_number)
 
     @property
     def run_reference_id(self):

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -115,6 +115,11 @@ def add_setup_command(cmdparser):
     p.add_argument('-r','--run-number',action='store',dest='run_number',
                    metavar="RUN_NUMBER",default=None,
                    help="Set facility run number")
+    p.add_argument('-n','--analysis-number',action='store',
+                   dest='analysis_number',metavar="ANALYSIS_NUMBER",
+                   help="Set analysis number (e.g. if reprocessing "
+                   "a run); will be appended to analysis directory "
+                   "name if '--analysis-dir' not supplied")
     p.add_argument('-f','--file',action='append',dest='extra_files',
                    metavar="FILE",default=None,
                    help="Additional file(s) to copy into new analysis "
@@ -129,7 +134,7 @@ def add_setup_command(cmdparser):
     p.add_argument('--analysis-dir',action='store',dest='analysis_dir',
                    default=None,
                    help="Make new directory called ANALYSIS_DIR (otherwise "
-                   "default is '<RUN_DIR>_analysis')")
+                   "default is '<RUN_DIR>_analysis[<ANALYSIS_NUMBER>]')")
     p.add_argument('run_dir',metavar="RUN_DIR",
                    help="directory with the output from an Illumina "
                    "sequencer")
@@ -1179,6 +1184,7 @@ def setup(args):
                 analysis_dir=args.analysis_dir,
                 sample_sheet=args.sample_sheet,
                 run_number=args.run_number,
+                analysis_number=args.analysis_number,
                 extra_files=args.extra_files,
                 unaligned_dir=args.unaligned_dir)
 

--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -450,6 +450,9 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                        value=ap.metadata.run_number)
     params_tbl.add_row(param="Platform",
                        value=ap.metadata.platform)
+    if ap.metadata.analysis_number:
+        params_tbl.add_row(param="Analysis number",
+                           value=ap.metadata.analysis_number)
     if ap.metadata.sequencer_model:
         params_tbl.add_row(param="Sequencer",
                            value="%s%s" %

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -353,7 +353,7 @@ def report_summary(ap):
     else:
         title = "%s" % os.path.basename(ap.analysis_dir)
     if analysis_number:
-        title += "[analysis #%s]" % analysis_number
+        title += " [analysis #%s]" % analysis_number
     report.append("%s\n%s" % (title,'='*len(title)))
     # General information
     field_width = max([len(i) for i in report_items])

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -306,6 +306,7 @@ def report_summary(ap):
     datestamp = None
     instrument = None
     run_number = None
+    analysis_number = None
     run_name = ap.run_name
     try:
         datestamp,instrument,run_number = IlluminaData.split_run_name(run_name)
@@ -319,6 +320,8 @@ def report_summary(ap):
         platform = 'unknown'
     if ap.metadata.run_number is not None:
         run_number = ap.metadata.run_number
+    if ap.metadata.analysis_number is not None:
+        analysis_number = ap.metadata.analysis_number
     # Processing software information
     try:
         processing_software = ast.literal_eval(
@@ -349,6 +352,8 @@ def report_summary(ap):
                                                datestamp)
     else:
         title = "%s" % os.path.basename(ap.analysis_dir)
+    if analysis_number:
+        title += "[analysis #%s]" % analysis_number
     report.append("%s\n%s" % (title,'='*len(title)))
     # General information
     field_width = max([len(i) for i in report_items])

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -613,6 +613,9 @@ def fetch_value(ap,project,field):
     elif field == 'run_number':
         return ('' if not ap.metadata.run_number
                 else str(ap.metadata.run_number))
+    elif field == 'analysis_number':
+        return ('' if not ap.metadata.analysis_number
+                else str(ap.metadata.analysis_number))
     elif field == 'source' or field == 'data_source':
         return ('' if not ap.metadata.source
                 else ap.metadata.source)

--- a/auto_process_ngs/commands/setup_cmd.py
+++ b/auto_process_ngs/commands/setup_cmd.py
@@ -34,7 +34,8 @@ logger = logging.getLogger(__name__)
 #######################################################################
 
 def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
-          run_number=None,extra_files=None,unaligned_dir=None):
+          run_number=None,analysis_number=None,extra_files=None,
+          unaligned_dir=None):
     """
     Set up the initial analysis directory
 
@@ -51,6 +52,11 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
         a URL (optional, will use sample sheet from the
         source data directory if present)
       run_number (str): facility run number
+      analysis_number (str): optional number assigned to the
+        analysis to distinguish it from other processing or
+        analysis attempts. If supplied then will be appended
+        to the analysis directory name (unless a name is
+        explicitly supplied via 'analysis_dir')
       extra_files (list): arbitrary additional files to copy
         into the new analysis directory; each file can be a
         local or remote file or a URL
@@ -68,6 +74,8 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
     if analysis_dir is None:
         analysis_dir = os.path.join(
             os.getcwd(),run_name)+'_analysis'
+        if analysis_number:
+            analysis_dir += str(analysis_number)
     else:
         analysis_dir = os.path.abspath(analysis_dir)
     # Create the analysis directory structure
@@ -259,6 +267,7 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
     ap.metadata['sequencer_model'] = model
     ap.metadata['source'] = data_source
     ap.metadata['run_number'] = run_number
+    ap.metadata['analysis_number'] = analysis_number
     # Make a 'projects.info' metadata file
     if not ap.params.project_metadata:
         if unaligned_dir is not None:

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -337,6 +337,8 @@ class AnalysisDirMetadata(MetadataDict):
 
     run_name: name of the run
     run_number: run number assigned by local facility
+    analysis_number: arbitrary number assigned to analysis (to
+      distinguish it from other analysis attempts)
     source: source of the data (e.g. local facility)
     platform: sequencing platform e.g. 'miseq'
     processing_software: dictionary of software packages used in
@@ -379,10 +381,12 @@ class AnalysisDirMetadata(MetadataDict):
                                   'instrument_run_number': 'instrument_run_number',
                                   'sequencer_model': 'sequencer_model',
                                   'flow_cell_mode': 'flow_cell_mode',
+                                  'analysis_number': 'analysis_number',
                               },
                               order=('run_name',
                                      'platform',
                                      'run_number',
+                                     'analysis_number',
                                      'source',),
                               filen=filen)
 

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -1734,7 +1734,9 @@ class QCProject:
             return run_id(self.info['run'],
                           platform=self.info['platform'],
                           facility_run_number=
-                          self.run_metadata['run_number'])
+                          self.run_metadata['run_number'],
+                          analysis_number=
+                          self.run_metadata['analysis_number'])
         except (AttributeError,TypeError) as ex:
             logger.warning("Run reference ID can't be "
                            "determined: %s (ignored)" % ex)

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -1166,7 +1166,8 @@ class TestFetchValueFunction(unittest.TestCase):
             'miseq',
             metadata={ "source": "testing",
                        "run_number": 87,
-                       "sequencer_model": "MiSeq" },
+                       "sequencer_model": "MiSeq",
+                       "analysis_number": 2 },
             project_metadata={
                 "AB": { "User": "Alison Bell",
                         "Library type": "scRNA-seq",
@@ -1190,8 +1191,9 @@ class TestFetchValueFunction(unittest.TestCase):
                                   os.path.join(mockdir.dirn,'AB'))
         # Check the returned values
         self.assertEqual(fetch_value(ap,project,'datestamp'),'170901')
-        self.assertEqual(fetch_value(ap,project,'run_id'),'MISEQ_170901#87')
+        self.assertEqual(fetch_value(ap,project,'run_id'),'MISEQ_170901#87.2')
         self.assertEqual(fetch_value(ap,project,'run_number'),'87')
+        self.assertEqual(fetch_value(ap,project,'analysis_number'),'2')
         self.assertEqual(fetch_value(ap,project,'source'),'testing')
         self.assertEqual(fetch_value(ap,project,'data_source'),'testing')
         self.assertEqual(fetch_value(ap,project,'analysis_dir'),mockdir.dirn)

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -597,6 +597,56 @@ Additional notes/comments:
                        expected.split('\n')):
             self.assertEqual(o,e)
 
+    def test_report_summary_with_analysis_number(self):
+        """report: report run with analysis number in 'summary' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "sequencer_model": "MiSeq",
+                       "analysis_number": 2 },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "RNA-seq",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Sequencer model": "MiSeq" },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "MiSeq",
+                         "Comments": "Repeat of previous run" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate summary report
+        expected = """MISEQ run #87 datestamped 170901 [analysis #2]
+==============================================
+Run name : 170901_M00879_0087_000000000-AGEW9
+Reference: MISEQ_170901#87.2
+Platform : MISEQ
+Sequencer: MiSeq
+Directory: %s
+Endedness: Paired end
+Bcl2fastq: Unknown
+
+2 projects:
+- 'AB':  Alison Bell           Human RNA-seq  2 samples (PI Audrey Bower)           
+- 'CDE': Charles David Edwards Mouse ChIP-seq 2 samples (PI Colin Delaney Eccleston)
+
+Additional notes/comments:
+- CDE: Repeat of previous run
+""" % mockdir.dirn
+        for o,e in zip(report_summary(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
     def test_report_summary_single_cell(self):
         """report: report single-cell run in 'summary' mode
         """

--- a/auto_process_ngs/test/commands/test_setup_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_cmd.py
@@ -107,6 +107,7 @@ model = {model}
         self.assertEqual(ap.metadata.run_name,
                          "151125_M00879_0001_000000000-ABCDE1")
         self.assertEqual(ap.metadata.run_number,None)
+        self.assertEqual(ap.metadata.analysis_number,None)
         self.assertEqual(ap.metadata.source,None)
         self.assertEqual(ap.metadata.platform,"miseq")
         self.assertEqual(ap.metadata.bcl2fastq_software,None)
@@ -162,6 +163,63 @@ model = {model}
         self.assertEqual(ap.metadata.run_name,
                          "151125_M00879_0001_000000000-ABCDE1")
         self.assertEqual(ap.metadata.run_number,'1')
+        self.assertEqual(ap.metadata.analysis_number,None)
+        self.assertEqual(ap.metadata.source,None)
+        self.assertEqual(ap.metadata.platform,"miseq")
+        self.assertEqual(ap.metadata.bcl2fastq_software,None)
+        self.assertEqual(ap.metadata.cellranger_software,None)
+        self.assertEqual(ap.metadata.cellranger_software,None)
+        self.assertEqual(ap.metadata.instrument_name,"M00879")
+        self.assertEqual(ap.metadata.instrument_datestamp,"151125")
+        self.assertEqual(ap.metadata.instrument_run_number,"1")
+        self.assertEqual(ap.metadata.instrument_flow_cell_id,
+                         "000000000-ABCDE1")
+        self.assertEqual(ap.metadata.sequencer_model,None)
+        # Delete to force write of data to disk
+        del(ap)
+        # Check directory exists
+        self.assertTrue(os.path.isdir(analysis_dirn))
+        # Check files exists
+        for filen in ('SampleSheet.orig.csv',
+                      'custom_SampleSheet.csv',
+                      'auto_process.info',
+                      'metadata.info',):
+            self.assertTrue(os.path.exists(os.path.join(analysis_dirn,
+                                                        filen)),
+                            "Missing file: %s" % filen)
+        # Check subdirs have been created
+        for subdirn in ('ScriptCode',
+                        'logs',):
+            self.assertTrue(os.path.isdir(os.path.join(analysis_dirn,
+                                                       subdirn)),
+                            "Missing subdir: %s" % subdirn)
+
+    def test_autoprocess_setup_specify_analysis_number(self):
+        """setup: specify analysis number
+        """
+        # Create mock Illumina run directory
+        mock_illumina_run = MockIlluminaRun(
+            '151125_M00879_0001_000000000-ABCDE1',
+            'miseq',
+            top_dir=self.dirn)
+        mock_illumina_run.create()
+        # Set up autoprocessor
+        ap = AutoProcess(settings=self.settings())
+        setup_(ap,mock_illumina_run.dirn,analysis_number='2')
+        analysis_dirn = "%s_analysis2" % mock_illumina_run.name
+        # Check parameters
+        self.assertEqual(ap.analysis_dir,
+                         os.path.join(self.dirn,analysis_dirn))
+        self.assertEqual(ap.params.data_dir,mock_illumina_run.dirn)
+        self.assertEqual(ap.params.sample_sheet,
+                         os.path.join(self.dirn,analysis_dirn,
+                                      'custom_SampleSheet.csv'))
+        self.assertEqual(ap.params.bases_mask,'auto')
+        # Check metadata
+        self.assertEqual(ap.metadata.run_name,
+                         "151125_M00879_0001_000000000-ABCDE1")
+        self.assertEqual(ap.metadata.run_number,None)
+        self.assertEqual(ap.metadata.analysis_number,"2")
         self.assertEqual(ap.metadata.source,None)
         self.assertEqual(ap.metadata.platform,"miseq")
         self.assertEqual(ap.metadata.bcl2fastq_software,None)
@@ -217,6 +275,7 @@ model = {model}
         self.assertEqual(ap.metadata.run_name,
                          "151125_M00879_0001")
         self.assertEqual(ap.metadata.run_number,None)
+        self.assertEqual(ap.metadata.analysis_number,None)
         self.assertEqual(ap.metadata.source,None)
         self.assertEqual(ap.metadata.platform,"miseq")
         self.assertEqual(ap.metadata.bcl2fastq_software,None)

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -1409,6 +1409,23 @@ class TestRunIdFunction(unittest.TestCase):
                                 facility_run_number="BCLFiles"),
                          "RAG_10x_BCLFiles_Download")
 
+    def test_run_id_with_analysis_number(self):
+        """
+        run_id: handle analysis number
+        """
+        self.assertEqual(
+            run_id("160621_M00879_0087_000000000-AGEW9",
+                   platform="miseq",
+                   facility_run_number=87,
+                   analysis_number=2),
+            "MISEQ_160621#87.2")
+        self.assertEqual(
+            run_id("160621_M00879_0087_000000000-AGEW9",
+                   platform="miseq",
+                   facility_run_number=22,
+                   analysis_number=3),
+            "MISEQ_160621/87#22.3")
+
 class TestSplitSampleNameFunction(unittest.TestCase):
     """
     Tests for the 'split_sample_name' function

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -315,6 +315,7 @@ class TestAnalysisDirMetadata(unittest.TestCase):
         """
         metadata = AnalysisDirMetadata()
         self.assertEqual(metadata.run_number,None)
+        self.assertEqual(metadata.analysis_number,None)
         self.assertEqual(metadata.platform,None)
         self.assertEqual(metadata.source,None)
         self.assertEqual(metadata.processing_software,None)

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -194,11 +194,11 @@ Run IDs and run reference IDs
 =============================
 
 Within the ``auto_process`` package runs can be identified by
-automatically generated run IDs of the general form:
+automatically generated **run IDs** of the general form:
 
 ::
 
-   PLATFORM_DATESTAMP[/INSTRUMENT_RUN_NUMBER]#FACILITY_RUN_NUMBER
+   PLATFORM_DATESTAMP[/INSTRUMENT_RUN_NUMBER]#FACILITY_RUN_NUMBER[.ANALYSIS_NUMBER]
 
 where:
 
@@ -211,6 +211,8 @@ where:
   ``140701_SN0123_0045_000000000-A1BCD`` it would be ``45``)
 * ``FACILITY_RUN_NUMBER`` is the run number that has been
   assigned by the facility
+* ``ANALYSIS_NUMBER`` is an optional arbitrary number that can be
+  assigned to different analyses of the same run
 
 For example:
 
@@ -240,7 +242,14 @@ The special cases are handled as follows:
   been supplied (e.g. for a run called ``rag_05_2017`` the run ID
   might look like ``rag_05_2017#90`` or ``MISEQ_rag_05_2017#90``)
 
-Run reference IDs are based on the run ID with additional
+If an analysis number is assigned then the example run ID will
+look like:
+
+::
+
+   NOVASEQ6000_230419#22.2
+
+**Run reference IDs** are based on the run ID with additional
 arbitrary elements appended, i.e.:
 
 ::

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -716,6 +716,18 @@ would produce ``bcl2fastq_no_trimming``, ``barcodes_no_trimming``,
    can be used to create projects which carry the same identifier,
    see :ref:`setup_analysis_dirs-add-identifier`.
 
+.. note::
+
+   A simpler alternative is to set up a completely new parallel
+   analysis directory for reprocessing, and expliciting assigning
+   a unique analysis number to distinguish it from other analysis
+   attempts.
+
+   This can be done via the ``setup`` command using the ``-n``
+   option (see :ref:`setup_specifying_analysis_run_number`), or by
+   setting the ``analysis_number`` metadata item within an existing
+   analysis directory.
+
 .. _make_fastqs-outputs:
 
 Outputs

--- a/docs/source/using/report.rst
+++ b/docs/source/using/report.rst
@@ -95,6 +95,7 @@ Field name                Associated value
 ``run_reference_id``      Run reference ID (e.g.
                           ``NOVASEQ6000_230419#73_SP``)
 ``run_number``            Facility run number (e.g. ``88``)
+``analysis_number``       Analysis number (e.g. ``2``)
 ``sequencer_platform``    Sequencer platform for the run
                           (e.g. ``MISEQ``)
 ``sequencer_model``       Sequencer model (e.g. ``MiSeq``)

--- a/docs/source/using/setup.rst
+++ b/docs/source/using/setup.rst
@@ -151,6 +151,21 @@ Specifying the facility run number
 The facility run number can be explicitly specified using the
 ``-r``/``--run-number`` option of the ``setup`` command.
 
+.. _setup_specifying_analysis_run_number:
+
+******************************
+Specifying the analysis number
+******************************
+
+An arbitrary number can be assigned to the analysis using the
+``-n``/``--analysis-number`` option of the ``setup`` command.
+
+.. note::
+
+   If an analysis number is assigned at setup then it will be
+   appended to the analysis directory name, unless this is
+   overridden by the ``--analysis-dir`` option.
+
 .. _setup_specifying_additional_files:
 
 ***************************


### PR DESCRIPTION
Updates the analysis directory metadata to include a new `analysis_number` item, which can optionally be specified to distinguish between different processing and analysis attempts of the same run.

If the analysis number is set when creating a new analysis directory via the `setup` command (via the new `-n` option), then this number will be appended to the automatically generated directory name (e.g. `-n 2` will result in `<RUN>_analysis2`).

Run IDs have also been modified to include the analysis number appended after a period (e.g. `NOVASEQ6000_230601#79.2` would indicate that the analysis is labelled as number 2).