### PR TITLE
Enable QC reporting to include arbitrary externally generated outputs

### DIFF
--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python
 #
 #     qc/outputs: utilities to predict and check QC pipeline outputs
-#     Copyright (C) University of Manchester 2019-2023 Peter Briggs
+#     Copyright (C) University of Manchester 2019-2024 Peter Briggs
 #
 """
 Provides utility classes and functions for QC outputs.
 
-Provides the following class:
+Provides the following classes:
 
 - QCOutputs: detect and characterise QC outputs
+- ExtraOutputs: helper class for reading 'extra_outputs.tsv' file
 
 Provides the following functions:
 
@@ -118,6 +119,7 @@ class QCOutputs:
     - 'cellranger-atac_count'
     - 'cellranger-arc_count'
     - 'multiqc'
+    - 'extra_outputs'
 
     The following are valid values for the 'config_files'
     property:
@@ -240,7 +242,8 @@ class QCOutputs:
                 self._collect_icell8(self.qc_dir),
                 self._collect_cellranger_count(self.qc_dir),
                 self._collect_cellranger_multi(self.qc_dir),
-                self._collect_multiqc(self.qc_dir),):
+                self._collect_multiqc(self.qc_dir),
+                self._collect_extra_outputs(self.qc_dir)):
             self._add_qc_outputs(qc_data)
         # Collect QC config files
         self.config_files = self._collect_qc_config_files(files)
@@ -1287,7 +1290,7 @@ class QCOutputs:
 
     def _collect_multiqc(self,qc_dir):
         """
-        Collect information on MultQC reports
+        Collect information on MultiQC reports
 
         Returns an AttributeDictionary with the following
         attributes:
@@ -1338,6 +1341,40 @@ class QCOutputs:
             tags=sorted(list(tags))
         )
 
