### PR TITLE
Implement functionality for per-lane QC in QC pipeline

### DIFF
--- a/auto_process_ngs/cli/run_qc.py
+++ b/auto_process_ngs/cli/run_qc.py
@@ -288,6 +288,11 @@ def add_advanced_options(p,use_legacy_screen_names):
                           help="ignore information from project metadata "
                           "file even if one is located (default is to use "
                           "project metadata)")
+    advanced.add_argument('--split-fastqs-by-lane',action="store_true",
+                          dest="split_fastqs_by_lane",default=True,
+                          help="run QC on copies of input Fastqs where "
+                          "reads have been split according to lane "
+                          "(default is to run QC on original Fastqs)")
     advanced.add_argument('--use-legacy-screen-names',choices=['yes','no'],
                           dest="use_legacy_screen_names",default=None,
                           help="use 'legacy' naming convention for "
@@ -976,7 +981,8 @@ def main():
                       qc_dir=qc_dir,
                       report_html=out_file,
                       multiqc=(not args.no_multiqc),
-                      verify_fastqs=True)
+                      verify_fastqs=True,
+                      split_fastqs_by_lane=args.split_fastqs_by_lane)
     status = runqc.run(nthreads=nthreads,
                        fastq_screens=fastq_screens,
                        fastq_subset=args.fastq_subset,

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -239,7 +239,10 @@ def run_qc(ap,projects=None,fastq_screens=None,
         # Set up splitting of Fastqs by lane
         split_lanes = False
         if split_undetermined_fastqs and project.name == "undetermined":
-            split_lanes = True
+            # Lanes will be split if at least one Fastq doesn't
+            # have an explicit lane number in its name
+            split_lanes = any([project.fastq_attrs(fq).lane_number is None
+                               for fq in project.fastqs])
         # Add the project to the QC
         runqc.add_project(project,
                           protocol,

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -170,6 +170,9 @@ def run_qc(ap,projects=None,fastq_screens=None,
                                      cellranger_extra_project_dirs.split(',')]
     else:
         cellranger_extra_projects = None
+    # Split Fastqs by lane for 'undetermined'
+    split_undetermined_fastqs = \
+            bool(ap.settings.qc.split_undetermined_fastqs)
     # Legacy FastqScreen naming convention
     legacy_screens = bool(ap.settings.qc.use_legacy_screen_names)
     # Set up runners
@@ -233,12 +236,18 @@ def run_qc(ap,projects=None,fastq_screens=None,
         # Determine and fetch the QC protocol
         qc_protocol = determine_qc_protocol(project)
         protocol = fetch_protocol_definition(qc_protocol)
+        # Set up splitting of Fastqs by lane
+        split_lanes = False
+        if split_undetermined_fastqs and project.name == "undetermined":
+            split_lanes = True
+        # Add the project to the QC
         runqc.add_project(project,
                           protocol,
                           qc_dir=qc_dir,
                           fastq_dir=fastq_dir,
                           organism=project.info.organism,
                           sample_pattern=sample_pattern,
+                          split_fastqs_by_lane=split_lanes,
                           multiqc=True)
     # Collect the cellranger data and parameters
     cellranger_settings = ap.settings['10xgenomics']

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -671,6 +671,7 @@ class AnalysisProjectQCDirInfo(MetadataDict):
     The data items are:
 
     fastq_dir: the name of the associated Fastq subdirectory
+    fastqs: list of the Fastq files (without leading paths)
     protocol: name of the QC protocol used
     organism: the organism(s) that the QC was run with
     seq_data_samples: samples with sequence (i.e. biological) data
@@ -695,6 +696,7 @@ class AnalysisProjectQCDirInfo(MetadataDict):
             self,
             attributes = {
                 'fastq_dir' :'Fastq dir',
+                'fastqs': 'Fastqs',
                 'protocol': 'QC protocol',
                 'organism': 'Organism',
                 'seq_data_samples': 'Sequence data samples',
@@ -712,5 +714,6 @@ class AnalysisProjectQCDirInfo(MetadataDict):
                 'fastq_dir',
                 'protocol',
                 'organism',
+                'fastqs',
             ),
             filen=filen)

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -709,6 +709,7 @@ class AnalysisProjectQCDirInfo(MetadataDict):
                 'annotation_gtf': 'GTF gene annotation file',
                 'protocol_summary': 'Protocol summary',
                 'protocol_specification': 'Protocol specification',
+                'fastqs_split_by_lane': 'Fastqs split by lane',
             },
             order = (
                 'fastq_dir',

--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -1756,7 +1756,8 @@ def check_fastq_screen_outputs(project,qc_dir,screen,fastqs=None,
                 fastqs.add(fastq)
     return sorted(list(fastqs))
 
-def check_fastqc_outputs(project,qc_dir,read_numbers=None):
+def check_fastqc_outputs(project,qc_dir,fastqs=None,
+                         read_numbers=None):
     """
     Return Fastqs missing QC outputs from FastQC
 
@@ -1770,6 +1771,8 @@ def check_fastqc_outputs(project,qc_dir,read_numbers=None):
       qc_dir (str): path to the QC directory (relative
         path is assumed to be a subdirectory of the
         project)
+      fastqs (list): optional list of Fastqs to check
+        against (defaults to Fastqs from the project)
       read_numbers (list): read numbers to predict
         outputs for
 
@@ -1778,8 +1781,12 @@ def check_fastqc_outputs(project,qc_dir,read_numbers=None):
     """
     if not os.path.isabs(qc_dir):
         qc_dir = os.path.join(project.dirn,qc_dir)
+    if not fastqs:
+        fastqs_in = project.fastqs
+    else:
+        fastqs_in = fastqs
     fastqs = set()
-    for fastq in remove_index_fastqs(project.fastqs,
+    for fastq in remove_index_fastqs(fastqs_in,
                                      project.fastq_attrs):
         if read_numbers and \
            project.fastq_attrs(fastq).read_number not in read_numbers:

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -14,6 +14,7 @@ Pipeline classes:
 Pipeline task classes:
 
 - SetupQCDirs
+- SplitFastqsByLane
 - GetSequenceDataSamples
 - GetSequenceDataFastqs
 - UpdateQCMetadata
@@ -185,7 +186,7 @@ class QCPipeline(Pipeline):
     def add_project(self,project,protocol,qc_dir=None,organism=None,
                     fastq_dir=None,report_html=None,multiqc=False,
                     sample_pattern=None,log_dir=None,convert_gtf=True,
-                    verify_fastqs=False):
+                    verify_fastqs=False,split_fastqs_by_lane=False):
         """
         Add a project to the QC pipeline
 
@@ -215,6 +216,10 @@ class QCPipeline(Pipeline):
           verify_fastqs (bool): if True then verify
             Fastq integrity as part of the pipeline
             (default: False, skip verification)
+          split_fastqs_by_lanes (bool): if True then
+            split input Fastqs into lanes and run QC
+            as per-lane (default: False, don't split
+            QC by lanes)
         """
         ###################
         # Do internal setup
@@ -339,6 +344,19 @@ class QCPipeline(Pipeline):
                           log_dir=log_dir)
             startup_tasks.append(verify_fqs)
 
+        # Split Fastqs by lane for QC?
+        if split_fastqs_by_lane:
+            split_fastqs = SplitFastqsByLane(
+                "%s: split Fastqs by lane" % project_name,
+                project,
+                os.path.join(qc_dir,'__fastqs.split'))
+            self.add_task(split_fastqs,
+                          requires=(setup_qc_dirs,))
+            startup_tasks.append(split_fastqs)
+            fastqs_in = split_fastqs.output.fastqs
+        else:
+            fastqs_in = project.fastqs
+
         # Update QC metadata
         update_qc_metadata = UpdateQCMetadata(
             "%s: update QC metadata" % project_name,
@@ -354,7 +372,9 @@ class QCPipeline(Pipeline):
         verify_qc = VerifyQC(
             "%s: verify QC outputs" % project_name,
             project,
-            qc_dir)
+            qc_dir,
+            str(protocol),
+            fastqs=fastqs_in)
         self.add_task(verify_qc,
                       requires=startup_tasks,
                       runner=self.runners['verify_runner'],
@@ -382,7 +402,8 @@ class QCPipeline(Pipeline):
             os.path.join(qc_dir,'__fastqs'),
             read_range=protocol.read_range,
             samples=get_seq_data.output.seq_data_samples,
-            fastq_attrs=project.fastq_attrs)
+            fastq_attrs=project.fastq_attrs,
+            fastqs=fastqs_in)
         self.add_task(get_seq_fastqs,
                       requires=startup_tasks,
                       log_dir=log_dir)
@@ -490,6 +511,7 @@ class QCPipeline(Pipeline):
                     project,
                     qc_dir,
                     read_numbers=read_numbers.qc,
+                    fastqs=fastqs_in,
                     fastq_attrs=project.fastq_attrs)
                 self.add_task(get_seq_lengths,
                               requires=startup_tasks,
@@ -552,6 +574,7 @@ class QCPipeline(Pipeline):
                     project,
                     qc_dir,
                     read_numbers=read_numbers.qc,
+                    fastqs=fastqs_in,
                     verbose=self.params.VERBOSE
                 )
                 self.add_task(check_fastqc,
@@ -1307,6 +1330,68 @@ class SetupQCDirs(PipelineFunctionTask):
         if not os.path.exists(log_dir):
             mkdir(log_dir)
 
+class SplitFastqsByLane(PipelineTask):
+    """
+    Split reads into multiple Fastqs according to lane
+    """
+    def init(self,project,out_dir):
+        """
+        Initialise the SplitFastqsByLane task
+
+        Arguments:
+          project (AnalysisProject): project with source
+            Fastqs to split by lane
+          out_dir (str): path to directory where split
+            Fastqs will be written
+
+        Outputs:
+          fastqs (list): list of paths to output Fastqs
+            split by lanes
+        """
+        self.add_output('fastqs',list())
+    def setup(self):
+        pre_split_fastqs = set()
+        # Make output directory
+        if not os.path.exists(self.args.out_dir):
+            print("Making output dir: %s" % self.args.out_dir)
+            os.makedirs(self.args.out_dir)
+        else:
+            # Identify Fastqs that have already been split
+            for fq in os.path.listdir(self.args.out_dir):
+                print("Checking existing Fastq: %s" %
+                      os.path.basename(fq))
+                fqname = self.args.project.fastq_attrs(fq)
+                fqname.lane_number = None
+                pre_split_fastqs.add(str(fqname))
+        print("Pre-split Fastqs: %s" % pre_split_fastqs)
+        # Make copies of Fastqs split by lane (if not already
+        # present)
+        for fq in self.args.project.fastqs:
+            if self.args.project.fastq_attrs(fq) in pre_split_fastqs:
+                print("%s: already split" % os.path.basename(fq))
+                continue
+            self.add_cmd("Split %s by lane" % os.path.basename(fq),
+                         """
+                         echo "Making temp dir"
+                         tmp_dir=$(mktemp -d --tmpdir=.)
+                         cd $tmp_dir
+                         echo "Moved to $(pwd)"
+                         split_fastq.py {fastq}
+                         for f in $(ls *.fastq) ; do
+                            echo "Compressing $f"
+                            gzip $f
+                         done
+                         echo "Moving .fastq.gz files to final dir"
+                         mv -f *.fastq.gz {out_dir}
+                         """.format(fastq=fq,
+                                    out_dir=self.args.out_dir))
+    def finish(self):
+        # Collect split files
+        self.output.fastqs.extend(
+            [os.path.join(self.args.out_dir,fq)
+             for fq in os.listdir(self.args.out_dir)
+             if fq.endswith(".fastq.gz")])
+
 class GetSequenceDataSamples(PipelineTask):
     """
     Identify samples with sequence (i.e. biological) data
@@ -1342,7 +1427,7 @@ class GetSequenceDataFastqs(PipelineTask):
     Set up Fastqs with sequence (i.e. biological) data
     """
     def init(self,project,out_dir,read_range,samples,
-             fastq_attrs):
+             fastq_attrs,fastqs=None):
         """
         Initialise the GetSequenceDataFastqs task
 
@@ -1357,6 +1442,8 @@ class GetSequenceDataFastqs(PipelineTask):
             data
           fastq_attrs (BaseFastqAttrs): class to use for
             extracting data from Fastq names
+          fastqs (list): optional, list of Fastq files
+            (overrides Fastqs in project)
 
         Outputs:
           fastqs (list): list of Fastqs with biological
@@ -1375,12 +1462,17 @@ class GetSequenceDataFastqs(PipelineTask):
                 rng = "%s-%s" % (rng[0] if rng[0] else "",
                                  rng[1] if rng[1] else "")
             print("- %s: %s" % (rd.upper(),rng))
+        # Get input Fastqs
+        if self.args.fastqs:
+            fastqs = self.args.fastqs
+        else:
+            fastqs = self.args.project.fastqs
         # Remove Fastqs not in listed sample names
         if self.args.fastq_attrs:
             fastq_attrs = self.args.fastq_attrs
         else:
             fastq_attrs = AnalysisFastq
-        fastqs = [fq for fq in self.args.project.fastqs
+        fastqs = [fq for fq in fastqs
                       if fastq_attrs(fq).sample_name in
                       self.args.samples]
         # Check for output directory
@@ -1556,7 +1648,8 @@ class GetSeqLengthStats(PipelineFunctionTask):
     for Fastqs in a project, and write the data to
     JSON files.
     """
-    def init(self,project,qc_dir,read_numbers=None,fastq_attrs=None):
+    def init(self,project,qc_dir,read_numbers=None,fastqs=None,
+             fastq_attrs=None):
         """
         Initialise the GetSeqLengthStats task
 
@@ -1567,14 +1660,21 @@ class GetSeqLengthStats(PipelineFunctionTask):
             to subdirectory 'qc' of project directory)
           read_numbers (sequence): list of read numbers to
             include (or None to include all reads)
+          fastqs (list): optional, list of Fastq files
+            (overrides Fastqs in project)
           fastq_attrs (BaseFastqAttrs): class to use for
             extracting data from Fastq names
         """
         self._fastqs = list()
     def setup(self):
+        # Input Fastqs
+        if self.args.fastqs:
+            fastqs_in = self.args.fastqs
+        else:
+            fastqs_in = self.args.project.fastqs
         # Remove index Fastqs
         self._fastqs = remove_index_fastqs(
-            self.args.project.fastqs,
+            fastqs_in,
             fastq_attrs=self.args.fastq_attrs)
         # Get sequence length data for Fastqs
         for fastq in self._fastqs:
@@ -1798,7 +1898,8 @@ class CheckFastQCOutputs(PipelineFunctionTask):
     """
     Check the outputs from FastQC
     """
-    def init(self,project,qc_dir,read_numbers,verbose=False):
+    def init(self,project,qc_dir,read_numbers,fastqs=None,
+             verbose=False):
         """
         Initialise the CheckFastQCOutputs task.
 
@@ -1809,6 +1910,8 @@ class CheckFastQCOutputs(PipelineFunctionTask):
             to subdirectory 'qc' of project directory)
           read_numbers (list): list of read numbers to
             include
+          fastqs (list): optional, list of Fastq files
+            (overrides Fastqs in project)
           verbose (bool): if True then print additional
             information from the task
 
@@ -1824,7 +1927,8 @@ class CheckFastQCOutputs(PipelineFunctionTask):
                       check_fastqc_outputs,
                       self.args.project,
                       self.args.qc_dir,
-                      self.args.read_numbers)
+                      fastqs=self.args.fastqs,
+                      read_numbers=self.args.read_numbers)
     def finish(self):
         fastqs = set()
         for result in self.result():
@@ -3876,7 +3980,7 @@ class VerifyQC(PipelineFunctionTask):
     """
     Verify outputs from the QC pipeline
     """
-    def init(self,project,qc_dir):
+    def init(self,project,qc_dir,protocol,fastqs):
         """
         Initialise the VerifyQC task.
 
@@ -3885,15 +3989,20 @@ class VerifyQC(PipelineFunctionTask):
             number of cells for
           qc_dir (str): directory for QC outputs (defaults
             to subdirectory 'qc' of project directory)
+          protocol (QCProtocl): QC protocol to verify against
+          fastqs (list): Fastqs to include in the
+            verification
         """
         pass
     def setup(self):
-        # Run the 'verify_project' function
+        # Call the verification function
         self.add_call(
             "Verify QC outputs for %s" % self.args.project.name,
             verify_project,
             self.args.project,
-            self.args.qc_dir)
+            self.args.qc_dir,
+            qc_protocol=self.args.protocol,
+            fastqs=self.args.fastqs)
     def finish(self):
         # Report the verification output
         for line in self.stdout.split('\n'):

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1361,7 +1361,7 @@ class SplitFastqsByLane(PipelineTask):
             os.makedirs(self.args.out_dir)
         else:
             # Identify Fastqs that have already been split
-            for fq in os.path.listdir(self.args.out_dir):
+            for fq in os.listdir(self.args.out_dir):
                 print("Checking existing Fastq: %s" %
                       os.path.basename(fq))
                 fqname = self.args.project.fastq_attrs(fq)

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -330,7 +330,8 @@ class QCPipeline(Pipeline):
                            organism=organism,
                            seq_data_samples=\
                            get_seq_data.output.seq_data_samples,
-                           fastq_dir=project.fastq_dir)
+                           fastq_dir=project.fastq_dir,
+                           fastqs_split_by_lane=split_fastqs_by_lane)
 
         # Verify Fastqs
         if verify_fastqs:

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -581,6 +581,11 @@ class QCReport(Document):
                                       "contain biological data: %s" %
                                       pretty_print_names(
                                           project.seq_data_samples))
+            # Fastq lane splitting used
+            if project.qc_info.fastqs_split_by_lane:
+                project_notes.add("Input Fastqs were split by lane "
+                                  "within the QC pipeline to generate "
+                                  "per-lane metrics")
             # Create a new summary table
             summary_table = self.add_summary_table(project,
                                                    summary_fields_,

--- a/auto_process_ngs/qc/verification.py
+++ b/auto_process_ngs/qc/verification.py
@@ -753,7 +753,8 @@ def filter_10x_pipelines(p,pipelines):
         matching_pipelines.append(pipeline)
     return matching_pipelines
 
-def verify_project(project,qc_dir=None,qc_protocol=None):
+def verify_project(project,qc_dir=None,qc_protocol=None,
+                   fastqs=None):
     """
     Check the QC outputs are correct for a project
 
@@ -764,6 +765,8 @@ def verify_project(project,qc_dir=None,qc_protocol=None):
         project being checked.
       qc_protocol (str): QC protocol name or specification
         to verify against (optional)
+      fastqs (list): list of Fastqs to include (optional,
+        defaults to Fastqs in the project)
 
      Returns:
        Boolean: Returns True if all expected QC products
@@ -777,6 +780,10 @@ def verify_project(project,qc_dir=None,qc_protocol=None):
             qc_dir = os.path.join(project.dirn,
                                   qc_dir)
     logger.debug("verify: qc_dir (final)  : %s" % qc_dir)
+    if fastqs:
+        fastqs_in = fastqs
+    else:
+        fastqs_in = project.fastqs
     cellranger_version = None
     cellranger_refdata = None
     star_index = None
@@ -838,7 +845,7 @@ def verify_project(project,qc_dir=None,qc_protocol=None):
     verifier = QCVerifier(qc_dir,
                           fastq_attrs=project.fastq_attrs)
     return verifier.verify(protocol,
-                           project.fastqs,
+                           fastqs_in,
                            organism=organism,
                            seq_data_samples=seq_data_samples,
                            fastq_screens=fastq_screens,

--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -150,6 +150,7 @@ class Settings:
         "bcl_conversion.no_lane_splitting": False,
         "bcl_conversion.create_empty_fastqs": False,
         "qc.fastq_subset_size": 100000,
+        "qc.split_undetermined_fastqs": True,
         "qc.use_legacy_screen_names": False,
         "10xgenomics.cellranger_jobmode": "local",
         "10xgenomics.cellranger_maxjobs": 24,
@@ -283,6 +284,9 @@ class Settings:
         self.qc['fastq_subset_size'] = config.getint(
             'qc',
             'fastq_subset_size')
+        self.qc['split_undetermined_fastqs'] = config.getboolean(
+            'qc',
+            'split_undetermined_fastqs')
         self.qc['use_legacy_screen_names'] = config.getboolean(
             'qc',
             'use_legacy_screen_names')

--- a/auto_process_ngs/test/commands/test_run_qc_cmd.py
+++ b/auto_process_ngs/test/commands/test_run_qc_cmd.py
@@ -9,6 +9,7 @@ import os
 import zipfile
 from bcftbx.JobRunner import SimpleJobRunner
 from auto_process_ngs.auto_processor import AutoProcess
+from auto_process_ngs.metadata import AnalysisProjectQCDirInfo
 from auto_process_ngs.mock import MockAnalysisDirFactory
 from auto_process_ngs.mock import MockFastqScreen
 from auto_process_ngs.mock import MockFastQC
@@ -180,6 +181,12 @@ annotation_gtf = {mm10_gtf}
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
+        # Check lane splitting for undetermined
+        qc_info = AnalysisProjectQCDirInfo(os.path.join(mockdir.dirn,
+                                                        "undetermined",
+                                                        "qc",
+                                                        "qc.info"))
+        self.assertTrue(qc_info.fastqs_split_by_lane)
 
     def test_run_qc_single_end(self):
         """run_qc: single-end QC run
@@ -274,6 +281,12 @@ annotation_gtf = {mm10_gtf}
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
+        # Check lane splitting for undetermined
+        qc_info = AnalysisProjectQCDirInfo(os.path.join(mockdir.dirn,
+                                                        "undetermined",
+                                                        "qc",
+                                                        "qc.info"))
+        self.assertTrue(qc_info.fastqs_split_by_lane)
 
     def test_run_qc_icell8_single_cell(self):
         """run_qc: ICELL8 scRNA-seq run
@@ -370,6 +383,12 @@ annotation_gtf = {mm10_gtf}
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
+        # Check lane splitting for undetermined
+        qc_info = AnalysisProjectQCDirInfo(os.path.join(mockdir.dirn,
+                                                        "undetermined",
+                                                        "qc",
+                                                        "qc.info"))
+        self.assertTrue(qc_info.fastqs_split_by_lane)
 
     def test_run_qc_single_end(self):
         """run_qc: single-end QC run
@@ -464,6 +483,12 @@ annotation_gtf = {mm10_gtf}
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
+        # Check lane splitting for undetermined
+        qc_info = AnalysisProjectQCDirInfo(os.path.join(mockdir.dirn,
+                                                        "undetermined",
+                                                        "qc",
+                                                        "qc.info"))
+        self.assertTrue(qc_info.fastqs_split_by_lane)
 
     def test_run_qc_10x_scRNAseq(self):
         """run_qc: 10x scRNA-seq with single library analysis
@@ -569,6 +594,12 @@ cellranger_reference = /data/cellranger/transcriptomes/mm10
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
+        # Check lane splitting for undetermined
+        qc_info = AnalysisProjectQCDirInfo(os.path.join(mockdir.dirn,
+                                                        "undetermined",
+                                                        "qc",
+                                                        "qc.info"))
+        self.assertTrue(qc_info.fastqs_split_by_lane)
 
     def test_run_qc_10x_snRNAseq_310(self):
         """run_qc: 10x snRNA-seq with single library analysis (cellranger 3.1.0)
@@ -676,6 +707,12 @@ cellranger_premrna_reference = /data/cellranger/transcriptomes/mm10_pre_mrna
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
+        # Check lane splitting for undetermined
+        qc_info = AnalysisProjectQCDirInfo(os.path.join(mockdir.dirn,
+                                                        "undetermined",
+                                                        "qc",
+                                                        "qc.info"))
+        self.assertTrue(qc_info.fastqs_split_by_lane)
 
     def test_run_qc_10x_snRNAseq_501(self):
         """run_qc: 10x snRNA-seq with single library analysis (cellranger 5.0.1)
@@ -784,6 +821,12 @@ cellranger_reference = /data/cellranger/transcriptomes/mm10
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
+        # Check lane splitting for undetermined
+        qc_info = AnalysisProjectQCDirInfo(os.path.join(mockdir.dirn,
+                                                        "undetermined",
+                                                        "qc",
+                                                        "qc.info"))
+        self.assertTrue(qc_info.fastqs_split_by_lane)
 
     def test_run_qc_10x_snRNAseq_600(self):
         """run_qc: 10x snRNA-seq with single library analysis (cellranger 6.0.0)
@@ -892,6 +935,12 @@ cellranger_reference = /data/cellranger/transcriptomes/mm10
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
+        # Check lane splitting for undetermined
+        qc_info = AnalysisProjectQCDirInfo(os.path.join(mockdir.dirn,
+                                                        "undetermined",
+                                                        "qc",
+                                                        "qc.info"))
+        self.assertTrue(qc_info.fastqs_split_by_lane)
 
     def test_run_qc_10x_scATACseq(self):
         """run_qc: 10x scATAC-seq with single library analysis
@@ -1002,6 +1051,12 @@ cellranger_atac_reference = /data/cellranger/atac_references/mm10
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
+        # Check lane splitting for undetermined
+        qc_info = AnalysisProjectQCDirInfo(os.path.join(mockdir.dirn,
+                                                        "undetermined",
+                                                        "qc",
+                                                        "qc.info"))
+        self.assertTrue(qc_info.fastqs_split_by_lane)
 
     def test_run_qc_10x_visium(self):
         """run_qc: 10x Visium spatial RNA-seq
@@ -1104,6 +1159,12 @@ annotation_gtf = {mm10_gtf}
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
+        # Check lane splitting for undetermined
+        qc_info = AnalysisProjectQCDirInfo(os.path.join(mockdir.dirn,
+                                                        "undetermined",
+                                                        "qc",
+                                                        "qc.info"))
+        self.assertTrue(qc_info.fastqs_split_by_lane)
 
     def test_run_qc_10x_multiome_atac(self):
         """run_qc: 10x Multiome ATAC
@@ -1204,6 +1265,12 @@ cellranger_atac_reference = /data/cellranger/atac_references/hg38-atac
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
+        # Check lane splitting for undetermined
+        qc_info = AnalysisProjectQCDirInfo(os.path.join(mockdir.dirn,
+                                                        "undetermined",
+                                                        "qc",
+                                                        "qc.info"))
+        self.assertTrue(qc_info.fastqs_split_by_lane)
 
     def test_run_qc_10x_multiome_gex(self):
         """run_qc: 10x Multiome GEX
@@ -1302,6 +1369,12 @@ cellranger_arc_reference = /data/cellranger/arc_references/mm10-arc
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
+        # Check lane splitting for undetermined
+        qc_info = AnalysisProjectQCDirInfo(os.path.join(mockdir.dirn,
+                                                        "undetermined",
+                                                        "qc",
+                                                        "qc.info"))
+        self.assertTrue(qc_info.fastqs_split_by_lane)
 
     def test_run_qc_parse_evercode_scRNAseq(self):
         """run_qc: Parse Evercode scRNA-seq
@@ -1394,3 +1467,110 @@ annotation_gtf = {hg38_gtf}
                         p,'170901_M00879_0087_000000000-AGEW9'),
                     "multiqc_report.html")
                 self.assertTrue(multiqc in z.namelist())
