### PR TITLE
Add support for 10x Genomics Chromium 5' Single Cell Immune Profiling

### DIFF
--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -10,6 +10,7 @@
 #######################################################################
 
 import os
+import fnmatch
 import shutil
 import json
 import logging
@@ -113,6 +114,17 @@ def setup_analysis_dirs(ap,
                 logger.error("Unknown single cell platform for '%s': "
                              "'%s'" % (line['Project'],sc_platform))
                 raise Exception("Unknown single cell platform")
+            if sc_platform in tenx.PLATFORMS:
+                library_type = line['Library']
+                for pltfrm in tenx.LIBRARIES:
+                    if fnmatch.fnmatch(sc_platform,pltfrm):
+                        if not library_type in tenx.LIBRARIES[pltfrm]:
+                            # Warn if library is not recognised but carry on
+                            logger.warning("Unrecognised platform/library "
+                                           "combination for '%s': '%s/%s'"
+                                           % (line['Project'],
+                                              sc_platform,
+                                              library_type))
     # Create the projects
     n_projects = 0
     for line in project_metadata:

--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -196,9 +196,7 @@ def setup_analysis_dirs(ap,
            (library_type.startswith("CellPlex") or
             library_type == "Flex" or
             library_type == "Single Cell Immune Profiling"):
-            # Set library type for config
-            library = library_type.split()[0]
-            print("-- setting up 'multi' config file for '%s'" % library)
+            print("-- setting up 'multi' config file for '%s'" % library_type)
             # Acquire reference transcriptome dataset
             print("-- looking up transcriptome for '%s'" % organism)
             try:
@@ -213,7 +211,7 @@ def setup_analysis_dirs(ap,
                                (project_name,ex))
                 reference_dataset = None
             # Acquire probe set
-            if library == "Flex":
+            if library_type == "Flex":
                 print("-- looking up probe set for '%s'" % organism)
                 try:
                     organism_id = normalise_organism_name(organism)
@@ -239,7 +237,7 @@ def setup_analysis_dirs(ap,
                     probe_set=probe_set,
                     fastq_dir=project.fastq_dir,
                     samples=[s.name for s in project.samples],
-                    library_type=library)
+                    library_type=library_type)
             except Exception as ex:
                 logger.warning("Failed to create '%s': %s" % (f,ex))
         # Additional subdir for Visium images

--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     setup_analysis_dirs_cmd.py: implement 'setup_analysis_dirs' command
-#     Copyright (C) University of Manchester 2018-2023 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2024 Peter Briggs
 #
 #########################################################################
 
@@ -182,7 +182,8 @@ def setup_analysis_dirs(ap,
                 logger.warning("Failed to create '%s': %s" % (f,ex))
         elif single_cell_platform.startswith("10xGenomics Chromium") and \
            (library_type.startswith("CellPlex") or
-            library_type == "Flex"):
+            library_type == "Flex" or
+            library_type == "Single Cell Immune Profiling"):
             # Set library type for config
             library = library_type.split()[0]
             print("-- setting up 'multi' config file for '%s'" % library)

--- a/auto_process_ngs/mockqc.py
+++ b/auto_process_ngs/mockqc.py
@@ -1,5 +1,5 @@
 #     mockqc.py: module providing mock Illumina QC data for testing
-#     Copyright (C) University of Manchester 2016-2023 Peter Briggs
+#     Copyright (C) University of Manchester 2016-2024 Peter Briggs
 #
 ########################################################################
 
@@ -513,6 +513,7 @@ def make_mock_qc_dir(qc_dir,fastq_names,fastq_dir=None,
                             '10x_Multiome_GEX',
                             '10x_CellPlex',
                             '10x_Flex',
+                            '10x_ImmuneProfiling',
                             '10x_Visium',) and \
             (AnalysisFastq(fq).read_number == 1):
                 # Skip for R1 reads
@@ -527,6 +528,7 @@ def make_mock_qc_dir(qc_dir,fastq_names,fastq_dir=None,
                         '10x_Multiome_GEX',
                         '10x_CellPlex',
                         '10x_Flex',
+                        '10x_ImmuneProfiling',
                         '10x_Visium',):
             fq = fq_group[1]
         else:

--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -898,7 +898,6 @@ class QCOutputs:
                         lambda ff:
                         ff.endswith(".infer_experiment.log"),
                         os.listdir(os.path.join(infer_experiment_dir,d))):
-                    print("- %s" % f)
                     name = f[:-len(".infer_experiment.log")]
                     organisms.add(d)
                     bam_files.add(name)

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -826,7 +826,7 @@ class QCPipeline(Pipeline):
                     (project_name,
                      project.info.library_type),
                     project,
-                    get_cellranger_multi_config.output.config_csv,
+                    get_cellranger_multi_config.output.config_csvs,
                     get_cellranger_multi_config.output.samples,
                     get_cellranger_multi_config.output.reference_data_path,
                     cellranger_out_dir,
@@ -2398,7 +2398,7 @@ class MakeCellrangerArcCountLibraries(PipelineFunctionTask):
 
 class GetCellrangerMultiConfig(PipelineFunctionTask):
     """
-    Locate 'config.csv' file for cellranger multi
+    Locate 'config.csv' files for cellranger multi
     """
     def init(self,project,qc_dir):
         """
@@ -2410,29 +2410,35 @@ class GetCellrangerMultiConfig(PipelineFunctionTask):
           qc_dir (str): top-level QC directory to put
             'config.csv' files
         """
-        self.add_output('config_csv',Param(type=str))
+        self.add_output('config_csvs',ListParam())
         self.add_output('samples',ListParam())
         self.add_output('gex_libraries',ListParam())
         self.add_output('fastq_dirs',dict())
         self.add_output('reference_data_path',Param(type=str))
         self.add_output('probe_set_path',Param(type=str))
     def setup(self):
-        # Check for top-level libraries file
-        config_file = os.path.join(self.args.project.dirn,
-                                   "10x_multi_config.csv")
-        if not os.path.exists(config_file):
-            # Nothing to do
-            print("No 10x multi config file '%s': nothing to do" %
-                  config_file)
+        # Check for top-level multi config files
+        config_files = [os.path.join(self.args.project.dirn,f)
+                        for f in os.listdir(self.args.project.dirn)
+                        if f.startswith("10x_multi_config.")
+                        and f.endswith(".csv")]
+        if not config_files:
+            # No configs found
+            print("No 10x multi config files found: nothing to do")
             return
-        # Extract information from config.csv file
-        print("Reading config.csv file")
-        config_csv = CellrangerMultiConfigCsv(config_file)
-        samples = config_csv.sample_names
-        gex_libraries = config_csv.gex_libraries
-        reference_data_path = config_csv.reference_data_path
-        probe_set_path = config_csv.probe_set_path
-        fastq_dirs = config_csv.fastq_dirs
+        samples = list()
+        gex_libraries = list()
+        fastq_dirs = dict()
+        for config_file in config_files:
+            # Extract information from each config.csv file
+            print("Reading '%s'" % os.path.basename(config_file))
+            config_csv = CellrangerMultiConfigCsv(config_file)
+            reference_data_path = config_csv.reference_data_path
+            probe_set_path = config_csv.probe_set_path
+            samples.extend(config_csv.sample_names)
+            gex_libraries.extend(config_csv.gex_libraries)
+            for sample in config_csv.fastq_dirs:
+                fastq_dirs[sample] = config_csv.fastq_dirs[sample]
         print("Samples:")
         for sample in samples:
             print("- %s" % sample)
