### PR TITLE
Fix broken unit test for 'setup' command for NovaSeq data

### DIFF
--- a/auto_process_ngs/test/commands/test_setup_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_cmd.py
@@ -195,7 +195,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(ap.metadata.flow_cell_mode,"SP")
         self.assertEqual(ap.metadata.sequencer_model,"NovaSeq 5000")
         self.assertEqual(ap.metadata.default_bases_mask,
-                         "y76,I0,I10,y76")
+                         "y76,I10,I10,y76")
         # Delete to force write of data to disk
         del(ap)
         # Check directory exists


### PR DESCRIPTION
Fixes a bug in the unit test for the `setup` command when using mock NovaSeq data produced by the `MockIlluminaRun` class from the `bcftbx.mock` library.

The bug is due to a fix to the class in this PR:

https://github.com/fls-bioinformatics-core/genomics/pull/215

which updates the expected bases mask for these data. The fix here is to also update the expected bases mask in the unit test.