### PR TITLE
transfer_data.py: add options to put Fastqs into ZIP files or exclude Fastqs

### DIFF
--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -105,6 +105,9 @@ def main():
                    "used")
     p.add_argument('--zip_fastqs',action='store_true',
                    help="put Fastqs into a ZIP file")
+    p.add_argument('--no_fastqs',action='store_true',
+                   help="don't copy Fastqs (other artefacts will be "
+                   "copied, if specified)")
     p.add_argument('--readme',action='store',
                    metavar='README_TEMPLATE',dest='readme_template',
                    help="template file to generate README file from; "
@@ -149,6 +152,9 @@ def main():
     # Process command line
     args = p.parse_args()
 
+    # Flag for Fastq transfer
+    include_fastqs = not args.no_fastqs
+
     # Check if target is pre-defined destination
     if args.dest in destinations:
         print("Loading settings for destination '%s'" % args.dest)
@@ -182,6 +188,18 @@ def main():
         weburl = args.weburl
     if args.link:
         hard_links = args.link
+
+    # Additional artefacts
+    include_10x_outputs = bool(args.include_10x_outputs)
+
+    # Check at least one artefact is being transferred
+    if not (include_fastqs or
+            include_downloader or
+            include_qc_report or
+            include_10x_outputs or
+            readme_template):
+        logger.error("No artefacts specified for transfer")
+        return 1
 
     # Sort out project directory
     project = AnalysisProject(args.project)
@@ -296,7 +314,7 @@ def main():
         qc_zips = None
 
     # Locate 10xGenomics outputs
-    if args.include_10x_outputs:
+    if include_10x_outputs:
         print("Locating outputs from 10xGenomics pipelines for "
               "inclusion")
         cellranger_dirs = list()
@@ -428,64 +446,73 @@ def main():
                             poll_interval=settings.general.poll_interval)
     sched.start()
 
-    # Build command to run manage_fastqs.py to copy Fastqs
-    if not args.zip_fastqs:
-        copy_cmd = Command("manage_fastqs.py")
-        if args.filter_pattern:
-            copy_cmd.add_args("--filter",args.filter_pattern)
-        if hard_links:
-            copy_cmd.add_args("--link")
-        if fastq_dir is not None:
-            copy_cmd.add_args("--fastq_dir",
-                              fastq_dir)
-        copy_cmd.add_args(analysis_dir.analysis_dir,
-                          project_name,
-                          "copy",
-                          target_dir)
-        print("Running %s" % copy_cmd)
-        copy_job = sched.submit(copy_cmd.command_line,
-                                name="copy.%s" % job_id,
-                                wd=working_dir)
+    # List of jobs to check at the end
+    check_jobs = {}
 