@@ -2440,12 +2446,15 @@ class GetCellrangerMultiConfig(PipelineFunctionTask):
         for library in gex_libraries:
             print("- %s" % library)
         print("Reference dataset: %s" % reference_data_path)
-        # Copy config file to QC dir
-        print("Copy '%s' into %s" % (config_file,self.args.qc_dir))
-        shutil.copy(config_file,self.args.qc_dir)
+        print("Probe set        : %s" % probe_set_path)
+        # Copy config files to QC dir
+        for config_file in config_files:
+            print("Copy '%s' into %s" % (config_file,self.args.qc_dir))
+            shutil.copy(config_file,self.args.qc_dir)
         # Set outputs
-        self.output.config_csv.set(os.path.join(self.args.qc_dir,
-                                                os.path.basename(config_file)))
+        self.output.config_csvs.extend(
+            [os.path.join(self.args.qc_dir,os.path.basename(cf))
+             for cf in config_files])
         self.output.samples.extend(samples)
         self.output.gex_libraries.extend(gex_libraries)
         self.output.reference_data_path.set(reference_data_path)
@@ -2843,7 +2852,7 @@ class RunCellrangerMulti(PipelineTask):
     """
     Run 'cellranger multi'
     """
-    def init(self,project,config_csv,samples,reference_data_path,out_dir,
+    def init(self,project,config_csvs,samples,reference_data_path,out_dir,
              qc_dir=None,cellranger_exe=None,cellranger_version=None,
              cellranger_jobmode='local',cellranger_maxjobs=None,
              cellranger_mempercore=None,cellranger_jobinterval=None,
@@ -2855,8 +2864,8 @@ class RunCellrangerMulti(PipelineTask):
         Arguments:
           project (AnalysisProject): project to run
             QC for
-          config_csv (str): path to 'cellranger multi'
-            configuration file
+          config_csvs (list): list of paths to
+            'cellranger multi' configuration files
           samples (list): list of sample names from the
             config.csv file
           reference_data_path (str): path to the cellranger
@@ -2899,8 +2908,11 @@ class RunCellrangerMulti(PipelineTask):
         self.run_cellranger_multi = False
     def setup(self):
         # Check if there's anything to do
-        if not self.args.config_csv:
+        if not self.args.config_csvs:
             print("No config file: nothing to do")
+            return
+        if len(self.args.config_csvs) > 1:
+            print("Too many config files: skipping multi analysis")
             return
         if not self.args.cellranger_exe:
             raise Exception("No cellranger executable provided")
@@ -2947,7 +2959,7 @@ class RunCellrangerMulti(PipelineTask):
         cmd = Command(cellranger_exe,
                       "multi",
                       "--id",self.args.project.name,
-                      "--csv",self.args.config_csv)
+                      "--csv",self.args.config_csvs[0])
         # Set number of local cores
         if self.args.cellranger_localcores:
             localcores = self.args.cellranger_localcores
@@ -3004,8 +3016,12 @@ class RunCellrangerMulti(PipelineTask):
                        dest_dir=multi_dir))
     def finish(self):
         # If no config.csv then ignore and return
