### PR TITLE
Allow biological data samples to be explicitly defined for QC pipeline

### DIFF
--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -673,6 +673,7 @@ class AnalysisProjectQCDirInfo(MetadataDict):
     fastq_dir: the name of the associated Fastq subdirectory
     protocol: name of the QC protocol used
     organism: the organism(s) that the QC was run with
+    seq_data_samples: samples with sequence (i.e. biological) data
     cellranger_version: version of cellranger/10x software used
     cellranger_refdata: reference datasets used with cellranger
     cellranger_probeset: probe set used with cellranger
@@ -696,6 +697,7 @@ class AnalysisProjectQCDirInfo(MetadataDict):
                 'fastq_dir' :'Fastq dir',
                 'protocol': 'QC protocol',
                 'organism': 'Organism',
+                'seq_data_samples': 'Sequence data samples',
                 'cellranger_version': 'Cellranger version',
                 'cellranger_refdata': 'Cellranger reference datasets',
                 'cellranger_probeset': 'Cellranger reference probe set',

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -128,7 +128,7 @@ class MetadataDict(bcf_utils.AttributeDictionary):
                 if key in self.__attributes:
                     self.__key_order.append(key)
                 else:
-                    raise KeyError("Key '%s' not defined in attributes")
+                    raise KeyError("Key '%s' not defined in attributes" % key)
             # Append keys not explicitly listed in the order
             extra_keys = []
             for key in self.__attributes:

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -414,6 +414,7 @@ class AnalysisProjectInfo(MetadataDict):
     paired_end: True if the data is paired end, False if not
     primary_fastq_dir: the primary subdir with FASTQ files
     samples: textual description of the samples in the project
