### PR TITLE
Explicitly specify 'numpy' version in conda dependencies for reporting in QC pipeline

### DIFF
--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -3851,6 +3851,9 @@ class ReportQC(PipelineTask):
         # issue as reported here:
         # https://github.com/ewels/MultiQC/issues/1413
         self.conda("python=3.8")
+        # Now also seem to need to specify numpy version to
+        # get a working version (fails with latest numpy)
+        self.conda("numpy=1.20.3")
     def setup(self):
         # Check for 10x multiome libraries file with linked projects
         libraries_file = os.path.join(self.args.project.dirn,


### PR DESCRIPTION
Updates the `conda` dependencies specified in the `ReportQC` task (which performs the QC report generation and includes running `multiqc`) in the QC pipeline, to explicitly specify the version of `numpy` as 1.20.3. Without this update, using the implied default `numpy` now results in a broken install of `multiqc`.