### PR TITLE
'make_fastqs': add specific protocol for Parse Evercode single cell data

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -115,7 +115,8 @@ PROTOCOLS = ('standard',
              '10x_visium',
              '10x_multiome',
              '10x_multiome_atac',
-             '10x_multiome_gex')
+             '10x_multiome_gex',
+             'parse_evercode',)
 
 # 10xGenomics protocols
 PROTOCOLS_10X = ('10x_chromium_sc',
@@ -615,7 +616,11 @@ class MakeFastqs(Pipeline):
                 self._update_subset(s,
                                     tenx_filter_dual_index=True,
                                     trim_adapters=False)
-            
+            elif protocol == 'parse_evercode':
+                # Parse Evercode
+                # Disable adapter trimming
+                self._update_subset(s,
+                                    trim_adapters=False)
         # Finally update parameters for user-defined
         # lane subsets (overriding both pipeline and
         # protocol defaults)
@@ -1166,7 +1171,9 @@ class MakeFastqs(Pipeline):
             self.add_task(restore_backup)
 
             # Standard protocols
-            if protocol in ("standard","mirna"):
+            if protocol in ("standard",
+                            "mirna",
+                            "parse_evercode"):
 
                 if converter == "bcl2fastq":
                     # Get bcl2fastq information

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_parse_evercode.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_parse_evercode.py
@@ -1,0 +1,94 @@
+#######################################################################
+# Unit tests for bcl2fastq/pipeline.py (parse_evercode protocol)
+#######################################################################
+
+# All imports declared in __init__.py file
+from . import *
+
+class TestMakeFastqs(BaseMakeFastqsTestCase):
+    """
+    Tests for MakeFastqs pipeline (parse_evercode protocol)
+    """
+    #@unittest.skip("Skipped")
+    def test_makefastqs_parse_evercode_protocol(self):
+        """
+        MakeFastqs: 'parse_evercode' protocol
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            bases_mask="y76,I8,I8,y86",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write("""[Settings]
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+Sample1,Sample1,,,D701,CGTGTAGG,D501,GACCTGTA,,
+Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 version='2.20.0.422',
+                                 assert_bases_mask="y76,I8,I8,y86",
+                                 assert_adapter='',
+                                 assert_adapter2='')
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="parse_evercode")
+        status = p.run(analysis_dir,
+                       poll_interval=POLL_INTERVAL)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)

--- a/docs/source/single_cell/parse.rst
+++ b/docs/source/single_cell/parse.rst
@@ -17,7 +17,7 @@ or QC.
 Fastq generation
 ----------------
 
-Currently the (default) standard Fastq generation protocol is used
+The ``parse_evercode`` Fastq generation protocol should be used
 for Parse Evercode samples when running the
 :doc:`make_fastqs <../using/make_fastqs>` command.
 

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -81,6 +81,7 @@ Protocol option          Used for
 ``10x_multiome_gex``     10xGenomics Multiome single cell
                          GEX data only (run with pooled GEX
                          and ATAC data)
+``parse_evercode``       Parse Evercode single cell data
 ``icell8``               ICELL8 single-cell RNA-seq data
 ``icell8_atac``          ICELL8 single-cell ATAC-seq data
 ======================== =====================================


### PR DESCRIPTION
Adds a new Fastq generation protocol `parse_evercode` for use with Parse Evercode data.

The main difference from the `standard` protocol is that adapter trimming is disabled automatically when the new protocol is used, which is recommended by Parse. (When adapter trimming is applied erroneously then it can result in R2 reads which are shorter than 86bp, which causes Parse's downstream `split-pipe` analysis pipeline to reject those reads.)