### PR TITLE
run_qc.py: fix incorrect default for --split-fastqs-by-lane

### DIFF
--- a/auto_process_ngs/cli/run_qc.py
+++ b/auto_process_ngs/cli/run_qc.py
@@ -674,6 +674,16 @@ def main():
         logger.fatal("No Fastqs found")
         sys.exit(1)
 
+    # Check Fastq names are compatible with lane splitting
+    if args.split_fastqs_by_lane:
+        for fq in inputs.fastqs:
+            fq = AnalysisFastq(fq)
+            if fq.format != "Illumina" or fq.extras:
+                logger.fatal("Can only split Fastqs by lane for "
+                             "Fastqs with canonical Illumina-style "
+                             "names")
+                sys.exit(1)
+
     # Report what was found
     for fqs in group_fastqs_by_name(inputs.fastqs,fastq_attrs=fastq_attrs):
         print("%s:" % fastq_attrs(fqs[0]).sample_name)

--- a/auto_process_ngs/cli/run_qc.py
+++ b/auto_process_ngs/cli/run_qc.py
@@ -289,7 +289,7 @@ def add_advanced_options(p,use_legacy_screen_names):
                           "file even if one is located (default is to use "
                           "project metadata)")
     advanced.add_argument('--split-fastqs-by-lane',action="store_true",
-                          dest="split_fastqs_by_lane",default=True,
+                          dest="split_fastqs_by_lane",default=False,
                           help="run QC on copies of input Fastqs where "
                           "reads have been split according to lane "
                           "(default is to run QC on original Fastqs)")


### PR DESCRIPTION
Fixes a bug in the standalone QC pipeline runner `run_qc.py`, whereby the option to split Fastqs by lane for the QC (i.e. the `--split-fastqs-by-lane` option) always defaulted to be being switched on. The fix is to change the default to off, and only enable the splitting if the option is specified on the command line.

Also adds a trap to check for non-canonical Illumina-style Fastq names when splitting is explicitly requested, as the pipeline (actually the `split_fastqs.py` utility) currently can't handle the resulting names when the Fastqs are split (issue #924).