### PR TITLE
Fix bug when creating Fastqs in mock analysis projects without specifying lanes

### DIFF
--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -461,6 +461,8 @@ class MockAnalysisProject:
             if populate_fastqs:
                 read_number = AnalysisFastq(fq).read_number
                 lane = AnalysisFastq(fq).lane_number
+                if lane is None:
+                    lane = 1
                 read = """@ILLUMINA-545855:49:FC61RLR:%s:1:10979:1695 %s:N:0:TCCTGA
 GCATACTCAGCTTTAGTAATAAGTGTGATTCTGGTA
 +


### PR DESCRIPTION
Fixes a bug in the `MockAnalysisProject.create` method (in the `mock` module) when making Fastqs without explicitly specifying a lane in the names (e.g. because merging across lanes is being simulated).

Without the fix the Fastq read headers have the lane set to `None` (creating an invalid read header and potentially breaking code which tries to extract information from it). The fix is to have the lane number default to `1` if not otherwise specified.