-        if not self.args.config_csv:
-            print("No config file: cell multiplexing analysis was skipped")
+        if not self.args.config_csvs:
+            print("No config file: cellranger multi analysis was skipped")
+            return
+        elif len(self.args.config_csvs) > 1:
+            print("Too many config files: cellranger multi analysis was "
+                  "skipped")
             return
         # Location of final outputs
         multi_dir = os.path.abspath(

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -822,8 +822,9 @@ class QCPipeline(Pipeline):
 
                 # Run cellranger multi
                 run_cellranger_multi = RunCellrangerMulti(
-                    "%s: analyse cell multiplexing data (cellranger multi)" %
-                    project_name,
+                    "%s: run cellranger multi (%s)" %
+                    (project_name,
+                     project.info.library_type),
                     project,
                     get_cellranger_multi_config.output.config_csv,
                     get_cellranger_multi_config.output.samples,

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     protocols: define and handle QC protocols
-#     Copyright (C) University of Manchester 2022-2023 Peter Briggs
+#     Copyright (C) University of Manchester 2022-2024 Peter Briggs
 #
 
 """
@@ -238,6 +238,26 @@ QC_PROTOCOLS = {
             'strandedness',
             'rseqc_genebody_coverage',
             'qualimap_rnaseq',
+            'cellranger_multi'
+        ]
+    },
+
+    "10x_ImmuneProfiling": {
+        "description": "10xGenomics single cell immune profiling data",
+        "reads": {
+            "seq_data": ('r2',),
+            "index": ('r1',)
+        },
+        "qc_modules": [
+            'fastqc',
+            'fastq_screen',
+            'sequence_lengths',
+            'strandedness',
+            'rseqc_genebody_coverage',
+            'qualimap_rnaseq',
+            'cellranger_count(cellranger_use_multi_config=True;'
+                             'set_cell_count=false;'
+                             'set_metadata=False)',
             'cellranger_multi'
         ]
     },
@@ -629,6 +649,10 @@ def determine_qc_protocol(project):
             elif library_type == "Flex":
                 # 10xGenomics Flex (fixed RNA profiling)
                 protocol = "10x_Flex"
+        elif single_cell_platform.startswith('10xGenomics Chromium 5\''):
+            if library_type == "Single Cell Immune Profiling":
+                # 10xGenomics single cell immune profiling
+                protocol = "10x_ImmuneProfiling"
         elif single_cell_platform == 'Parse Evercode':
             if library_type in ("scRNA-seq",
                                 "snRNA-seq"):

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -258,7 +258,7 @@ QC_PROTOCOLS = {
             'cellranger_count(cellranger_use_multi_config=True;'
                              'set_cell_count=false;'
                              'set_metadata=False)',
-            'cellranger_multi'
+            #'cellranger_multi'
         ]
     },
 

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -1259,6 +1259,7 @@ class QCReport(Document):
             for each sample in the summary table
         """
         # Create a unique name and title
+        print("=> Reporting sample '%s' <=" % sample)
         if self.multi_project:
             sample_name = "sample_%s_%s" % (sanitize_name(project.id),
                                             sample)

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -1982,12 +1982,17 @@ class SampleQCReporter:
                 for reference in os.listdir(
                         os.path.join(cellranger_multi_dir,version)):
                     # Add the cellranger multi information
-                    self.cellranger_multi.append(
-                        CellrangerMulti(os.path.join(cellranger_multi_dir,
-                                                     version,
-                                                     reference),
-                                        version=version,
-                                        reference_data=reference))
+                    try:
+                        self.cellranger_multi.append(
+                            CellrangerMulti(os.path.join(cellranger_multi_dir,
+                                                         version,
+                                                         reference),
+                                            version=version,
+                                            reference_data=reference))
+                    except Exception as ex:
+                        logger.warning("exception reading 'cellranger multi' "
+                                       "output from %s (ignored): %s" %
+                                       (cellranger_multi_dir,ex))
         # 10x multiome libraries
         multiome_libraries_file = os.path.join(
             project.dirn,

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     utils: utility classes and functions for QC
-#     Copyright (C) University of Manchester 2018-2022 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2024 Peter Briggs
 #
 """
 Provides utility classes and functions for analysis project QC.
@@ -317,8 +317,9 @@ def get_seq_data_samples(project_dir,fastq_attrs=None):
     # 10x Genomics CellPlex
     single_cell_platform = project.info.single_cell_platform
     if single_cell_platform:
-        if single_cell_platform.startswith("10xGenomics Chromium 3'") and \
-           project.info.library_type == "CellPlex":
+        if single_cell_platform.startswith("10xGenomics Chromium") and \
+           project.info.library_type in ("CellPlex",
+                                         "Single Cell Immune Profiling",):
             # Check for config file
             config_file = os.path.join(project.dirn,
                                        "10x_multi_config.csv")

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -339,8 +339,12 @@ def get_seq_data_samples(project_dir,fastq_attrs=None):
             samples_ = []
             for config_file in config_files:
                 config_csv = CellrangerMultiConfigCsv(config_file)
-                samples_.extend([s for s in config_csv.gex_libraries
-                                 if s in samples])
+                for feature_type in ("gene_expression",
+                                     "vdj_b",
+                                     "vdj_t"):
+                    samples_.extend([s for s in
+                                     config_csv.libraries(feature_type)
+                                     if s in samples])
             samples = sorted(samples_)
     return samples
 

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -319,14 +319,29 @@ def get_seq_data_samples(project_dir,fastq_attrs=None):
     if single_cell_platform:
         if single_cell_platform.startswith("10xGenomics Chromium") and \
            project.info.library_type in ("CellPlex",
-                                         "Single Cell Immune Profiling",):
-            # Check for config file
+                                         "Flex"):
+            # CellPlex/Flex
+            # Check for a single config file
             config_file = os.path.join(project.dirn,
                                        "10x_multi_config.csv")
             if os.path.exists(config_file):
                 config_csv = CellrangerMultiConfigCsv(config_file)
                 samples = sorted([s for s in config_csv.gex_libraries
                                   if s in samples])
+        elif single_cell_platform.startswith("10xGenomics Chromium") and \
+             project.info.library_type == "Single Cell Immune Profiling":
+            # Single Cell Immune Profiling
+            # Check for multiple config files
+            config_files = [os.path.join(project.dirn,f)
+                            for f in os.listdir(project.dirn)
+                            if (f.startswith("10x_multi_config.") and
+                                f.endswith(".csv"))]
+            samples_ = []
+            for config_file in config_files:
+                config_csv = CellrangerMultiConfigCsv(config_file)
+                samples_.extend([s for s in config_csv.gex_libraries
+                                 if s in samples])
+            samples = sorted(samples_)
     return samples
 
 def set_cell_count_for_project(project_dir,qc_dir=None,

--- a/auto_process_ngs/tenx/__init__.py
+++ b/auto_process_ngs/tenx/__init__.py
@@ -16,6 +16,31 @@ PLATFORMS = (
     "10xGenomics Single Cell Multiome",
 )
 
+# List of known library types for 10xGenomics
+LIBRARIES = {
+    "10xGenomics Chromium*": (
+        "scRNA-seq",
+        "snRNA-seq",
+        "CellPlex",
+        "Flex",
+    ),
+    "10xGenomics Single Cell ATAC": (
+        "scATAC-seq",
+        "snATAC-seq",
+    ),
+    "10xGenomics * Visium": (
+        "FFPE Spatial RNA-seq",
+        "Fresh Frozen RNA-seq",
+        "GEX",
+        "PEX",
+        "Spatial RNA-seq",
+    ),
+    "10xGenomics Single Cell Multiome": (
+        "ATAC",
+        "GEX",
+    ),
+}
+
 # Permissible values for cellranger count --chemistry option
 # See https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/count
 CELLRANGER_ASSAY_CONFIGS = {

--- a/auto_process_ngs/tenx/__init__.py
+++ b/auto_process_ngs/tenx/__init__.py
@@ -22,7 +22,9 @@ LIBRARIES = {
         "scRNA-seq",
         "snRNA-seq",
         "CellPlex",
+        "CellPlex scRNA-seq",
         "Flex",
+        "Single Cell Immune Profiling",
     ),
     "10xGenomics Single Cell ATAC": (
         "scATAC-seq",

--- a/auto_process_ngs/tenx/__init__.py
+++ b/auto_process_ngs/tenx/__init__.py
@@ -9,6 +9,7 @@ PLATFORMS = (
     "10xGenomics Chromium 3'v2",
     "10xGenomics Chromium 3'v3",
     "10xGenomics Chromium 3'v3.1",
+    "10xGenomics Chromium 5'",
     "10xGenomics Single Cell ATAC",
     "10xGenomics Visium",
     "10xGenomics CytAssist Visium",

--- a/auto_process_ngs/tenx/cellplex.py
+++ b/auto_process_ngs/tenx/cellplex.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     tenx/cellplex.py: utilities for handling 10xGenomics Cellplex data
-#     Copyright (C) University of Manchester 2023 Peter Briggs
+#     Copyright (C) University of Manchester 2023-2024 Peter Briggs
 #
 
 """
@@ -35,6 +35,7 @@ class CellrangerMultiConfigCsv:
     Provides the following properties:
 
     - sample_names: list of multiplexed sample names
+    - sections: list of the sections in the config
     - reference_data_path: path to the reference dataset
     - probe_set_path: path to the probe set
     - feature_reference_path: path to the feature reference
@@ -62,6 +63,7 @@ class CellrangerMultiConfigCsv:
             file
         """
         self._filen = os.path.abspath(filen)
+        self._sections = []
         self._samples = {}
         self._reference_data_path = None
         self._probe_set_path = None
@@ -76,9 +78,12 @@ class CellrangerMultiConfigCsv:
         Internal: read in data from a multiplex 'config.csv' file
         """
         logger.debug("Reading data from '%s'" % self._filen)
+        sections = set()
         with open(self._filen,'rt') as config_csv:
             current_section = None
             for line in config_csv:
+                if current_section:
+                    sections.add(current_section)
                 line = line.rstrip('\n')
                 if line == "[samples]":
                     current_section = "samples"
@@ -171,6 +176,7 @@ class CellrangerMultiConfigCsv:
                             'feature_type': feature_type,
                             'subsample_rate': subsample_rate
                         }
+        self._sections = sorted(list(sections))
 
     @property
     def sample_names(self):
@@ -180,6 +186,13 @@ class CellrangerMultiConfigCsv:
         Samples are listed in the '[samples]' section.
         """
         return sorted(list(self._samples.keys()))
+
+    @property
+    def sections(self):
+        """
+        Return the list of sections in the config.csv file
+        """
+        return self._sections
 
     @property
     def reference_data_path(self):

--- a/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
@@ -586,6 +586,70 @@ AB\tAB1\tAlan Brown\tFlex\t10xGenomics Chromium 3'v3\tHuman\tAudrey Benson\t1% P
                 self.assertFalse(os.path.exists(template_multi_config_file),
                                  "Found %s" % template_multi_config_file)
 
+    def test_setup_analysis_dirs_10x_immune_profiling(self):
+        """
+        setup_analysis_dirs: create new analysis dir for 10x single cell immune profiling
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901" },
+            reads=('R1','R2','I1','I2'),
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq")))
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq","AB")))
+        # Add required metadata to 'projects.info'
+        projects_info = os.path.join(mockdir.dirn,"projects.info")
+        with open(projects_info,"w") as fp:
+            fp.write(
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+AB\tAB1\tAlan Brown\tSingle Cell Immune Profiling\t10xGenomics Chromium 5'\tMouse\tAudrey Benson\t1% PhiX
+""")
+        # Expected data
+        projects = {
+            "AB": ["AB1_S1_R1_001.fastq.gz",
+                   "AB1_S1_R2_001.fastq.gz",
+                   "AB1_S1_I1_001.fastq.gz",
+                   "AB1_S1_I2_001.fastq.gz",],
+            "undetermined": ["Undetermined_S0_R1_001.fastq.gz",]
+        }
+        # Check project dirs don't exist
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertFalse(os.path.exists(project_dir_path))
+        # Setup the project dirs
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        setup_analysis_dirs(ap)
+        # Check project dirs and contents
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertTrue(os.path.exists(project_dir_path))
+            # Check README.info file
+            readme_file = os.path.join(project_dir_path,
+                                       "README.info")
+            self.assertTrue(os.path.exists(readme_file))
+            # Check Fastqs
+            fastqs_dir = os.path.join(project_dir_path,
+                                      "fastqs")
+            self.assertTrue(os.path.exists(fastqs_dir))
+            for fq in projects[project]:
+                fastq = os.path.join(fastqs_dir,fq)
+                self.assertTrue(os.path.exists(fastq))
+            # Check template 10x_multi_config.csv
+            template_multi_config_file = os.path.join(
+                project_dir_path,
+                "10x_multi_config.csv.template")
+            if project == "AB":
+                # Template file should exist
+                self.assertTrue(os.path.exists(template_multi_config_file),
+                                "Missing %s" % template_multi_config_file)
+            else:
+                # No template file
+                self.assertFalse(os.path.exists(template_multi_config_file),
+                                 "Found %s" % template_multi_config_file)
+
     def test_setup_analysis_dirs_missing_metadata(self):
         """
         setup_analysis_dirs: raise exception if metadata not set

--- a/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
@@ -588,7 +588,7 @@ AB\tAB1\tAlan Brown\tFlex\t10xGenomics Chromium 3'v3\tHuman\tAudrey Benson\t1% P
 
     def test_setup_analysis_dirs_10x_immune_profiling(self):
         """
-        setup_analysis_dirs: create new analysis dir for 10x single cell immune profiling
+        setup_analysis_dirs: create new analysis dir for 10x Single Cell Immune Profiling
         """
         # Make a mock auto-process directory
         mockdir = MockAnalysisDirFactory.bcl2fastq2(

--- a/auto_process_ngs/test/qc/pipeline/test_10x_sc_immune_profiling.py
+++ b/auto_process_ngs/test/qc/pipeline/test_10x_sc_immune_profiling.py
@@ -116,7 +116,7 @@ PJB1_TCR,%s,any,PJB1,VDJ-T,
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
                             "Missing %s" % f)
-        # Verify no cellranger counts outputs for VDJ-T samples
+        # Verify no cellranger count outputs for VDJ-T samples
         for f in ("qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/_cmdline",
                   "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/web_summary.html",
                   "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/metrics_summary.csv",

--- a/auto_process_ngs/test/qc/pipeline/test_10x_sc_immune_profiling.py
+++ b/auto_process_ngs/test/qc/pipeline/test_10x_sc_immune_profiling.py
@@ -1,0 +1,129 @@
+#######################################################################
+# Unit tests for qc/pipeline.py (10x single cell immune profiling data)
+#######################################################################
+
+# All imports declared in __init__.py file
+from . import *
+
+class TestQCPipeline(BaseQCPipelineTestCase):
+    """
+    Tests for 10xGenomics single cell immune profiling data
+    """
+    #@unittest.skip("Skipped")
+    def test_qcpipeline_immune_profiling(self):
+        """
+        QCPipeline: 10xGenomics single cell immune profiling run
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="7.1.0")
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x single cell immune profiling project
+        p = MockAnalysisProject("PJB",("PJB1_GEX_S1_R1_001.fastq.gz",
+                                       "PJB1_GEX_S1_R2_001.fastq.gz",
+                                       "PJB1_TCR_S2_R1_001.fastq.gz",
+                                       "PJB1_TCR_S2_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 5\'',
+                                           'Library type':
+                                           'Single Cell Immune Profiling' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv file
+        # (This is only used to identify the GEX samples)
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[vdj]
+reference,/data/refdata-cellranger-vdj-GRCh38-alts-ensembl-7.1.0
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,%s,any,PJB1,gene expression,
+PJB1_TCR,%s,any,PJB1,VDJ-T,
+""" % (fastq_dir,fastq_dir))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_ImmuneProfiling"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"10x_ImmuneProfiling")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_ImmuneProfiling")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_GEX")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz,"
+                         "PJB1_TCR_S2_R1_001.fastq.gz,"
+                         "PJB1_TCR_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/_cmdline",
+                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/outs/web_summary.html",
+                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/outs/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/_cmdline",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/outs/web_summary.html",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+        # Verify missing outputs for VDJ-T samples
+        for f in ("PJB1_TCR_S2_R2_001_fastq_strand.txt",
+                  "PJB1_TCR_S2_R2_001_screen_model_organisms.txt",
+                  "PJB1_TCR_S2_R2_001_screen_other_organisms.txt",
+                  "PJB1_TCR_S2_R2_001_screen_rRNA.txt",
+                  "qualimap-rnaseq/human/PJB2_TCR_S2_001",):
+            self.assertFalse(os.path.exists(os.path.join(self.wd,
+                                                         "PJB",
+                                                         "qc",
+                                                         f)),
+                             "Found %s (shouldn't exist)" % f)

--- a/auto_process_ngs/test/qc/pipeline/test_10x_sc_immune_profiling.py
+++ b/auto_process_ngs/test/qc/pipeline/test_10x_sc_immune_profiling.py
@@ -45,7 +45,7 @@ class TestQCPipeline(BaseQCPipelineTestCase):
         # (This is only used to identify the GEX samples)
         with open(os.path.join(self.wd,
                                "PJB",
-                               "10x_multi_config.csv"),'wt') as fp:
+                               "10x_multi_config.PJB1.csv"),'wt') as fp:
             fastq_dir = os.path.join(self.wd,
                                      "PJB",
                                      "fastqs")
