### PR TITLE
'setup': collect default bases mask and flow cell mode

### DIFF
--- a/auto_process_ngs/commands/setup_cmd.py
+++ b/auto_process_ngs/commands/setup_cmd.py
@@ -13,6 +13,7 @@ import os
 import uuid
 import shutil
 import logging
+from ..bcl2fastq.utils import get_bases_mask
 from ..bcl2fastq.utils import get_sequencer_platform
 from ..bcl2fastq.utils import make_custom_sample_sheet
 from ..applications import general as general_applications
@@ -202,9 +203,28 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
             # Don't need sample sheet if Fastqs already exist
             original_sample_sheet = None
             custom_sample_sheet = None
-    # Bases mask
-    print("Bases mask set to 'auto' (will be determined at run time)")
-    bases_mask = "auto"
+    # Attempt to acquire RunInfo.xml
+    try:
+        print("Acquiring run info...")
+        target = os.path.join(data_dir,"RunInfo.xml")
+        run_info_xml = os.path.join(ap.tmp_dir,"RunInfo.xml")
+        fetch_file(target,run_info_xml)
+        default_bases_mask = get_bases_mask(run_info_xml)
+        print("Default bases mask: %s" % default_bases_mask)
+    except Exception as ex:
+        # Failed to acquire RunInfo.xml
+        if not unaligned_dir:
+            # Fatal error
+            try:
+                # Remove temporary directory
+                shutil.rmtree(tmp_analysis_dir)
+                ap.analysis_dir = None
+            except Exception:
+                pass
+            raise Exception("Failed to acquire RunInfo.xml: %s" % ex)
+        else:
+            # Can ignore if Fastqs already exist
+            default_bases_mask = None
     # Data source metadata
     data_source = ap.settings.metadata.default_data_source
     # Generate and print predicted outputs and warnings
@@ -254,7 +274,7 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
     ap.params['data_dir'] = data_dir
     ap.params['analysis_dir'] = ap.analysis_dir
     ap.params['sample_sheet'] = custom_sample_sheet
-    ap.params['bases_mask'] = bases_mask
+    ap.params['bases_mask'] = 'auto'
     ap.params['unaligned_dir'] = unaligned_dir
     ap.params['acquired_primary_data'] = False
     # Store the metadata
@@ -264,6 +284,7 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
     ap.metadata['instrument_datestamp'] = datestamp
     ap.metadata['instrument_run_number'] = instrument_run_number
     ap.metadata['instrument_flow_cell_id'] = flow_cell
+    ap.metadata['default_bases_mask'] = default_bases_mask
     ap.metadata['sequencer_model'] = model
     ap.metadata['source'] = data_source
     ap.metadata['run_number'] = run_number

--- a/auto_process_ngs/commands/setup_cmd.py
+++ b/auto_process_ngs/commands/setup_cmd.py
@@ -155,13 +155,13 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
             # Look for sample sheet
             print("Acquiring sample sheet...")
             if sample_sheet is None:
-                targets = ('Data/Intensities/BaseCalls/SampleSheet.csv',
-                           'SampleSheet.csv',)
+                targets = ('SampleSheet.csv',
+                           'Data/Intensities/BaseCalls/SampleSheet.csv',)
             else:
                 targets = (sample_sheet,)
             # Try each possibility until one sticks
             for target in targets:
-                if not (Location(target).is_url or Location(target).is_remote) :
+                if not (Location(target).is_url or Location(target).is_remote):
                     target = os.path.join(data_dir,target)
                 print("Trying '%s'" % target)
                 try:

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -356,6 +356,7 @@ class AnalysisDirMetadata(MetadataDict):
     sequencer_model: the model of the sequencing instrument
     flow_cell_mode: the flow cell configuration (if present in the
       run parameters)
