### PR TITLE
Add 'TCR scRNA-seq' and 'WT scRNA-seq' as recognised libraries for Parse Evercode

### DIFF
--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -655,6 +655,8 @@ def determine_qc_protocol(project):
                 protocol = "10x_ImmuneProfiling"
         elif single_cell_platform == 'Parse Evercode':
             if library_type in ("scRNA-seq",
+                                "TCR scRNA-seq",
+                                "WT scRNA-seq",
                                 "snRNA-seq"):
                 # Parse Evercode snRNAseq
                 protocol = "ParseEvercode"

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -740,6 +740,46 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
         self.assertEqual(determine_qc_protocol(project),
                          "ParseEvercode")
 
+    def test_determine_qc_protocol_parse_evercode_tcr_sc_rnaseq(self):
+        """determine_qc_protocol: TCR single-cell RNA-seq (Parse Evercode)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz",
+                                       "PJB1_S1_I1_001.fastq.gz",
+                                       "PJB1_S1_I2_001.fastq.gz"),
+                                metadata={'Single cell platform':
+                                          "Parse Evercode",
+                                          'Library type':
+                                          "TCR scRNA-seq"})
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        self.assertEqual(determine_qc_protocol(project),
+                         "ParseEvercode")
+
+    def test_determine_qc_protocol_parse_evercode_wt_sc_rnaseq(self):
+        """determine_qc_protocol: WT single-cell RNA-seq (Parse Evercode)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz",
+                                       "PJB1_S1_I1_001.fastq.gz",
+                                       "PJB1_S1_I2_001.fastq.gz"),
+                                metadata={'Single cell platform':
+                                          "Parse Evercode",
+                                          'Library type':
+                                          "WT scRNA-seq"})
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        self.assertEqual(determine_qc_protocol(project),
+                         "ParseEvercode")
+
     def test_determine_qc_protocol_parse_evercode_sn_rnaseq(self):
         """determine_qc_protocol: single-nuclei RNA-seq (Parse Evercode)
         """

--- a/docs/source/single_cell/parse.rst
+++ b/docs/source/single_cell/parse.rst
@@ -31,11 +31,12 @@ for the Parse Evercode project(s) in the ``projects.info`` control file.
 
 The following values are valid options:
 
-===================================== ==============================
+===================================== =================================
 Single cell platform                  Library types
-===================================== ==============================
-``Parse Evercode``                    ``scRNA-seq``
-===================================== ==============================
+===================================== =================================
+``Parse Evercode``                    ``scRNA-seq``, ``TCR scRNA-seq``,
+                                      ``WT scRNA-seq``, ``snRNA-seq``
+===================================== =================================
 
 Running the :doc:`setup_analysis_dirs <../using/setup_analysis_dirs>`
 command will automatically transfer these values into the project


### PR DESCRIPTION
Update the QC protocol determination function (`determine_qc_protocol` in `qc/protocols`) to recognise `TCR scRNA-seq` and `WT scRNA-seq` as Parse Evercode libraries, and return the `ParseEvercode` QC protocol if these combinations are found.