@@ -122,6 +122,161 @@ PJB1_TCR,%s,any,PJB1,VDJ-T,
                   "PJB1_TCR_S2_R2_001_screen_other_organisms.txt",
                   "PJB1_TCR_S2_R2_001_screen_rRNA.txt",
                   "qualimap-rnaseq/human/PJB2_TCR_S2_001",):
+            self.assertFalse(os.path.exists(os.path.join(self.wd,
+                                                         "PJB",
+                                                         "qc",
+                                                         f)),
+                             "Found %s (shouldn't exist)" % f)
+
+    #@unittest.skip("Skipped")
+    def test_qcpipeline_immune_profiling_multiple_samples(self):
+        """
+        QCPipeline: 10xGenomics single cell immune profiling run (multiple samples)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="7.1.0")
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x single cell immune profiling project
+        p = MockAnalysisProject("PJB",("PJB1_GEX_S1_R1_001.fastq.gz",
+                                       "PJB1_GEX_S1_R2_001.fastq.gz",
+                                       "PJB1_TCR_S2_R1_001.fastq.gz",
+                                       "PJB1_TCR_S2_R2_001.fastq.gz",
+                                       "PJB2_GEX_S3_R1_001.fastq.gz",
+                                       "PJB2_GEX_S3_R2_001.fastq.gz",
+                                       "PJB2_TCR_S4_R1_001.fastq.gz",
+                                       "PJB2_TCR_S4_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 5\'',
+                                           'Library type':
+                                           'Single Cell Immune Profiling' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv files
+        # (This is only used to identify the GEX samples)
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB1.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[vdj]
+reference,/data/refdata-cellranger-vdj-GRCh38-alts-ensembl-7.1.0
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,%s,any,PJB1,gene expression,
+PJB1_TCR,%s,any,PJB1,VDJ-T,
+""" % (fastq_dir,fastq_dir))
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB2.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[vdj]
+reference,/data/refdata-cellranger-vdj-GRCh38-alts-ensembl-7.1.0
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB2_GEX,%s,any,PJB2,gene expression,
+PJB2_TCR,%s,any,PJB2,VDJ-T,
+""" % (fastq_dir,fastq_dir))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_ImmuneProfiling"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"10x_ImmuneProfiling")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_ImmuneProfiling")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_GEX,PJB2_GEX")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz,"
+                         "PJB1_TCR_S2_R1_001.fastq.gz,"
+                         "PJB1_TCR_S2_R2_001.fastq.gz,"
+                         "PJB2_GEX_S3_R1_001.fastq.gz,"
+                         "PJB2_GEX_S3_R2_001.fastq.gz,"
+                         "PJB2_TCR_S4_R1_001.fastq.gz,"
+                         "PJB2_TCR_S4_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/_cmdline",
+                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/outs/web_summary.html",
+                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/outs/metrics_summary.csv",
+                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/_cmdline",
+                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/outs/web_summary.html",
+                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/outs/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/_cmdline",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/outs/web_summary.html",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/outs/metrics_summary.csv",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/_cmdline",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/outs/web_summary.html",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+        # Verify missing outputs for VDJ-T samples
+        for f in ("PJB1_TCR_S2_R2_001_fastq_strand.txt",
+                  "PJB1_TCR_S2_R2_001_screen_model_organisms.txt",
+                  "PJB1_TCR_S2_R2_001_screen_other_organisms.txt",
+                  "PJB1_TCR_S2_R2_001_screen_rRNA.txt",
+                  "qualimap-rnaseq/human/PJB2_TCR_S2_001",
+                  "PJB2_TCR_S4_R2_001_fastq_strand.txt",
+                  "PJB2_TCR_S4_R2_001_screen_model_organisms.txt",
+                  "PJB2_TCR_S4_R2_001_screen_other_organisms.txt",
+                  "PJB2_TCR_S4_R2_001_screen_rRNA.txt",
+                  "qualimap-rnaseq/human/PJB4_TCR_S2_001",):
             self.assertFalse(os.path.exists(os.path.join(self.wd,
                                                          "PJB",
                                                          "qc",

--- a/auto_process_ngs/test/qc/pipeline/test_10x_sc_immune_profiling.py
+++ b/auto_process_ngs/test/qc/pipeline/test_10x_sc_immune_profiling.py
@@ -83,7 +83,7 @@ PJB1_TCR,%s,any,PJB1,VDJ-T,
         self.assertEqual(qc_info.protocol_specification,
                          str(fetch_protocol_definition("10x_ImmuneProfiling")))
         self.assertEqual(qc_info.organism,"Human")
-        self.assertEqual(qc_info.seq_data_samples,"PJB1_GEX")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_GEX,PJB1_TCR")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
         self.assertEqual(qc_info.fastqs,
@@ -116,17 +116,16 @@ PJB1_TCR,%s,any,PJB1,VDJ-T,
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
                             "Missing %s" % f)
-        # Verify missing outputs for VDJ-T samples
-        for f in ("PJB1_TCR_S2_R2_001_fastq_strand.txt",
-                  "PJB1_TCR_S2_R2_001_screen_model_organisms.txt",
-                  "PJB1_TCR_S2_R2_001_screen_other_organisms.txt",
-                  "PJB1_TCR_S2_R2_001_screen_rRNA.txt",
-                  "qualimap-rnaseq/human/PJB2_TCR_S2_001",):
+        # Verify no cellranger counts outputs for VDJ-T samples
+        for f in ("qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/_cmdline",
+                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/web_summary.html",
+                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/metrics_summary.csv",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/_cmdline",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/web_summary.html",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/metrics_summary.csv"):
             self.assertFalse(os.path.exists(os.path.join(self.wd,
-                                                         "PJB",
-                                                         "qc",
-                                                         f)),
-                             "Found %s (shouldn't exist)" % f)
+                                                        "PJB",f)),
+                            "Found %s (shouldn't exist)" % f)
 
     #@unittest.skip("Skipped")
     def test_qcpipeline_immune_profiling_multiple_samples(self):
@@ -223,7 +222,8 @@ PJB2_TCR,%s,any,PJB2,VDJ-T,
         self.assertEqual(qc_info.protocol_specification,
                          str(fetch_protocol_definition("10x_ImmuneProfiling")))
         self.assertEqual(qc_info.organism,"Human")
-        self.assertEqual(qc_info.seq_data_samples,"PJB1_GEX,PJB2_GEX")
+        self.assertEqual(qc_info.seq_data_samples,
+                         "PJB1_GEX,PJB1_TCR,PJB2_GEX,PJB2_TCR")
         self.assertEqual(qc_info.fastq_dir,
                          os.path.join(self.wd,"PJB","fastqs"))
         self.assertEqual(qc_info.fastqs,
@@ -266,19 +266,19 @@ PJB2_TCR,%s,any,PJB2,VDJ-T,
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
                             "Missing %s" % f)
-        # Verify missing outputs for VDJ-T samples
-        for f in ("PJB1_TCR_S2_R2_001_fastq_strand.txt",
-                  "PJB1_TCR_S2_R2_001_screen_model_organisms.txt",
-                  "PJB1_TCR_S2_R2_001_screen_other_organisms.txt",
-                  "PJB1_TCR_S2_R2_001_screen_rRNA.txt",
-                  "qualimap-rnaseq/human/PJB2_TCR_S2_001",
-                  "PJB2_TCR_S4_R2_001_fastq_strand.txt",
-                  "PJB2_TCR_S4_R2_001_screen_model_organisms.txt",
-                  "PJB2_TCR_S4_R2_001_screen_other_organisms.txt",
-                  "PJB2_TCR_S4_R2_001_screen_rRNA.txt",
-                  "qualimap-rnaseq/human/PJB4_TCR_S2_001",):
+        # Verify no cellranger counts outputs for VDJ-T samples
+        for f in ("qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/_cmdline",
+                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/web_summary.html",
+                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/metrics_summary.csv",
+                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR/_cmdline",
+                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR/outs/web_summary.html",
+                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR/outs/metrics_summary.csv",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/_cmdline",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/web_summary.html",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/metrics_summary.csv",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR/_cmdline",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR/outs/web_summary.html",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR/outs/metrics_summary.csv"):
             self.assertFalse(os.path.exists(os.path.join(self.wd,
-                                                         "PJB",
-                                                         "qc",
-                                                         f)),
-                             "Found %s (shouldn't exist)" % f)
+                                                        "PJB",f)),
+                            "Found %s (shouldn't exist)" % f)

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -1687,7 +1687,8 @@ class TestQCOutputs(unittest.TestCase):
                                    ))
         qc_outputs = QCOutputs(qc_dir)
         self.assertEqual(qc_outputs.outputs,
-                         ['cellranger_multi',
+                         ['cellranger_count',
+                          'cellranger_multi',
                           'fastqc_r1',
                           'fastqc_r2',
                           'multiqc',

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -498,6 +498,24 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
         self.assertEqual(determine_qc_protocol(project),
                          "10x_Flex")
 
+    def test_determine_qc_protocol_10xchromium5_immune_profiling(self):
+        """determine_qc_protocol: single cell immune profiling (10xGenomics Chromium 5')
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={'Single cell platform':
+                                          "10xGenomics Chromium 5'",
+                                          'Library type':
+                                          "Single Cell Immune Profiling"})
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        self.assertEqual(determine_qc_protocol(project),
+                         "10x_ImmuneProfiling")
+
     def test_determine_qc_protocol_10x_single_cell_atac_seq(self):
         """determine_qc_protocol: single-cell ATAC-seq (10xGenomics Single Cell ATAC)
         """

