### PR TITLE
Update to work with Spaceranger 2.1.1

### DIFF
--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1917,7 +1917,7 @@ sys.exit(Mock10xPackageExe(path=sys.argv[0],
             elif self._package_name == 'cellranger-arc':
                 self._version = '2.0.0'
             elif self._package_name == 'spaceranger':
-                self._version = '1.3.1'
+                self._version = '2.1.1'
         else:
             self._version = version
         self._exit_code = exit_code

--- a/auto_process_ngs/test/bcl2fastq/test_pipeline.py
+++ b/auto_process_ngs/test/bcl2fastq/test_pipeline.py
@@ -6412,6 +6412,100 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_makefastqs_10x_visium_protocol_211(self):
+        """
+        MakeFastqs: '10x_visium' protocol (Spaceranger 2.1.1)
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics Chromium SC indices
+        samplesheet_visium_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+smpl1,smpl1,,,SI-TT-A1,SI-TT-A1,SI-TT-A1,SI-TT-A1,10xGenomics,
+smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_visium_indices)
+        # Create mock bcl2fastq and spaceranger
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        Mock10xPackageExe.create(os.path.join(self.bin,
+                                              "spaceranger"),
+                                 version='2.1.1')
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="10x_visium")
+        status = p.run(analysis_dir,
+                       poll_interval=POLL_INTERVAL)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.spaceranger_info,
+                         (os.path.join(self.bin,"spaceranger"),
+                          "spaceranger",
+                          "2.1.1"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html",):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
     def test_makefastqs_mirna_protocol(self):
         """
         MakeFastqs: 'mirna' protocol/bcl2fastq

--- a/auto_process_ngs/test/tenx/test_utils.py
+++ b/auto_process_ngs/test/tenx/test_utils.py
@@ -525,14 +525,20 @@ class TestSpacerangerInfo(unittest.TestCase):
             fp.write("#!/bin/bash\necho -n spaceranger 1.1.0")
         os.chmod(spaceranger_110,0o775)
         return spaceranger_110
-
     def _make_mock_spaceranger_131(self):
         # Make a fake spaceranger 1.3.1 executable
-        spaceranger_110 = os.path.join(self.wd,"spaceranger")
-        with open(spaceranger_110,'w') as fp:
+        spaceranger_131 = os.path.join(self.wd,"spaceranger")
+        with open(spaceranger_131,'w') as fp:
             fp.write("#!/bin/bash\necho -n spaceranger spaceranger-1.3.1")
-        os.chmod(spaceranger_110,0o775)
-        return spaceranger_110
+        os.chmod(spaceranger_131,0o775)
+        return spaceranger_131
+    def _make_mock_spaceranger_211(self):
+        # Make a fake spaceranger 2.1.1 executable
+        spaceranger_211 = os.path.join(self.wd,"spaceranger")
+        with open(spaceranger_211,'w') as fp:
+            fp.write("#!/bin/bash\necho -n spaceranger spaceranger-2.1.1")
+        os.chmod(spaceranger_211,0o775)
+        return spaceranger_211
 
     def test_spaceranger_110(self):
         """spaceranger_info: collect info for spaceranger 1.1.0
@@ -567,6 +573,23 @@ class TestSpacerangerInfo(unittest.TestCase):
         spaceranger = self._make_mock_spaceranger_131()
         self.assertEqual(spaceranger_info(name='spaceranger'),
                          (spaceranger,'spaceranger','1.3.1'))
+
+    def test_spaceranger_211(self):
+        """spaceranger_info: collect info for spaceranger 2.1.1
+        """
+        spaceranger = self._make_mock_spaceranger_211()
+        self.assertEqual(spaceranger_info(path=spaceranger),
+                         (spaceranger,'spaceranger','2.1.1'))
+
+    def test_spaceranger_211_on_path(self):
+        """spaceranger_info: collect info for spaceranger 2.1.1 from PATH
+        """
+        os.environ['PATH'] = "%s%s%s" % (os.environ['PATH'],
+                                         os.pathsep,
+                                         self.wd)
+        spaceranger = self._make_mock_spaceranger_211()
+        self.assertEqual(spaceranger_info(name='spaceranger'),
+                         (spaceranger,'spaceranger','2.1.1'))
 
 class TestMakeMultiConfigTemplate(unittest.TestCase):
     """


### PR DESCRIPTION
Updates to work with 10x Genomics `spaceranger` version 2.1.1 (used for Visium spatial RNA-seq data).