### PR TITLE
Add 10xGenomics Chromium 3' as a known 10x platform

### DIFF
--- a/auto_process_ngs/tenx/__init__.py
+++ b/auto_process_ngs/tenx/__init__.py
@@ -5,6 +5,7 @@
 # Permissible values for 10xGenomics platforms
 PLATFORMS = (
     "10xGenomics Chromium",
+    "10xGenomics Chromium 3'",
     "10xGenomics Chromium 3'v2",
     "10xGenomics Chromium 3'v3",
     "10xGenomics Chromium 3'v3.1",


### PR DESCRIPTION
Updates the list of platforms in `tenx/__init__.py` to include `10xGenomics Chromium 3'` (i.e. no version) as a known 10x platform.