### PR TITLE
Implement new auto-process 'info' command

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1300,11 +1300,12 @@ def info(args):
         logger.fatal("Missing metadata and/or parameters")
         sys.exit(1)
     # Report information
-    print("Run ID        : %s" % d.run_id)
-    print("Platform      : %s" % d.metadata.platform)
-    print("Flow cell mode: %s" % d.metadata.flow_cell_mode)
-    print("Bases mask    : %s" % d.metadata.default_bases_mask)
-    print("Sample sheet  : %s" % d.params.sample_sheet)
+    print("Run ID            : %s" % d.run_id)
+    print("Platform          : %s" % d.metadata.platform)
+    print("Flow cell mode    : %s" % d.metadata.flow_cell_mode)
+    print("Run configuration : %s" % d.metadata.run_configuration)
+    print("Default bases mask: %s" % d.metadata.default_bases_mask)
+    print("Sample sheet      : %s" % d.params.sample_sheet)
 
 def metadata(args):
     """

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1295,10 +1295,16 @@ def info(args):
     if not analysis_dir:
         analysis_dir = os.getcwd()
     d = AutoProcess(analysis_dir,allow_save_params=False)
-    # Run ID
-    print("Run ID      : %s" % d.run_id)
-    print("Platform    : %s" % d.metadata.platform)
-    print("Sample sheet: %s" % d.params.sample_sheet)
+    # Check metadata and params were loaded
+    if not (d.metadata and d.params):
+        logger.fatal("Missing metadata and/or parameters")
+        sys.exit(1)
+    # Report information
+    print("Run ID        : %s" % d.run_id)
+    print("Platform      : %s" % d.metadata.platform)
+    print("Flow cell mode: %s" % d.metadata.flow_cell_mode)
+    print("Bases mask    : %s" % d.metadata.default_bases_mask)
+    print("Sample sheet  : %s" % d.params.sample_sheet)
 
 def metadata(args):
     """

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -34,6 +34,7 @@ each project.
 The following commands enable the querying and setting of configuration
 settings and project metadata:
 
+    info
     config
     params
     metadata
@@ -196,6 +197,20 @@ def add_params_command(cmdparser):
                    help="Set the value of a parameter. KEY_VALUE should be "
                    "of the form '<param>=<value>'. Multiple --set options "
                    "can be specified.")
+    add_debug_option(p)
+    p.add_argument('analysis_dir',metavar="ANALYSIS_DIR",nargs="?",
+                   help="auto_process analysis directory (optional: defaults "
+                   "to the current directory)")
+
+def add_info_command(cmdparser):
+    """
+    Create a parser for the 'info' command
+    """
+    p = cmdparser.add_command('info',
+                              help="Information about the analysis "
+                              "directory",
+                              description="Print information about the "
+                              "analysis associated with ANALYSIS_DIR.")
     add_debug_option(p)
     p.add_argument('analysis_dir',metavar="ANALYSIS_DIR",nargs="?",
                    help="auto_process analysis directory (optional: defaults "
@@ -1272,6 +1287,19 @@ def params(args):
     else:
         d.print_params()
 
+def info(args):
+    """
+    Implement functionality for the 'info' command
+    """
+    analysis_dir = args.analysis_dir
+    if not analysis_dir:
+        analysis_dir = os.getcwd()
+    d = AutoProcess(analysis_dir,allow_save_params=False)
+    # Run ID
+    print("Run ID      : %s" % d.run_id)
+    print("Platform    : %s" % d.metadata.platform)
+    print("Sample sheet: %s" % d.params.sample_sheet)
+
 def metadata(args):
     """
     Implement functionality for 'metadata' command
@@ -1837,6 +1865,7 @@ def main():
 
     # Add commands
     add_config_command(p)
+    add_info_command(p)
     add_setup_command(p)
     add_params_command(p)
     add_metadata_command(p)
@@ -1858,6 +1887,7 @@ def main():
     # Map commands to functions
     commands = {
         'config': config,
+        'info': info,
         'setup': setup,
         'params': params,
         'metadata': metadata,

--- a/auto_process_ngs/commands/setup_cmd.py
+++ b/auto_process_ngs/commands/setup_cmd.py
@@ -14,6 +14,7 @@ import uuid
 import shutil
 import logging
 from ..bcl2fastq.utils import get_bases_mask
+from ..bcl2fastq.utils import get_run_config
 from ..bcl2fastq.utils import get_sequencer_platform
 from ..bcl2fastq.utils import make_custom_sample_sheet
 from ..applications import general as general_applications
@@ -210,6 +211,8 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
         target = os.path.join(data_dir,"RunInfo.xml")
         run_info_xml = os.path.join(ap.tmp_dir,"RunInfo.xml")
         fetch_file(target,run_info_xml)
+        run_config = get_run_config(run_info_xml)
+        print("Run configuration: %s" % run_config)
         default_bases_mask = get_bases_mask(run_info_xml)
         print("Default bases mask: %s" % default_bases_mask)
     except Exception as ex:
@@ -225,6 +228,7 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
             raise Exception("Failed to acquire RunInfo.xml: %s" % ex)
         else:
             # Can ignore if Fastqs already exist
+            run_config = None
             default_bases_mask = None
     # Attempt to acquire RunParameters.xml
     try:
@@ -309,6 +313,7 @@ def setup(ap,data_dir,analysis_dir=None,sample_sheet=None,
     ap.metadata['instrument_run_number'] = instrument_run_number
     ap.metadata['instrument_flow_cell_id'] = flow_cell
     ap.metadata['flow_cell_mode'] = flow_cell_mode
+    ap.metadata['run_configuration'] = run_config
     ap.metadata['default_bases_mask'] = default_bases_mask
     ap.metadata['sequencer_model'] = model
     ap.metadata['source'] = data_source

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -356,6 +356,7 @@ class AnalysisDirMetadata(MetadataDict):
     sequencer_model: the model of the sequencing instrument
     flow_cell_mode: the flow cell configuration (if present in the
       run parameters)
+    run_configuration: read names & lengths derived from RunInfo.xml
     default_bases_mask: default bases mask derived from RunInfo.xml
 
     """
@@ -382,6 +383,7 @@ class AnalysisDirMetadata(MetadataDict):
                                   'instrument_run_number': 'instrument_run_number',
                                   'sequencer_model': 'sequencer_model',
                                   'flow_cell_mode': 'flow_cell_mode',
+                                  'run_configuration': 'run_configuration',
                                   'default_bases_mask': 'default_bases_mask',
                                   'analysis_number': 'analysis_number',
                               },

