### PR TITLE
Check hard links are possible when requested for transferring data

### DIFF
--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -290,6 +290,19 @@ def main():
     else:
         print("Target directory %s" % target_dir)
 
+    # Check hard links are possible
+    if hard_links:
+        if Location(target_dir).is_remote:
+            print("'%s': hard links requested but target directory "
+                  "is on a remote filesystem" % target_dir)
+            return
+        else:
+            if os.lstat(project.fastq_dir).st_dev != \
+               os.lstat(target_dir).st_dev:
+                print("'%s': hard links requested but target directory "
+                  "is on a different filesystem" % target_dir)
+                return
+
     # Locate downloader
     if include_downloader:
         print("Locating downloader for inclusion")

--- a/bin/manage_fastqs.py
+++ b/bin/manage_fastqs.py
@@ -129,11 +129,23 @@ def copy_to_dest(f,dirn,chksum=None,link=False):
         raise Exception("'%s': not found" % f)
     if not exists(dirn):
         raise Exception("'%s': destination not found" % dirn)
+    # Characterise destination
+    user,host,dest = utils.split_user_host_dir(dirn)
+    remote = (host is not None)
+    # If linking then check source and destination
+    # are on the same device
+    if link:
+        if remote:
+            raise Exception("'%s': hard linking requested but "
+                            "destination is on a remote system" % dirn)
+        else:
+            if os.lstat(f).st_dev != os.lstat(dirn).st_dev:
+                raise Exception("'%s': hard linking requested but "
+                                "destination is on a different "
+                                "filesystem" % dirn)
     # Copy the file
     copy(f,dirn,link=link)
     if chksum is not None:
-        user,host,dest = utils.split_user_host_dir(dirn)
-        remote = (host is not None)
         if not remote:
             # Check local copy
             if chksum is not None:


### PR DESCRIPTION
Adds checks to `manage_fastqs.py` and `transfer_data.py` utilities that hard linking is possible when the `--link` option is specified, by checking that 1) the destination is not on a remote system, and 2) that it is on the same filesystem/device as the target Fastqs.

If either of these conditions are not met when `--link` is specified then the utilities will now exit without executing the copy/transfer operations. Removing the hard linking option should allow the transfer to proceed.

This PR address a bug previous highlighted in issue #639.