--- a/auto_process_ngs/test/qc/test_reporting.py
+++ b/auto_process_ngs/test/qc/test_reporting.py
@@ -153,6 +153,29 @@ class TestReportFunction(unittest.TestCase):
         self.assertTrue(os.path.exists(
             os.path.join(self.top_dir,'report.PE.html')))
 
+    def test_report_paired_end_bad_cellranger_multi(self):
+        """
+        report: paired-end data with 'bad' 'cellranger_multi' subdir
+        """
+        analysis_dir = self._make_analysis_project(
+            protocol='10x_CellPlex',
+            cellranger_multi_samples=('PJB_CML1','PJB_CML2',))
+        # Make a "bad" 'cellranger_multi' dir
+        # i.e. doesn't conform to expected format
+        bad_cellranger_multi_dir = os.path.join(analysis_dir,
+                                                "qc",
+                                                "cellranger_multi",
+                                                "PJB")
+        os.makedirs(bad_cellranger_multi_dir)
+        with open(os.path.join(bad_cellranger_multi_dir,"web_summary.html"),
+                  "wt") as fp:
+            fp.write("Placeholder")
+        project = AnalysisProject(analysis_dir)
+        report((project,),filename=os.path.join(self.top_dir,
+                                                'report.PE.html'))
+        self.assertTrue(os.path.exists(
+            os.path.join(self.top_dir,'report.PE.html')))
+
     def test_report_paired_end_cellranger_count_and_multi(self):
         """
         report: paired-end data with cellranger 'count' and 'multi'

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -288,6 +288,32 @@ PBB,CMO302,PBB
         self.assertEqual(get_seq_data_samples(project_dir),
                          ["PJB1"])
 
+    def test_get_seq_data_samples_10x_immune_profiling(self):
+        """
+        get_seq_data_samples: 10x Single Cell Immune Profiling project
+        """
+        # Set up mock project
+        project_dir = self._make_mock_analysis_project(
+            "Single Cell Immune Profiling",
+            single_cell_platform="10xGenomics Chromium 5'")
+        # Make 10x_multi_config.csv file
+        with open(os.path.join(project_dir,"10x_multi_config.csv"),
+                  'wt') as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[vdj]
+reference,/data/refdata-cellranger-vdj-GRCh38-alts-ensembl-7.1.0
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1,{fastq_dir},any,PJB1,gene expression,
+PJB2,{fastq_dir},any,PJB2,VDJ-T,
+""".format(fastq_dir=os.path.join(project_dir,'fastqs')))
+        # Check sequence data samples
+        self.assertEqual(get_seq_data_samples(project_dir),
+                         ["PJB1"])
+
 class TestSetCellCountForProject(unittest.TestCase):
     """
     Tests for the 'set_cell_count_for_project' function

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -224,14 +224,18 @@ class TestGetSeqDataSamples(unittest.TestCase):
         if REMOVE_TEST_OUTPUTS:
             shutil.rmtree(self.wd)
     def _make_mock_analysis_project(self,library_type,
+                                    fastq_names=None,
                                     single_cell_platform=None,
                                     bio_samples=None):
+        # Default Fastqs
+        if not fastq_names:
+            fastq_names = ("PJB1_S1_L001_R1_001.fastq.gz",
+                           "PJB1_S1_L001_R2_001.fastq.gz",
+                           "PJB2_S2_L001_R1_001.fastq.gz",
+                           "PJB2_S2_L001_R2_001.fastq.gz",)
         # Create a mock AnalysisProject
         m = MockAnalysisProject('PJB',
-                                fastq_names=("PJB1_S1_L001_R1_001.fastq.gz",
-                                             "PJB1_S1_L001_R2_001.fastq.gz",
-                                             "PJB2_S2_L001_R1_001.fastq.gz",
-                                             "PJB2_S2_L001_R2_001.fastq.gz",),
+                                fastq_names=fastq_names,
                                 metadata={'Single cell platform':
                                           single_cell_platform,
                                           'Library type': library_type,
@@ -288,6 +292,35 @@ PBB,CMO302,PBB
         self.assertEqual(get_seq_data_samples(project_dir),
                          ["PJB1"])
 
+    def test_get_seq_data_samples_10x_flex(self):
+        """
+        get_seq_data_samples: 10x Flex project
+        """
+        # Set up mock project
+        project_dir = self._make_mock_analysis_project(
+            "Flex",
+            single_cell_platform="10xGenomics Chromium 3'v3",
+            fastq_names=("PJB1_S1_L001_R1_001.fastq.gz",
+                         "PJB1_S1_L001_R2_001.fastq.gz",))
+        # Make 10x_multi_config.csv file
+        with open(os.path.join(project_dir,"10x_multi_config.csv"),
+                  'wt') as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1,{fastq_dir},any,PJB1,gene expression,
+
+[samples]
+sample_id,probe_barcode_ids,description
+PBA,BC001,PBA
+PBB,BC002,PBB
+""".format(fastq_dir=os.path.join(project_dir,'fastqs')))
+        # Check sequence data samples
+        self.assertEqual(get_seq_data_samples(project_dir),
+                         ["PJB1"])
+
     def test_get_seq_data_samples_10x_immune_profiling(self):
         """
         get_seq_data_samples: 10x Single Cell Immune Profiling project
@@ -295,9 +328,17 @@ PBB,CMO302,PBB
         # Set up mock project
         project_dir = self._make_mock_analysis_project(
             "Single Cell Immune Profiling",
-            single_cell_platform="10xGenomics Chromium 5'")
-        # Make 10x_multi_config.csv file
-        with open(os.path.join(project_dir,"10x_multi_config.csv"),
+            single_cell_platform="10xGenomics Chromium 5'",
+            fastq_names=("PJB1_GEX_S1_L001_R1_001.fastq.gz",
+                         "PJB1_GEX_S1_L001_R2_001.fastq.gz",
+                         "PJB1_TCR_S2_L001_R1_001.fastq.gz",
+                         "PJB1_TCR_S2_L001_R2_001.fastq.gz",
+                         "PJB2_GEX_S3_L001_R1_001.fastq.gz",
+                         "PJB2_GEX_S3_L001_R2_001.fastq.gz",
+                         "PJB2_TRC_S4_L001_R1_001.fastq.gz",
+                         "PJB2_TCR_S4_L001_R2_001.fastq.gz",))
+        # Make 10x_multi_config.csv files
+        with open(os.path.join(project_dir,"10x_multi_config.PJB1.csv"),
                   'wt') as fp:
             fp.write("""[gene-expression]
 reference,/data/refdata-cellranger-gex-GRCh38-2020-A