+    default_bases_mask: default bases mask derived from RunInfo.xml
 
     """
     def __init__(self,filen=None):
@@ -381,6 +382,7 @@ class AnalysisDirMetadata(MetadataDict):
                                   'instrument_run_number': 'instrument_run_number',
                                   'sequencer_model': 'sequencer_model',
                                   'flow_cell_mode': 'flow_cell_mode',
+                                  'default_bases_mask': 'default_bases_mask',
                                   'analysis_number': 'analysis_number',
                               },
                               order=('run_name',

--- a/auto_process_ngs/test/commands/test_setup_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_cmd.py
@@ -793,69 +793,6 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                                                        subdirn)),
                             "Missing subdir: %s" % subdirn)
 
-    def test_autoprocess_setup_samplesheet_from_url(self):
-        """setup: works when samplesheet is a URL
-        """
-        # Create mock Illumina run directory
-        mock_illumina_run = MockIlluminaRun(
-            '151125_M00879_0001_000000000-ABCDE1',
-            'miseq',
-            top_dir=self.dirn)
-        mock_illumina_run.create()
-        # Copy samplesheet
-        sample_sheet = os.path.join(self.dirn,'samplesheet.csv')
-        with open(os.path.join(mock_illumina_run.dirn,
-                               'Data','Intensities','BaseCalls',
-                               'SampleSheet.csv'),'r') as fp1:
-            with open(sample_sheet,'w') as fp2:
-                fp2.write(fp1.read())
-        sample_sheet = "file://%s" % sample_sheet
-        print(sample_sheet)
-        # Set up autoprocessor
-        ap = AutoProcess(settings=self.settings())
-        setup_(ap,mock_illumina_run.dirn,sample_sheet=sample_sheet)
-        analysis_dirn = "%s_analysis" % mock_illumina_run.name
-        # Check parameters
-        self.assertEqual(ap.analysis_dir,
-                         os.path.join(self.dirn,analysis_dirn))
-        self.assertEqual(ap.params.data_dir,mock_illumina_run.dirn)
-        self.assertEqual(ap.params.sample_sheet,
-                         os.path.join(self.dirn,analysis_dirn,
-                                      'custom_SampleSheet.csv'))
-        self.assertEqual(ap.params.bases_mask,'auto')
-        # Check metadata
-        self.assertEqual(ap.metadata.run_name,
-                         "151125_M00879_0001_000000000-ABCDE1")
-        self.assertEqual(ap.metadata.run_number,None)
-        self.assertEqual(ap.metadata.source,None)
-        self.assertEqual(ap.metadata.platform,"miseq")
-        self.assertEqual(ap.metadata.bcl2fastq_software,None)
-        self.assertEqual(ap.metadata.cellranger_software,None)
-        self.assertEqual(ap.metadata.instrument_name,"M00879")
-        self.assertEqual(ap.metadata.instrument_datestamp,"151125")
-        self.assertEqual(ap.metadata.instrument_run_number,"1")
-        self.assertEqual(ap.metadata.instrument_flow_cell_id,
-                         "000000000-ABCDE1")
-        self.assertEqual(ap.metadata.sequencer_model,None)
-        # Delete to force write of data to disk
-        del(ap)
-        # Check directory exists
-        self.assertTrue(os.path.isdir(analysis_dirn))
-        # Check files exists
-        for filen in ('SampleSheet.orig.csv',
-                      'custom_SampleSheet.csv',
-                      'auto_process.info',
-                      'metadata.info',):
-            self.assertTrue(os.path.exists(os.path.join(analysis_dirn,
-                                                        filen)),
-                            "Missing file: %s" % filen)
-        # Check subdirs have been created
-        for subdirn in ('ScriptCode',
-                        'logs',):
-            self.assertTrue(os.path.isdir(os.path.join(analysis_dirn,
-                                                       subdirn)),
-                            "Missing subdir: %s" % subdirn)
-
     def test_autoprocess_setup_import_extra_files(self):
         """setup: check extra files can be imported
         """

--- a/auto_process_ngs/test/commands/test_setup_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_cmd.py
@@ -118,7 +118,84 @@ model = {model}
         self.assertEqual(ap.metadata.instrument_run_number,"1")
         self.assertEqual(ap.metadata.instrument_flow_cell_id,
                          "000000000-ABCDE1")
+        self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.default_bases_mask,
+                         "y101,I8,I8,y101")
+        # Delete to force write of data to disk
+        del(ap)
+        # Check directory exists
+        self.assertTrue(os.path.isdir(analysis_dirn))
+        # Check files exists
+        for filen in ('SampleSheet.orig.csv',
+                      'custom_SampleSheet.csv',
+                      'auto_process.info',
+                      'metadata.info',):
+            self.assertTrue(os.path.exists(os.path.join(analysis_dirn,
+                                                        filen)),
+                            "Missing file: %s" % filen)
+        # Check subdirs have been created
+        for subdirn in ('ScriptCode',
+                        'logs',):
+            self.assertTrue(os.path.isdir(os.path.join(analysis_dirn,
+                                                       subdirn)),
+                            "Missing subdir: %s" % subdirn)
+
+    def test_autoprocess_setup_novaseq_run(self):
+        """setup: works for mock NovaSeq run (set flow cell mode)
+        """
+        # Create mock Illumina run directory
+        mock_illumina_run = MockIlluminaRun(
+            '230711_A00879_0089_000000000-ABCDE1',
+            'novaseq',
+            top_dir=self.dirn)
+        mock_illumina_run.create()
+        # Make a samplesheet file
+        sample_sheet = os.path.join(self.dirn,
+                                    "SampleSheet_NovaSeq_Run_89.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write("""[Header]
+IEMFileVersion,4
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+1,Sample1,Sample1,,,D701,CGTGTAGG,D501,GACCTGTA,Project1,
+2,Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,Project2,
+""")
+        # Set up autoprocessor
+        ap = AutoProcess(
+            settings=self.settings(
+                sequencer=dict(name="A00879",
+                               platform="novaseq",
+                               model="NovaSeq 5000")))
+        setup_(ap,mock_illumina_run.dirn,sample_sheet=sample_sheet)
+        analysis_dirn = "%s_analysis" % mock_illumina_run.name
+        # Check parameters
+        self.assertEqual(ap.analysis_dir,
+                         os.path.join(self.dirn,analysis_dirn))
+        self.assertEqual(ap.params.data_dir,mock_illumina_run.dirn)
+        self.assertEqual(ap.params.sample_sheet,
+                         os.path.join(self.dirn,analysis_dirn,
+                                      'custom_SampleSheet.csv'))
+        self.assertEqual(ap.params.bases_mask,'auto')
+        # Check metadata
+        self.assertEqual(ap.metadata.run_name,
+                         "230711_A00879_0089_000000000-ABCDE1")
+        self.assertEqual(ap.metadata.run_number,None)
+        self.assertEqual(ap.metadata.analysis_number,None)
+        self.assertEqual(ap.metadata.platform,"novaseq")
+        self.assertEqual(ap.metadata.bcl2fastq_software,None)
+        self.assertEqual(ap.metadata.cellranger_software,None)
+        self.assertEqual(ap.metadata.cellranger_software,None)
+        self.assertEqual(ap.metadata.instrument_name,"A00879")
+        self.assertEqual(ap.metadata.instrument_datestamp,"230711")
+        self.assertEqual(ap.metadata.instrument_run_number,"89")
+        self.assertEqual(ap.metadata.instrument_flow_cell_id,
+                         "000000000-ABCDE1")
+        self.assertEqual(ap.metadata.flow_cell_mode,"SP")
+        self.assertEqual(ap.metadata.sequencer_model,"NovaSeq 5000")
+        self.assertEqual(ap.metadata.default_bases_mask,
+                         "y76,I0,I10,y76")
         # Delete to force write of data to disk
         del(ap)
         # Check directory exists
@@ -174,7 +251,10 @@ model = {model}
         self.assertEqual(ap.metadata.instrument_run_number,"1")
         self.assertEqual(ap.metadata.instrument_flow_cell_id,
                          "000000000-ABCDE1")
+        self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.default_bases_mask,
+                         "y101,I8,I8,y101")
         # Delete to force write of data to disk
         del(ap)
         # Check directory exists
@@ -230,7 +310,10 @@ model = {model}
         self.assertEqual(ap.metadata.instrument_run_number,"1")
         self.assertEqual(ap.metadata.instrument_flow_cell_id,
                          "000000000-ABCDE1")
+        self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.default_bases_mask,
+                         "y101,I8,I8,y101")
         # Delete to force write of data to disk
         del(ap)
         # Check directory exists
@@ -284,7 +367,10 @@ model = {model}
         self.assertEqual(ap.metadata.instrument_datestamp,None)
         self.assertEqual(ap.metadata.instrument_run_number,None)
         self.assertEqual(ap.metadata.instrument_flow_cell_id,None)
+        self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.default_bases_mask,
+                         "y101,I8,I8,y101")
 
     def test_autoprocess_setup_existing_target_dir(self):
         """setup: works when target dir exists
