### PR TITLE
Fix bug with splitting Fastqs by lane when QC pipeline is re-run

### DIFF
--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1372,7 +1372,10 @@ class SplitFastqsByLane(PipelineTask):
         # Make copies of Fastqs split by lane (if not already
         # present)
         for fq in self.args.project.fastqs:
-            if self.args.project.fastq_attrs(fq) in pre_split_fastqs:
+            fqname = self.args.project.fastq_attrs(fq)
+            fqname.lane_number = None
+            fqname = str(fqname)
+            if fqname in pre_split_fastqs:
                 print("%s: already split" % os.path.basename(fq))
                 continue
             self.add_cmd("Split %s by lane" % os.path.basename(fq),


### PR DESCRIPTION
Fixes a bug in the QC pipeline when rerunning the QC on a project where Fastqs have been split by lanes and the outputs from the `SplitFastqsByLane` task (in `qc/pipeline`) already exist. Without the fix, these existing split Fastqs were ignored and the splitting was performed again unnecessarily.

The fix corrects the detection of the existing split Fastqs and only runs the splitting for those that are missing.