### PR TITLE
Update QC reporting to handle "external" 'cellranger multi' outputs

### DIFF
--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -1240,8 +1240,9 @@ class QCOutputs:
                             cellranger_name = cellranger_multi.pipeline_name
                             if cellranger_name is None:
                                 cellranger_name = 'cellranger'
-                            cellranger_references.add(
-                                cellranger_multi.reference_data)
+                            if cellranger_multi.reference_data:
+                                cellranger_references.add(
+                                    cellranger_multi.reference_data)
                             if cellranger_multi.probe_set:
                                 cellranger_probe_sets.add(
                                     cellranger_multi.probe_set)

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -2143,6 +2143,12 @@ class SampleQCReporter:
         first_line = True
         # Report each multiplexing analysis
         for cellranger_multi in self.cellranger_multi:
+            if self.sample not in cellranger_multi.sample_names:
+                logger.warning("Sample '%s' not found in multiplexing "
+                               "outputs under %s" % (self.sample,
+                                                     cellranger_multi.dir))
+                # Ignore missing multiplexed sample
+                continue
             # Shortcut to metrics
             metrics = cellranger_multi.metrics(self.sample)
             web_summary = cellranger_multi.web_summary(self.sample)

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -9,6 +9,7 @@ import os
 from auto_process_ngs.mock import MockAnalysisProject
 from auto_process_ngs.mock import UpdateAnalysisProject
 from auto_process_ngs.mockqc import make_mock_qc_dir
+from auto_process_ngs.mockqc import MockQCOutputs
 from auto_process_ngs.analysis import AnalysisProject
 from auto_process_ngs.qc.outputs import QCOutputs
 from auto_process_ngs.qc.outputs import fastq_screen_output
@@ -1665,6 +1666,83 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.config_files,
                          ['10x_multi_config.csv',
                           'fastq_strand.conf'])