+        # Check lane splitting for undetermined
+        qc_info = AnalysisProjectQCDirInfo(os.path.join(mockdir.dirn,
+                                                        "undetermined",
+                                                        "qc",
+                                                        "qc.info"))
+        self.assertTrue(qc_info.fastqs_split_by_lane)
+
+    def test_run_qc_fastqs_without_no_lane_splitting(self):
+        """run_qc: Fastqs without --no-lane-splitting
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,
+                                              "fastq_strand.py"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            no_lane_splitting=False,
+            paired_end=False,
+            metadata={ "instrument_datestamp": "170901" },
+            project_metadata={ "AB": { "Organism": "human", },
+                               "CDE": { "Organism": "mouse", } },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Settings file with reference data and polling interval
+        settings_ini = os.path.join(self.dirn,"auto_process.ini")
+        with open(settings_ini,'w') as s:
+            s.write("""[general]
+poll_interval = {poll_interval}
+
+[organism:human]
+star_index = /data/genomeIndexes/hg38/STAR
+annotation_bed = {hg38_bed}
+annotation_gtf = {hg38_gtf}
+
+[organism:mouse]
+star_index = /data/genomeIndexes/mm10/STAR
+annotation_bed = {mm10_bed}
+annotation_gtf = {mm10_gtf}
+""".format(hg38_bed=self.ref_data['hg38']['bed'],
+           hg38_gtf=self.ref_data['hg38']['gtf'],
+           mm10_bed=self.ref_data['mm10']['bed'],
+           mm10_gtf=self.ref_data['mm10']['gtf'],
+           poll_interval=POLL_INTERVAL))
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=Settings(settings_ini))
+        # Run the QC
+        status = run_qc(ap,
+                        fastq_screens=self.fastq_screens,
+                        run_multiqc=True,
+                        max_jobs=1)
+        self.assertEqual(status,0)
+        # Check detected outputs
+        for p in ("AB","CDE"):
+            qc_dir = os.path.join(mockdir.dirn,p,"qc")
+            qcoutputs = QCOutputs(qc_dir)
+            for qc_module in ("fastqc_r1",
+                              "screens_r1",
+                              "sequence_lengths",
+                              "strandedness",
+                              "rseqc_genebody_coverage",
+                              "rseqc_infer_experiment",
+                              "qualimap_rnaseq",
+                              "multiqc"):
+                self.assertTrue(qc_module in qcoutputs.outputs,
+                                "Project '%s': missing output '%s'" %
+                                (p,qc_module))
+        # Check output and reports
+        for p in ("AB","CDE","undetermined"):
+            for f in ("qc",
+                      "qc_report.html",
+                      "qc_report.%s.%s.zip" % (
+                          p,
+                          '170901_M00879_0087_000000000-AGEW9'),
+                      "multiqc_report.html"):
+                self.assertTrue(os.path.exists(os.path.join(mockdir.dirn,
+                                                            p,f)),
+                                "Missing %s in project '%s'" % (f,p))
+            # Check zip file has MultiQC report
+            zip_file = os.path.join(mockdir.dirn,p,
+                                    "qc_report.%s.%s.zip" % (
+                                        p,
+                                        '170901_M00879_0087_000000000-AGEW9'))
+            with zipfile.ZipFile(zip_file) as z:
+                multiqc = os.path.join(
+                    "qc_report.%s.%s" % (
+                        p,'170901_M00879_0087_000000000-AGEW9'),
+                    "multiqc_report.html")
+                self.assertTrue(multiqc in z.namelist())
+        # Check lane splitting for undetermined
+        qc_info = AnalysisProjectQCDirInfo(os.path.join(mockdir.dirn,
+                                                        "undetermined",
+                                                        "qc",
+                                                        "qc.info"))
+        self.assertFalse(qc_info.fastqs_split_by_lane)

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -2746,6 +2746,92 @@ class TestCheckFastQCOutputs(unittest.TestCase):
                          [os.path.join(project.fastq_dir,
                                        "PJB1_S1_R1_001.fastq.gz")])
 
+    def test_check_fastqc_outputs_from_fastq_list_all_missing(self):
+        """
+        check_fastqc_outputs: all FastQC outputs missing (Fastq list)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # List of Fastqs (subset of all Fastqs)
+        fastqs = ["PJB2_S2_R1_001.fastq.gz",
+                  "PJB2_S2_R2_001.fastq.gz"]
+        # Get the outputs
+        project = AnalysisProject("PJB",os.path.join(self.wd,"PJB"))
+        # Check
+        self.assertEqual(check_fastqc_outputs(project,
+                                              qc_dir="qc",
+                                              fastqs=fastqs,
+                                              read_numbers=(1,2,)),
+                         fastqs)
+
+    def test_check_fastqc_outputs_from_fastq_list_all_present(self):
+        """
+        check_fastqc_outputs: all FastQC outputs present (Fastq list)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # Add QC artefacts
+        project = AnalysisProject("PJB",os.path.join(self.wd,"PJB"))
+        UpdateAnalysisProject(project).add_qc_outputs(
+            include_fastq_strand=False,
+            include_multiqc=False)
+        # List of Fastqs (subset of all Fastqs)
+        fastqs = ["PJB2_S2_R1_001.fastq.gz",
+                  "PJB2_S2_R2_001.fastq.gz"]
+        # Remove FastQC outputs for Fastqs not in the list
+        for f in ("PJB1_S1_R1_001_fastqc.html",
+                  "PJB1_S1_R2_001_fastqc.html"):
+            os.remove(os.path.join(project.qc_dir,f))
+        # Check
+        self.assertEqual(check_fastqc_outputs(project,
+                                              qc_dir="qc",
+                                              fastqs=fastqs,
+                                              read_numbers=(1,2,)),
+                         [])
+
+    def test_check_fastqc_outputs_from_fastq_list_some_missing(self):
+        """
+        check_fastqc_outputs: some FastQC outputs missing (Fastq list)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # Add QC artefacts
+        project = AnalysisProject("PJB",os.path.join(self.wd,"PJB"))
+        UpdateAnalysisProject(project).add_qc_outputs(
+            include_fastq_strand=False,
+            include_multiqc=False)
+        # List of Fastqs (subset of all Fastqs)
+        fastqs = ["PJB2_S2_R1_001.fastq.gz",
+                  "PJB2_S2_R2_001.fastq.gz"]
+        # Remove FastQC outputs for Fastqs not in the list
+        for f in ("PJB1_S1_R1_001_fastqc.html",
+                  "PJB1_S1_R2_001_fastqc.html"):
+            os.remove(os.path.join(project.qc_dir,f))
+        # Remove a FastQC output from the list
+        os.remove(os.path.join(project.qc_dir,
+                               "PJB2_S2_R1_001_fastqc.html"))
+        # Check
+        self.assertEqual(check_fastqc_outputs(project,
+                                              qc_dir="qc",
+                                              fastqs=fastqs,
+                                              read_numbers=(1,2,)),
+                         ["PJB2_S2_R1_001.fastq.gz"])
+
 class TestCheckFastqStrandOutputs(unittest.TestCase):
     """
     Tests for the 'fastq_strand_outputs' function

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -140,6 +140,7 @@ class TestQCPipeline(unittest.TestCase):
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -224,6 +225,7 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,None)
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
         self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
@@ -292,6 +294,7 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,None)
@@ -370,6 +373,7 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -448,6 +452,7 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -529,6 +534,7 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -601,6 +607,7 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -677,6 +684,7 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -759,6 +767,7 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.fastqs,
                          "PJB1_S1_R1_001.fastq.gz,"
                          "PJB1_S1_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -829,6 +838,7 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.fastqs,
                          "PJB1_S1_R1_001.fastq.gz,"
                          "PJB1_S1_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,None)
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
         self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
@@ -904,6 +914,7 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.fastqs,
                          "PJB1_S1_R1_001.fastq.gz,"
                          "PJB1_S1_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -974,6 +985,7 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.fastqs,
                          "PJB1_S1_R1_001.fastq.gz,"
                          "PJB1_S1_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1048,6 +1060,7 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.fastqs,
                          "PJB1_S1_R1_001.fastq.gz,"
                          "PJB1_S1_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1117,6 +1130,7 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.fastqs,
                          "PJB1_S1_R1_001.fastq.gz,"
                          "PJB1_S1_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1195,6 +1209,7 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1265,6 +1280,7 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1330,6 +1346,7 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_L001_R2_001.fastq.gz,"
                          "PJB2_S2_L001_R1_001.fastq.gz,"
                          "PJB2_S2_L001_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,True)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1411,6 +1428,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.fastqs,
                          "PJB1_S1_R1_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1493,6 +1511,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "AB1_S1_R2_001.fastq.gz,"
                          "AB2_S2_R1_001.fastq.gz,"
                          "AB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1516,6 +1535,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "CD3_S3_R2_001.fastq.gz,"
                          "CD4_S4_R1_001.fastq.gz,"
                          "CD4_S4_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/mm10/star_index")
@@ -1592,6 +1612,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB2_S2_I1_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1665,6 +1686,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1740,6 +1762,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1814,6 +1837,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.fastqs,
                          "PJB1_S1_R1_001.fastq.gz,"
                          "PJB1_S1_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1900,6 +1924,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1995,6 +2020,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2090,6 +2116,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2185,6 +2212,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2286,6 +2314,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2381,6 +2410,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2476,6 +2506,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2584,6 +2615,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2692,6 +2724,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2787,6 +2820,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2882,6 +2916,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2981,6 +3016,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz,"
                          "PJB2_S2_R3_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -3080,6 +3116,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz,"
                          "PJB2_S2_R3_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -3180,6 +3217,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz,"
                          "PJB2_S2_R3_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -3285,6 +3323,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB2_ATAC_S2_R1_001.fastq.gz,"
                          "PJB2_ATAC_S2_R2_001.fastq.gz,"
                          "PJB2_ATAC_S2_R3_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -3386,6 +3425,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB1_GEX_S1_R2_001.fastq.gz,"
                          "PJB2_GEX_S2_R1_001.fastq.gz,"
                          "PJB2_GEX_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -3519,6 +3559,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB2_ATAC_S2_R1_001.fastq.gz,"
                          "PJB2_ATAC_S2_R2_001.fastq.gz,"
                          "PJB2_ATAC_S2_R3_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -3665,6 +3706,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB2_ATAC_S2_R1_001.fastq.gz,"
                          "PJB2_ATAC_S2_R2_001.fastq.gz,"
                          "PJB2_ATAC_S2_R3_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -3808,6 +3850,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB1_GEX_S1_R2_001.fastq.gz,"
                          "PJB2_GEX_S2_R1_001.fastq.gz,"
                          "PJB2_GEX_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -3951,6 +3994,7 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
                          "PJB1_GEX_S1_R2_001.fastq.gz,"
                          "PJB2_GEX_S2_R1_001.fastq.gz,"
                          "PJB2_GEX_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4080,6 +4124,7 @@ PBB,CMO302,PBB
                          "PJB1_GEX_S1_R2_001.fastq.gz,"
                          "PJB2_MC_S2_R1_001.fastq.gz,"
                          "PJB2_MC_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4196,6 +4241,7 @@ PBB,CMO302,PBB
                          "PJB1_GEX_S1_R2_001.fastq.gz,"
                          "PJB2_MC_S2_R1_001.fastq.gz,"
                          "PJB2_MC_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4299,6 +4345,7 @@ PB2,BC002,PB2
         self.assertEqual(qc_info.fastqs,
                          "PJB1_Flex_S1_R1_001.fastq.gz,"
                          "PJB1_Flex_S1_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4396,6 +4443,7 @@ PB2,BC002,PB2
         self.assertEqual(qc_info.fastqs,
                          "PJB1_Flex_S1_R1_001.fastq.gz,"
                          "PJB1_Flex_S1_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4479,6 +4527,7 @@ PB2,BC002,PB2
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4557,6 +4606,7 @@ PB2,BC002,PB2
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4632,6 +4682,7 @@ PB2,BC002,PB2
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4711,6 +4762,7 @@ PB2,BC002,PB2
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4803,6 +4855,7 @@ PB2,BC002,PB2
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4877,6 +4930,7 @@ PB2,BC002,PB2
                          "SRR7089001_2.fastq.gz,"
                          "SRR7089002_1.fastq.gz,"
                          "SRR7089002_2.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4960,6 +5014,7 @@ SRR7089002.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.fastqs,
                          "SRR7089001.fastq.gz,"
                          "SRR7089002.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -5039,6 +5094,7 @@ SRR7089002.bam	153.754829	69.675347	139	37
                          "PJB1_S1_R2_001.fastq.gz,"
                          "PJB2_S2_R1_001.fastq.gz,"
                          "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -1206,6 +1206,87 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.cellranger_refdata,None)
         self.assertEqual(qc_info.cellranger_probeset,None)
 
+    def test_qcpipeline_with_fastqs_split_by_lane(self):
+        """QCPipeline: standard QC run (Fastqs split by lane)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standardPE"),
+                          multiqc=True,
+                          split_fastqs_by_lane=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"standardPE")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("standardPE")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+        # Check collated Picard insert sizes
+        collated_insert_sizes = os.path.join(self.wd,
+                                             "PJB",
+                                             "qc",
+                                             "insert_sizes.human.tsv")
+        self.assertTrue(os.path.exists(collated_insert_sizes),
+                        "Missing collated insert sizes TSV")
+        with open(collated_insert_sizes,'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """#Bam file	Mean insert size	Standard deviation	Median insert size	Median absolute deviation
+PJB1_S1_L001_001.bam	153.754829	69.675347	139	37
+PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
+""")
+
     def test_qcpipeline_single_end(self):
         """QCPipeline: standard QC run (single-end data)
         """

--- a/auto_process_ngs/test/qc/test_pipeline.py
+++ b/auto_process_ngs/test/qc/test_pipeline.py
@@ -135,6 +135,11 @@ class TestQCPipeline(unittest.TestCase):
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -214,6 +219,11 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,None)
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
         self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
@@ -277,6 +287,11 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,None)
@@ -350,6 +365,11 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -423,6 +443,11 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -499,6 +524,11 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -566,6 +596,11 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -637,6 +672,11 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -716,6 +756,9 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -783,6 +826,9 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,None)
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
         self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
@@ -855,6 +901,9 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -922,6 +971,9 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -993,6 +1045,9 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs.cells"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1059,6 +1114,9 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1132,6 +1190,11 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1197,6 +1260,11 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1257,6 +1325,11 @@ PJB1_S1_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_L001_R1_001.fastq.gz,"
+                         "PJB1_S1_L001_R2_001.fastq.gz,"
+                         "PJB2_S2_L001_R1_001.fastq.gz,"
+                         "PJB2_S2_L001_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1335,6 +1408,9 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1412,6 +1488,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"AB1,AB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"AB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "AB1_S1_R1_001.fastq.gz,"
+                         "AB1_S1_R2_001.fastq.gz,"
+                         "AB2_S2_R1_001.fastq.gz,"
+                         "AB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1430,6 +1511,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"CD3,CD4")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"CD","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "CD3_S3_R1_001.fastq.gz,"
+                         "CD3_S3_R2_001.fastq.gz,"
+                         "CD4_S4_R1_001.fastq.gz,"
+                         "CD4_S4_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/mm10/star_index")
@@ -1499,6 +1585,13 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_I1_001.fastq.gz,"
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_I1_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1567,6 +1660,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1637,6 +1735,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1708,6 +1811,9 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1789,6 +1895,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1879,6 +1990,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -1969,6 +2085,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2059,6 +2180,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2155,6 +2281,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2245,6 +2376,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2335,6 +2471,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2438,6 +2579,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2541,6 +2687,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2631,6 +2782,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2721,6 +2877,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2813,6 +2974,13 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB1_S1_R3_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz,"
+                         "PJB2_S2_R3_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2905,6 +3073,13 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB1_S1_R3_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz,"
+                         "PJB2_S2_R3_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -2998,6 +3173,13 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB1_S1_R3_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz,"
+                         "PJB2_S2_R3_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -3096,6 +3278,13 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1_ATAC,PJB2_ATAC")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB_ATAC","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_ATAC_S1_R1_001.fastq.gz,"
+                         "PJB1_ATAC_S1_R2_001.fastq.gz,"
+                         "PJB1_ATAC_S1_R3_001.fastq.gz,"
+                         "PJB2_ATAC_S2_R1_001.fastq.gz,"
+                         "PJB2_ATAC_S2_R2_001.fastq.gz,"
+                         "PJB2_ATAC_S2_R3_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -3192,6 +3381,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1_GEX,PJB2_GEX")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB_GEX","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz,"
+                         "PJB2_GEX_S2_R1_001.fastq.gz,"
+                         "PJB2_GEX_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -3318,6 +3512,13 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1_ATAC,PJB2_ATAC")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB_ATAC","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_ATAC_S1_R1_001.fastq.gz,"
+                         "PJB1_ATAC_S1_R2_001.fastq.gz,"
+                         "PJB1_ATAC_S1_R3_001.fastq.gz,"
+                         "PJB2_ATAC_S2_R1_001.fastq.gz,"
+                         "PJB2_ATAC_S2_R2_001.fastq.gz,"
+                         "PJB2_ATAC_S2_R3_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -3457,6 +3658,13 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1_ATAC,PJB2_ATAC")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB_ATAC","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_ATAC_S1_R1_001.fastq.gz,"
+                         "PJB1_ATAC_S1_R2_001.fastq.gz,"
+                         "PJB1_ATAC_S1_R3_001.fastq.gz,"
+                         "PJB2_ATAC_S2_R1_001.fastq.gz,"
+                         "PJB2_ATAC_S2_R2_001.fastq.gz,"
+                         "PJB2_ATAC_S2_R3_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -3595,6 +3803,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1_GEX,PJB2_GEX")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB_GEX","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz,"
+                         "PJB2_GEX_S2_R1_001.fastq.gz,"
+                         "PJB2_GEX_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -3733,6 +3946,11 @@ PJB2_S2_L001_001.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1_GEX,PJB2_GEX")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB_GEX","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz,"
+                         "PJB2_GEX_S2_R1_001.fastq.gz,"
+                         "PJB2_GEX_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -3857,6 +4075,11 @@ PBB,CMO302,PBB
         self.assertEqual(qc_info.seq_data_samples,"PJB1_GEX")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz,"
+                         "PJB2_MC_S2_R1_001.fastq.gz,"
+                         "PJB2_MC_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -3968,6 +4191,11 @@ PBB,CMO302,PBB
         self.assertEqual(qc_info.seq_data_samples,"PJB1_GEX,PJB2_MC")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz,"
+                         "PJB2_MC_S2_R1_001.fastq.gz,"
+                         "PJB2_MC_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4068,6 +4296,9 @@ PB2,BC002,PB2
         self.assertEqual(qc_info.seq_data_samples,"PJB1_Flex")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_Flex_S1_R1_001.fastq.gz,"
+                         "PJB1_Flex_S1_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4162,6 +4393,9 @@ PB2,BC002,PB2
         self.assertEqual(qc_info.seq_data_samples,"PJB1_Flex")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_Flex_S1_R1_001.fastq.gz,"
+                         "PJB1_Flex_S1_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4240,6 +4474,11 @@ PB2,BC002,PB2
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4313,6 +4552,11 @@ PB2,BC002,PB2
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4383,6 +4627,11 @@ PB2,BC002,PB2
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4457,6 +4706,11 @@ PB2,BC002,PB2
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4544,6 +4798,11 @@ PB2,BC002,PB2
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4613,6 +4872,11 @@ PB2,BC002,PB2
                          "SRR7089001,SRR7089002")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"SRA","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "SRR7089001_1.fastq.gz,"
+                         "SRR7089001_2.fastq.gz,"
+                         "SRR7089002_1.fastq.gz,"
+                         "SRR7089002_2.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4693,6 +4957,9 @@ SRR7089002.bam	153.754829	69.675347	139	37
                          "SRR7089001,SRR7089002")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"SRA","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "SRR7089001.fastq.gz,"
+                         "SRR7089002.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
@@ -4767,6 +5034,11 @@ SRR7089002.bam	153.754829	69.675347	139	37
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastq_screens,
                          "model_organisms,other_organisms,rRNA")
         self.assertEqual(qc_info.star_index,"/data/hg38/star_index")

--- a/auto_process_ngs/test/qc/test_verification.py
+++ b/auto_process_ngs/test/qc/test_verification.py
@@ -1864,3 +1864,31 @@ class TestVerifyProject(unittest.TestCase):
                                                    legacy_screens=True)
         project = AnalysisProject(analysis_dir)
         self.assertTrue(verify_project(project))
+
+    def test_verify_project_using_fastq_list(self):
+        """
+        verify_project: paired-end data with legacy screen names
+        """
+        analysis_dir = self._make_analysis_project(
+            protocol="standardPE",
+            fastq_names=
+            ("PJB1_S1_R1_001_paired.fastq.gz",
+             "PJB1_S1_R2_001_paired.fastq.gz",
+             "PJB2_S2_R1_001_paired.fastq.gz",
+             "PJB2_S2_R2_001_paired.fastq.gz",))
+        project = AnalysisProject(analysis_dir)
+        # Remove some QC outputs from sample 'PJB1'
+        qc_dir = os.path.join(analysis_dir,"qc")
+        for f in os.listdir(qc_dir):
+            if f.startswith("PJB1_"):
+                ff = os.path.join(qc_dir,f)
+                print("Removing %s" % ff)
+                if os.path.isfile(ff):
+                    os.remove(ff)
+        # Fails for default (all Fastqs in project)
+        self.assertFalse(verify_project(project))
+        # OK for subset specified explicitly
+        self.assertTrue(verify_project(project,
+                                       fastqs=
+                                       ["PJB2_S2_R1_001_paired.fastq.gz",
+                                        "PJB2_S2_R2_001_paired.fastq.gz",]))

--- a/config/auto_process.ini.sample
+++ b/config/auto_process.ini.sample
@@ -73,6 +73,7 @@
 ;fastq_screens = model_organisms,other_organisms,rRNA
 ;fastq_subset_size = 100000
 ;nprocessors = None
+;split_undetermined_fastqs = True
 ;use_legacy_screen_names = False
 
 # Fastq screen panels

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -560,6 +560,9 @@ defined as described in the section
 Additionally the ``[qc]`` section allows other aspects of the
 QC pipeline operation to be explicitly specified.
 
+Setting size of Fastq read subsets
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 The default size of the subset of reads used by FastqScreen
 when generating the screens, generating BAM files and so on
 can be set using the ``fastq_subset_size`` parameter, e.g.:
@@ -570,7 +573,7 @@ can be set using the ``fastq_subset_size`` parameter, e.g.:
    fastq_subset_size = 10000
    ...
 
-Setting this to 0 will force all reads to be used for the
+Setting this to zero will force all reads to be used for the
 appropriate QC stages (note that this can result in extended
 run time for the QC pipeline, and larger intermediate and
 final output files).
@@ -580,6 +583,27 @@ final output files).
    ``fastq_subset_size`` replaces the deprecated legacy
    ``fastq_screen_subset`` parameter (which will however be
    used as a fallback if ``subset_size`` is not present).
+
+Per-lane QC for undetermined Fastqs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default the QC pipeline will split Fastqs from the
+``undetermined`` project into separate lanes, in order to
+generate per-lane metrics.
+
+This is controlled by the ``split_undetermined_fastqs``
+parameter, which by default is implicitly set as:
+
+::
+
+    [qc]
+    split_undetermined_fastqs = True
+    ...
+
+To disable the lane splitting, set this parameter to ``False``.
+
+FastqScreen output file naming conventions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 By default the QC pipeline creates FastqScreen outputs using
 the following naming convention:

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -141,9 +141,9 @@ biological samples; these metrics will be omitted for non-biological
 samples (even if they have been specified as part of the QC
 protocol).
 
--------------------------------------
-QC metric using subsequences in reads
--------------------------------------
+--------------------------------------
+QC metrics using subsequences in reads
+--------------------------------------
 
 Some metrics can be applied to subsequences within reads (rather
 than the whole sequence), if a range of bases is defined within
@@ -153,6 +153,28 @@ Specifically, where subsequences are specified for sequence data
 reads (i.e. reads containing biological data) then the "mapped"
 QC modules (for example, FastqScreen or strandedness) will only
 use those subsequences.
+
+(See the :doc:`QC protocol specification <../reference/qc_protocol_specification.rst>`
+documentation for the subsequence specification syntax.)
+
+-------------------------------------------
+Per-lane QC metrics for undetermined Fastqs
+-------------------------------------------
+
+By default when handling Fastqs for the ``undetermined``
+project, the pipeline runs in mode whereby it generates
+copies of the input Fastqs for each lane that appears in the
+read headers of each Fastq, and then run the QC on those
+per-lane Fastqs (rather the originals, which are not changed).
+
+This results in per-lane QC metrics, which can be useful for
+diagnostic purposes when handling Fastqs which have been merged
+across multiple lanes (for example, to determine whether
+contanimation is confined to a single lane).
+
+The behaviour is controlled by the ``split_undetermined_fastqs``
+setting in the ``qc`` section of the configuration file (see
+:ref:`qc_pipeline_configuration`).
 
 ------------------
 Additional options

--- a/docs/source/using/run_qc_standalone.rst
+++ b/docs/source/using/run_qc_standalone.rst
@@ -206,3 +206,16 @@ ell platforms and FastqScreen ``.conf`` files.
 
 Once the information is displayed, ``run_qc.py`` will exit
 without performing any further action.
+
+Per-lane QC: ``--split-fastqs-by-lane``
+---------------------------------------
+
+The ``--split-fastqs-by-lane`` forces the pipeline to generate
+copies of the input Fastqs for each lane that appears in the
+read headers of each Fastq, and then run the QC on those
+per-lane Fastqs (rather the originals, which are not changed).
+
+This results in per-lane QC metrics, which can be useful for
+diagnostic purposes when handling Fastqs which have been merged
+across multiple lanes (for example, to determine whether
+contanimation is confined to a single lane).


### PR DESCRIPTION
Implements new functionality that enables the QC pipeline to run on a per-lane basis, even if the input Fastqs have been produced using `--no-lane-splitting`.

Updates include adding a task with the pipeline to split Fastqs by lane, and allowing the QC to be verified against an arbitrary lists of Fastqs (as the splitting results in a set of derived Fastqs which differ from those in the project).

For the `auto_process.py run_qc` command, there is a new configuration setting (`qc.split_undetermined_fastqs`): if this is set to `True` (the default) then Fastqs in the `undetermined` project will be split if there is no explicit lane number in their names. Setting the option to `False` disables this behaviour.

For the `run_qc.py` utility, the functionality is exposed in the `run_qc.py` utility via a new `--split-fastqs-by-lane` command line option (the `qc.split_undetermined_fastqs` setting is ignored in the utility).

The QC directory metadata now contains two new items: a list of Fastq names that the pipeline was run against (which will be used in preference to the list from the project's `fastqs` directory), and a flag to indicate whether the pipeline run with the Fastqs split by lanes (if the flag is set then a note is added to the QC report to indicate that this was the case).