### PR TITLE
'make_fastqs': add support to specify workflow for '10x_visium' protocol (Spaceranger --rc-i2-override)

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -251,8 +251,9 @@ class MakeFastqs(Pipeline):
             (overrides sequence set in the sample sheet file)
           spaceranger_rc_i2_override (bool): if set then used as
             the value for Spaceranger's --rc-i2-override option
-            (to specify whether the workflow used was forward or
-            reverse strand) (overrides automatic detection)
+            (False specifies forward strand workflow A was used,
+            True that it was reverse complement workflow B)
+            (overrides automatic detection)
           icell8_atac_swap_i1_and_i2 (bool): if True then
             swap the I1 and I2 indexes when demultiplexing ICELL8
             ATAC data

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -140,6 +140,7 @@ LANE_SUBSET_ATTRS = (
     'no_lane_splitting',
     'tenx_filter_single_index',
     'tenx_filter_dual_index',
+    'spaceranger_rc_i2_override',
     'icell8_well_list',
     'icell8_atac_swap_i1_and_i2',
     'icell8_atac_reverse_complement',
@@ -208,6 +209,7 @@ class MakeFastqs(Pipeline):
                  minimum_trimmed_read_length=None,
                  mask_short_adapter_reads=None,
                  adapter_sequence=None,adapter_sequence_read2=None,
+                 spaceranger_rc_i2_override=None,
                  icell8_atac_swap_i1_and_i2=None,
                  icell8_atac_reverse_complement=None,
                  lanes=None,trim_adapters=True,fastq_statistics=True,
@@ -247,6 +249,10 @@ class MakeFastqs(Pipeline):
           adapter_sequence_read2 (str): optionally specify the
             'read2' adapter sequence to use for trimming
             (overrides sequence set in the sample sheet file)
+          spaceranger_rc_i2_override (bool): if set then used as
+            the value for Spaceranger's --rc-i2-override option
+            (to specify whether the workflow used was forward or
+            reverse strand) (overrides automatic detection)
           icell8_atac_swap_i1_and_i2 (bool): if True then
             swap the I1 and I2 indexes when demultiplexing ICELL8
             ATAC data
@@ -333,6 +339,7 @@ class MakeFastqs(Pipeline):
         self._adapter_sequence_read2 = adapter_sequence_read2
         self._minimum_trimmed_read_length = minimum_trimmed_read_length
         self._mask_short_adapter_reads = mask_short_adapter_reads
+        self._spaceranger_rc_i2_override = spaceranger_rc_i2_override
         self._icell8_well_list = icell8_well_list
         self._icell8_atac_swap_i1_and_i2 = icell8_atac_swap_i1_and_i2
         self._icell8_atac_reverse_complement = \
@@ -482,6 +489,8 @@ class MakeFastqs(Pipeline):
                 self.params.find_adapters_with_sliding_window,
                 tenx_filter_single_index=None,
                 tenx_filter_dual_index=None,
+                spaceranger_rc_i2_override=\
+                self._spaceranger_rc_i2_override,
                 icell8_well_list=self._icell8_well_list,
                 icell8_atac_swap_i1_and_i2=\
                 self._icell8_atac_swap_i1_and_i2,
@@ -1093,6 +1102,8 @@ class MakeFastqs(Pipeline):
             ##############
             filter_single_index = subset['tenx_filter_single_index']
             filter_dual_index = subset['tenx_filter_dual_index']
+            spaceranger_rc_i2_override = \
+                subset['spaceranger_rc_i2_override']
 
             #########
             # ICELL8
@@ -1594,7 +1605,7 @@ class MakeFastqs(Pipeline):
                     self.add_task(get_spaceranger,
                                   envmodules=\
                                   self.envmodules['spaceranger_mkfastq'])
-                # Run cellranger mkfastq
+                # Run spaceranger mkfastq
                 make_fastqs = Run10xMkfastq(
                     "Run spaceranger mkfastq%s" %
                     (" for lanes %s" % ','.join([str(x) for x in lanes])
@@ -1608,6 +1619,7 @@ class MakeFastqs(Pipeline):
                     minimum_trimmed_read_length,
                     mask_short_adapter_reads=\
                     mask_short_adapter_reads,
+                    rc_i2_override=spaceranger_rc_i2_override,
                     jobmode=self.params.cellranger_jobmode,
                     mempercore=self.params.cellranger_mempercore,
                     maxjobs=self.params.cellranger_maxjobs,
@@ -3194,7 +3206,7 @@ class Run10xMkfastq(PipelineTask):
              minimum_trimmed_read_length=None,
              mask_short_adapter_reads=None,
              filter_single_index=None,filter_dual_index=None,
-             jobmode='local',maxjobs=None,
+             rc_i2_override=None,jobmode='local',maxjobs=None,
              mempercore=None,jobinterval=None,
              localcores=None,localmem=None,
              create_empty_fastqs=False,platform=None,
@@ -3225,6 +3237,9 @@ class Run10xMkfastq(PipelineTask):
             (e.g., SI-TT-A6), ignoring single-index samples
             (which will not be demultiplexed) (i.e. use
             --filter-dual-index option)
+          rc_i2_override (bool): for spaceranger, set the value
+            of the --rc-i2-override option (default is not to
+            pass this option to spaceranger)
           jobmode (str): jobmode to use for
             running cellranger
           maxjobs (int): maximum number of concurrent
@@ -3422,6 +3437,11 @@ class Run10xMkfastq(PipelineTask):
                 mkfastq_cmd.add_args('--filter-single-index')
             if self.args.filter_dual_index:
                 mkfastq_cmd.add_args('--filter-dual-index')
+        if self.pkg == "spaceranger":
+            if self.args.rc_i2_override is True:
+                mkfastq_cmd.add_args('--rc-i2-override=true')
+            elif self.args.rc_i2_override is False:
+                mkfastq_cmd.add_args('--rc-i2-override=false')
         add_cellranger_args(
             mkfastq_cmd,
             jobmode=self.args.jobmode,

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -186,9 +186,9 @@ def make_fastqs(ap,protocol='standard',platform=None,
          sample, ignore it (10xGenomics Chromium SC data only)
       spaceranger_rc_i2_override (bool): (optional) if set then value
          is passed to Spaceranger's '--rc-i2-override' option (True for
-         workflow B/ NovaSeq reagent kit v1.5+, False for workflow B/
-         older NovaSeq reagent kits). If not set then Spaceranger will
-         be left to determine the correct workflow automatically
+         reverse complement workflow B, False for forward complement
+         workflow A). If not set then Spaceranger will be left to
+         determine the workflow automatically
       max_jobs (int): maximum number of concurrent jobs allowed
       max_cores (int): maximum number of cores available
       batch_limit (int): if set then run commands in each task in

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -63,6 +63,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 cellranger_localcores=None,
                 cellranger_localmem=None,
                 cellranger_ignore_dual_index=False,
+                spaceranger_rc_i2_override=None,
                 max_jobs=None,max_cores=None,batch_limit=None,
                 verbose=False,working_dir=None):
     """
@@ -183,6 +184,11 @@ def make_fastqs(ap,protocol='standard',platform=None,
       cellranger_ignore_dual_index (bool): (optional) on a dual-indexed
          flowcell where the second index was not used for the 10x
          sample, ignore it (10xGenomics Chromium SC data only)
+      spaceranger_rc_i2_override (bool): (optional) if set then value
+         is passed to Spaceranger's '--rc-i2-override' option (True for
+         workflow B/ NovaSeq reagent kit v1.5+, False for workflow B/
+         older NovaSeq reagent kits). If not set then Spaceranger will
+         be left to determine the correct workflow automatically
       max_jobs (int): maximum number of concurrent jobs allowed
       max_cores (int): maximum number of cores available
       batch_limit (int): if set then run commands in each task in
@@ -383,6 +389,8 @@ def make_fastqs(ap,protocol='standard',platform=None,
                              adapter_sequence=adapter_sequence,
                              adapter_sequence_read2=\
                              adapter_sequence_read2,
+                             spaceranger_rc_i2_override=\
+                             spaceranger_rc_i2_override,
                              icell8_atac_swap_i1_and_i2=\
                              icell8_swap_i1_and_i2,
                              icell8_atac_reverse_complement=\

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1791,6 +1791,7 @@ class Mock10xPackageExe:
                assert_force_cells=None,
                assert_filter_single_index=None,
                assert_filter_dual_index=None,
+               assert_rc_i2_override=None,
                reads=None,multiome_data=None,
                multi_outputs=None,version=None):
         """
@@ -1832,6 +1833,10 @@ class Mock10xPackageExe:
             the '--filter-dual-index' option
             was/n't supplied (ignored if set to
             None)
+          assert_rc_i2_override (str): check
+            that the '--rc-i2-override' option
+            was supplied and set to the supplied
+            value (ignore if set to None)
           reads (list): list of 'reads' that
             will be created
           multiome_data (str): either 'GEX' or
@@ -1859,6 +1864,7 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
                            assert_force_cells=%s,
                            assert_filter_single_index=%s,
                            assert_filter_dual_index=%s,
+                           assert_rc_i2_override=%r,
                            reads=%s,
                            multiome_data=%s,
                            multi_outputs=%r,
@@ -1877,6 +1883,7 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
                    assert_force_cells,
                    assert_filter_single_index,
                    assert_filter_dual_index,
+                   assert_rc_i2_override,
                    reads,
                    ("\"%s\"" % multiome_data
                     if multiome_data is not None
@@ -1900,6 +1907,7 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
                  assert_force_cells=None,
                  assert_filter_single_index=None,
                  assert_filter_dual_index=None,
+                 assert_rc_i2_override=None,
                  reads=None,
                  multiome_data=None,
                  multi_outputs=None,
@@ -1928,6 +1936,7 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
         self._assert_force_cells = assert_force_cells
         self._assert_filter_single_index = assert_filter_single_index
         self._assert_filter_dual_index = assert_filter_dual_index
+        self._assert_rc_i2_override = assert_rc_i2_override
         self._multiome_data = str(multiome_data).upper()
         self._multi_outputs = str(multi_outputs).lower()
         if self._package_name == 'cellranger-arc':
@@ -2112,6 +2121,8 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
         mkfastq.add_argument("--maxjobs",action="store")
         mkfastq.add_argument("--jobinterval",action="store")
         mkfastq.add_argument("--disable-ui",action="store_true")
+        if self._package_name == "spaceranger":
+            mkfastq.add_argument("--rc-i2-override",action="store")
         include_qc_arg = True
         if self._package_name == "cellranger" and version[0] >= 6:
             # --qc removed in cellranger 6.0.0
@@ -2215,6 +2226,11 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
                   args.filter_dual_index)
             assert(args.filter_dual_index ==
                    self._assert_filter_dual_index)
+        # Check --rc-i2-override
+        if self._assert_rc_i2_override is not None:
+             print("Checking --rc-i2-override: %s" %
+                  args.rc_i2_override)
+             assert(args.rc_i2_override == self._assert_rc_i2_override)
         # Handle commands
         if args.command == "mkfastq":
             ##################

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -6506,6 +6506,200 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_makefastqs_10x_visium_protocol_forward_strand_workflow_A(self):
+        """
+        MakeFastqs: '10x_visium' protocol (forward strand workflow 'A')
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics Chromium SC indices
+        samplesheet_visium_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+smpl1,smpl1,,,SI-TT-A1,SI-TT-A1,SI-TT-A1,SI-TT-A1,10xGenomics,
+smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_visium_indices)
+        # Create mock bcl2fastq and spaceranger
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        Mock10xPackageExe.create(os.path.join(self.bin,
+                                              "spaceranger"),
+                                 assert_rc_i2_override='true')
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,
+                       sample_sheet,
+                       protocol="10x_visium",
+                       spaceranger_rc_i2_override=True)
+        status = p.run(analysis_dir,
+                       poll_interval=POLL_INTERVAL)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.spaceranger_info,
+                         (os.path.join(self.bin,"spaceranger"),
+                          "spaceranger",
+                          "1.3.1"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html",):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_10x_visium_protocol_reverse_complement_workflow_B(self):
+        """
+        MakeFastqs: '10x_visium' protocol (reverse complement workflow 'B')
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics Chromium SC indices
+        samplesheet_visium_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+smpl1,smpl1,,,SI-TT-A1,SI-TT-A1,SI-TT-A1,SI-TT-A1,10xGenomics,
+smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_visium_indices)
+        # Create mock bcl2fastq and spaceranger
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        Mock10xPackageExe.create(os.path.join(self.bin,
+                                              "spaceranger"),
+                                 assert_rc_i2_override='false')
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,
+                       sample_sheet,
+                       protocol="10x_visium",
+                       spaceranger_rc_i2_override=False)
+        status = p.run(analysis_dir,
+                       poll_interval=POLL_INTERVAL)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.spaceranger_info,
+                         (os.path.join(self.bin,"spaceranger"),
+                          "spaceranger",
+                          "1.3.1"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html",):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
     def test_makefastqs_mirna_protocol(self):
         """
         MakeFastqs: 'mirna' protocol/bcl2fastq

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -6543,7 +6543,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
                                               "bcl2fastq"))
         Mock10xPackageExe.create(os.path.join(self.bin,
                                               "spaceranger"),
-                                 assert_rc_i2_override='true')
+                                 assert_rc_i2_override='false')
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         analysis_dir = os.path.join(self.wd,"analysis")
@@ -6552,7 +6552,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         p = MakeFastqs(run_dir,
                        sample_sheet,
                        protocol="10x_visium",
-                       spaceranger_rc_i2_override=True)
+                       spaceranger_rc_i2_override=False)
         status = p.run(analysis_dir,
                        poll_interval=POLL_INTERVAL)
         self.assertEqual(status,0)
@@ -6640,7 +6640,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
                                               "bcl2fastq"))
         Mock10xPackageExe.create(os.path.join(self.bin,
                                               "spaceranger"),
-                                 assert_rc_i2_override='false')
+                                 assert_rc_i2_override='true')
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         analysis_dir = os.path.join(self.wd,"analysis")
@@ -6649,7 +6649,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         p = MakeFastqs(run_dir,
                        sample_sheet,
                        protocol="10x_visium",
-                       spaceranger_rc_i2_override=False)
+                       spaceranger_rc_i2_override=True)
         status = p.run(analysis_dir,
                        poll_interval=POLL_INTERVAL)
         self.assertEqual(status,0)

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -6569,7 +6569,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(p.output.spaceranger_info,
                          (os.path.join(self.bin,"spaceranger"),
                           "spaceranger",
-                          "1.3.1"))
+                          "2.1.1"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))
@@ -6666,7 +6666,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(p.output.spaceranger_info,
                          (os.path.join(self.bin,"spaceranger"),
                           "spaceranger",
-                          "1.3.1"))
+                          "2.1.1"))
         self.assertTrue(p.output.acquired_primary_data)
         self.assertEqual(p.output.stats_file,
                          os.path.join(analysis_dir,"statistics.info"))

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -773,7 +773,7 @@ smpl2,smpl2,,,A005,SI-TT-B1,10xGenomics,
                                               "bcl2fastq"))
         Mock10xPackageExe.create(os.path.join(self.bin,
                                               "spaceranger"),
-                                 assert_rc_i2_override='true')
+                                 assert_rc_i2_override='false')
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
@@ -787,7 +787,7 @@ smpl2,smpl2,,,A005,SI-TT-B1,10xGenomics,
         self.assertFalse(ap.params.acquired_primary_data)
         make_fastqs(ap,
                     protocol="10x_visium",
-                    spaceranger_rc_i2_override=True)
+                    spaceranger_rc_i2_override=False)
         # Check parameters
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertEqual(ap.params.primary_data_dir,
@@ -845,7 +845,7 @@ smpl2,smpl2,,,A005,SI-TT-B1,10xGenomics,
                                               "bcl2fastq"))
         Mock10xPackageExe.create(os.path.join(self.bin,
                                               "spaceranger"),
-                                 assert_rc_i2_override='false')
+                                 assert_rc_i2_override='true')
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Do the test
@@ -859,7 +859,7 @@ smpl2,smpl2,,,A005,SI-TT-B1,10xGenomics,
         self.assertFalse(ap.params.acquired_primary_data)
         make_fastqs(ap,
                     protocol="10x_visium",
-                    spaceranger_rc_i2_override=False)
+                    spaceranger_rc_i2_override=True)
         # Check parameters
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertEqual(ap.params.primary_data_dir,

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -749,6 +749,150 @@ smpl2,smpl2,,,A005,SI-TT-B1,10xGenomics,
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_make_fastqs_10x_visium_protocol_forward_strand_workflow_A(self):
+        """make_fastqs: 10x_visium protocol (forward strand workflow 'A')
+        """
+        # Sample sheet with 10xGenomics Visium indices
+        samplesheet_10x_atac_indices = """[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-TT-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-TT-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_10x_atac_indices)
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            bases_mask="y101,I8,I8,y101",
+            top_dir=self.wd)
+        illumina_run.create()
+        # Create mock bcl2fastq and cellranger-atac
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        Mock10xPackageExe.create(os.path.join(self.bin,
+                                              "spaceranger"),
+                                 assert_rc_i2_override='true')
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Do the test
+        ap = AutoProcess(settings=self.settings)
+        ap.setup(os.path.join(self.wd,
+                              "171020_NB500968_00002_AHGXXXX"),
+                 sample_sheet=sample_sheet)
+        self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
+        make_fastqs(ap,
+                    protocol="10x_visium",
+                    spaceranger_rc_i2_override=True)
+        # Check parameters
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(self.wd,
+                                      "171020_NB500968_00002_AHGXXXX_analysis",
+                                      "primary_data"))
+        self.assertTrue(ap.params.acquired_primary_data)
+        self.assertEqual(ap.params.unaligned_dir,"bcl2fastq")
+        self.assertEqual(ap.params.barcode_analysis_dir,"barcode_analysis")
+        self.assertEqual(ap.params.stats_file,"statistics.info")
+        # Check outputs
+        analysis_dir = os.path.join(
+            self.wd,
+            "171020_NB500968_00002_AHGXXXX_analysis")
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       os.path.join("logs",
+                                    "002_make_fastqs_10x_visium"),
+                       "bcl2fastq",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "projects.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_make_fastqs_10x_visium_protocol_reverse_complement_workflow_B(self):
+        """make_fastqs: 10x_visium protocol (reverse complement workflow 'B')
+        """
+        # Sample sheet with 10xGenomics Visium indices
+        samplesheet_10x_atac_indices = """[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-TT-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-TT-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_10x_atac_indices)
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            bases_mask="y101,I8,I8,y101",
+            top_dir=self.wd)
+        illumina_run.create()
+        # Create mock bcl2fastq and cellranger-atac
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        Mock10xPackageExe.create(os.path.join(self.bin,
+                                              "spaceranger"),
+                                 assert_rc_i2_override='false')
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Do the test
+        ap = AutoProcess(settings=self.settings)
+        ap.setup(os.path.join(self.wd,
+                              "171020_NB500968_00002_AHGXXXX"),
+                 sample_sheet=sample_sheet)
+        self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
+        make_fastqs(ap,
+                    protocol="10x_visium",
+                    spaceranger_rc_i2_override=False)
+        # Check parameters
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(self.wd,
+                                      "171020_NB500968_00002_AHGXXXX_analysis",
+                                      "primary_data"))
+        self.assertTrue(ap.params.acquired_primary_data)
+        self.assertEqual(ap.params.unaligned_dir,"bcl2fastq")
+        self.assertEqual(ap.params.barcode_analysis_dir,"barcode_analysis")
+        self.assertEqual(ap.params.stats_file,"statistics.info")
+        # Check outputs
+        analysis_dir = os.path.join(
+            self.wd,
+            "171020_NB500968_00002_AHGXXXX_analysis")
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       os.path.join("logs",
+                                    "002_make_fastqs_10x_visium"),
+                       "bcl2fastq",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "projects.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
     def test_make_fastqs_10x_multiome_protocol_gex(self):
         """make_fastqs: 10x_multiome protocol (GEX data)
         """

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -590,6 +590,9 @@ Option                                Description
                                       option for ``cellranger-arc``
 ``tenx_filter_dual_index=yes|no``     Set ``--filter-dual-index``
                                       option for ``cellranger-arc``
+``spaceranger_rc_i2_override=BOOL``   Set ``--rc-i2-override`` option
+                                      for ``spaceranger`` (can be
+                                      either ``true`` or ``false``)
 ``icell8_well_list=FILE``             Well list file (``icell8`` and
                                       ``icell8_atac`` protocols only)
 ``icell8_atac_swap_i1_and_i2=yes|no`` Turn I1/I2 swapping on or off


### PR DESCRIPTION
Updates the Fastq generation pipeline and the `make_fastqs` command to add a new `--rc-i2-override` option for the `10x_visium` protocol (which handles 10x Genomics Visium spatial RNA-seq data). This in turn is used to set the eponymous option in the `spaceranger mkfastq` command, to explicitly specify the workflow used to prepare the samples (and thus map the 10x Genomics indexes to the correct sequences for demultiplexing).

Spaceranger should automatically determine the workflow however the switch can be used to override this and explicitly specify which to use:

* `--rc-i2-override=false`: use for workflow A (older forward strand workflow) 
* `--rc-i2-override=true`: use for workflow B (current reverse complement workflow)

More information can be found in the 10x knowledge base article at https://kb.10xgenomics.com/hc/en-us/articles/360056364852-Should-I-select-Workflow-A-or-Workflow-B-for-the-i5-index-sequence-

**NB testing with Spaceranger 1.3.1 suggests that the effect of the `true`/`false` settings might be the opposite of those above?**