### PR TITLE
analysis: update 'match_run_id' to account for analysis numbers

### DIFF
--- a/auto_process_ngs/analysis.py
+++ b/auto_process_ngs/analysis.py
@@ -1477,7 +1477,8 @@ def match_run_id(run,d):
         run_id_ = run_id(
             analysis_dir.run_name,
             platform=analysis_dir.metadata.platform,
-            facility_run_number=analysis_dir.metadata.run_number)
+            facility_run_number=analysis_dir.metadata.run_number,
+            analysis_number=analysis_dir.metadata.analysis_number)
         logger.debug("%s: run ID = %s" % (d,run_id_))
         if run_id_ == run:
             return True

--- a/auto_process_ngs/test/test_analysis.py
+++ b/auto_process_ngs/test/test_analysis.py
@@ -1519,6 +1519,25 @@ class TestMatchRunId(unittest.TestCase):
         self.assertFalse(
             match_run_id("UNKNOWN_201029#87",run_dir))
 
+    def test_match_run_id_with_analysis_number(self):
+        """
+        match_run_id: check run ID with analysis number
+        """
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '201029_SN00879_0087_000000000-AGEW9',
+            'hiseq',
+            metadata={ 'run_number': 87,
+                       'analysis_number': 2, },
+            top_dir=self.dirn)
+        mockdir.create()
+        run_dir = mockdir.dirn
+        # Run doesn't match when analysis number is missing
+        self.assertFalse(
+            match_run_id("HISEQ_201029#87",run_dir))
+        # Run matches when analysis number is included
+        self.assertTrue(
+            match_run_id("HISEQ_201029#87.2",run_dir))
+
 class TestLocateRun(unittest.TestCase):
     """
     Tests for the 'locate_run' function


### PR DESCRIPTION
Updates the `match_run_id` function in the `analysis` submodule to take into account the analysis number (introduced in PR #859) when matching run IDs. The update enables the `locate_run` function to handle the analysis number when looking for the corresponding run based on ID.