@@ -449,7 +535,10 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
         self.assertEqual(ap.metadata.instrument_run_number,"2")
         self.assertEqual(ap.metadata.instrument_flow_cell_id,
                          "AHGXXXX")
+        self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.default_bases_mask,
+                         "y76,I6,y76")
         # Delete to force write of data to disk
         del(ap)
         # Check directory exists
@@ -512,7 +601,10 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
         self.assertEqual(ap.metadata.instrument_run_number,"1")
         self.assertEqual(ap.metadata.instrument_flow_cell_id,
                          "000000000-ABCDE1")
+        self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.default_bases_mask,
+                         "y101,I8,I8,y101")
         # Delete to force write of data to disk
         del(ap)
         # Check directory exists
@@ -592,7 +684,10 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(ap.metadata.instrument_run_number,"2")
         self.assertEqual(ap.metadata.instrument_flow_cell_id,
                          "AHGXXXX")
+        self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.default_bases_mask,
+                         "y76,I6,y76")
         # Delete to force write of data to disk
         del(ap)
         # Check directory exists
@@ -675,7 +770,10 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(ap.metadata.instrument_run_number,"2")
         self.assertEqual(ap.metadata.instrument_flow_cell_id,
                          "AHGXXXX")
+        self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.default_bases_mask,
+                         "y76,I6,y76")
         # Delete to force write of data to disk
         del(ap)
         # Check directory exists