@@ -307,12 +348,25 @@ reference,/data/refdata-cellranger-vdj-GRCh38-alts-ensembl-7.1.0
 
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
-PJB1,{fastq_dir},any,PJB1,gene expression,
-PJB2,{fastq_dir},any,PJB2,VDJ-T,
+PJB1_GEX,{fastq_dir},any,PJB1,gene expression,
+PJB1_TCR,{fastq_dir},any,PJB1,VDJ-T,
+""".format(fastq_dir=os.path.join(project_dir,'fastqs')))
+        with open(os.path.join(project_dir,"10x_multi_config.PJB2.csv"),
+                  'wt') as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[vdj]
+reference,/data/refdata-cellranger-vdj-GRCh38-alts-ensembl-7.1.0
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB2_GEX,{fastq_dir},any,PJB2,gene expression,
+PJB2_TCR,{fastq_dir},any,PJB2,VDJ-T,
 """.format(fastq_dir=os.path.join(project_dir,'fastqs')))
         # Check sequence data samples
         self.assertEqual(get_seq_data_samples(project_dir),
-                         ["PJB1"])
+                         ["PJB1_GEX","PJB2_GEX"])
 
 class TestSetCellCountForProject(unittest.TestCase):
     """

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -335,7 +335,7 @@ PBB,BC002,PBB
                          "PJB1_TCR_S2_L001_R2_001.fastq.gz",
                          "PJB2_GEX_S3_L001_R1_001.fastq.gz",
                          "PJB2_GEX_S3_L001_R2_001.fastq.gz",
-                         "PJB2_TRC_S4_L001_R1_001.fastq.gz",
+                         "PJB2_TCC_S4_L001_R1_001.fastq.gz",
                          "PJB2_TCR_S4_L001_R2_001.fastq.gz",))
         # Make 10x_multi_config.csv files
         with open(os.path.join(project_dir,"10x_multi_config.PJB1.csv"),
@@ -366,7 +366,7 @@ PJB2_TCR,{fastq_dir},any,PJB2,VDJ-T,
 """.format(fastq_dir=os.path.join(project_dir,'fastqs')))
         # Check sequence data samples
         self.assertEqual(get_seq_data_samples(project_dir),
-                         ["PJB1_GEX","PJB2_GEX"])
+                         ["PJB1_GEX","PJB1_TCR","PJB2_GEX","PJB2_TCR"])
 
 class TestSetCellCountForProject(unittest.TestCase):
     """

--- a/auto_process_ngs/test/tenx/test_cellplex.py
+++ b/auto_process_ngs/test/tenx/test_cellplex.py
@@ -45,6 +45,9 @@ PBB,CMO302,PBB
             os.path.join(self.wd,
                          "10x_multi_config.csv"))
         self.assertEqual(config_csv.sample_names,['PBA','PBB'])
+        self.assertEqual(config_csv.sections,['gene-expression',
+                                              'libraries',
+                                              'samples'])
         self.assertEqual(config_csv.reference_data_path,
                          "/data/refdata-cellranger-gex-GRCh38-2020-A")
         self.assertEqual(config_csv.probe_set_path,None)
@@ -89,6 +92,9 @@ PB2,BC002,PB2
             os.path.join(self.wd,
                          "10x_multi_config.csv"))
         self.assertEqual(config_csv.sample_names,['PB1','PB2'])
+        self.assertEqual(config_csv.sections,['gene-expression',
+                                              'libraries',
+                                              'samples'])
         self.assertEqual(config_csv.reference_data_path,
                          "/data/refdata-cellranger-gex-GRCh38-2020-A")
         self.assertEqual(config_csv.probe_set_path,
@@ -136,6 +142,10 @@ PBB,CMO302,PBB
             os.path.join(self.wd,
                          "10x_multi_config.csv"))
         self.assertEqual(config_csv.sample_names,['PBA','PBB'])
+        self.assertEqual(config_csv.sections,['feature',
+                                              'gene-expression',
+                                              'libraries',
+                                              'samples'])
         self.assertEqual(config_csv.reference_data_path,
                          "/data/refdata-cellranger-gex-GRCh38-2020-A")
         self.assertEqual(config_csv.probe_set_path,None)
@@ -183,6 +193,10 @@ PBB,CMO302,PBB
             os.path.join(self.wd,
                          "10x_multi_config.csv"))
         self.assertEqual(config_csv.sample_names,['PBA','PBB'])
+        self.assertEqual(config_csv.sections,['gene-expression',
+                                              'libraries',
+                                              'samples',
+                                              'vdj'])
         self.assertEqual(config_csv.reference_data_path,
                          "/data/refdata-cellranger-gex-GRCh38-2020-A")
         self.assertEqual(config_csv.probe_set_path,None)
@@ -227,6 +241,9 @@ PBB,CMO302
             os.path.join(self.wd,
                          "10x_multi_config.csv"))
         self.assertEqual(config_csv.sample_names,['PBA','PBB'])
+        self.assertEqual(config_csv.sections,['gene-expression',
+                                              'libraries',
+                                              'samples'])
         self.assertEqual(config_csv.reference_data_path,
                          "/data/refdata-cellranger-gex-GRCh38-2020-A")
         self.assertEqual(config_csv.probe_set_path,None)

--- a/auto_process_ngs/test/tenx/test_utils.py
+++ b/auto_process_ngs/test/tenx/test_utils.py
@@ -617,9 +617,6 @@ reference,/path/to/transcriptome
 #[feature]
 #reference,/path/to/feature/reference
 
-#[vdj]
-#reference,/path/to/vdj/reference
-
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
 
@@ -629,6 +626,40 @@ MULTIPLEXED_SAMPLE,CMO1|CMO2|...,DESCRIPTION
 """
         out_file = os.path.join(self.wd,"10x_multi_config.csv")
         make_multi_config_template(out_file)
