### PR TITLE
Fix bug in QC pipeline if working dir is on different device to QC dir

### DIFF
--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -3386,8 +3386,8 @@ class GetBAMFiles(PipelineFunctionTask):
             raise Exception("samtools index returned non-zero exit code: %s" %
                             status)
         # Move the BAM and BAI files to final location
-        os.rename(sorted_bam_file,bam_file)
-        os.rename(sorted_bam_file_index,"%s.bai" % bam_file)
+        shutil.move(sorted_bam_file,bam_file)
+        shutil.move(sorted_bam_file_index,"%s.bai" % bam_file)
         # Remove the temporary working directories
         for dirn in (fastqs_dir,star_dir,sort_dir):
             print("Removing %s" % dirn)


### PR DESCRIPTION
Fixes a bug in the QC pipeline (`qc/pipeline`) when the working directory is on a different filesystem device to the final output QC directory.

This specifically affects the `GetBAMFiles` task, which uses `os.rename` to move files from the working area to the QC directory; in this case the move fails with `OSError: [Errno 18] invalid cross-device link`.

The fix is to use `shutil.move` instead (see https://stackoverflow.com/a/43967659/579925).