### PR TITLE
'commands/make_fastq_cmd': drop unused import of 'time' module

### DIFF
--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     make_fastqs_cmd.py: implement auto process make_fastqs command
-#     Copyright (C) University of Manchester 2018-2021 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2023 Peter Briggs
 #
 #########################################################################
 
@@ -10,7 +10,6 @@
 #######################################################################
 
 import os
-import time
 import shutil
 import gzip
 import ast


### PR DESCRIPTION
Remove redundant import of the `time` module in `commands/make_fastq_cmd.py`.