### PR TITLE
Update QC protocols for 10x Visium spatial GEX and PEX data

### DIFF
--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -259,7 +259,7 @@ QC_PROTOCOLS = {
     },
 
     "10x_Visium_FFPE": {
-        "description": "10xGenomics Visium FFPE spatial data",
+        "description": "10xGenomics Visium FFPE spatial RNA-seq/GEX",
         "reads": {
             "seq_data": ('r2:1-50',),
             "index": ('r1',)
@@ -271,6 +271,18 @@ QC_PROTOCOLS = {
             'strandedness',
             'rseqc_genebody_coverage',
             'qualimap_rnaseq'
+        ]
+    },
+
+    "10x_Visium_FFPE_PEX": {
+        "description": "10xGenomics Visium FFPE spatial PEX",
+        "reads": {
+            "seq_data": ('r2:1-50',),
+            "index": ('r1',)
+        },
+        "qc_modules": [
+            'fastqc',
+            'sequence_lengths'
         ]
     },
 
@@ -635,9 +647,10 @@ def determine_qc_protocol(project):
                                              "10xGenomics CytAssist Visium"):
         # 10xGenomics Visium spatial transcriptomics
         if project.info.library_type in ("FFPE Spatial RNA-seq",
-                                         "FFPE Spatial GEX",
-                                         "FFPE Spatial PEX"):
+                                         "FFPE Spatial GEX"):
             protocol = "10x_Visium_FFPE"
+        elif project.info.library_type == "FFPE Spatial PEX":
+            protocol = "10x_Visium_FFPE_PEX"
         else:
             protocol = "10x_Visium"
     # Multiome ATAC+GEX

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -634,7 +634,9 @@ def determine_qc_protocol(project):
     if project.info.single_cell_platform in ("10xGenomics Visium",
                                              "10xGenomics CytAssist Visium"):
         # 10xGenomics Visium spatial transcriptomics
-        if project.info.library_type == "FFPE Spatial RNA-seq":
+        if project.info.library_type in ("FFPE Spatial RNA-seq",
+                                         "FFPE Spatial GEX",
+                                         "FFPE Spatial PEX"):
             protocol = "10x_Visium_FFPE"
         else:
             protocol = "10x_Visium"

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -259,7 +259,7 @@ QC_PROTOCOLS = {
     },
 
     "10x_Visium_FFPE": {
-        "description": "10xGenomics Visium FFPE spatial RNA-seq",
+        "description": "10xGenomics Visium FFPE spatial data",
         "reads": {
             "seq_data": ('r2:1-50',),
             "index": ('r1',)

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -658,7 +658,7 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
         project = AnalysisProject("PJB",
                                   os.path.join(self.wd,"PJB"))
         self.assertEqual(determine_qc_protocol(project),
-                         "10x_Visium_FFPE")
+                         "10x_Visium_FFPE_PEX")
 
     def test_determine_qc_protocol_10x_multiome_atac(self):
         """determine_qc_protocol: single cell multiome ATAC run (10xGenomics Multiome ATAC)

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -570,7 +570,7 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
         self.assertEqual(determine_qc_protocol(project),
                          "10x_Visium")
 
-    def test_determine_qc_protocol_10x_visium_ffpe(self):
+    def test_determine_qc_protocol_10x_visium_ffpe_rnaseq(self):
         """determine_qc_protocol: FFPE spatial RNA-seq run (10xGenomics Visium)
         """
         # Make mock analysis project
@@ -606,7 +606,7 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
         self.assertEqual(determine_qc_protocol(project),
                          "10x_Visium")
 
-    def test_determine_qc_protocol_10x_visium_cytassist_ffpe(self):
+    def test_determine_qc_protocol_10x_visium_cytassist_ffpe_rnaseq(self):
         """determine_qc_protocol: FFPE spatial RNA-seq run (10xGenomics CytAssist Visium)
         """
         # Make mock analysis project
@@ -618,6 +618,42 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
                                           "10xGenomics CytAssist Visium",
                                           'Library type':
                                           "FFPE Spatial RNA-seq"})
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        self.assertEqual(determine_qc_protocol(project),
+                         "10x_Visium_FFPE")
+
+    def test_determine_qc_protocol_10x_visium_cytassist_ffpe_gex(self):
+        """determine_qc_protocol: FFPE spatial GEX run (10xGenomics CytAssist Visium)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={'Single cell platform':
+                                          "10xGenomics CytAssist Visium",
+                                          'Library type':
+                                          "FFPE Spatial GEX"})
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        self.assertEqual(determine_qc_protocol(project),
+                         "10x_Visium_FFPE")
+
+    def test_determine_qc_protocol_10x_visium_cytassist_ffpe_pex(self):
+        """determine_qc_protocol: FFPE spatial PEX run (10xGenomics CytAssist Visium)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={'Single cell platform':
+                                          "10xGenomics CytAssist Visium",
+                                          'Library type':
+                                          "FFPE Spatial PEX"})
         p.create(top_dir=self.wd)
         project = AnalysisProject("PJB",
                                   os.path.join(self.wd,"PJB"))

--- a/docs/source/control_files/projects_info.rst
+++ b/docs/source/control_files/projects_info.rst
@@ -109,6 +109,8 @@ Single cell platform                  Library types
                                       ``FFPE Spatial RNA-seq``,
                                       ``Fresh Frozen RNA-seq``
 ``10xGenomics CytAssist Visium``      ``FFPE Spatial RNA-seq``
+                                      ``FFPE Spatial GEX``,
+                                      ``FFPE Spatial PEX``
 ===================================== ==============================
 
 .. note::


### PR DESCRIPTION
Implements a new QC protocol `10x_Visium_FFPE_PEX` in `qc/protocols` for 10x Genomics CytAssist Visium protein expression (PEX) data.

The new protocol is minimal (only runs basic QC metrics) and is automatically selected by the `determine_qc_protocol` function when the library type for a project is set to `FFPE Spatial PEX` and the platform is either `10xGenomics Visium` and `10xGenomic CytAssist Visium` platforms.

The existing `10x_Visium_FFPE` protocol has not been changed (aside from extending the description text). It is now also selected by `determine_qc_protocol` when the library type is set to `FFPE Spatial GEX`.