+    def _collect_extra_outputs(self,qc_dir):
+        """
+        Collect information on additional outputs
+
+        Returns an AttributeDictionary with the following
+        attributes:
+
+        - name: set to 'extra_outputs'
+        - software: dictionary of software and versions
+        - output_files: list of associated output files
+        - tags: list of associated output classes
+
+        Arguments:
+          qc_dir (str): top-level directory to look under.
+        """
+        version = None
+        software = dict()
+        output_files = set()
+        tags = set()
+        # Look for extra_outputs.tsv
+        extra_outputs_tsv = os.path.join(qc_dir,"extra_outputs.tsv")
+        for output in ExtraOutputs(extra_outputs_tsv).outputs:
+            output_files.add(os.path.join(qc_dir,output.file_path))
+        if output_files:
+            tags.add("extra_outputs")
+        # Return collected information
+        return AttributeDictionary(
+            name='extra_outputs',
+            software=software,
+            fastqs=[],
+            output_files=sorted(list(output_files)),
+            tags=sorted(list(tags))
+        )
+
     def _collect_qc_config_files(self,files):
         """
         Collect information on QC config files
@@ -1368,6 +1405,72 @@ class QCOutputs:
                              files)):
             config_files.add(os.path.basename(f))
         return sorted(list(config_files))
+
+class ExtraOutputs:
+    """
+    Class for handling files specifying external QC outputs
+
+    Reads data from the supplied tab-delimited (TSV) file
+    specifying one or more external QC output files.
+
+    Each line in the file should have up to three items
+    separated by tabs:
+
+    - file or directory (relative to the qc dir)
+    - text description (used in HTML)
+    - optionally, list of additional files or directories
+      to include in the final ZIP archive (relative to the
+      qc dir)
+
+    Blank lines and lines starting with the '#' comment
+    character are ignored.
+
+    The data from each line of the file is then available
+    via the 'outputs' attribute, which provides a list
+    of 'AttributeDictionary' objects with the following
+    properties:
+
+    - 'file_path': relative path to the output file
+    - 'description': associated description
+    - 'additional_files': list of the associated files
+
+    Arguments:
+      tsv_file (str): path to the input TSV file
+    """
+    def __init__(self,tsv_file):
+        self.tsv_file = os.path.abspath(tsv_file)
+        self.outputs = list()
+        self.__load()
+
+    def __load(self):
+        """
+        Internal: loads data from the supplied TSV file
+        """
+        if not os.path.exists(self.tsv_file):
+            return
+        with open(self.tsv_file,'rt') as fp:
+            for line in fp:
+                line = line.strip()
+                if line.startswith('#') or not line:
+                    continue
+                items = line.split('\t')
+                if len(items) > 3:
+                    raise IndexError("Bad line (too many items): '%s'" %
+                                     line)
+                try:
+                    file_path = items[0]
+                    description = items[1]
+                except IndexError:
+                    raise IndexError("Bad line (not enough items): '%s'" %
+                                     line)
+                try:
+                    additional_files = items[2].split(',')
+                except IndexError:
+                    additional_files = None
+                self.outputs.append(
+                    AttributeDictionary(file_path=file_path,
+                                        description=description,
+                                        additional_files=additional_files))
 
 #######################################################################
 # Functions

--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -1364,6 +1364,10 @@ class QCOutputs:
         extra_outputs_tsv = os.path.join(qc_dir,"extra_outputs.tsv")
         for output in ExtraOutputs(extra_outputs_tsv).outputs:
             output_files.add(os.path.join(qc_dir,output.file_path))
+            if output.additional_files:
+                # Add in any additional files or dirs
+                for f in output.additional_files:
+                    output_files.add(os.path.join(qc_dir,f))
         if output_files:
             tags.add("extra_outputs")
         # Return collected information
@@ -1418,9 +1422,9 @@ class ExtraOutputs:
 
     - file or directory (relative to the qc dir)
     - text description (used in HTML)
-    - optionally, list of additional files or directories
-      to include in the final ZIP archive (relative to the
-      qc dir)
+    - optionally, comma-separated list of additional files
+      or directories to include in the final ZIP archive
+      (relative to the qc dir)
 
     Blank lines and lines starting with the '#' comment
     character are ignored.

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -1121,7 +1121,7 @@ class TestQCOutputs(unittest.TestCase):
                                    ))
         extra_outputs_tsv = os.path.join(qc_dir,"extra_outputs.tsv")
         with open(extra_outputs_tsv,'wt') as fp:
-            fp.write("# Extra files to include in QC reporting\nanalyser/index.html\tReport from 'analyser'")
+            fp.write("# Extra files to include in QC reporting\nanalyser/index.html\tReport from 'analyser'\nfinal_result/main.html\tFinal result\tfinal_result/files")
         qc_outputs = QCOutputs(qc_dir)
         self.assertEqual(qc_outputs.outputs,
                          ['extra_outputs',
@@ -1168,6 +1168,11 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.stats.max_sequence_length_read['r2'],76)
         self.assertEqual(qc_outputs.config_files,
                          ['fastq_strand.conf'])
+        for f in ("analyser/index.html",
+                  "final_result/main.html",
+                  "final_result/files"):
+            self.assertTrue(os.path.join(qc_dir,f)
+                            in qc_outputs.output_files)
 
     def test_qcoutputs_10x_cellranger_count(self):
         """

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -12,6 +12,7 @@ from auto_process_ngs.mockqc import make_mock_qc_dir
 from auto_process_ngs.mockqc import MockQCOutputs
 from auto_process_ngs.analysis import AnalysisProject
 from auto_process_ngs.qc.outputs import QCOutputs
+from auto_process_ngs.qc.outputs import ExtraOutputs
 from auto_process_ngs.qc.outputs import fastq_screen_output
 from auto_process_ngs.qc.outputs import fastqc_output
 from auto_process_ngs.qc.outputs import fastq_strand_output
@@ -1107,6 +1108,67 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.config_files,
                          ['fastq_strand.conf'])
 