+
+    def test_qcoutputs_10x_cellranger_external_multi_outputs(self):
+        """
+        QCOutputs: data with external 'cellranger multi' outputs
+        """
+        qc_dir = self._make_qc_dir('qc',
+                                   protocol="10x_CellPlex",
+                                   fastq_names=(
+                                       'PJB1_GEX_S1_R1_001',
+                                       'PJB1_GEX_S1_R2_001',
+                                       'PJB2_MC_S2_R1_001',
+                                       'PJB2_MC_S2_R2_001',
+                                   ),
+                                   include_cellranger_multi=False,
+                                   cellranger_pipelines=('cellranger',),
+                                   cellranger_samples=(
+                                       'PJB1_GEX',
+                                       'PJB2_MC',
+                                   ),
+                                   cellranger_multi_samples=(
+                                       'PJB_CML1',
+                                       'PJB_CML2',
+                                   ))
+        external_multi_dir = os.path.join("cellranger_multi",
+                                          "7.1.0",
+                                          "external")
+        MockQCOutputs.cellranger_multi(("EX1",),
+                                       qc_dir,
+                                       prefix=external_multi_dir)
+        qc_outputs = QCOutputs(qc_dir)
+        self.assertEqual(qc_outputs.outputs,
+                         ['cellranger_multi',
+                          'fastqc_r1',
+                          'fastqc_r2',
+                          'multiqc',
+                          'screens_r2',
+                          'sequence_lengths',
+                          'strandedness'])
+        self.assertEqual(qc_outputs.fastqs,
+                         ['PJB1_GEX_S1_R1_001',
+                          'PJB1_GEX_S1_R2_001',
+                          'PJB2_MC_S2_R1_001',
+                          'PJB2_MC_S2_R2_001'])
+        self.assertEqual(qc_outputs.samples,
+                         ['PJB1_GEX','PJB2_MC'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1_GEX','PJB2_MC'])
+        self.assertEqual(qc_outputs.bams,[])
+        self.assertEqual(qc_outputs.organisms,[])
+        self.assertEqual(qc_outputs.fastq_screens,
+                         ['model_organisms',
+                          'other_organisms',
+                          'rRNA'])
+        self.assertEqual(qc_outputs.cellranger_references,[])
+        self.assertEqual(qc_outputs.cellranger_probe_sets,[])
+        self.assertEqual(qc_outputs.multiplexed_samples,
+                         ['EX1'])
+        self.assertEqual(qc_outputs.reads,['r1','r2'])
+        self.assertEqual(qc_outputs.software,
+                         { 'cellranger': [ '7.1.0' ],
+                           'fastqc': [ '0.11.3' ],
+                           'fastq_screen': [ '0.9.2' ],
+                           'fastq_strand': [ '0.0.4' ],
+                           'multiqc': [ '1.8' ],
+                         })
+        self.assertEqual(qc_outputs.stats.max_seqs,37285443)
+        self.assertEqual(qc_outputs.stats.min_sequence_length,65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length,76)
+        self.assertEqual(sorted(
+            list(qc_outputs.stats.min_sequence_length_read.keys())),
+                         ['r1','r2'])
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r1'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r1'],76)
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r2'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r2'],76)
+        self.assertEqual(qc_outputs.config_files,
+                         ['fastq_strand.conf'])
 
     def test_qcoutputs_with_non_standard_qc_dir(self):
         """

--- a/auto_process_ngs/test/qc/test_reporting.py
+++ b/auto_process_ngs/test/qc/test_reporting.py
@@ -596,13 +596,36 @@ class TestReportFunction(unittest.TestCase):
             include_cellranger_multi=False)
         project = AnalysisProject(analysis_dir)
         # Todo Remove 10x_config.csv?
-        # Todo Add external 'cellranger multi'-style outputs
+        # Add external 'cellranger multi'-style outputs
         multi_dir = os.path.join("cellranger_multi",
                                  "7.1.0",
                                  "external")
         MockQCOutputs.cellranger_multi(("EX1",),
                                        project.qc_dir,
                                        prefix=multi_dir)
+        report((project,),filename=os.path.join(self.top_dir,
+                                                'report.PE.html'))
+        self.assertTrue(os.path.exists(
+            os.path.join(self.top_dir,'report.PE.html')))
+
+    def test_report_paired_end_multiple_external_cellranger_multi_outputs(self):
+        """
+        report: paired-end data with multiple external cellranger 'multi' outputs
+        """
+        analysis_dir = self._make_analysis_project(
+            protocol='10x_CellPlex',
+            include_cellranger_multi=False)
+        project = AnalysisProject(analysis_dir)
+        # Todo Remove 10x_config.csv?
+        # Add multiple external 'cellranger multi'-style outputs
+        # corresponding to different samples
+        for s in ("EX1","EX2",):
+            multi_dir = os.path.join("cellranger_multi",
+                                     "7.1.0",
+                                     s)
+            MockQCOutputs.cellranger_multi((s,),
+                                           project.qc_dir,
+                                           prefix=multi_dir)
         report((project,),filename=os.path.join(self.top_dir,
                                                 'report.PE.html'))
         self.assertTrue(os.path.exists(

--- a/auto_process_ngs/test/qc/test_reporting.py
+++ b/auto_process_ngs/test/qc/test_reporting.py
@@ -8,6 +8,7 @@ import tempfile
 import shutil
 import zipfile
 from auto_process_ngs.mock import make_mock_analysis_project
+from auto_process_ngs.mockqc import MockQCOutputs
 from auto_process_ngs.analysis import AnalysisProject
 from auto_process_ngs.qc.reporting import report
 from auto_process_ngs.qc.reporting import pretty_print_reads
@@ -585,6 +586,27 @@ class TestReportFunction(unittest.TestCase):
             'report.multiple_projects.PJB/report.multiple_projects_data/Test_PJB2/qc/PJB2_S2_R1_001_screen_rRNA.txt')
         for f in expected:
             self.assertTrue(f in contents,"%s is missing from ZIP file" % f)
+
+    def test_report_paired_end_external_cellranger_multi_outputs(self):
+        """
+        report: paired-end data with external cellranger 'multi' outputs
+        """
+        analysis_dir = self._make_analysis_project(
+            protocol='10x_CellPlex',
+            include_cellranger_multi=False)
+        project = AnalysisProject(analysis_dir)
+        # Todo Remove 10x_config.csv?
+        # Todo Add external 'cellranger multi'-style outputs
+        multi_dir = os.path.join("cellranger_multi",
+                                 "7.1.0",
+                                 "external")
+        MockQCOutputs.cellranger_multi(("EX1",),
+                                       project.qc_dir,
+                                       prefix=multi_dir)
+        report((project,),filename=os.path.join(self.top_dir,
+                                                'report.PE.html'))
+        self.assertTrue(os.path.exists(
+            os.path.join(self.top_dir,'report.PE.html')))
 
 class TestPrettyPrintReadsFunction(unittest.TestCase):
 


### PR DESCRIPTION
Updates the QC output detection and reporting to try and handle "external" 'cellranger multi' outputs in a QC directory, i.e. outputs generated outside of the QC pipeline but which have a similar directory structure to the "canonical" versions i.e.

    QC_DIR/cellranger_multi/VERSION/REFERENCE/...

The idea is that these would then also be reported in the HTML reports.