+    biological_samples: comma-separated sample names with biological data
     comments: free-text comments
 
     """
@@ -441,6 +442,7 @@ class AnalysisProjectInfo(MetadataDict):
                                   'paired_end':'Paired_end',
                                   'primary_fastq_dir':'Primary fastqs',
                                   'samples':'Samples',
+                                  'biological_samples': 'Biological samples',
                                   'comments':'Comments',
                               },
                               order = (
@@ -457,6 +459,7 @@ class AnalysisProjectInfo(MetadataDict):
                                   'paired_end',
                                   'primary_fastq_dir',
                                   'samples',
+                                  'biological_samples',
                                   'sequencer_model',
                                   'comments',
                               ),

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -4305,10 +4305,15 @@ def make_mock_analysis_project(name="PJB",top_dir=None,
             for read in reads:
                 fq = "%s_S%d_R%d_001.fastq.gz" % (sname,i,read)
                 fastq_names.append(fq)
+    # Metadata
+    metadata = {}
+    if seq_data_samples:
+        metadata['Biological samples'] = ','.join(seq_data_samples)
     # Set up the analysis project
     analysis_project = MockAnalysisProject(name,
                                            fastq_names,
-                                           fastq_dir=fastq_dir)
+                                           fastq_dir=fastq_dir,
+                                           metadata=metadata)
     project_dir = analysis_project.create(top_dir=top_dir)
     # Populate with fake QC products
     make_mock_qc_dir(os.path.join(project_dir,qc_dir),

--- a/auto_process_ngs/mockqc.py
+++ b/auto_process_ngs/mockqc.py
@@ -490,6 +490,8 @@ def make_mock_qc_dir(qc_dir,fastq_names,fastq_dir=None,
     qc_info['protocol'] = protocol
     if organisms:
         qc_info['organism'] = ','.join(organisms)
+    if seq_data_samples:
+        qc_info['seq_data_samples'] = ','.join(seq_data_samples)
     # Normalise organism names
     organisms_ = [normalise_organism_name(x) for x in organisms]
     # Populate with fake QC products

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -84,6 +84,7 @@ from bcftbx.qc.report import strip_ngs_extensions
 from bcftbx.utils import AttributeDictionary
 from bcftbx.utils import extract_prefix
 from bcftbx.utils import extract_index
+from bcftbx.utils import pretty_print_names
 from bcftbx.utils import walk
 from ..analysis import AnalysisFastq
 from ..analysis import run_id
@@ -570,6 +571,16 @@ class QCReport(Document):
             # Protocol summary
             if project.qc_info.protocol_summary:
                 project_notes.add(project.qc_info.protocol_summary)
+            # Biological (seq data) samples
+            if project.seq_data_samples:
+                # Only add a note if these are a subset of the
+                # full set of samples
+                if sorted(project.samples) != \
+                   sorted(project.seq_data_samples):
+                    project_notes.add("Subset of samples considered to "
+                                      "contain biological data: %s" %
+                                      pretty_print_names(
+                                          project.seq_data_samples))
             # Create a new summary table
             summary_table = self.add_summary_table(project,
                                                    summary_fields_,

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -301,6 +301,18 @@ def get_seq_data_samples(project_dir,fastq_attrs=None):
                               fastq_attrs=fastq_attrs)
     # Initial sample list
     samples = sorted([s.name for s in project.samples])
+    # If biological samples explicitly defined in
+    # project metadata then use those
+    if project.info.biological_samples:
+        bio_samples = []
+        for s in [str(s).strip()
+                  for s in project.info.biological_samples.split(',')]:
+            if s not in samples:
+                logger.warning("Sample '%s' defined as biological data "
+                               "but no sample found with that name?" % s)
+            else:
+                bio_samples.append(s)
+        return bio_samples
     # 10x Genomics CellPlex
     single_cell_platform = project.info.single_cell_platform
     if single_cell_platform:

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -48,6 +48,7 @@ class TestQCOutputs(unittest.TestCase):
                      cellranger_pipelines=('cellranger',),
                      cellranger_samples=None,
                      cellranger_multi_samples=None,
+                     seq_data_samples=None,
                      include_fastqc=True,
                      include_fastq_screen=True,
                      include_strandedness=True,
@@ -73,6 +74,7 @@ class TestQCOutputs(unittest.TestCase):
             cellranger_pipelines=cellranger_pipelines,
             cellranger_samples=cellranger_samples,
             cellranger_multi_samples=cellranger_multi_samples,
+            seq_data_samples=seq_data_samples,
             include_fastqc=include_fastqc,
             include_fastq_screen=include_fastq_screen,
             include_strandedness=include_strandedness,
@@ -1018,6 +1020,64 @@ class TestQCOutputs(unittest.TestCase):
                          ['PJB1','PJB2'])
         self.assertEqual(qc_outputs.seq_data_samples,
                          ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.bams,[])
+        self.assertEqual(qc_outputs.organisms,[])
+        self.assertEqual(qc_outputs.fastq_screens,
+                         ['model_organisms',
+                          'other_organisms',
+                          'rRNA'])
+        self.assertEqual(qc_outputs.cellranger_references,[])
+        self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.reads,['r1','r2'])
+        self.assertEqual(qc_outputs.software,
+                         { 'fastqc': [ '0.11.3' ],
+                           'fastq_screen': [ '0.9.2' ],
+                           'fastq_strand': [ '0.0.4' ],
+                           'multiqc': [ '1.8' ],
+                         })
+        self.assertEqual(qc_outputs.stats.max_seqs,37285443)
+        self.assertEqual(qc_outputs.stats.min_sequence_length,65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length,76)
+        self.assertEqual(sorted(
+            list(qc_outputs.stats.min_sequence_length_read.keys())),
+                         ['r1','r2'])
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r1'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r1'],76)
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r2'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r2'],76)
+        self.assertEqual(qc_outputs.config_files,
+                         ['fastq_strand.conf'])
+
+    def test_qcoutputs_paired_end_explicit_biological_samples(self):
+        """
+	QCOutputs: paired-end data (biological samples explicitly specified)
+        """
+        qc_dir = self._make_qc_dir('qc',
+                                   fastq_names=(
+                                       'PJB1_S1_R1_001',
+                                       'PJB1_S1_R2_001',
+                                       'PJB2_S2_R1_001',
+                                       'PJB2_S2_R2_001',
+                                   ),
+                                   seq_data_samples=('PJB2',))
+        qc_outputs = QCOutputs(qc_dir)
+        self.assertEqual(qc_outputs.outputs,
+                         ['fastqc_r1',
+                          'fastqc_r2',
+                          'multiqc',
+                          'screens_r1',
+                          'screens_r2',
+                          'sequence_lengths',
+                          'strandedness'])
+        self.assertEqual(qc_outputs.fastqs,
+                         ['PJB1_S1_R1_001',
+                          'PJB1_S1_R2_001',
+                          'PJB2_S2_R1_001',
+                          'PJB2_S2_R2_001'])
+        self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB2'])
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
         self.assertEqual(qc_outputs.fastq_screens,

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -224,7 +224,8 @@ class TestGetSeqDataSamples(unittest.TestCase):
         if REMOVE_TEST_OUTPUTS:
             shutil.rmtree(self.wd)
     def _make_mock_analysis_project(self,library_type,
-                                    single_cell_platform=None):
+                                    single_cell_platform=None,
+                                    bio_samples=None):
         # Create a mock AnalysisProject
         m = MockAnalysisProject('PJB',
                                 fastq_names=("PJB1_S1_L001_R1_001.fastq.gz",
@@ -233,7 +234,8 @@ class TestGetSeqDataSamples(unittest.TestCase):
                                              "PJB2_S2_L001_R2_001.fastq.gz",),
                                 metadata={'Single cell platform':
                                           single_cell_platform,
-                                          'Library type': library_type,})
+                                          'Library type': library_type,
+                                          'Biological samples': bio_samples})
         m.create(top_dir=self.wd)
         return os.path.join(self.wd,'PJB')
 
@@ -246,6 +248,17 @@ class TestGetSeqDataSamples(unittest.TestCase):
         # Check sequence data samples
         self.assertEqual(get_seq_data_samples(project_dir),
                          ["PJB1","PJB2"])
+
+    def test_get_seq_data_samples_defined_in_metadata(self):
+        """
+        get_seq_data_samples: biological samples defined in project metadata
+        """
+        # Set up mock project
+        project_dir = self._make_mock_analysis_project("RNA-seq",
+                                                       bio_samples="PJB1")
+        # Check sequence data samples
+        self.assertEqual(get_seq_data_samples(project_dir),
+                         ["PJB1"])
 
     def test_get_seq_data_samples_10x_cellplex(self):
         """

