### PR TITLE
Add basic support for 10xGenomics single cell immune profiling data

### DIFF
--- a/auto_process_ngs/tenx/cellplex.py
+++ b/auto_process_ngs/tenx/cellplex.py
@@ -38,6 +38,7 @@ class CellrangerMultiConfigCsv:
     - reference_data_path: path to the reference dataset
     - probe_set_path: path to the probe set
     - feature_reference_path: path to the feature reference
+    - vdj_reference_path: path to the V(D)J-compatible reference
     - gex_libraries: list of Fastq IDs associated
       with GEX data
 
@@ -65,6 +66,7 @@ class CellrangerMultiConfigCsv:
         self._reference_data_path = None
         self._probe_set_path = None
         self._feature_reference_path = None
+        self._vdj_reference_path = None
         self._gex_libraries = {}
         self._fastq_dirs = {}
         self._read_config_csv()
@@ -86,6 +88,9 @@ class CellrangerMultiConfigCsv:
                     continue
                 elif line == "[feature]":
                     current_section = "feature"
+                    continue
+                elif line == "[vdj]":
+                    current_section = "vdj"
                     continue
                 elif line == "[libraries]":
                     current_section = "libraries"
@@ -128,6 +133,11 @@ class CellrangerMultiConfigCsv:
                     if line.startswith('reference,'):
                         # Extract feature reference file
                         self._feature_reference_path = ','.join(
+                            line.split(',')[1:]).strip()
+                elif current_section == "vdj":
+                    if line.startswith('reference,'):
+                        # Extract feature reference file
+                        self._vdj_reference_path = ','.join(
                             line.split(',')[1:]).strip()
                 elif current_section == "libraries":
                     if line.startswith('fastq_id,fastqs,'):
@@ -191,6 +201,13 @@ class CellrangerMultiConfigCsv:
         Return the path to the feature reference file from config.csv
         """
         return self._feature_reference_path
+
+    @property
+    def vdj_reference_path(self):
+        """
+        Return the path to the V(D)J reference file from config.csv
+        """
+        return self._vdj_reference_path
 
     @property
     def gex_libraries(self):

--- a/auto_process_ngs/tenx/utils.py
+++ b/auto_process_ngs/tenx/utils.py
@@ -581,17 +581,22 @@ def make_multi_config_template(f,reference=None,probe_set=None,
             fp.write("no-bam,%s\n" % str(no_bam).lower())
         else:
             fp.write("#no-bam,true|false\n")
+        fp.write("#cmo-set,/path/to/custom/cmo/reference\n")
         fp.write("\n")
         # Feature section
         fp.write("#[feature]\n"
                  "#reference,/path/to/feature/reference\n")
+        fp.write("\n")
+        # V(D)J section
+        fp.write("#[vdj]\n"
+                 "#reference,/path/to/vdj/reference\n")
         fp.write("\n")
         # Libraries section
         fp.write("[libraries]\n"
                  "fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate\n")
         if samples:
             if library_type == "CellPlex":
-                tenx_library_type = "[Gene Expression|Multiplexing Capture|Antibody Capture]"
+                tenx_library_type = "[Gene Expression|Multiplexing Capture|Antibody Capture|VDJ-B|VDJ-T]"
             elif library_type == "Flex":
                 tenx_library_type = "[Gene Expression|Antibody Capture]"
             for sample in samples:

--- a/auto_process_ngs/test/tenx/test_cellplex.py
+++ b/auto_process_ngs/test/tenx/test_cellplex.py
@@ -49,6 +49,7 @@ PBB,CMO302,PBB
                          "/data/refdata-cellranger-gex-GRCh38-2020-A")
         self.assertEqual(config_csv.probe_set_path,None)
         self.assertEqual(config_csv.feature_reference_path,None)
+        self.assertEqual(config_csv.vdj_reference_path,None)
         self.assertEqual(config_csv.gex_libraries,
                          ['PJB1_GEX',])
         self.assertEqual(config_csv.gex_library('PJB1_GEX'),
@@ -93,6 +94,7 @@ PB2,BC002,PB2
         self.assertEqual(config_csv.probe_set_path,
                          "/data/Probe_Set_v1.0_GRCh38-2020-A.csv")
         self.assertEqual(config_csv.feature_reference_path,None)
+        self.assertEqual(config_csv.vdj_reference_path,None)
         self.assertEqual(config_csv.gex_libraries,
                          ['PJB1_Flex',])
         self.assertEqual(config_csv.gex_library('PJB1_Flex'),
@@ -139,6 +141,54 @@ PBB,CMO302,PBB
         self.assertEqual(config_csv.probe_set_path,None)
         self.assertEqual(config_csv.feature_reference_path,
                          "/data/feature_ref.csv")
+        self.assertEqual(config_csv.vdj_reference_path,None)
+        self.assertEqual(config_csv.gex_libraries,
+                         ['PJB1_GEX',])
+        self.assertEqual(config_csv.gex_library('PJB1_GEX'),
+                         { 'fastqs': '/data/runs/fastqs_gex',
+                           'lanes': 'any',
+                           'library_id': 'PJB1',
+                           'feature_type': 'Gene Expression',
+                           'subsample_rate': ''
+                         })
+        self.assertEqual(config_csv.fastq_dirs,
+                         { 'PJB1_GEX': '/data/runs/fastqs_gex',
+                           'PJB2_MC': '/data/runs/fastqs_mc'
+                         })
+        self.assertEqual(config_csv.pretty_print_samples(),
+                         "PBA, PBB")
+
+    def test_cellranger_multi_config_csv_vdj_ref(self):
+        """
+        CellrangerMultiConfigCsv: check V(D)J reference is extracted from config.csv
+        """
+        with open(os.path.join(self.wd,"10x_multi_config.csv"),'wt') as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[vdj]
+reference,/data/vdj_ref.csv
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,/data/runs/fastqs_gex,any,PJB1,Gene Expression,
+PJB2_MC,/data/runs/fastqs_mc,any,PJB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+PBA,CMO301,PBA
+PBB,CMO302,PBB
+""")
+        config_csv = CellrangerMultiConfigCsv(
+            os.path.join(self.wd,
+                         "10x_multi_config.csv"))
+        self.assertEqual(config_csv.sample_names,['PBA','PBB'])
+        self.assertEqual(config_csv.reference_data_path,
+                         "/data/refdata-cellranger-gex-GRCh38-2020-A")
+        self.assertEqual(config_csv.probe_set_path,None)
+        self.assertEqual(config_csv.feature_reference_path,None)
+        self.assertEqual(config_csv.vdj_reference_path,
+                         "/data/vdj_ref.csv")
         self.assertEqual(config_csv.gex_libraries,
                          ['PJB1_GEX',])
         self.assertEqual(config_csv.gex_library('PJB1_GEX'),
@@ -181,6 +231,7 @@ PBB,CMO302
                          "/data/refdata-cellranger-gex-GRCh38-2020-A")
         self.assertEqual(config_csv.probe_set_path,None)
         self.assertEqual(config_csv.feature_reference_path,None)