-    # Build commands to zip Fastqs and rename/move
-    if args.zip_fastqs:
-        zip_cmd = Command("manage_fastqs.py")
-        if args.filter_pattern:
-            zip_cmd.add_args("--filter",args.filter_pattern)
-        if fastq_dir is not None:
-            zip_cmd.add_args("--fastq_dir",
-                             fastq_dir)
-        zip_cmd.add_args(analysis_dir.analysis_dir,
-                          project_name,
-                         "zip")
-        print("Running %s" % zip_cmd)
-        zip_job = sched.submit(zip_cmd.command_line,
-                               name="zip.%s" % job_id,
-                               wd=working_dir)
-        final_zip = \
-            "{platform}_{datestamp}.{run_number}-{project}-fastqs.zip".\
-            format(
-                platform=analysis_dir.metadata.platform.upper(),
-                datestamp=analysis_dir.metadata.instrument_datestamp,
-                run_number=analysis_dir.metadata.run_number,
-                project=project.name)
-        copy_cmd = copy_command(
-            os.path.join(working_dir,"%s.zip" % project_name),
-            os.path.join(target_dir,final_zip))
-        copy_job = sched.submit(copy_cmd.command_line,
-                                name="copyzip.%s" % job_id,
-                                wd=working_dir,
-                                wait_for=(zip_job.job_name,))
+    # Transfer Fastqs
+    if include_fastqs:
+        if not args.zip_fastqs:
+            # Build command to run manage_fastqs.py to copy Fastqs
+            copy_cmd = Command("manage_fastqs.py")
+            if args.filter_pattern:
+                copy_cmd.add_args("--filter",args.filter_pattern)
+            if hard_links:
+                copy_cmd.add_args("--link")
+            if fastq_dir is not None:
+                copy_cmd.add_args("--fastq_dir",
+                                  fastq_dir)
+            copy_cmd.add_args(analysis_dir.analysis_dir,
+                              project_name,
+                              "copy",
+                              target_dir)
+            print("Running %s" % copy_cmd)
+            copy_job = sched.submit(copy_cmd.command_line,
+                                    name="copy_fastqs.%s" % job_id,
+                                    wd=working_dir)
+            check_jobs[copy_job.name] = copy_job
+        else:
+            # Build command to zip Fastqs
+            zip_cmd = Command("manage_fastqs.py")
+            if args.filter_pattern:
+                zip_cmd.add_args("--filter",args.filter_pattern)
+            if fastq_dir is not None:
+                zip_cmd.add_args("--fastq_dir",
+                                 fastq_dir)
+            zip_cmd.add_args(analysis_dir.analysis_dir,
+                             project_name,
+                             "zip")
+            print("Running %s" % zip_cmd)
+            zip_job = sched.submit(zip_cmd.command_line,
+                                   name="zip_fastqs.%s" % job_id,
+                                   wd=working_dir)
+            check_jobs[zip_job.name] = zip_job
+            # Rename ZIP file and move to final location
+            final_zip = \
+                "{platform}_{datestamp}.{run_number}-{project}-fastqs.zip".\
+                format(
+                    platform=analysis_dir.metadata.platform.upper(),
+                    datestamp=analysis_dir.metadata.instrument_datestamp,
+                    run_number=analysis_dir.metadata.run_number,
+                    project=project.name)
+            copy_cmd = copy_command(
+                os.path.join(working_dir,"%s.zip" % project_name),
+                os.path.join(target_dir,final_zip))
+            copy_job = sched.submit(copy_cmd.command_line,
+                                    name="copy_zipped_fastqs.%s" % job_id,
+                                    wd=working_dir,
+                                    wait_for=(zip_job.job_name,))
+            check_jobs[copy_job.name] = copy_job
 
     # Copy README
     if readme_file is not None:
         print("Copying README file")
         copy_cmd = copy_command(readme_file,
                                 os.path.join(target_dir,"README"))
-        sched.submit(copy_cmd.command_line,
-                     name="copy.%s.readme" % job_id,
-                     runner=SimpleJobRunner(),
-                     wd=working_dir)
+        copy_job = sched.submit(copy_cmd.command_line,
+                                name="copy_readme.%s" % job_id,
+                                runner=SimpleJobRunner(),
+                                wd=working_dir)
+        check_jobs[copy_job.name] = copy_job
 
     # Copy download_fastqs.py
     if downloader:
@@ -494,10 +521,11 @@ def main():
                                 os.path.join(
                                     target_dir,
                                     os.path.basename(downloader)))
-        sched.submit(copy_cmd.command_line,
-                     name="copy.%s.downloader" % job_id,
-                     runner=SimpleJobRunner(),
-                     wd=working_dir)
+        copy_job = sched.submit(copy_cmd.command_line,
+                                name="copy_downloader.%s" % job_id,
+                                runner=SimpleJobRunner(),
+                                wd=working_dir)
+        check_jobs[copy_job.name] = copy_job
 
     # Copy QC reports
     if qc_zips:
@@ -507,11 +535,13 @@ def main():
                 qc_zip,
                 os.path.join(target_dir,os.path.basename(qc_zip)),
                 link=hard_links)
