### PR TITLE
Keep checksum file separate from ZIP archives when transferring Fastqs

### DIFF
--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -528,7 +528,19 @@ def main():
                     project=project.name)
             job_ix = 0
             for f in listdir(working_dir):
-                if f.endswith(".zip") and \
+                if f == "%s.chksums" % project_name:
+                    # Assume it's the checksum file
+                    # Copy to final location
+                    copy_cmd = copy_command(os.path.join(working_dir,f),
+                                            os.path.join(target_dir,
+                                                         "%s.checksums" %
+                                                         final_zip_basename))
+                    copy_job = sched.submit(copy_cmd.command_line,
+                                            name="copy_checksums.%s" % job_id,
+                                            runner=SimpleJobRunner(),
+                                            wd=working_dir)
+                    check_jobs[copy_job.name] = copy_job
+                elif f.endswith(".zip") and \
                    f.startswith("%s." % project_name):
                     # Assume it's ZIP output from packaging process
                     final_zip = "%s%s" % (final_zip_basename,

--- a/bin/manage_fastqs.py
+++ b/bin/manage_fastqs.py
@@ -381,7 +381,7 @@ if __name__ == "__main__":
         try:
             md5file = os.path.join(tmp,"%s.chksums" % project.name)
             sys.stdout.write("Creating checksum file %s..." % md5file)
-            write_checksums(project,filen=md5file)
+            write_checksums(project,pattern=options.pattern,filen=md5file)
             print("done")
             if include_checksums_in_zip:
                 # Put checksum file into ZIP archive

--- a/bin/manage_fastqs.py
+++ b/bin/manage_fastqs.py
@@ -348,6 +348,7 @@ if __name__ == "__main__":
                   bcf_utils.format_file_size(max_zip_size))
         else:
             max_zip_size = None
+        include_checksums_in_zip = False
         idx = 0
         zip_file = None
         zz = None
@@ -375,15 +376,20 @@ if __name__ == "__main__":
                 zz = zipfile.ZipFile(zip_file,'w',allowZip64=True)
             # Add Fastq
             zz.write(fq,arcname=os.path.basename(fq))
-        # Make a temporary MD5 file
+        # Make an MD5 file
         tmp = tempfile.mkdtemp()
         try:
             md5file = os.path.join(tmp,"%s.chksums" % project.name)
             sys.stdout.write("Creating checksum file %s..." % md5file)
             write_checksums(project,filen=md5file)
             print("done")
-            print("Adding to %s" % zip_file)
-            zz.write(md5file,arcname=os.path.basename(md5file))
+            if include_checksums_in_zip:
+                # Put checksum file into ZIP archive
+                print("Adding to %s" % zip_file)
+                zz.write(md5file,arcname=os.path.basename(md5file))
+            else:
+                # Keep checksum file separate
+                copy_to_dest(md5file,os.getcwd())
         finally:
             shutil.rmtree(tmp)
         zz.close()


### PR DESCRIPTION
Addresses issue #882 by updating `manage_fastqs.py`'s `zip` mode so that the MD5 checksum file is now a separate file (rather than being included in the ZIP archive with the Fastqs). The `transfer_data.py` utility has also been updated to accommodate this change. (Note that these changes don't introduce any new command line options for either of these utilities.)

There is also a minor bug fix in `manage_fastqs.py` to ensure that any filter on Fastq names is also applied when generating the checksums in `zip` mode (was previously not applied so all Fastqs were included in the checksum file).