+        self.assertEqual(config_csv.vdj_reference_path,None)
         self.assertEqual(config_csv.gex_libraries,
                          ['PJB1_GEX',])
         self.assertEqual(config_csv.gex_library('PJB1_GEX'),

--- a/auto_process_ngs/test/tenx/test_utils.py
+++ b/auto_process_ngs/test/tenx/test_utils.py
@@ -589,9 +589,13 @@ class TestMakeMultiConfigTemplate(unittest.TestCase):
 reference,/path/to/transcriptome
 #force-cells,n
 #no-bam,true|false
+#cmo-set,/path/to/custom/cmo/reference
 
 #[feature]
 #reference,/path/to/feature/reference
+
+#[vdj]
+#reference,/path/to/vdj/reference
 
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
@@ -617,9 +621,13 @@ reference,/data/mm10_transcriptome
 probe-set,/data/mm10_probe_set.csv
 #force-cells,n
 no-bam,true
+#cmo-set,/path/to/custom/cmo/reference
 
 #[feature]
 #reference,/path/to/feature/reference
+
+#[vdj]
+#reference,/path/to/vdj/reference
 
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
@@ -651,14 +659,18 @@ MULTIPLEXED_SAMPLE,BC001|BC002|...,DESCRIPTION
 reference,/data/mm10_transcriptome
 #force-cells,n
 #no-bam,true|false
+#cmo-set,/path/to/custom/cmo/reference
 
 #[feature]
 #reference,/path/to/feature/reference
 
+#[vdj]
+#reference,/path/to/vdj/reference
+
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
-PJB_CML,/runs/novaseq_50/fastqs,any,PJB_CML,[Gene Expression|Multiplexing Capture|Antibody Capture],
-PJB_GEX,/runs/novaseq_50/fastqs,any,PJB_GEX,[Gene Expression|Multiplexing Capture|Antibody Capture],
+PJB_CML,/runs/novaseq_50/fastqs,any,PJB_CML,[Gene Expression|Multiplexing Capture|Antibody Capture|VDJ-B|VDJ-T],
+PJB_GEX,/runs/novaseq_50/fastqs,any,PJB_GEX,[Gene Expression|Multiplexing Capture|Antibody Capture|VDJ-B|VDJ-T],
 
 [samples]
 sample_id,cmo_ids,description


### PR DESCRIPTION
Updates code for generating template `cellranger multi` CSV config files to add fields for 10x Genomics single cell immune profiling (V(D)J) data as per the documentation at https://support.10xgenomics.com/single-cell-vdj/software/pipelines/latest/using/multi.

Specifically:

* Adds `[vdj]` section
* Adds `VDJ-B` and `VDJ-T` as possible library types in `[libraries]` section

(Additionally the `cmo-set` field is also added to the template in the `[gene-expression]` section, to allow custom CMO references to be added - see https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/multi#cmoreference)

The `CellrangerMultiConfigCsv` class is also updated to enable the V(D)J reference file to be extracted from the file and returned via a new property `vdj_reference`.