+    def test_qcoutputs_paired_end_extra_outputs_tsv(self):
+        """
+        QCOutputs: paired-end data with 'extra_outputs.tsv'
+        """
+        qc_dir = self._make_qc_dir('qc',
+                                   fastq_names=(
+                                       'PJB1_S1_R1_001',
+                                       'PJB1_S1_R2_001',
+                                       'PJB2_S2_R1_001',
+                                       'PJB2_S2_R2_001',
+                                   ))
+        extra_outputs_tsv = os.path.join(qc_dir,"extra_outputs.tsv")
+        with open(extra_outputs_tsv,'wt') as fp:
+            fp.write("# Extra files to include in QC reporting\nanalyser/index.html\tReport from 'analyser'")
+        qc_outputs = QCOutputs(qc_dir)
+        self.assertEqual(qc_outputs.outputs,
+                         ['extra_outputs',
+                          'fastqc_r1',
+                          'fastqc_r2',
+                          'multiqc',
+                          'screens_r1',
+                          'screens_r2',
+                          'sequence_lengths',
+                          'strandedness'])
+        self.assertEqual(qc_outputs.fastqs,
+                         ['PJB1_S1_R1_001',
+                          'PJB1_S1_R2_001',
+                          'PJB2_S2_R1_001',
+                          'PJB2_S2_R2_001'])
+        self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.bams,[])
+        self.assertEqual(qc_outputs.organisms,[])
+        self.assertEqual(qc_outputs.fastq_screens,
+                         ['model_organisms',
+                          'other_organisms',
+                          'rRNA'])
+        self.assertEqual(qc_outputs.cellranger_references,[])
+        self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.reads,['r1','r2'])
+        self.assertEqual(qc_outputs.software,
+                         { 'fastqc': [ '0.11.3' ],
+                           'fastq_screen': [ '0.9.2' ],
+                           'fastq_strand': [ '0.0.4' ],
+                           'multiqc': [ '1.8' ],
+                         })
+        self.assertEqual(qc_outputs.stats.max_seqs,37285443)
+        self.assertEqual(qc_outputs.stats.min_sequence_length,65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length,76)
+        self.assertEqual(sorted(
+            list(qc_outputs.stats.min_sequence_length_read.keys())),
+                         ['r1','r2'])
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r1'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r1'],76)
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r2'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r2'],76)
+        self.assertEqual(qc_outputs.config_files,
+                         ['fastq_strand.conf'])
+
     def test_qcoutputs_10x_cellranger_count(self):
         """
         QCOutputs: 10xGenomics data with cellranger 'count'
@@ -1857,6 +1919,45 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.stats.max_sequence_length_read['r2'],76)
         self.assertEqual(qc_outputs.config_files,
                          ['fastq_strand.conf'])
+
+class TestExtraOutputs(unittest.TestCase):
+    def setUp(self):
+        # Temporary working dir
+        self.wd = tempfile.mkdtemp(suffix='.test_ExtraOutputs')
+    def tearDown(self):
+        # Remove temporary working dir
+        if not REMOVE_TEST_OUTPUTS:
+            return
+        if self.wd is not None and os.path.isdir(self.wd):
+            shutil.rmtree(self.wd)
+
+    def test_extra_outputs(self):
+        """
+        ExtraOutputs: load data from TSV file
+        """
+        tsv_file = os.path.join(self.wd,"example.tsv")
+        with open(tsv_file,'wt') as fp:
+            fp.write("""# Example TSV file with external files
+stuff.html\tSome random output
+#more_stuff.html\tMore random output
+external_stuff/index.html\tBunch of external stuff\texternal_stuff/results,external_stuff/more_results
+
+""")
+        extra_outputs = ExtraOutputs(tsv_file)
+        self.assertEqual(len(extra_outputs.outputs),2)
+        self.assertEqual(extra_outputs.outputs[0].file_path,
+                         "stuff.html")
+        self.assertEqual(extra_outputs.outputs[0].description,
+                         "Some random output")
+        self.assertEqual(extra_outputs.outputs[0].additional_files,
+                         None)
+        self.assertEqual(extra_outputs.outputs[1].file_path,
+                         "external_stuff/index.html")
+        self.assertEqual(extra_outputs.outputs[1].description,
+                         "Bunch of external stuff")
+        self.assertEqual(extra_outputs.outputs[1].additional_files,
+                         ["external_stuff/results",
+                          "external_stuff/more_results"])
 
 class TestFastqScreenOutputFunction(unittest.TestCase):
     def test_fastq_screen_output(self):

--- a/auto_process_ngs/test/qc/test_reporting.py
+++ b/auto_process_ngs/test/qc/test_reporting.py
@@ -638,9 +638,10 @@ class TestReportFunction(unittest.TestCase):
         analysis_dir = self._make_analysis_project(paired_end=False)
         # Add extra outputs to QC dir
         os.makedirs(os.path.join(self.top_dir,
-                                  "PJB",
-                                  "qc",
-                                  "external_outs"))
+                                 "PJB",
+                                 "qc",
+                                 "external_outs",
+                                 "results"))
         index_file = os.path.join(self.top_dir,
                                   "PJB",
                                   "qc",
@@ -648,6 +649,15 @@ class TestReportFunction(unittest.TestCase):
                                   "index.html")
         with open(index_file,'wt') as fp:
             fp.write("placeholder")
+        for f in ("result1.txt","result2.txt"):
+            ff = os.path.join(self.top_dir,
+                              "PJB",
+                              "qc",
+                              "external_outs",
+                              "results",
+                              f)
+            with open(ff,'wt') as fp:
+                fp.write("placeholder")
         # Add extra_outputs.tsv
         tsv_file = os.path.join(self.top_dir,
                                 "PJB",
@@ -655,7 +665,7 @@ class TestReportFunction(unittest.TestCase):
                                 "extra_outputs.tsv")
         with open(tsv_file,'wt') as fp:
             fp.write("""# External files to include in QC report