-            sched.submit(copy_cmd.command_line,
-                         name="copy.%s.%s" % (job_id,
-                                                os.path.basename(qc_zip)),
-                         runner=SimpleJobRunner(),
-                         wd=working_dir)
+            copy_job = sched.submit(copy_cmd.command_line,
+                                    name="copy_qc_zip.%s.%s" %
+                                    (job_id,
+                                     os.path.basename(qc_zip)),
+                                    runner=SimpleJobRunner(),
+                                    wd=working_dir)
+            check_jobs[copy_job.name] = copy_job
 
     # Tar and copy 10xGenomics outputs
     if cellranger_dirs:
@@ -533,22 +563,24 @@ def main():
                                 os.path.basename(cellranger_dir))
             print("Running %s" % targz_cmd)
             targz_job = sched.submit(targz_cmd.command_line,
-                                     name="targz.%s.%s" % (
+                                     name="targz_10x_output.%s.%s" % (
                                          job_id,
                                          os.path.basename(cellranger_dir)),
                                      wd=working_dir)
+            check_jobs[targz_job.name] = targz_job
             # Copy the targz file
             copy_cmd = copy_command(targz,
                                     os.path.join(target_dir,
                                                  os.path.basename(targz)))
             print("Running %s" % copy_cmd)
             copy_job = sched.submit(copy_cmd.command_line,
-                                    name="copytgz.%s.%s" % (
+                                    name="copy_10x_tgz.%s.%s" % (
                                         job_id,
                                         os.path.basename(cellranger_dir)),
                                     runner=SimpleJobRunner(),
                                     wd=working_dir,
                                     wait_for=(targz_job.job_name,))
+            check_jobs[copy_job.name] = copy_job
 
     # Wait for scheduler jobs to complete
     sched.wait()
@@ -559,16 +591,22 @@ def main():
                                               target_dir)
     print("Running %s" % permissions_cmd)
     permissions_job = sched.submit(permissions_cmd.command_line,
-                                   name="copy.%s.permissions" % job_id,
+                                   name="set_permissions.%s" % job_id,
                                    runner=SimpleJobRunner(),
                                    wd=working_dir)
     permissions_job.wait()
+    check_jobs[copy_job.name] = copy_job
 
-    # Check exit code for Fastq copying
-    exit_code = copy_job.exit_code
-    if exit_code != 0:
-        logger.error("File copy exited with an error")
-        return exit_code
+    # Check all jobs completed successfully
+    status = 0
+    for name in check_jobs:
+        if check_jobs[name].exit_code != 0:
+            logger.warning("'%s': operation failed" % name)
+            status = 1
+    if status != 0:
+        logger.error("some transfer operations did not complete "
+                     "successfully (see warnings above)")
+        return 1
     else:
         print("Files now at %s" % target_dir)
         if weburl:

--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -170,6 +170,8 @@ def main():
         target_dir = dest.directory
         readme_template = dest.readme_template
         subdir = dest.subdir
+        zip_fastqs = dest.zip_fastqs
+        max_zip_size = dest.max_zip_size
         include_downloader = dest.include_downloader
         include_qc_report = dest.include_qc_report
         hard_links = dest.hard_links
@@ -178,6 +180,8 @@ def main():
         target_dir = args.dest
         readme_template = None
         subdir = None
+        zip_fastqs = False
+        max_zip_size = None
         include_downloader = False
         include_qc_report = False
         hard_links = False
@@ -188,6 +192,10 @@ def main():
         readme_template = args.readme_template
     if args.subdir:
         subdir = args.subdir
+    if args.zip_fastqs:
+        zip_fastqs = True
+    if args.max_zip_size:
+        max_zip_size = args.max_zip_size
     if args.include_downloader:
         include_downloader = True
     if args.include_qc_report:
@@ -459,7 +467,7 @@ def main():
 
     # Transfer Fastqs
     if include_fastqs:
-        if not args.zip_fastqs:
+        if not zip_fastqs:
             # Build command to run manage_fastqs.py to copy Fastqs
             copy_cmd = Command("manage_fastqs.py")
             if args.filter_pattern:
@@ -483,8 +491,8 @@ def main():
             zip_cmd = Command("manage_fastqs.py")
             if args.filter_pattern:
                 zip_cmd.add_args("--filter",args.filter_pattern)
-            if args.max_zip_size:
-                zip_cmd.add_args("--max_zip_size",args.max_zip_size)
+            if max_zip_size:
+                zip_cmd.add_args("--max_zip_size",max_zip_size)
             if fastq_dir is not None:
                 zip_cmd.add_args("--fastq_dir",
                                  fastq_dir)

--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -435,11 +435,13 @@ def main():
             copy_cmd.add_args("--filter",args.filter_pattern)
         if hard_links:
             copy_cmd.add_args("--link")
-        copy_cmd.add_args(analysis_dir.analysis_dir,
-                          project_name)
         if fastq_dir is not None:
-            copy_cmd.add_args(fastq_dir)
-        copy_cmd.add_args("copy",target_dir)
+            copy_cmd.add_args("--fastq_dir",
+                              fastq_dir)
+        copy_cmd.add_args(analysis_dir.analysis_dir,
+                          project_name,
+                          "copy",
+                          target_dir)
         print("Running %s" % copy_cmd)
         copy_job = sched.submit(copy_cmd.command_line,
                                 name="copy.%s" % job_id,
@@ -451,8 +453,8 @@ def main():
         if args.filter_pattern:
             zip_cmd.add_args("--filter",args.filter_pattern)
         if fastq_dir is not None:
-            copy_cmd.add_args("--fastq_dir",
-                              fastq_dir)
+            zip_cmd.add_args("--fastq_dir",
+                             fastq_dir)
         zip_cmd.add_args(analysis_dir.analysis_dir,
                           project_name,
                          "zip")

--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -616,7 +616,7 @@ def main():
                                    runner=SimpleJobRunner(),
                                    wd=working_dir)
     permissions_job.wait()
-    check_jobs[copy_job.name] = copy_job
+    check_jobs[permissions_job.name] = permissions_job
 
     # Check all jobs completed successfully
     status = 0

--- a/auto_process_ngs/fileops.py
+++ b/auto_process_ngs/fileops.py
@@ -23,6 +23,7 @@ The following functions perform specific operations directly:
 - set_permissions: set permissions on a file or directory
 - unzip: unpack a ZIP archive
 - rename: rename (move) a file or directory
+- listdir: list the contents of a directory
 - exists: test if a file or directory exists
 - isdir: test if a path is a directory
 - remove_file: remove (delete) a file
@@ -265,6 +266,24 @@ def rename(src,dst):
     # Run command and return
     retval,output = rename_cmd.subprocess_check_output()
     return retval
+
+def listdir(path):
+    """
+    List contents of a directory (including hidden files)
+    """
+    path = Location(path)
+    list_cmd = applications.Command('ls',
+                                    '-1',
+                                    '-a',
+                                    path.path)
+    if path.is_remote:
+        # Run test on remote system
+        list_cmd = applications.general.ssh_command(
+            path.user,
+            path.server,
+            list_cmd.command_line)
+    retval,output = list_cmd.subprocess_check_output()
+    return output.rstrip('\n').split('\n')
 
 def exists(path):
     """

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -483,6 +483,8 @@ class Settings:
 
         - directory (compulsory, str)
         - subdir (optional, str, default 'None')
+        - zip_fastqs (optional, boolean, default 'False')
+        - max_zip_size (option, str, default 'None')
         - readme_template (optional, str, default 'None')
         - url (optional, str, default 'None')
         - include_downloader (optional, boolean, default 'False')
@@ -501,6 +503,8 @@ class Settings:
         values = AttributeDictionary()
         values['directory'] = config.get(section,'directory',None)
         values['subdir'] = config.get(section,'subdir',None)
+        values['zip_fastqs'] = config.getboolean(section,'zip_fastqs',False)
+        values['max_zip_size'] = config.get(section,'max_zip_size',None)
         values['readme_template'] = config.get(section,'readme_template',None)
         values['url'] = config.get(section,'url',None)
         values['include_downloader'] = config.getboolean(

--- a/auto_process_ngs/test/test_fileops.py
+++ b/auto_process_ngs/test/test_fileops.py
@@ -253,6 +253,44 @@ class TestRename(FileopsTestCase):
         self.assertFalse(os.path.exists(old_dir))
         self.assertTrue(os.path.exists(new_dir))
 
+class TestListdir(FileopsTestCase):
+    """Tests for the 'listdir' function
+    """
+    def test_local_listdir(self):
+        """
+        fileops.listdir: test for a local directory
+        """
+        expected = ['.','..']
+        test_files = ("test1.txt","test2.txt")
+        for f in test_files:
+            expected.append(f)
+            f = os.path.join(self.test_dir,f)
+            with open(f,'w') as fp:
+                fp.write("This is a test file")
+        test_dirs = ("dir1",)
+        for d in test_dirs:
+            expected.append(d)
+            os.mkdir(os.path.join(self.test_dir,d))
+        self.assertEqual(listdir(self.test_dir),
+                         sorted(expected))
+    def test_local_listdir_hidden_files(self):
+        """
+        fileops.listdir: test for a local directory with hidden files
+        """
+        expected = ['.','..']
+        test_files = ("test1.txt","test2.txt",".hidden1.txt")
+        for f in test_files:
+            expected.append(f)
+            f = os.path.join(self.test_dir,f)
+            with open(f,'w') as fp:
+                fp.write("This is a test file")
+        test_dirs = ("dir1",".hidden1")
+        for d in test_dirs:
+            expected.append(d)
+            os.mkdir(os.path.join(self.test_dir,d))
+        self.assertEqual(sorted(listdir(self.test_dir)),
+                         sorted(expected))
+
 class TestExists(FileopsTestCase):
     """Tests for the 'exists' function
     """

--- a/auto_process_ngs/test/test_settings.py
+++ b/auto_process_ngs/test/test_settings.py
@@ -208,6 +208,12 @@ hard_links = true
 [destination:local]
 directory = /mnt/shared
 subdir = run_id
+
+[destination:zips]
+directory = /mnt/www/zipped
+subdir = run_id
+zip_fastqs = true
+max_zip_size = 5G
 """)
         # Load settings
         s = Settings(settings_file)
