### PR TITLE
Fix documentation build failure on ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,4 +15,3 @@ python:
     - requirements: docs/requirements.txt
     - method: pip
       path: .
-  system_packages: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,11 @@
 
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 python:
   install:
     - requirements: requirements.txt


### PR DESCRIPTION
Updates the `.readthedocs.yaml` configuration file to fix a failure when building documentation on ReadTheDocs, by adding a `build` section (to specify OS and Python versions).