### PR TITLE
Fix updating stored paths when creating final archive

### DIFF
--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -419,13 +419,14 @@ def archive(ap,archive_dir=None,platform=None,year=None,
             # FIXME should do all QC dirs (not just the primary one)
             qc_info = project.qc_info(project.qc_dir)
             if qc_info.fastq_dir:
-                print("%s: updating stored Fastq directory for QC" %
+                print("Project '%s': updating stored Fastq directory for QC" %
                       project.name)
-                new_fastq_dir = os.path.join(archived_analysis_dir,
-                                             os.path.relpath(
-                                                 qc_info.fastq_dir,
-                                                 base_path))
-                print("-- updated Fastq directory: %s" % new_fastq_dir)
+                # FIXME could we just set it to the current Fastq path?
+                new_fastq_dir = os.path.normpath(
+                    os.path.join(archived_analysis_dir,
+                                 os.path.relpath(qc_info.fastq_dir,
+                                                 base_path)))
+                print("...updated Fastq directory: %s" % new_fastq_dir)
                 qc_info['fastq_dir'] = new_fastq_dir
                 if not dry_run:
                     qc_info.save()

--- a/auto_process_ngs/test/commands/test_archive_cmd.py
+++ b/auto_process_ngs/test/commands/test_archive_cmd.py
@@ -229,6 +229,11 @@ poll_interval = 0.5
         for f in files:
             f = os.path.join(final_archive_dir,f)
             self.assertTrue(os.path.exists(f))
+        # Check paths are updated
+        archived_ap = AutoProcess(analysis_dir=final_archive_dir,
+                                  settings=self.settings)
+        self.assertEqual(archived_ap.params.analysis_dir,
+                         final_archive_dir)
         # Check that Fastqs are not writable
         for project in ("AB","CDE","undetermined"):
             fq_dir = os.path.join(final_archive_dir,
@@ -291,6 +296,11 @@ poll_interval = 0.5
         for f in files:
             f = os.path.join(final_archive_dir,f)
             self.assertTrue(os.path.exists(f))
+        # Check paths are updated
+        archived_ap = AutoProcess(analysis_dir=final_archive_dir,
+                                  settings=self.settings)
+        self.assertEqual(archived_ap.params.analysis_dir,
+                         final_archive_dir)
         # Check that Fastqs are not writable
         for project in ("AB","CDE","undetermined"):
             fq_dir = os.path.join(final_archive_dir,
@@ -358,6 +368,11 @@ poll_interval = 0.5
         for f in files:
             f = os.path.join(final_archive_dir,f)
             self.assertTrue(os.path.exists(f))
+        # Check paths are updated
+        archived_ap = AutoProcess(analysis_dir=final_archive_dir,
+                                  settings=self.settings)
+        self.assertEqual(archived_ap.params.analysis_dir,
+                         final_archive_dir)
         # Check that Fastqs are not writable
         for project in ("AB","CDE","undetermined"):
             fq_dir = os.path.join(final_archive_dir,
@@ -445,6 +460,11 @@ poll_interval = 0.5
         for f in files:
             f = os.path.join(final_archive_dir,f)
             self.assertTrue(os.path.exists(f))
+        # Check paths are updated
+        archived_ap = AutoProcess(analysis_dir=final_archive_dir,
+                                  settings=self.settings)
+        self.assertEqual(archived_ap.params.analysis_dir,
+                         final_archive_dir)
 
     def test_archive_staging_to_final(self):
         """archive: test archiving directly from staging dir
@@ -523,6 +543,11 @@ poll_interval = 0.5
         for f in files:
             f = os.path.join(final_archive_dir,f)
             self.assertTrue(os.path.exists(f))
+        # Check paths are updated
+        archived_ap = AutoProcess(analysis_dir=final_archive_dir,
+                                  settings=self.settings)
+        self.assertEqual(archived_ap.params.analysis_dir,
+                         final_archive_dir)
 
     def test_archive_automatically_sets_correct_year(self):
         """archive: test archiving sets the year correctly if not specified
@@ -1042,6 +1067,11 @@ poll_interval = 0.5
         for f in files:
             f = os.path.join(final_archive_dir,f)
             self.assertTrue(os.path.exists(f))
+        # Check paths are updated
+        archived_ap = AutoProcess(analysis_dir=final_archive_dir,
+                                  settings=self.settings)
+        self.assertEqual(archived_ap.params.analysis_dir,
+                         final_archive_dir)
 
     def test_archive_force_fails_for_no_data(self):
         """archive: force archiving fails if run has no data


### PR DESCRIPTION
Fixes a bug with updating the stored paths in the `archive` command, when the analysis directory is move to the final archive location.

The bug actually manifests in the `report` command, when the path to the archive is reported - the stored version of the path is reported, however this was not correct due to the failure of the update operations (which this PR is intended to fix). 