### PR TITLE
'transfer_data.py': ensure copied files have read-write permissions

### DIFF
--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -28,6 +28,7 @@ from ..simple_scheduler import SchedulerReporter
 from ..fileops import exists
 from ..fileops import mkdir
 from ..fileops import copy_command
+from ..fileops import set_permissions_command
 from ..settings import Settings
 from ..settings import get_config_dir
 from ..utils import Location
@@ -516,6 +517,17 @@ def main():
 
     # Wait for scheduler jobs to complete
     sched.wait()
+
+    # Update the permissions once everything else has copied
+    print("Update permissions to read-write")
+    permissions_cmd = set_permissions_command("u+rwX,g+rwX,o=rX",
+                                              target_dir)
+    print("Running %s" % permissions_cmd)
+    permissions_job = sched.submit(permissions_cmd.command_line,
+                                   name="copy.%s.permissions" % job_id,
+                                   runner=SimpleJobRunner(),
+                                   wd=working_dir)
+    permissions_job.wait()
 
     # Check exit code for Fastq copying
     exit_code = copy_job.exit_code


### PR DESCRIPTION
Updates the `transfer_data.py` utility so that the transferred data have read-write permissions set for 'user' and 'group' ('others' only get read permission).

PR includes a pair of new functions in the `fileops` module (`set_permissions` and `set_permissions_cmd`) which are used to perform the permission resetting operations.