### PR TITLE
'report' command: fix reporting of samples for 10xGenomics Flex data

### DIFF
--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -344,6 +344,113 @@ Summary of data in 'bcl2fastq' dir:
                        expected.split('\n')):
             self.assertEqual(o,e)
 
+    def test_report_info_10x_flex(self):
+        """report: report 10xGenomics Flex run in 'info' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '240213_A00879_0087_000000000-AGEW9',
+            'novaseq',
+            metadata={ "source": "testing",
+                       "run_number": 87, },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "Flex",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Single cell platform": "10xGenomics Chromium 3'v3",
+                        "Number of cells": 1311
+                        },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add a cellranger multi config.csv file
+        with open(os.path.join(mockdir.dirn,
+                               "AB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(mockdir.dirn,
+                                     "AB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+probe-set,/data/Probe_Set_v1.0_GRCh38-2020-A.csv
+no-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_Flex,{fastq_dir},any,PJB1,Gene Expression,
+
+[samples]
+sample_id,probe_barcode_ids,description
+ABF1,BC001,ABF1
+ABF2,BC002,ABF2
+ABF3,BC003,ABF3
+ABF4,BC004,ABF4
+""".format(fastq_dir=fastq_dir))
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate concise report
+        expected = """Run ID       : NOVASEQ_240213#87
+Directory    : %s
+Platform     : novaseq
+Unaligned dir: bcl2fastq
+
+Summary of data in 'bcl2fastq' dir:
+
+- AB: AB1-2 (2 paired end samples)
+- CDE: CDE3-4 (2 paired end samples)
+
+3 analysis projects:
+
+- AB
+  --
+  User    : Alison Bell
+  PI      : Audrey Bower
+  Library : Flex
+  SC Plat.: 10xGenomics Chromium 3'v3
+  Organism: Human
+  Dir     : AB
+  #samples: 4 multiplexed (2 physical)
+  #cells  : 1311
+  Samples : ABF1-4 (AB1-2)
+  QC      : not verified
+  Comments: None
+
+- CDE
+  ---
+  User    : Charles David Edwards
+  PI      : Colin Delaney Eccleston
+  Library : ChIP-seq
+  SC Plat.: None
+  Organism: Mouse
+  Dir     : CDE
+  #samples: 2
+  #cells  : 
+  Samples : CDE3-4
+  QC      : not verified
+  Comments: None
+
+- undetermined
+  ------------
+  User    : None
+  PI      : None
+  Library : None
+  SC Plat.: None
+  Organism: None
+  Dir     : undetermined
+  #samples: 1
+  #cells  : 
+  Samples : Undetermined
+  QC      : not verified
+  Comments: None""" % mockdir.dirn
+        for o,e in zip(report_info(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
     def test_report_info_no_projects(self):
         """report: report run with no projects in 'info' mode
         """
@@ -506,6 +613,58 @@ ABM4,CMO304,ABM4
         # Generate concise report
         self.assertEqual(report_concise(ap),
                          "Paired end: 'AB': Alison Bell, Human 10xGenomics Chromium 3'v3 CellPlex (PI: Audrey Bower) (4 samples/1311 cells); 'CDE': Charles David Edwards, Mouse ChIP-seq (PI: Colin Delaney Eccleston) (2 samples)")
+
+    def test_report_concise_10x_flex(self):
+        """report: report 10xGenomics Flex run in 'concise' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '240213_A00879_0087_000000000-AGEW9',
+            'novaseq',
+            metadata={ "source": "testing",
+                       "run_number": 87, },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "Flex",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Single cell platform": "10xGenomics Chromium 3'v3",
+                        "Number of cells": 1311 },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add a cellranger multi config.csv file
+        with open(os.path.join(mockdir.dirn,
+                               "AB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(mockdir.dirn,
+                                     "AB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+probe-set,/data/Probe_Set_v1.0_GRCh38-2020-A.csv
+no-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_Flex,{fastq_dir},any,PJB1,Gene Expression,
+
+[samples]
+sample_id,probe_barcode_ids,description
+ABF1,BC001,ABF1
+ABF2,BC002,ABF2
+ABF3,BC003,ABF3
+ABF4,BC004,ABF4
+""".format(fastq_dir=fastq_dir))
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate concise report
+        self.assertEqual(report_concise(ap),
+                         "Paired end: 'AB': Alison Bell, Human 10xGenomics Chromium 3'v3 Flex (PI: Audrey Bower) (4 samples/1311 cells); 'CDE': Charles David Edwards, Mouse ChIP-seq (PI: Colin Delaney Eccleston) (2 samples)")
 
     def test_report_concise_no_projects(self):
         """report: report run with no projects in 'concise' mode
@@ -769,6 +928,83 @@ Cellranger: cellranger 3.0.1
 2 projects:
 - 'AB':  Alison Bell           Human CellPlex (10xGenomics Chromium 3'v3) 4 samples/1311 cells (PI Audrey Bower)           
 - 'CDE': Charles David Edwards Mouse ChIP-seq                             2 samples            (PI Colin Delaney Eccleston)
+
+Additional notes/comments:
+- CDE: Repeat of previous run
+""" % mockdir.dirn
+        for o,e in zip(report_summary(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
+    def test_report_summary_10x_flex(self):
+        """report: report 10xGenomics Flex run in 'summary' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '240213_A00879_0087_000000000-AGEW9',
+            'novaseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "bcl2fastq_software":
+                       "('/usr/bin/bcl2fastq', 'bcl2fastq', '2.17.1.14')",
+                       "cellranger_software":
+                       "('/usr/bin/cellranger', 'cellranger', '3.0.1')",
+                       "sequencer_model": "NovaSeq" },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "Flex",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Single cell platform": "10xGenomics Chromium 3'v3",
+                        "Number of cells": 1311 },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston",
+                         "Comments": "Repeat of previous run" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add a cellranger multi config.csv file
+        with open(os.path.join(mockdir.dirn,
+                               "AB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(mockdir.dirn,
+                                     "AB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+probe-set,/data/Probe_Set_v1.0_GRCh38-2020-A.csv
+no-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_Flex,{fastq_dir},any,PJB1,Gene Expression,
+
+[samples]
+sample_id,probe_barcode_ids,description
+ABF1,BC001,ABF1
+ABF2,BC002,ABF2
+ABF3,BC003,ABF3
+ABF4,BC004,ABF4
+""".format(fastq_dir=fastq_dir))
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate summary report
+        expected = """NOVASEQ run #87 datestamped 240213
+==================================
+Run name  : 240213_A00879_0087_000000000-AGEW9
+Reference : NOVASEQ_240213#87
+Platform  : NOVASEQ
+Sequencer : NovaSeq
+Directory : %s
+Endedness : Paired end
+Bcl2fastq : bcl2fastq 2.17.1.14
+Cellranger: cellranger 3.0.1
+
+2 projects:
+- 'AB':  Alison Bell           Human Flex (10xGenomics Chromium 3'v3) 4 samples/1311 cells (PI Audrey Bower)           
+- 'CDE': Charles David Edwards Mouse ChIP-seq                         2 samples            (PI Colin Delaney Eccleston)
 
 Additional notes/comments:
 - CDE: Repeat of previous run
@@ -1148,6 +1384,65 @@ ABM4,CMO304,ABM4
         # Generate projects report
         expected = """MISEQ_170901#87\t87\ttesting\t\tAlison Bell\tAudrey Bower\tCellPlex\t10xGenomics Chromium 3'v3\tHuman\tMISEQ\t4\t1311\tyes\tABM1-4
 MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\tChIP-seq\t\tMouse\tMISEQ\t2\t\tyes\tCDE3-4
+"""
+        for o,e in zip(report_projects(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
+    def test_report_projects_10x_flex(self):
+        """report: report 10xGenomics Flex run in 'projects' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '240213_A00879_0087_000000000-AGEW9',
+            'novaseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "sequencer_model": "MiSeq" },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "Flex",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Single cell platform": "10xGenomics Chromium 3'v3",
+                        "Number of cells": 1311,
+                        "Sequencer model": "NovaSeq" },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "NovaSeq" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add a cellranger multi config.csv file
+        with open(os.path.join(mockdir.dirn,
+                               "AB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(mockdir.dirn,
+                                     "AB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+probe-set,/data/Probe_Set_v1.0_GRCh38-2020-A.csv
+no-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_Flex,{fastq_dir},any,PJB1,Gene Expression,
+
+[samples]
+sample_id,probe_barcode_ids,description
+ABF1,BC001,ABF1
+ABF2,BC002,ABF2
+ABF3,BC003,ABF3
+ABF4,BC004,ABF4
+""".format(fastq_dir=fastq_dir))
+        # Make autoprocess instance and set required metadata
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate projects report
+        expected = """NOVASEQ_240213#87\t87\ttesting\t\tAlison Bell\tAudrey Bower\tFlex\t10xGenomics Chromium 3'v3\tHuman\tNOVASEQ\t4\t1311\tyes\tABF1-4
+NOVASEQ_240213#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\tChIP-seq\t\tMouse\tNOVASEQ\t2\t\tyes\tCDE3-4
 """
         for o,e in zip(report_projects(ap).split('\n'),
                        expected.split('\n')):


### PR DESCRIPTION
Fixes a bug in the `report` command when reporting on projects with 10xGenomics Flex data, with handling the multiplexed samples.

Without this fix, the multiplexed samples are not reported and instead the sample names and count are taken from the physical samples. With the fix, the names and count are reported from the multiplexed samples (as is the case for CellPlex data). 