+        self.assertTrue(os.path.exists(out_file))
+        with open(out_file,'rt') as fp:
+            actual_content = '\n'.join([line for line in fp.read().split('\n')
+                                        if not line.startswith('##')])
+        self.assertEqual(expected_content,actual_content)
+
+    def test_make_multi_config_template_cellplex(self):
+        """
+        make_multi_config_template: check CellPlex template
+        """
+        expected_content = """[gene-expression]
+reference,/data/mm10_transcriptome
+#force-cells,n
+#no-bam,true|false
+#cmo-set,/path/to/custom/cmo/reference
+
+#[feature]
+#reference,/path/to/feature/reference
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB_CML,/runs/novaseq_50/fastqs,any,PJB_CML,[Gene Expression|Multiplexing Capture],
+PJB_GEX,/runs/novaseq_50/fastqs,any,PJB_GEX,[Gene Expression|Multiplexing Capture],
+
+[samples]
+sample_id,cmo_ids,description
+MULTIPLEXED_SAMPLE,CMO1|CMO2|...,DESCRIPTION
+"""
+        out_file = os.path.join(self.wd,"10x_multi_config.csv")
+        make_multi_config_template(out_file,
+                                   reference="/data/mm10_transcriptome",
+                                   fastq_dir="/runs/novaseq_50/fastqs",
+                                   samples=("PJB_CML","PJB_GEX"),
+                                   library_type="CellPlex")
         self.assertTrue(os.path.exists(out_file))
         with open(out_file,'rt') as fp:
             actual_content = '\n'.join([line for line in fp.read().split('\n')
@@ -648,9 +679,6 @@ no-bam,true
 
 #[feature]
 #reference,/path/to/feature/reference
-
-#[vdj]
-#reference,/path/to/vdj/reference
 
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
@@ -674,9 +702,9 @@ MULTIPLEXED_SAMPLE,BC001|BC002|...,DESCRIPTION
                                         if not line.startswith('##')])
         self.assertEqual(expected_content,actual_content)
 
