### PR TITLE
Automatically assign project-specific log directories to tasks in the QC pipeline

### DIFF
--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -375,8 +375,7 @@ class QCPipeline(Pipeline):
                 fastq_attrs=project.fastq_attrs)
             self.add_task(verify_fqs,
                           requires=(setup_qc_dirs,),
-                          runner=self.runners['verify_runner'],
-                          log_dir=log_dir)
+                          runner=self.runners['verify_runner'])
             startup_tasks.append(verify_fqs)
 
         # Update QC metadata


### PR DESCRIPTION
Update the QC pipeline code in `qc/pipeline.py` to allow a default log directory to be defined when adding each project (via new `set_default_log_dir` method), which is then implicitly used when tasks are added (by overriding the `add_task` method of the base `Pipeline` class).

This allows the explicit setting of the log directory to be removed from each `add_task` call in the `add_project` and related methods, reducing the amount of boilerplate code and ensuring that any new tasks which are added in future will automatically have the correct log directory assigned.