### PR TITLE
Verify integrity of Fastqs in QC pipeline

### DIFF
--- a/auto_process_ngs/cli/run_qc.py
+++ b/auto_process_ngs/cli/run_qc.py
@@ -975,7 +975,8 @@ def main():
                       protocol,
                       qc_dir=qc_dir,
                       report_html=out_file,
-                      multiqc=(not args.no_multiqc))
+                      multiqc=(not args.no_multiqc),
+                      verify_fastqs=True)
     status = runqc.run(nthreads=nthreads,
                        fastq_screens=fastq_screens,
                        fastq_subset=args.fastq_subset,

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1525,13 +1525,14 @@ class VerifyFastqs(PipelineFunctionTask):
                 fq)
     def read_fastq(self,fastq):
         # Iterate through Fastq file
+        fq = os.path.basename(fastq)
         try:
             for r in FastqIterator(fastq_file=fastq):
                 continue
         except Exception as ex:
-            print("%s...FAILED: '%s'" % (fastq,ex))
+            print("%s...FAILED: '%s'" % (q,ex))
             return False
-        print("%s...PASSED" % fastq)
+        print("%s...PASSED" % fq)
         return True
     def finish(self):
         # Report the output (will contain any errors)

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1530,7 +1530,7 @@ class VerifyFastqs(PipelineFunctionTask):
             for r in FastqIterator(fastq_file=fastq):
                 continue
         except Exception as ex:
-            print("%s...FAILED: '%s'" % (q,ex))
+            print("%s...FAILED: '%s'" % (fq,ex))
             return False
         print("%s...PASSED" % fq)
         return True

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -329,15 +329,15 @@ class QCPipeline(Pipeline):
 
         # Verify Fastqs
         if verify_fastqs:
-            verify_fastqs_ = VerifyFastqs(
+            verify_fqs = VerifyFastqs(
                 "%s: verify Fastqs" % project_name,
                 project,
                 fastq_attrs=project.fastq_attrs)
-            self.add_task(verify_fastqs_,
+            self.add_task(verify_fqs,
                           requires=(setup_qc_dirs,),
-                          runner=self.runners['fastqc_runner'],
+                          runner=self.runners['verify_runner'],
                           log_dir=log_dir)
-            startup_tasks.append(verify_fastqs_)
+            startup_tasks.append(verify_fqs)
 
         # Update QC metadata
         update_qc_metadata = UpdateQCMetadata(

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -185,7 +185,7 @@ class QCPipeline(Pipeline):
     def add_project(self,project,protocol,qc_dir=None,organism=None,
                     fastq_dir=None,report_html=None,multiqc=False,
                     sample_pattern=None,log_dir=None,convert_gtf=True,
-                    verify_fastqs=True):
+                    verify_fastqs=False):
         """
         Add a project to the QC pipeline
 
@@ -214,6 +214,7 @@ class QCPipeline(Pipeline):
             defined BED files)
           verify_fastqs (bool): if True then verify
             Fastq integrity as part of the pipeline
+            (default: False, skip verification)
         """
         ###################
         # Do internal setup

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -184,7 +184,8 @@ class QCPipeline(Pipeline):
 
     def add_project(self,project,protocol,qc_dir=None,organism=None,
                     fastq_dir=None,report_html=None,multiqc=False,
-                    sample_pattern=None,log_dir=None,convert_gtf=True):
+                    sample_pattern=None,log_dir=None,convert_gtf=True,
+                    verify_fastqs=True):
         """
         Add a project to the QC pipeline
 
@@ -211,6 +212,8 @@ class QCPipeline(Pipeline):
             GTF files to BED for 'infer_experiment.py'
             (default; otherwise only use the explicitly
             defined BED files)
+          verify_fastqs (bool): if True then verify
+            Fastq integrity as part of the pipeline
         """
         ###################
         # Do internal setup
@@ -324,15 +327,16 @@ class QCPipeline(Pipeline):
                            fastq_dir=project.fastq_dir)
 
         # Verify Fastqs
-        verify_fastqs = VerifyFastqs(
-            "%s: verify Fastqs" % project_name,
-            project,
-            fastq_attrs=project.fastq_attrs)
-        self.add_task(verify_fastqs,
-                      requires=(setup_qc_dirs,),
-                      runner=self.runners['fastqc_runner'],
-                      log_dir=log_dir)
-        startup_tasks.append(verify_fastqs)
+        if verify_fastqs:
+            verify_fastqs_ = VerifyFastqs(
+                "%s: verify Fastqs" % project_name,
+                project,
+                fastq_attrs=project.fastq_attrs)
+            self.add_task(verify_fastqs_,
+                          requires=(setup_qc_dirs,),
+                          runner=self.runners['fastqc_runner'],
+                          log_dir=log_dir)
+            startup_tasks.append(verify_fastqs_)
 
         # Update QC metadata
         update_qc_metadata = UpdateQCMetadata(

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -1082,6 +1082,56 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
                                                         "PJB",f)),
                             "Missing %s" % f)
 
+    def test_qcpipeline_verify_fastqs_with_corrupted_fastq(self):
+        """QCPipeline: verify Fastqs with corrupted file
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # Replace a Fastq file with 'bad' version
+        bad_fastq = os.path.join(self.wd,
+                                 "PJB","fastqs",
+                                 "PJB1_S1_R2_001.fastq.gz")
+        with open(bad_fastq,'wb') as fp:
+            fp.write(b"Corrupted\ndata\nfor\nGzipped file!")
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,1)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        self.assertEqual(qc_info.cellranger_probeset,None)
+
     def test_qcpipeline_single_end(self):
         """QCPipeline: standard QC run (single-end data)
         """

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -1082,9 +1082,82 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
                                                         "PJB",f)),
                             "Missing %s" % f)
 
+    def test_qcpipeline_verify_fastqs_with_valid_fastqs(self):
+        """QCPipeline: verify Fastqs with valid files
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
+                          verify_fastqs=True,
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        self.assertEqual(qc_info.cellranger_probeset,None)
+
     def test_qcpipeline_verify_fastqs_with_corrupted_fastq(self):
         """QCPipeline: verify Fastqs with corrupted file
         """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
         # Make mock analysis project
         p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
                                        "PJB1_S1_R2_001.fastq.gz",
@@ -1102,6 +1175,7 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
                           fetch_protocol_definition("standardPE"),
+                          verify_fastqs=True,
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=


### PR DESCRIPTION
Updates the QC pipeline in `qc/pipeline` to add a verification task which checks the integrity of Fastq files (i.e. can they be opened and read).

This PR is intended to address issue #854, although it should work for both compressed and uncompressed Fastqs.

The verification adds some overhead (as QC metrics are not generated until the Fastqs have been checked). Therefore, while it is always turned on in the standalone QC utility `run_qc.py` (where Fastqs can potentially come from any source) it is turned off in the `auto_process.py run_qc` command (which typically is executed on Fastqs directly from `bcl2fastq` or similar).