-    def test_make_multi_config_template_cellplex(self):
+    def test_make_multi_config_template_immune_profiling(self):
         """
-        make_multi_config_template: check CellPlex template
+        make_multi_config_template: check Single Cell Immune Profiling template
         """
         expected_content = """[gene-expression]
 reference,/data/mm10_transcriptome
@@ -692,19 +720,15 @@ reference,/data/mm10_transcriptome
 
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
-PJB_CML,/runs/novaseq_50/fastqs,any,PJB_CML,[Gene Expression|Multiplexing Capture|Antibody Capture|VDJ-B|VDJ-T],
-PJB_GEX,/runs/novaseq_50/fastqs,any,PJB_GEX,[Gene Expression|Multiplexing Capture|Antibody Capture|VDJ-B|VDJ-T],
-
-[samples]
-sample_id,cmo_ids,description
-MULTIPLEXED_SAMPLE,CMO1|CMO2|...,DESCRIPTION
+PJB_CML,/runs/novaseq_50/fastqs,any,PJB_CML,[Gene Expression|Antibody Capture|VDJ-B|VDJ-T],
+PJB_GEX,/runs/novaseq_50/fastqs,any,PJB_GEX,[Gene Expression|Antibody Capture|VDJ-B|VDJ-T],
 """
         out_file = os.path.join(self.wd,"10x_multi_config.csv")
         make_multi_config_template(out_file,
                                    reference="/data/mm10_transcriptome",
                                    fastq_dir="/runs/novaseq_50/fastqs",
                                    samples=("PJB_CML","PJB_GEX"),
-                                   library_type="CellPlex")
+                                   library_type="Single Cell Immune Profiling")
         self.assertTrue(os.path.exists(out_file))
         with open(out_file,'rt') as fp:
             actual_content = '\n'.join([line for line in fp.read().split('\n')

--- a/docs/source/control_files/10x_multi_config_csv.rst
+++ b/docs/source/control_files/10x_multi_config_csv.rst
@@ -7,10 +7,22 @@ profiling) data, multiplexing analyses are run using the
 ``10x_multi_config.csv`` file is also present in the project
 directory.
 
+.. note::
+
+   Template versions of this file will be automatically and
+   partially populated by the
+   :doc:`setup_analysis_dirs <setup_analysis_dirs>` command
+   for the appropriate single cell data type (see
+   :doc:`../single_cell/10x_single_cell`).
+
 Depending on the library type, this file should have the format
-and content outlined at `cellranger_multi_cellplex`_ (for CellPlex
-data) or `cellranger_multi_frp`_ (for Flex data).
+and content outlined in the following 10x Genomics documentation:
+
+ * **CellPlex**: `cellranger_multi_cellplex`_
+ * **Flex**: `cellranger_multi_frp`_
+ * **Single cell immune profiling**: `cellranger_multi
 
 .. _cellranger: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/what-is-cell-ranger
 .. _cellranger_multi_cellplex: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/multi#cellranger-multi
 .. _cellranger_multi_frp: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/multi-frp
+.. _cellranger_multi_immune_profing: https://www.10xgenomics.com/support/software/cell-ranger/latest/analysis/running-pipelines/cr-5p-multi

--- a/docs/source/single_cell/10x_single_cell.rst
+++ b/docs/source/single_cell/10x_single_cell.rst
@@ -29,6 +29,7 @@ and available to ``auto_process.py``:
 Single cell/single nuclei RNA-seq CellRanger
 Single cell ATAC-seq              CellRanger-ATAC
 Single cell multiome              CellRanger-ARC
+Single cell immune profiling      Cellranger
 CellPlex (cell multiplexing)      CellRanger
 Flex (fixed RNA profiling)        CellRanger
 ================================= =================
@@ -58,6 +59,7 @@ Single cell ATAC-seq                                ``10x_atac``
 Single cell multiome (unpooled GEX or ATAC)         ``10x_multiome``
 Single cell multiome GEX (pooled GEX and ATAC)      ``10x_multiome_gex``
 Single cell multiome ATAC (pooled GEX and ATAC)     ``10x_multiome_atac``
+Single cell immune profiling                        ``10x_chromium_sc``
 CellPlex (cell multiplexing)                        ``10x_chromium_sc``
 Flex (fixed RNA profiling)                          ``10x_chromium_sc``
 =================================================== =====================
@@ -126,6 +128,7 @@ Single cell platform                  Library types
                                       ``CellPlex``, ``Flex``
 ``10xGenomics Chromium 3'v2``         ``scRNA-seq``, ``snRNA-seq``
                                       ``CellPlex``, ``Flex``
+``10xGenomics Chromium 5'``           ``Single Cell Immune Profiling``
 ``10xGenomics Single Cell ATAC``      ``scATAC-seq``, ``snATAC-seq``
 ``10xGenomics Single Cell Multiome``  ``ATAC``, ``GEX``
 ===================================== ==============================

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -176,6 +176,8 @@ The behaviour is controlled by the ``split_undetermined_fastqs``
 setting in the ``qc`` section of the configuration file (see
 :ref:`qc_pipeline_configuration`).
 
+.. _run_qc_including_external_outputs:
+
 -----------------------------------------
 Including external (non-pipeline) outputs
 -----------------------------------------

--- a/docs/source/using/setup_analysis_dirs.rst
+++ b/docs/source/using/setup_analysis_dirs.rst
@@ -48,9 +48,9 @@ field.
 Once the project directories have been created, the next step is to
 run the QC pipeline - see :doc:`Running the QC <run_qc>`.
 
-----------------
-Additional files
-----------------
+--------------------------------
+Additional files and directories
+--------------------------------
 
 For certain types of data there are additional files that should
 be added to the project directory manually after running
@@ -65,6 +65,9 @@ generate partially-populated template versions, with the
 
 These can be edited and renamed before use in downstream processing
 stages (e.g. the QC pipeline).
+
+For 10x Genomics Visium data an empty ``Visium_images`` subdirectory
+will also be created (see :doc:`../spatial/10x_visium`).
 
 .. _setup_analysis_dirs-add-identifier:
 


### PR DESCRIPTION
Adds support for handling 10x Genomics Chromium 5' Single Cell Immune Profiling data.

Information on handling immune profiling analysis via `cellranger multi` can be found at https://support.10xgenomics.com/single-cell-vdj/software/pipelines/latest/using/multi

* Adds `10xGenomics Chromium 5'` as a recognised 10x platform, and `Single Cell Immune Profiling` as a valid library type
* Implements a new QC protocol `10x_ImmuneProfiling` for these data

Other changes include adding a list of known 10x platform-library combinations to check when analysis directories are created, and updating the `cellranger multi` template config generation to include immune profiling (and fix some issues for CellPlex and Flex).