@@ -802,7 +900,10 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(ap.metadata.instrument_run_number,"1")
         self.assertEqual(ap.metadata.instrument_flow_cell_id,
                          "000000000-ABCDE1")
+        self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.default_bases_mask,
+                         "y101,I8,I8,y101")
         # Delete to force write of data to disk
         del(ap)
         # Check directory exists
@@ -876,7 +977,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(ap.metadata.instrument_run_number,"1")
         self.assertEqual(ap.metadata.instrument_flow_cell_id,
                          "000000000-ABCDE1")
+        self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.default_bases_mask,None)
         # Delete to force write of data to disk
         del(ap)
         # Check directory exists
@@ -955,7 +1058,9 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
         self.assertEqual(ap.metadata.instrument_run_number,"1")
         self.assertEqual(ap.metadata.instrument_flow_cell_id,
                          "000000000-ABCDE1")
+        self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.default_bases_mask,None)
         # Delete to force write of data to disk
         del(ap)
         # Check directory exists
@@ -1067,4 +1172,7 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
         self.assertEqual(ap.metadata.instrument_run_number,"1")
         self.assertEqual(ap.metadata.instrument_flow_cell_id,
                          "000000000-ABCDE1")
+        self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,"MiSeq")
+        self.assertEqual(ap.metadata.default_bases_mask,
+                         "y101,I8,I8,y101")

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -327,6 +327,7 @@ class TestAnalysisDirMetadata(unittest.TestCase):
         self.assertEqual(metadata.instrument_flow_cell_id,None)
         self.assertEqual(metadata.sequencer_model,None)
         self.assertEqual(metadata.flow_cell_mode,None)
+        self.assertEqual(metadata.default_bases_mask,None)
 
 class TestProjectMetadataFile(unittest.TestCase):
     """Tests for the ProjectMetadataFile class


### PR DESCRIPTION
Updates the `setup` command implementation in `commands/setup_cmd.py` to set additional metadata items:

* Default bases mask (extracted from `RunInfo.xml`), and
* Flow cell mode (extracted from `RunParameters.xml`)

This requires that `setup` fetches copies of both these files to extract the information (previously only the sample sheet file was fetched).

The default bases mask is not used directly but may be helpful in cases when the bases mask needs to be modified when running the `make_fastqs` command (for example to trim one or more reads).

The flow cell mode was previously not set until `make_fastqs` had completed (this mechanism remains for now), however setting it on setup seems to make more sense.