### PR TITLE
'setup' command: force specification of the facility run number

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -107,15 +107,16 @@ def add_setup_command(cmdparser):
                               help="Set up a new analysis directory",
                               description="Set up automatic processing of "
                               "Illumina sequencing data from RUN_DIR.")
+    p.add_argument('-r','--run-number',action='store',dest='run_number',
+                   metavar="RUN_NUMBER",default=None,
+                   help="Set facility run number (required)",
+                   required=True)
     p.add_argument('-s','--samplesheet','--sample-sheet',
                    action='store',dest='sample_sheet',default=None,
                    help="Copy sample sheet file from name and location "
                    "SAMPLE_SHEET (default is to look for SampleSheet.csv "
                    "inside DIR). SAMPLE_SHEET can be a local or remote "
                    "file, or a URL")
-    p.add_argument('-r','--run-number',action='store',dest='run_number',
-                   metavar="RUN_NUMBER",default=None,
-                   help="Set facility run number")
     p.add_argument('-n','--analysis-number',action='store',
                    dest='analysis_number',metavar="ANALYSIS_NUMBER",
                    help="Set analysis number (e.g. if reprocessing "


### PR DESCRIPTION
Updates the `setup` command to make the `-r`/`--run-number` command line argument compulsory, forcing the user to specify the facility run number (and addressing issue #906).