### PR TITLE
Enable job runner to be specified on command line for 'archive' command

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1571,7 +1571,7 @@ def archive(args):
                         final=args.final,
                         force=args.force,
                         dry_run=args.dry_run,
-                        runner=args.runner)
+                        runner=runner)
     sys.exit(retcode)
 
 def report(args):

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -900,6 +900,7 @@ def add_archive_command(cmdparser):
                    help="attempt to complete archiving operations ignoring "
                    "any errors (e.g. key metadata items not set, unable to "
                    "set group etc)")
+    add_runner_option(p)
     add_dry_run_option(p)
     add_debug_option(p)
     p.add_argument('analysis_dir',metavar="ANALYSIS_DIR",nargs="?",
@@ -1563,7 +1564,8 @@ def archive(args):
                         perms=args.permissions,
                         final=args.final,
                         force=args.force,
-                        dry_run=args.dry_run)
+                        dry_run=args.dry_run,
+                        runner=args.runner)
     sys.exit(retcode)
 
 def report(args):

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1557,6 +1557,12 @@ def archive(args):
     if not analysis_dir:
         analysis_dir = os.getcwd()
     d = AutoProcess(analysis_dir)
+    # Handle job runner specification
+    if args.runner is not None:
+        runner = fetch_runner(args.runner)
+    else:
+        runner = None
+    # Do the archive step
     retcode = d.archive(archive_dir=args.archive_dir,
                         platform=args.platform,
                         year=args.year,


### PR DESCRIPTION
Updates the `archive` command to add a `--runner` command line option which allows the user to explicitly specify the job runner (and override the default from the configuration file).