--- a/auto_process_ngs/test/bcl2fastq/test_utils.py
+++ b/auto_process_ngs/test/bcl2fastq/test_utils.py
@@ -380,6 +380,41 @@ FS10000171 = iseq
             instrument="BLEURGH",
             settings=settings),None)
 
+class TestGetRunConfig(unittest.TestCase):
+    """Tests for the get_run_config function
+    """
+    def setUp(self):
+        # Create a temporary working dir
+        self.wd = tempfile.mkdtemp()
+
+    def tearDown(self):
+        # Remove working dir
+        if self.wd is not None:
+            shutil.rmtree(self.wd)
+
+    def test_get_run_config_single_index(self):
+        """
+        get_run_config: handle single index
+        """
+        # Make a single index RunInfo.xml file
+        run_info_xml = os.path.join(self.wd,"RunInfo.xml")
+        with open(run_info_xml,'w') as fp:
+            fp.write(RunInfoXml.nextseq("171020_NB500968_00002_AHGXXXX"))
+        # Check the run config
+        self.assertEqual(get_run_config(run_info_xml),
+                         "R1:76bp, I1:6bp, R2:76bp")
+
+    def test_get_run_config_dual_index(self):
+        """get_run_config: handle dual index
+        """
+        # Make a RunInfo.xml file
+        run_info_xml = os.path.join(self.wd,"RunInfo.xml")
+        with open(run_info_xml,'w') as fp:
+            fp.write(RunInfoXml.hiseq("171020_SN7001250_00002_AHGXXXX"))
+        # Check the run config
+        self.assertEqual(get_run_config(run_info_xml),
+                         "R1:101bp, I1:8bp, I2:8bp, R2:101bp")
+
 class TestAvailableBcl2fastqVersions(unittest.TestCase):
     """
     Tests for the available_bcl2fastq_versions function

--- a/auto_process_ngs/test/commands/test_setup_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_cmd.py
@@ -120,6 +120,8 @@ model = {model}
                          "000000000-ABCDE1")
         self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.run_configuration,
+                         "R1:101bp, I1:8bp, I2:8bp, R2:101bp")
         self.assertEqual(ap.metadata.default_bases_mask,
                          "y101,I8,I8,y101")
         # Delete to force write of data to disk
@@ -194,6 +196,8 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                          "000000000-ABCDE1")
         self.assertEqual(ap.metadata.flow_cell_mode,"SP")
         self.assertEqual(ap.metadata.sequencer_model,"NovaSeq 5000")
+        self.assertEqual(ap.metadata.run_configuration,
+                         "R1:76bp, I1:10bp, I2:10bp, R2:76bp")
         self.assertEqual(ap.metadata.default_bases_mask,
                          "y76,I10,I10,y76")
         # Delete to force write of data to disk
@@ -253,6 +257,8 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                          "000000000-ABCDE1")
         self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.run_configuration,
+                         "R1:101bp, I1:8bp, I2:8bp, R2:101bp")
         self.assertEqual(ap.metadata.default_bases_mask,
                          "y101,I8,I8,y101")
         # Delete to force write of data to disk
@@ -312,6 +318,8 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                          "000000000-ABCDE1")
         self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.run_configuration,
+                         "R1:101bp, I1:8bp, I2:8bp, R2:101bp")
         self.assertEqual(ap.metadata.default_bases_mask,
                          "y101,I8,I8,y101")
         # Delete to force write of data to disk
@@ -369,6 +377,8 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(ap.metadata.instrument_flow_cell_id,None)
         self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.run_configuration,
+                         "R1:101bp, I1:8bp, I2:8bp, R2:101bp")
         self.assertEqual(ap.metadata.default_bases_mask,
                          "y101,I8,I8,y101")
 
@@ -537,6 +547,8 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
                          "AHGXXXX")
         self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.run_configuration,
+                         "R1:76bp, I1:6bp, R2:76bp")
         self.assertEqual(ap.metadata.default_bases_mask,
                          "y76,I6,y76")
         # Delete to force write of data to disk
@@ -603,6 +615,8 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
                          "000000000-ABCDE1")
         self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.run_configuration,
+                         "R1:101bp, I1:8bp, I2:8bp, R2:101bp")
         self.assertEqual(ap.metadata.default_bases_mask,
                          "y101,I8,I8,y101")
         # Delete to force write of data to disk
@@ -686,6 +700,8 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                          "AHGXXXX")
         self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.run_configuration,
+                         "R1:76bp, I1:6bp, R2:76bp")
         self.assertEqual(ap.metadata.default_bases_mask,
                          "y76,I6,y76")
         # Delete to force write of data to disk
@@ -772,6 +788,8 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                          "AHGXXXX")
         self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.run_configuration,
+                         "R1:76bp, I1:6bp, R2:76bp")
         self.assertEqual(ap.metadata.default_bases_mask,
                          "y76,I6,y76")
         # Delete to force write of data to disk
@@ -839,6 +857,8 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                          "000000000-ABCDE1")
         self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.run_configuration,
+                         "R1:101bp, I1:8bp, I2:8bp, R2:101bp")
         self.assertEqual(ap.metadata.default_bases_mask,
                          "y101,I8,I8,y101")
         # Delete to force write of data to disk
@@ -916,6 +936,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                          "000000000-ABCDE1")
         self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.run_configuration,None)
         self.assertEqual(ap.metadata.default_bases_mask,None)
         # Delete to force write of data to disk
         del(ap)
@@ -997,6 +1018,7 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
                          "000000000-ABCDE1")
         self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,None)
+        self.assertEqual(ap.metadata.run_configuration,None)
         self.assertEqual(ap.metadata.default_bases_mask,None)
         # Delete to force write of data to disk
         del(ap)
@@ -1111,5 +1133,7 @@ CDE\tCDE3,CDE4\t.\t.\t.\t.\t.\t.
                          "000000000-ABCDE1")
         self.assertEqual(ap.metadata.flow_cell_mode,None)
         self.assertEqual(ap.metadata.sequencer_model,"MiSeq")
+        self.assertEqual(ap.metadata.run_configuration,
+                         "R1:101bp, I1:8bp, I2:8bp, R2:101bp")
         self.assertEqual(ap.metadata.default_bases_mask,
                          "y101,I8,I8,y101")

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -327,6 +327,7 @@ class TestAnalysisDirMetadata(unittest.TestCase):
         self.assertEqual(metadata.instrument_flow_cell_id,None)
         self.assertEqual(metadata.sequencer_model,None)
         self.assertEqual(metadata.flow_cell_mode,None)
+        self.assertEqual(metadata.run_configuration,None)
         self.assertEqual(metadata.default_bases_mask,None)
 
 class TestProjectMetadataFile(unittest.TestCase):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -589,7 +589,8 @@ with open(commandref,'w') as commands:
 """)
 
 import subprocess
-for subcmd in ("setup",
+for subcmd in ("info",
+               "setup",
                "make_fastqs",
                "analyse_barcodes",
                "setup_analysis_dirs",


### PR DESCRIPTION
Implements a new `info` command within `auto_process.py`, as a lightweight alternative to using the `metadata` and `params` commands to get information about the current analysis directory.

Information to include:

- Run ID
- Bases mask
- Flow cell mode
- Run configuration

(The PR includes updates to the `setup` command internals, to acquire and store a new `run_configuration` metadata item which describes the reads and numbers of bases determined from the `RunInfo.xml` file of the sequencing run (e.g. `R1:101bp, I1:8bp, I2:8bp, R2:101bp`). The run configuration is generated by a new function `get_run_config`, in the `bcl2fastq/utils` module.)