### PR TITLE
Update documentation to add the ReadTheDoc theme

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,8 @@ sys.path.append('../')
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc',
+extensions = ['sphinx_rtd_theme',
+              'sphinx.ext.autodoc',
               'sphinx.ext.napoleon',
               'sphinx.ext.intersphinx',]
 
@@ -97,7 +98,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ matplotlib
 pandas
 pillow
 psutil
+sphinx
+sphinx_rtd_theme
 git+https://github.com/fls-bioinformatics-core/genomics.git#egg=genomics-bcftbx


### PR DESCRIPTION
Updates the documentation configuration to explicitly specify the default theme from ReadTheDocs (RTD):

https://sphinx-rtd-theme.readthedocs.io/en/stable/installing.html