@@ -216,6 +222,8 @@ subdir = run_id
         self.assertEqual(s.destination['webserver']['directory'],
                          '/mnt/www/data')
         self.assertEqual(s.destination['webserver']['subdir'],'random_bin')
+        self.assertEqual(s.destination['webserver']['zip_fastqs'],False)
+        self.assertEqual(s.destination['webserver']['max_zip_size'],None)
         self.assertEqual(s.destination['webserver']['readme_template'],
                          'README.webserver.template')
         self.assertEqual(s.destination['webserver']['url'],
@@ -228,11 +236,23 @@ subdir = run_id
         self.assertTrue('local' in s.destination)
         self.assertEqual(s.destination['local']['directory'],'/mnt/shared')
         self.assertEqual(s.destination['local']['subdir'],'run_id')
+        self.assertEqual(s.destination['local']['zip_fastqs'],False)
+        self.assertEqual(s.destination['local']['max_zip_size'],None)
         self.assertEqual(s.destination['local']['readme_template'],None)
         self.assertEqual(s.destination['local']['url'],None)
         self.assertEqual(s.destination['local']['include_downloader'],False)
         self.assertEqual(s.destination['local']['include_qc_report'],False)
         self.assertEqual(s.destination['local']['hard_links'],False)
+        self.assertTrue('zips' in s.destination)
+        self.assertEqual(s.destination['zips']['directory'],'/mnt/www/zipped')
+        self.assertEqual(s.destination['zips']['subdir'],'run_id')
+        self.assertEqual(s.destination['zips']['zip_fastqs'],True)
+        self.assertEqual(s.destination['zips']['max_zip_size'],'5G')
+        self.assertEqual(s.destination['zips']['readme_template'],None)
+        self.assertEqual(s.destination['zips']['url'],None)
+        self.assertEqual(s.destination['zips']['include_downloader'],False)
+        self.assertEqual(s.destination['zips']['include_qc_report'],False)
+        self.assertEqual(s.destination['zips']['hard_links'],False)
 
     def test_sequencer_definitions(self):
         """Settings: handle 'sequencer:...' sections

--- a/config/auto_process.ini.sample
+++ b/config/auto_process.ini.sample
@@ -192,6 +192,8 @@ exclude_zip_files = False
 #   according to this scheme:
 #   * 'random_bin': used a random pre-existing empty subdir
 #   * 'run_id': creates new subdir 'PLATFORM_DATESTAMP.RUN_ID-PROJECT'
+# - zip_fastqs: whether to bundle Fastqs into ZIP archives
+# - max_zip_size: maximum size for each ZIP archive
 # - readme_template: template file to generate README file from
 #   (either full path or the name of a file in the 'templates'
 #   directory of the installation
@@ -206,8 +208,10 @@ exclude_zip_files = False
 #[destination:webserver]
 #directory = /mnt/hosted/web
 #subdir = random_bin
+#zip_fastqs = true
+#max_zip_size = 5G
 #readme_template = README.webserver.txt
 #url = http://awesome.com/data
-#include_downloader = true
+#include_downloader = false
 #include_qc_report = true
 #hard_links = false

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -632,6 +632,9 @@ Parameter              Function
                        to copy files to; can be an arbitrary location
                        of the form ``[[USER@]HOST:]DIR``
 ``subdir``             Subdirectory naming scheme
+``zip_fastqs``         Whether to bundle Fastqs into ZIP archives
+``max_zip_size``       Maximum size for each ZIP archive (if Fastqs
+                       are bundled)
 ``readme_template``    Template file to generate ``README`` from
 ``url``                Base URL to access copied data at
 ``include_downloader`` Whether to include ``download_fastqs.py``

--- a/docs/source/using/managing_data.rst
+++ b/docs/source/using/managing_data.rst
@@ -188,6 +188,23 @@ option (or setting the ``hard_links`` parameter).
 Linking Fastqs is quicker than copying and saves space as hard links
 reference the same copy of the file's data on the file system.
 
+Bundling Fastqs into ZIP archives
+---------------------------------
+
+For datasets with contain very large numbers of Fastq files it may
+be undesirable to share the individual Fastqs (for example when
+downloading from a web server, or uploading to a file transfer
+service such as ZendTo).
+
+In these cases the following options can be used:
+
+ * ``--zip_fastqs`` will bundle the Fastqs into one or more ZIP
+   archives (instead of copying each Fastq individually)
+ * If specified then the ``--max_zip_size`` option additionally
+   sets the maximum size for each ZIP archive, resulting in multiple
+   ZIPs if the dataset cannot be put into a single archive of this
+   size.
+
 .. _download_fastqs:
 
 ``download_fastqs.py``: fetch Fastqs from a webserver in batch


### PR DESCRIPTION
Updates the `transfer_data.py` utility to add new options:

* `--zip_fastqs` puts all Fastqs into a ZIP archive before copying to the destination (using the `manage_fastqs.py zip` option)
* `--max_zip_size` sets a size limit on the Fastq ZIP archive, creating multiple ZIPs which individually will be no larger than this limit
* `--no_fastqs` excludes all Fastqs from transfer (for example, if only QC files are required)

Implementation of these changes requires a new function `listdir()` in the `fileops` module (list contents of a local or remote directory).

Additionally the configuration for file transfer destinations (defined in the config file by `[destination:...]` sections) has been extended to include settings for ZIP archives.

The PR also overhauls the error checking (if an operation fails) and fixes a minor bug with specifying Fastq subdirectories.