### PR TITLE
Add support for 10x Genomics CytAssist Visium spatial RNA-seq platform

### DIFF
--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -230,7 +230,8 @@ def setup_analysis_dirs(ap,
             except Exception as ex:
                 logger.warning("Failed to create '%s': %s" % (f,ex))
         # Additional subdir for Visium images
-        if single_cell_platform == "10xGenomics Visium":
+        if single_cell_platform in ("10xGenomics Visium",
+                                    "10xGenomics CytAssist Visium"):
             print("-- making 'Visium_images' directory")
             d = os.path.join(project.dirn,"Visium_images")
             os.mkdir(d)

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -631,7 +631,8 @@ def determine_qc_protocol(project):
                 # ICELL8 scATAC-seq
                 protocol = "ICELL8_scATAC"
     # Spatial RNA-seq
-    if project.info.single_cell_platform == "10xGenomics Visium":
+    if project.info.single_cell_platform in ("10xGenomics Visium",
+                                             "10xGenomics CytAssist Visium"):
         # 10xGenomics Visium spatial transcriptomics
         if project.info.library_type == "FFPE Spatial RNA-seq":
             protocol = "10x_Visium_FFPE"

--- a/auto_process_ngs/tenx/__init__.py
+++ b/auto_process_ngs/tenx/__init__.py
@@ -10,6 +10,7 @@ PLATFORMS = (
     "10xGenomics Chromium 3'v3.1",
     "10xGenomics Single Cell ATAC",
     "10xGenomics Visium",
+    "10xGenomics CytAssist Visium",
     "10xGenomics Single Cell Multiome",
 )
 

--- a/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
@@ -285,7 +285,68 @@ AB\tAB1,AB2\tAlan Brown\tscATAC-seq\tICELL8 ATAC\tHuman\tAudrey Benson\t1% PhiX
         with open(projects_info,"w") as fp:
             fp.write(
 """#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
-AB\tAB1,AB2\tAlan Brown\tscATAC-seq\t10xGenomics Visium\tHuman\tAudrey Benson\t1% PhiX
+AB\tAB1,AB2\tAlan Brown\tFFPE Spatial RNA-seq\t10xGenomics Visium\tHuman\tAudrey Benson\t1% PhiX
+""")
+        # Expected data
+        projects = {
+            "AB": ["AB1_S1_R1_001.fastq.gz",
+                   "AB1_S1_R2_001.fastq.gz",
+                   "AB1_S1_R3_001.fastq.gz",
+                   "AB1_S1_I1_001.fastq.gz",
+                   "AB2_S2_R1_001.fastq.gz",
+                   "AB2_S2_R2_001.fastq.gz",
+                   "AB2_S2_R3_001.fastq.gz",
+                   "AB2_S2_I1_001.fastq.gz"],
+            "undetermined": ["Undetermined_S0_R1_001.fastq.gz",]
+        }
+        # Check project dirs don't exist
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertFalse(os.path.exists(project_dir_path))
+        # Setup the project dirs
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        setup_analysis_dirs(ap)
+        # Check project dirs and contents
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertTrue(os.path.exists(project_dir_path))
+            # Check README.info file
+            readme_file = os.path.join(project_dir_path,
+                                       "README.info")
+            self.assertTrue(os.path.exists(readme_file))
+            # Check Fastqs
+            fastqs_dir = os.path.join(project_dir_path,
+                                      "fastqs")
+            self.assertTrue(os.path.exists(fastqs_dir))
+            for fq in projects[project]:
+                fastq = os.path.join(fastqs_dir,fq)
+                self.assertTrue(os.path.exists(fastq))
+        # Check that Visium project includes directory
+        # for images
+        self.assertTrue(os.path.isdir(os.path.join(mockdir.dirn,
+                                                   "AB",
+                                                   "Visium_images")))
+
+    def test_setup_analysis_dirs_10x_cytassist_visium(self):
+        """
+        setup_analysis_dirs: test create new analysis dir for 10x CytAssist Visium
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901" },
+            reads=('R1','R2','R3','I1'),
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq")))
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq","AB")))
+        # Add required metadata to 'projects.info'
+        projects_info = os.path.join(mockdir.dirn,"projects.info")
+        with open(projects_info,"w") as fp:
+            fp.write(
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+AB\tAB1,AB2\tAlan Brown\tFFPE Spatial RNA-seq\t10xGenomics CytAssist Visium\tHuman\tAudrey Benson\t1% PhiX
 """)
         # Expected data
         projects = {

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -588,6 +588,42 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
         self.assertEqual(determine_qc_protocol(project),
                          "10x_Visium_FFPE")
 
+    def test_determine_qc_protocol_10x_cytassist_visium(self):
+        """determine_qc_protocol: spatial RNA-seq run (10xGenomics CytAssist Visium)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={'Single cell platform':
+                                          "10xGenomics CytAssist Visium",
+                                          'Library type':
+                                          "spatial RNA-seq"})
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        self.assertEqual(determine_qc_protocol(project),
+                         "10x_Visium")
+
+    def test_determine_qc_protocol_10x_visium_cytassist_ffpe(self):
+        """determine_qc_protocol: FFPE spatial RNA-seq run (10xGenomics CytAssist Visium)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={'Single cell platform':
+                                          "10xGenomics CytAssist Visium",
+                                          'Library type':
+                                          "FFPE Spatial RNA-seq"})
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        self.assertEqual(determine_qc_protocol(project),
+                         "10x_Visium_FFPE")
+
     def test_determine_qc_protocol_10x_multiome_atac(self):
         """determine_qc_protocol: single cell multiome ATAC run (10xGenomics Multiome ATAC)
         """


### PR DESCRIPTION
Updates the pipeline to recognise the 10x Genomics CytAssist Visium spatial RNA-seq platform:

* `setup_analysis_dirs`: treats `10xGenomics CytAssist Visium` projects as a variant of Visium data when setting up an analysis directory;
* `qc/protocols`: treats `10xGenomics CytAssist Visium` projects as a variant of Visium data when determining which QC protocol should be applied