--- a/auto_process_ngs/test/qc/test_verification.py
+++ b/auto_process_ngs/test/qc/test_verification.py
@@ -888,6 +888,26 @@ class TestQCVerifier(unittest.TestCase):
                            'other_organisms',
                            'rRNA')))
 
+    def test_qcverifier_verify_single_end_biological_samples(self):
+        """
+	QCVerifier: verify single-end data (standardSE, biological samples defined)
+        """
+        ##self.remove_test_outputs = False
+        fastq_names=('PJB1_S1_R1_001.fastq.gz',
+                     'PJB2_S2_R1_001.fastq.gz',)
+        qc_dir = self._make_qc_dir('qc',
+                                   protocol="standardSE",
+                                   fastq_names=fastq_names,
+                                   seq_data_samples=["PJB1"])
+        qc_verifier = QCVerifier(qc_dir)
+        self.assertTrue(qc_verifier.verify(
+            fetch_protocol_definition("standardSE"),
+            fastq_names,
+            seq_data_samples="PJB1",
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA')))
+
     def test_qcverifier_verify_paired_end(self):
         """
 	QCVerifier: verify paired-end data (standardPE)
@@ -1009,6 +1029,28 @@ class TestQCVerifier(unittest.TestCase):
         self.assertTrue(qc_verifier.verify(
             fetch_protocol_definition("standardPE"),
             fastq_names,
+            fastq_screens=('model_organisms',
+                           'other_organisms',
+                           'rRNA')))
+
+    def test_qcverifier_verify_paired_end_biological_samples(self):
+        """
+	QCVerifier: verify paired-end data (standardPE, biological samples defined)
+        """
+        ##self.remove_test_outputs = False
+        fastq_names=('PJB1_S1_R1_001_paired.fastq.gz',
+                     'PJB1_S1_R2_001_paired.fastq.gz',
+                     'PJB2_S2_R1_001_paired.fastq.gz',
+                     'PJB2_S2_R2_001_paired.fastq.gz',)
+        qc_dir = self._make_qc_dir('qc',
+                                   protocol="standardPE",
+                                   fastq_names=fastq_names,
+                                   seq_data_samples=["PJB1"])
+        qc_verifier = QCVerifier(qc_dir)
+        self.assertTrue(qc_verifier.verify(
+            fetch_protocol_definition("standardPE"),
+            fastq_names,
+            seq_data_samples="PJB1",
             fastq_screens=('model_organisms',
                            'other_organisms',
                            'rRNA')))
@@ -1669,6 +1711,16 @@ class TestVerifyProject(unittest.TestCase):
         verify_project: paired-end data
         """
         analysis_dir = self._make_analysis_project(protocol="standardPE")
+        project = AnalysisProject(analysis_dir)
+        self.assertTrue(verify_project(project))
+
+    def test_verify_project_paired_end_with_biological_samples(self):
+        """
+        verify_project: paired-end data: biological samples defined
+        """
+        analysis_dir = self._make_analysis_project(
+            protocol="standardPE",
+            seq_data_samples=('PJB1',))
         project = AnalysisProject(analysis_dir)
         self.assertTrue(verify_project(project))
 

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -705,5 +705,6 @@ class TestAnalysisProjectInfo(unittest.TestCase):
         self.assertEqual(info.paired_end,None)
         self.assertEqual(info.primary_fastq_dir,None)
         self.assertEqual(info.samples,None)
+        self.assertEqual(info.biological_samples,None)
         self.assertEqual(info.sequencer_model,None)
         self.assertEqual(info.comments,None)

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -109,20 +109,37 @@ reports can be copied there for sharing using the
    pipeline by using the ``run_qc.py`` utility; see the
    section on :doc:`running the QC standalone <run_qc_standalone>`.
 
---------------------------------
-Samples with non-biological data
---------------------------------
+---------------------------------------------
+Biological versus non-biological data samples
+---------------------------------------------
 
 For some types of dataset (e.g. 10x Genomics CellPlex data), not
 all samples in the dataset contain biological data (for example,
 CellPlex datasets also have "multiplexing capture" samples which
 contain feature barcodes).
 
-Where these types of samples can be identified by the pipeline
-(for example, information in the ``10x_multi_config.csv`` file
-for CellPlex) only metrics that are appropriate for non-biological
-samples will be generated (e.g. screens, strandedness etc) and
-reported.
+Biological and non-biological data samples may be identified
+implicitly (for example, by using the library type information
+in the ``10x_multi_config.csv`` file for CellPlex datasets).
+Alternatively samples with biological data can be explicitly
+defined in the ``Biological samples`` field of the ``README.info``
+metadata file in the analysis project directory, as a
+comma-separated list of sample names. For example:
+
+::
+
+   Biological samples    SMPL1,SMPL2
+
+Samples in the project which are not in this list are treated as
+containing non-biological data; if no samples are listed then all
+samples are assumed to contain biological data.
+
+When biological and non-biological samples are differentiated,
+the pipeline will only run and report "mapped" metrics (for
+example screens, strandedness, gene body coverage etc) for the
+biological samples; these metrics will be omitted for non-biological
+samples (even if they have been specified as part of the QC
+protocol).
 
 -------------------------------------
 QC metric using subsequences in reads


### PR DESCRIPTION
Updates the analysis project metadata to include a new `Biological samples` field, which can be used to list samples which contain biological data. If this field is populated then samples which don't appear are assumed to have non-biological data.

This information is used in the QC pipeline and verification to determine whether the mapped metrics should be applied to each sample (building on the existing mechanism used to implicitly distinguish biological and non-biological samples from the `cellranger multi` config files).