-external_outs/index.html\tExternal outputs
+external_outs/index.html\tExternal outputs\texternal_outs/results
 """)
         # Generate report and ZIP archive
         project = AnalysisProject('PJB',analysis_dir)
@@ -694,7 +704,9 @@ external_outs/index.html\tExternal outputs
             'report.SE.PJB/qc/PJB2_S2_R1_001_screen_other_organisms.txt',
             'report.SE.PJB/qc/PJB2_S2_R1_001_screen_rRNA.png',
             'report.SE.PJB/qc/PJB2_S2_R1_001_screen_rRNA.txt',
-            'report.SE.PJB/qc/external_outs/index.html')
+            'report.SE.PJB/qc/external_outs/index.html',
+            'report.SE.PJB/qc/external_outs/results/result1.txt',
+            'report.SE.PJB/qc/external_outs/results/result2.txt')
         for f in expected:
             self.assertTrue(f in contents,"%s is missing from ZIP file" % f)
 

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -200,13 +200,37 @@ include, with the minimal specification being:
 
 ::
 
-   FILE     DESCRIPTION
+   FILE_PATH     DESCRIPTION
 
 For example:
 
 ::
 
    extra_metrics/metrics.html    Manually generated QC metrics
+
+If the output has additional associated files or directories
+(for example, the main output is an index file that then
+links to other files) then these can be included as a
+comma-separated list via an optional third field in the TSV
+file:
+
+::
+
+   FILE_PATH     DESCRIPTION     PATH1[,PATH2[,...]]
+
+For example:
+
+::
+
+   more_metrics/index.html    More QC metrics    more_metrics/results
+
+The additional files will then be included in the ZIP archive.
+
+.. note::
+
+   If any additional "files" are actually subdirectories
+   then the contents of those directories will also be
+   included automatically.
 
 ------------------
 Additional options

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -176,6 +176,38 @@ The behaviour is controlled by the ``split_undetermined_fastqs``
 setting in the ``qc`` section of the configuration file (see
 :ref:`qc_pipeline_configuration`).
 
+-----------------------------------------
+Including external (non-pipeline) outputs
+-----------------------------------------
+
+It is possible to include links within the QC reports to
+additional output files produced outside of the pipeline,
+by specifying them within an ``extra_outputs.tsv`` file.
+
+If this file is present in the QC directory being reported
+then any additional external files which it specifies
+will be linked from the "Extra outputs" section in the
+report. The specified files will also be included in the
+ZIP archive.
+
+.. note::
+
+   The additional files must also be within the QC
+   directory.
+
+Each line in the TSV file specifies an output file to
+include, with the minimal specification being:
+
+::
+
+   FILE     DESCRIPTION
+
+For example:
+
+::
+
+   extra_metrics/metrics.html    Manually generated QC metrics
+
 ------------------
 Additional options
 ------------------


### PR DESCRIPTION
Adds functionality to allow externally generated outputs (i.e. outputs not generated by the QC pipeline) to be included in the QC reporting, if they are specified in a user-generated `extra_outputs.tsv` file within the QC directory.

The file specifies one output per line with the basic format:

    FILE_PATH    DESCRIPTION

Note that the specified file must be present within the QC directory, and the path must be relative to the QC directory.

Specified files are linked from within the "Extra Outputs" section in the report, and will be included in the ZIP archive for the report. Additional files and or subdirectories can be included by adding a comma-separated list as a third field, i.e.

    FILE_PATH    DESCRIPTION    PATH1[,PATH[,...]]]

in which case these extra objects will also be added to the ZIP archive.