### PR TITLE
Update Fastq generation and QC pipelines for Cellranger 8.0.0

### DIFF
--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -10,6 +10,7 @@
 #######################################################################
 
 import os
+import ast
 import fnmatch
 import shutil
 import json
@@ -197,6 +198,18 @@ def setup_analysis_dirs(ap,
             library_type == "Flex" or
             library_type == "Single Cell Immune Profiling"):
             print("-- setting up 'multi' config file for '%s'" % library_type)
+            # Determine target Cellranger version
+            try:
+                processing_software = ast.literal_eval(
+                    ap.metadata.processing_software)
+                cellranger_version = processing_software['cellranger'][2]
+            except Exception as ex:
+                print("-- unable to determine Cellranger version used "
+                      "for processing: %s" % ex)
+                cellranger_version = None
+            if not cellranger_version:
+                cellranger_version = tenx.DEFAULT_CELLRANGER_VERSION
+            print("-- target Cellranger version: %s" % cellranger_version)
             # Acquire reference transcriptome dataset
             print("-- looking up transcriptome for '%s'" % organism)
             try:
@@ -237,7 +250,8 @@ def setup_analysis_dirs(ap,
                     probe_set=probe_set,
                     fastq_dir=project.fastq_dir,
                     samples=[s.name for s in project.samples],
-                    library_type=library_type)
+                    library_type=library_type,
+                    cellranger_version=cellranger_version)
             except Exception as ex:
                 logger.warning("Failed to create '%s': %s" % (f,ex))
         # Additional subdir for Visium images

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -2188,8 +2188,8 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
         # count subparser
         count = sp.add_parser("count")
         count.add_argument("--id",action="store",required=True)
-        count.add_argument("--fastqs",action="store",required=True)
-        count.add_argument("--sample",action="store",required=True)
+        count.add_argument("--fastqs",action="store")
+        count.add_argument("--sample",action="store")
         if self._package_name == "cellranger":
             count.add_argument("--transcriptome",action="store",
                                required=True)

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -2194,7 +2194,7 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
             count.add_argument("--transcriptome",action="store")
             count.add_argument("--chemistry",action="store")
             count.add_argument("--force-cells",action="store",type=int)
-            if version[0] == 7:
+            if version[0] in (7,8):
                 # Cellranger 7: include introns on by default
                 count.add_argument("--include-introns",
                                    choices=['true','false'],

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1,5 +1,5 @@
 #     mock.py: module providing mock Illumina data for testing
-#     Copyright (C) University of Manchester 2012-2023 Peter Briggs
+#     Copyright (C) University of Manchester 2012-2024 Peter Briggs
 #
 ########################################################################
 
@@ -2456,8 +2456,12 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
             # Per sample outs
             if version[0] < 7:
                 metrics_data = mock10xdata.CELLPLEX_METRICS_SUMMARY
-            else:
+            elif version[0] == 7:
                 metrics_data = mock10xdata.CELLPLEX_METRICS_SUMMARY_7_1_0
+            elif version[0] == 8:
+                metrics_data = mock10xdata.CELLPLEX_METRICS_SUMMARY_8_0_0
+            else:
+                raise Exception("%s: unsupported version" % self._version)
             for sample in config.sample_names:
                 sample_dir = os.path.join(outs_dir,
                                           "per_sample_outs",

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -4307,6 +4307,7 @@ def make_mock_analysis_project(name="PJB",top_dir=None,
                                cellranger_pipelines=('cellranger',),
                                cellranger_samples=None,
                                cellranger_multi_samples=None,
+                               cellranger_version=None,
                                legacy_screens=False,
                                legacy_cellranger_outs=False):
     """
@@ -4355,6 +4356,8 @@ def make_mock_analysis_project(name="PJB",top_dir=None,
         produce 'cellranger count' outputs for
       cellranger_multi_samples (list): list of sample names to
         produce 'cellranger multi' outputs for
+      cellranger_version (str): if set then specifies version of
+        Cellranger to mimick
       legacy_screens (bool): if True then use legacy naming
         convention for FastqScreen outputs
       legacy_cellranger_outs (bool): if True then use legacy
@@ -4412,6 +4415,7 @@ def make_mock_analysis_project(name="PJB",top_dir=None,
                      include_multiqc=include_multiqc,
                      include_cellranger_count=include_cellranger_count,
                      include_cellranger_multi=include_cellranger_multi,
+                     cellranger_version=cellranger_version,
                      legacy_screens=legacy_screens,
                      legacy_cellranger_outs=legacy_cellranger_outs)
     return project_dir

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -2187,15 +2187,16 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
             mkfastq.add_argument("--qc",action="store_true")
         # count subparser
         count = sp.add_parser("count")
-        count.add_argument("--id",action="store")
-        count.add_argument("--fastqs",action="store")
-        count.add_argument("--sample",action="store")
+        count.add_argument("--id",action="store",required=True)
+        count.add_argument("--fastqs",action="store",required=True)
+        count.add_argument("--sample",action="store",required=True)
         if self._package_name == "cellranger":
-            count.add_argument("--transcriptome",action="store")
+            count.add_argument("--transcriptome",action="store",
+                               required=True)
             count.add_argument("--chemistry",action="store")
             count.add_argument("--force-cells",action="store",type=int)
             if version[0] in (7,8):
-                # Cellranger 7: include introns on by default
+                # Cellranger 7,8: include introns on by default
                 count.add_argument("--include-introns",
                                    choices=['true','false'],
                                    default='true')
@@ -2206,6 +2207,11 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
             if version[0] >= 5:
                 count.add_argument("--r1-length",action="store")
                 count.add_argument("--r2-length",action="store")
+            if version[0] == 8:
+                # Cellranger 8: explicitly specify BAM creation
+                count.add_argument("--create-bam",
+                                   choices=['true','false'],
+                                   required=True)
         elif self._package_name == "cellranger-atac":
             count.add_argument("--reference",action="store")
             if version[0] >= 2:

--- a/auto_process_ngs/mock10xdata.py
+++ b/auto_process_ngs/mock10xdata.py
@@ -1,5 +1,5 @@
 #     mock.py: module providing mock 10xGenomics data for testing
-#     Copyright (C) University of Manchester 2018 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2024 Peter Briggs
 #
 ########################################################################
 
@@ -516,6 +516,224 @@ Library,Multiplexing Capture,Physical library ID,SS_CML,Samples assigned at leas
 Library,Multiplexing Capture,Physical library ID,SS_CML,Sequencing saturation,14.40%
 Library,Multiplexing Capture,Physical library ID,SS_CML,Valid UMIs,100.00%
 Library,Multiplexing Capture,Physical library ID,SS_CML,Valid barcodes,99.51%
+"""
+
+CELLPLEX_METRICS_SUMMARY_8_0_0 = """Category,Library Type,Grouped By,Group Name,Metric Name,Metric Value
+Cells,Antibody Capture,,,Cells,"1,582"
+Cells,Antibody Capture,,,Fraction antibody reads,44.13%
+Cells,Antibody Capture,,,Fraction antibody reads in aggregate barcodes,---
+Cells,Antibody Capture,,,Mean antibody reads usable per cell,"4,527"
+Cells,Antibody Capture,,,Median UMI counts per cell,"2,025"
+Cells,Antibody Capture,,,Number of reads from cells associated with this sample,"16,235,484"
+Cells,Antibody Capture,Physical library ID,SS_CSP,Cell-associated barcodes identified as multiplets,"4,167 (20.38%)"
+Cells,Antibody Capture,Physical library ID,SS_CSP,Cell-associated barcodes not assigned any CMOs,"1,728 (8.45%)"
+Cells,Antibody Capture,Physical library ID,SS_CSP,Cells assigned to other samples,"12,966 (63.43%)"
+Cells,Antibody Capture,Physical library ID,SS_CSP,Cells assigned to this sample,"1,582 (7.74%)"
+Cells,Gene Expression,,,Cells,"1,582"
+Cells,Gene Expression,,,Confidently mapped antisense,8.82%
+Cells,Gene Expression,,,Confidently mapped to exonic regions,66.29%
+Cells,Gene Expression,,,Confidently mapped to genome,93.98%
+Cells,Gene Expression,,,Confidently mapped to intergenic regions,3.99%
+Cells,Gene Expression,,,Confidently mapped to intronic regions,23.69%
+Cells,Gene Expression,,,Confidently mapped to transcriptome,80.52%
+Cells,Gene Expression,,,Mapped to genome,97.34%
+Cells,Gene Expression,,,Mean reads per cell,"20,614"
+Cells,Gene Expression,,,Median UMI counts per cell,"5,789"
+Cells,Gene Expression,,,Median genes per cell,"2,042"
+Cells,Gene Expression,,,Number of reads from cells called from this sample,"32,611,101"
+Cells,Gene Expression,,,Total genes detected,"23,199"
+Cells,Gene Expression,Physical library ID,SS_GEX,Cell-associated barcodes identified as multiplets,"4,167 (20.38%)"
+Cells,Gene Expression,Physical library ID,SS_GEX,Cell-associated barcodes not assigned any CMOs,"1,728 (8.45%)"
+Cells,Gene Expression,Physical library ID,SS_GEX,Cells assigned to other samples,"12,966 (63.43%)"
+Cells,Gene Expression,Physical library ID,SS_GEX,Cells assigned to this sample,"1,582 (7.74%)"
+Library,Antibody Capture,Fastq ID,SS_CSP,Number of reads,"286,620,444"
+Library,Antibody Capture,Fastq ID,SS_CSP,Number of short reads skipped,0
+Library,Antibody Capture,Fastq ID,SS_CSP,Q30 RNA read,96.0%
+Library,Antibody Capture,Fastq ID,SS_CSP,Q30 UMI,97.3%
+Library,Antibody Capture,Fastq ID,SS_CSP,Q30 barcodes,97.2%
+Library,Antibody Capture,Physical library ID,SS_CSP,Antibody reads in cells,65.34%
+Library,Antibody Capture,Physical library ID,SS_CSP,Cell-associated barcodes identified as multiplets,"4,167 (20.38%)"
+Library,Antibody Capture,Physical library ID,SS_CSP,Cell-associated barcodes not assigned any CMOs,"1,728 (8.45%)"
+Library,Antibody Capture,Physical library ID,SS_CSP,Cells assigned to a sample,"14,548 (71.16%)"
+Library,Antibody Capture,Physical library ID,SS_CSP,Estimated number of cells,"20,443"
+Library,Antibody Capture,Physical library ID,SS_CSP,Fraction antibody reads,44.74%
+Library,Antibody Capture,Physical library ID,SS_CSP,Fraction antibody reads in aggregate barcodes,2.01%
+Library,Antibody Capture,Physical library ID,SS_CSP,Fraction antibody reads usable,29.02%
+Library,Antibody Capture,Physical library ID,SS_CSP,Mean reads per cell,"14,020"
+Library,Antibody Capture,Physical library ID,SS_CSP,Number of reads,"286,620,444"
+Library,Antibody Capture,Physical library ID,SS_CSP,Number of reads in the library,"286,620,444"
+Library,Antibody Capture,Physical library ID,SS_CSP,Sequencing saturation,37.16%
+Library,Antibody Capture,Physical library ID,SS_CSP,Valid UMIs,100.00%
+Library,Antibody Capture,Physical library ID,SS_CSP,Valid barcodes,99.12%
+Library,Gene Expression,Fastq ID,SS_GEX,Number of reads,"510,571,324"
+Library,Gene Expression,Fastq ID,SS_GEX,Number of short reads skipped,0
+Library,Gene Expression,Fastq ID,SS_GEX,Q30 RNA read,93.3%
+Library,Gene Expression,Fastq ID,SS_GEX,Q30 UMI,95.8%
+Library,Gene Expression,Fastq ID,SS_GEX,Q30 barcodes,96.5%
+Library,Gene Expression,Physical library ID,SS_GEX,Cell-associated barcodes identified as multiplets,"4,167 (20.38%)"
+Library,Gene Expression,Physical library ID,SS_GEX,Cell-associated barcodes not assigned any CMOs,"1,728 (8.45%)"
+Library,Gene Expression,Physical library ID,SS_GEX,Cells assigned to a sample,"14,548 (71.16%)"
+Library,Gene Expression,Physical library ID,SS_GEX,Confidently mapped antisense,9.40%
+Library,Gene Expression,Physical library ID,SS_GEX,Confidently mapped reads in cells,94.20%
+Library,Gene Expression,Physical library ID,SS_GEX,Confidently mapped to exonic regions,65.20%
+Library,Gene Expression,Physical library ID,SS_GEX,Confidently mapped to genome,92.78%
+Library,Gene Expression,Physical library ID,SS_GEX,Confidently mapped to intergenic regions,3.60%
+Library,Gene Expression,Physical library ID,SS_GEX,Confidently mapped to intronic regions,23.99%
+Library,Gene Expression,Physical library ID,SS_GEX,Confidently mapped to transcriptome,79.14%
+Library,Gene Expression,Physical library ID,SS_GEX,Estimated number of cells,"20,443"
+Library,Gene Expression,Physical library ID,SS_GEX,Mapped to genome,96.67%
+Library,Gene Expression,Physical library ID,SS_GEX,Mean reads per cell,"24,975"
+Library,Gene Expression,Physical library ID,SS_GEX,Number of reads,"510,571,324"
+Library,Gene Expression,Physical library ID,SS_GEX,Number of reads in the library,"510,571,324"
+Library,Gene Expression,Physical library ID,SS_GEX,Sequencing saturation,59.89%
+Library,Gene Expression,Physical library ID,SS_GEX,Valid UMIs,99.94%
+Library,Gene Expression,Physical library ID,SS_GEX,Valid barcodes,97.81%
+Library,Multiplexing Capture,,,Cell-associated barcodes identified as multiplets,"4,167 (20.38%)"
+Library,Multiplexing Capture,,,Cells assigned to a sample,"14,548 (71.16%)"
+Library,Multiplexing Capture,,,Estimated number of cell-associated barcodes,"20,443"
+Library,Multiplexing Capture,,,Median CMO UMIs per cell,"1,865"
+Library,Multiplexing Capture,,,Number of samples assigned at least one cell,9
+Library,Multiplexing Capture,,,Singlet capture ratio,0.86
+Library,Multiplexing Capture,CMO Name,CMO301,CMO signal-to-noise ratio,5.97
+Library,Multiplexing Capture,CMO Name,CMO301,Cells assigned to CMO,10.87%
+Library,Multiplexing Capture,CMO Name,CMO301,Fraction reads in cell-associated barcodes,66.78%
+Library,Multiplexing Capture,CMO Name,CMO302,CMO signal-to-noise ratio,4.87
+Library,Multiplexing Capture,CMO Name,CMO302,Cells assigned to CMO,10.21%
+Library,Multiplexing Capture,CMO Name,CMO302,Fraction reads in cell-associated barcodes,63.16%
+Library,Multiplexing Capture,CMO Name,CMO303,CMO signal-to-noise ratio,4.98
+Library,Multiplexing Capture,CMO Name,CMO303,Cells assigned to CMO,12.87%
+Library,Multiplexing Capture,CMO Name,CMO303,Fraction reads in cell-associated barcodes,73.73%
+Library,Multiplexing Capture,CMO Name,CMO304,CMO signal-to-noise ratio,6.13
+Library,Multiplexing Capture,CMO Name,CMO304,Cells assigned to CMO,11.60%
+Library,Multiplexing Capture,CMO Name,CMO304,Fraction reads in cell-associated barcodes,63.48%
+Library,Multiplexing Capture,CMO Name,CMO305,CMO signal-to-noise ratio,4.55
+Library,Multiplexing Capture,CMO Name,CMO305,Cells assigned to CMO,9.99%
+Library,Multiplexing Capture,CMO Name,CMO305,Fraction reads in cell-associated barcodes,65.07%
+Library,Multiplexing Capture,CMO Name,CMO306,CMO signal-to-noise ratio,6.22
+Library,Multiplexing Capture,CMO Name,CMO306,Cells assigned to CMO,12.41%
+Library,Multiplexing Capture,CMO Name,CMO306,Fraction reads in cell-associated barcodes,64.30%
+Library,Multiplexing Capture,CMO Name,CMO307,CMO signal-to-noise ratio,5.84
+Library,Multiplexing Capture,CMO Name,CMO307,Cells assigned to CMO,9.61%
+Library,Multiplexing Capture,CMO Name,CMO307,Fraction reads in cell-associated barcodes,59.05%
+Library,Multiplexing Capture,CMO Name,CMO308,CMO signal-to-noise ratio,4.34
+Library,Multiplexing Capture,CMO Name,CMO308,Cells assigned to CMO,10.17%
+Library,Multiplexing Capture,CMO Name,CMO308,Fraction reads in cell-associated barcodes,56.30%
+Library,Multiplexing Capture,CMO Name,CMO309,CMO signal-to-noise ratio,5.54
+Library,Multiplexing Capture,CMO Name,CMO309,Cells assigned to CMO,12.27%
+Library,Multiplexing Capture,CMO Name,CMO309,Fraction reads in cell-associated barcodes,60.63%
+Library,Multiplexing Capture,Fastq ID,SS_CML,Number of reads,"123,420,555"
+Library,Multiplexing Capture,Fastq ID,SS_CML,Number of short reads skipped,0
+Library,Multiplexing Capture,Fastq ID,SS_CML,Q30 RNA read,97.0%
+Library,Multiplexing Capture,Fastq ID,SS_CML,Q30 UMI,97.3%
+Library,Multiplexing Capture,Fastq ID,SS_CML,Q30 barcodes,97.1%
+Library,Multiplexing Capture,Physical library ID,SS_CML,Cell-associated barcodes identified as multiplets,"4,167 (20.38%)"
+Library,Multiplexing Capture,Physical library ID,SS_CML,Cell-associated barcodes not assigned any CMOs,"1,728 (8.45%)"
+Library,Multiplexing Capture,Physical library ID,SS_CML,Cells assigned to a sample,"14,548 (71.16%)"
+Library,Multiplexing Capture,Physical library ID,SS_CML,Estimated number of cell-associated barcodes,"20,443"
+Library,Multiplexing Capture,Physical library ID,SS_CML,Fraction CMO reads,98.10%
+Library,Multiplexing Capture,Physical library ID,SS_CML,Fraction CMO reads usable,62.28%
+Library,Multiplexing Capture,Physical library ID,SS_CML,Fraction reads from multiplets,21.90%
+Library,Multiplexing Capture,Physical library ID,SS_CML,Fraction reads in cell-associated barcodes,63.75%
+Library,Multiplexing Capture,Physical library ID,SS_CML,Fraction unrecognized CMO,1.90%
+Library,Multiplexing Capture,Physical library ID,SS_CML,Mean reads per cell-associated barcode,"6,037"
+Library,Multiplexing Capture,Physical library ID,SS_CML,Median CMO UMIs per cell-associated barcode,"2,087"
+Library,Multiplexing Capture,Physical library ID,SS_CML,Number of reads,"123,420,555"
+Library,Multiplexing Capture,Physical library ID,SS_CML,Samples assigned at least one cell,9
+Library,Multiplexing Capture,Physical library ID,SS_CML,Sequencing saturation,14.40%
+Library,Multiplexing Capture,Physical library ID,SS_CML,Valid UMIs,100.00%
+Library,Multiplexing Capture,Physical library ID,SS_CML,Valid barcodes,99.51%
+"""
+
+FLEX_METRICS_SUMMARY_8_0_0 = """Category,Library Type,Grouped By,Group Name,Metric Name,Metric Value
+Cells,Gene Expression,,,Cells,"2,302"
+Cells,Gene Expression,,,Confidently mapped reads in cells,93.06%
+Cells,Gene Expression,,,Estimated UMIs from genomic DNA,0.14%
+Cells,Gene Expression,,,Estimated UMIs from genomic DNA per unspliced probe,1
+Cells,Gene Expression,,,Mean reads per cell,"27,485"
+Cells,Gene Expression,,,Median UMI counts per cell,"4,202"
+Cells,Gene Expression,,,Median genes per cell,"2,465"
+Cells,Gene Expression,,,Number of reads from cells called from this sample,"63,271,140"
+Cells,Gene Expression,,,Reads confidently mapped to filtered probe set,96.97%
+Cells,Gene Expression,,,Reads confidently mapped to probe set,97.30%
+Cells,Gene Expression,,,Reads half-mapped to probe set,0.18%
+Cells,Gene Expression,,,Reads mapped to probe set,99.53%
+Cells,Gene Expression,,,Reads split-mapped to probe set,2.04%
+Cells,Gene Expression,,,Total genes detected,"15,937"
+Cells,Gene Expression,Physical library ID,JMF1,Cells detected in other samples,"41,675 (94.77%)"
+Cells,Gene Expression,Physical library ID,JMF1,Cells detected in this sample,"2,302 (5.23%)"
+Library,Gene Expression,,,Estimated UMIs from genomic DNA,0.01%
+Library,Gene Expression,,,Estimated UMIs from genomic DNA per unspliced probe,2
+Library,Gene Expression,Fastq ID,JMF1,Number of reads,"1,947,449,723"
+Library,Gene Expression,Fastq ID,JMF1,Number of short reads skipped,0
+Library,Gene Expression,Fastq ID,JMF1,Q30 GEM barcodes,97.7%
+Library,Gene Expression,Fastq ID,JMF1,Q30 RNA read,97.3%
+Library,Gene Expression,Fastq ID,JMF1,Q30 UMI,97.4%
+Library,Gene Expression,Fastq ID,JMF1,Q30 barcodes,97.2%
+Library,Gene Expression,Fastq ID,JMF1,Q30 probe barcodes,96.3%
+Library,Gene Expression,Physical library ID,JMF1,Confidently mapped reads in cells,92.87%
+Library,Gene Expression,Physical library ID,JMF1,Estimated number of cells,"43,977"
+Library,Gene Expression,Physical library ID,JMF1,Fraction of initial cell barcodes passing high occupancy GEM filtering,99.46%
+Library,Gene Expression,Physical library ID,JMF1,Mean reads per cell,"44,283"
+Library,Gene Expression,Physical library ID,JMF1,Number of reads,"1,947,449,723"
+Library,Gene Expression,Physical library ID,JMF1,Number of reads in the library,"1,947,449,723"
+Library,Gene Expression,Physical library ID,JMF1,Reads confidently mapped to filtered probe set,94.91%
+Library,Gene Expression,Physical library ID,JMF1,Reads confidently mapped to probe set,95.23%
+Library,Gene Expression,Physical library ID,JMF1,Reads half-mapped to probe set,1.29%
+Library,Gene Expression,Physical library ID,JMF1,Reads mapped to probe set,98.66%
+Library,Gene Expression,Physical library ID,JMF1,Reads split-mapped to probe set,2.14%
+Library,Gene Expression,Physical library ID,JMF1,Sequencing saturation,64.85%
+Library,Gene Expression,Physical library ID,JMF1,Valid GEM barcodes,98.81%
+Library,Gene Expression,Physical library ID,JMF1,Valid UMIs,100.00%
+Library,Gene Expression,Physical library ID,JMF1,Valid barcodes,96.04%
+Library,Gene Expression,Physical library ID,JMF1,Valid probe barcodes,96.94%
+Library,Gene Expression,Probe barcode ID,BC001,Cells per probe barcode,"2,302 (5.23%)"
+Library,Gene Expression,Probe barcode ID,BC001,Sample ID,JMF1
+Library,Gene Expression,Probe barcode ID,BC001,UMIs per probe barcode,"23,357,091 (3.67%)"
+Library,Gene Expression,Probe barcode ID,BC002,Cells per probe barcode,"2,308 (5.25%)"
+Library,Gene Expression,Probe barcode ID,BC002,Sample ID,JMF2
+Library,Gene Expression,Probe barcode ID,BC002,UMIs per probe barcode,"22,251,203 (3.50%)"
+Library,Gene Expression,Probe barcode ID,BC003,Cells per probe barcode,"2,863 (6.51%)"
+Library,Gene Expression,Probe barcode ID,BC003,Sample ID,JMF3
+Library,Gene Expression,Probe barcode ID,BC003,UMIs per probe barcode,"29,304,274 (4.61%)"
+Library,Gene Expression,Probe barcode ID,BC004,Cells per probe barcode,"2,250 (5.12%)"
+Library,Gene Expression,Probe barcode ID,BC004,Sample ID,JMF4
+Library,Gene Expression,Probe barcode ID,BC004,UMIs per probe barcode,"31,493,332 (4.95%)"
+Library,Gene Expression,Probe barcode ID,BC005,Cells per probe barcode,"2,415 (5.49%)"
+Library,Gene Expression,Probe barcode ID,BC005,Sample ID,JMF5
+Library,Gene Expression,Probe barcode ID,BC005,UMIs per probe barcode,"35,011,126 (5.50%)"
+Library,Gene Expression,Probe barcode ID,BC006,Cells per probe barcode,"3,193 (7.26%)"
+Library,Gene Expression,Probe barcode ID,BC006,Sample ID,JMF6
+Library,Gene Expression,Probe barcode ID,BC006,UMIs per probe barcode,"46,457,109 (7.30%)"
+Library,Gene Expression,Probe barcode ID,BC007,Cells per probe barcode,"3,446 (7.84%)"
+Library,Gene Expression,Probe barcode ID,BC007,Sample ID,JMF7
+Library,Gene Expression,Probe barcode ID,BC007,UMIs per probe barcode,"43,765,251 (6.88%)"
+Library,Gene Expression,Probe barcode ID,BC008,Cells per probe barcode,"3,244 (7.38%)"
+Library,Gene Expression,Probe barcode ID,BC008,Sample ID,JMF8
+Library,Gene Expression,Probe barcode ID,BC008,UMIs per probe barcode,"42,711,979 (6.72%)"
+Library,Gene Expression,Probe barcode ID,BC009,Cells per probe barcode,"3,089 (7.02%)"
+Library,Gene Expression,Probe barcode ID,BC009,Sample ID,JMF9
+Library,Gene Expression,Probe barcode ID,BC009,UMIs per probe barcode,"60,515,493 (9.51%)"
+Library,Gene Expression,Probe barcode ID,BC010,Cells per probe barcode,"2,276 (5.18%)"
+Library,Gene Expression,Probe barcode ID,BC010,Sample ID,JMF10
+Library,Gene Expression,Probe barcode ID,BC010,UMIs per probe barcode,"44,437,435 (6.99%)"
+Library,Gene Expression,Probe barcode ID,BC011,Cells per probe barcode,"2,492 (5.67%)"
+Library,Gene Expression,Probe barcode ID,BC011,Sample ID,JMF11
+Library,Gene Expression,Probe barcode ID,BC011,UMIs per probe barcode,"47,811,412 (7.52%)"
+Library,Gene Expression,Probe barcode ID,BC012,Cells per probe barcode,"2,254 (5.13%)"
+Library,Gene Expression,Probe barcode ID,BC012,Sample ID,JMF12
+Library,Gene Expression,Probe barcode ID,BC012,UMIs per probe barcode,"32,291,662 (5.08%)"
+Library,Gene Expression,Probe barcode ID,BC013,Cells per probe barcode,"2,405 (5.47%)"
+Library,Gene Expression,Probe barcode ID,BC013,Sample ID,JMF13
+Library,Gene Expression,Probe barcode ID,BC013,UMIs per probe barcode,"37,113,794 (5.84%)"
+Library,Gene Expression,Probe barcode ID,BC014,Cells per probe barcode,"2,219 (5.05%)"
+Library,Gene Expression,Probe barcode ID,BC014,Sample ID,JMF14
+Library,Gene Expression,Probe barcode ID,BC014,UMIs per probe barcode,"35,921,883 (5.65%)"
+Library,Gene Expression,Probe barcode ID,BC015,Cells per probe barcode,"3,560 (8.10%)"
+Library,Gene Expression,Probe barcode ID,BC015,Sample ID,JMF15
+Library,Gene Expression,Probe barcode ID,BC015,UMIs per probe barcode,"51,216,165 (8.05%)"
+Library,Gene Expression,Probe barcode ID,BC016,Cells per probe barcode,"3,661 (8.32%)"
+Library,Gene Expression,Probe barcode ID,BC016,Sample ID,JMF16
+Library,Gene Expression,Probe barcode ID,BC016,UMIs per probe barcode,"52,394,225 (8.24%)"
 """
 
 MULTIOME_LIBRARIES = """#Local sample\tLinked sample

--- a/auto_process_ngs/mockqc.py
+++ b/auto_process_ngs/mockqc.py
@@ -41,6 +41,12 @@ from . import mockqcdata
 from . import mock10xdata
 
 #######################################################################
+# Constants
+#######################################################################
+
+_DEFAULT_CELLRANGER_VERSION = "6.1.2"
+
+#######################################################################
 # Class definitions
 #######################################################################
 
@@ -305,7 +311,7 @@ Fraction of reads explained by "1+-,1-+,2++,2--": 0.4925
         # Set internals based on 10x pipeline
         if cellranger == 'cellranger':
             if not version:
-                version = '6.1.2'
+                version = _DEFAULT_CELLRANGER_VERSION
             cmdline = "cellranger --transcriptome %s" \
                       % reference_data_path
             metrics_data = mock10xdata.METRICS_SUMMARY
@@ -342,7 +348,8 @@ Fraction of reads explained by "1+-,1-+,2++,2--": 0.4925
 
     @classmethod
     def cellranger_multi(self,samples,qc_dir,config_csv=None,
-                         prefix='cellranger_multi'):
+                         prefix='cellranger_multi',
+                         cellranger_version=None):
         """
         Create mock outputs for 'cellranger multi'
 
@@ -354,7 +361,22 @@ Fraction of reads explained by "1+-,1-+,2++,2--": 0.4925
             file
           prefix (str): relative path to QC directory to put
             mock outputs into (default: 'cellranger_multi')
+          cellranger_version (str): version of cellranger to
+            mimick (default: default defined in module)
         """
+        # Determine major version to mimick
+        if cellranger_version is None:
+            cellranger_version = _DEFAULT_CELLRANGER_VERSION
+        version = int(str(cellranger_version).split('.')[0])
+        if version < 7:
+            metrics_summary = mock10xdata.CELLPLEX_METRICS_SUMMARY
+        elif version == 7:
+            metrics_summary = mock10xdata.CELLPLEX_METRICS_SUMMARY_7_1_0
+        elif version == 8:
+            metrics_summary = mock10xdata.CELLPLEX_METRICS_SUMMARY_8_0_0
+        else:
+            raise Exception("%s: unsupported Cellranger "
+                            "version" % cellranger_version)
         # Read in multiplexing config
         if config_csv:
             config = CellrangerMultiConfigCsv(config_csv)
@@ -374,7 +396,7 @@ Fraction of reads explained by "1+-,1-+,2++,2--": 0.4925
             os.makedirs(sample_dir)
             for f in per_sample_output_files:
                 with open(os.path.join(sample_dir,f),'wt') as fp:
-                    fp.write(mock10xdata.CELLPLEX_METRICS_SUMMARY)
+                    fp.write(metrics_summary)
         # Multiplexing analysis outputs
         multiplexing_output_files = ("assignment_confidence_table.csv",
                                      "cells_per_tag.json",
@@ -427,6 +449,7 @@ def make_mock_qc_dir(qc_dir,fastq_names,fastq_dir=None,
                      include_multiqc=False,
                      include_cellranger_count=False,
                      include_cellranger_multi=False,
+                     cellranger_version=None,
                      legacy_screens=False,
                      legacy_cellranger_outs=False):
     """
@@ -450,6 +473,8 @@ def make_mock_qc_dir(qc_dir,fastq_names,fastq_dir=None,
         produce 'cellranger count' outputs for
       cellranger_multi_samples (list): list of multiplexed
         sample names for 10x CellPlex
+      cellranger_version (str): if set then specifies version of
+        Cellranger to mimick
       seq_data_samples (list): list with subset of sample
         names which include sequence (i.e. biological) data
       include_fastqc (bool): include outputs from Fastqc
@@ -494,6 +519,11 @@ def make_mock_qc_dir(qc_dir,fastq_names,fastq_dir=None,
         qc_info['seq_data_samples'] = ','.join(seq_data_samples)
     # Normalise organism names
     organisms_ = [normalise_organism_name(x) for x in organisms]
+    # Cellranger version
+    if cellranger_version is None:
+        cellranger_version = _DEFAULT_CELLRANGER_VERSION
+    else:
+        cellranger_version = str(cellranger_version)
     # Populate with fake QC products
     for fq in fastq_names:
         # Sequence lengths
@@ -612,7 +642,7 @@ def make_mock_qc_dir(qc_dir,fastq_names,fastq_dir=None,
         for cellranger in cellranger_pipelines:
             # Set defaults
             if cellranger == "cellranger":
-                version = "6.1.2"
+                version = cellranger_version
                 refdata = "/data/refdata-cellranger-2020-A"
             elif cellranger == "cellranger-atac":
                 version = "2.0.0"
@@ -684,7 +714,7 @@ PJB_CML2,CMO302,CML2
                                          "fastqs")
             fp.write(config_template.format(fastq_dir=fastq_dir))
         # Cellranger version
-        version = "6.1.2"
+        version = cellranger_version
         # Set top-level output dir
         multi_dir = os.path.join("cellranger_multi",
                                  version,
@@ -693,7 +723,8 @@ PJB_CML2,CMO302,CML2
         MockQCOutputs.cellranger_multi(cellranger_multi_samples,
                                        qc_dir,
                                        config_csv=multi_config,
-                                       prefix=multi_dir)
+                                       prefix=multi_dir,
+                                       cellranger_version=version)
         qc_info['cellranger_version'] = version
     # Additional metadata items
     star_index = "/data/star/hg38"

--- a/auto_process_ngs/mockqc.py
+++ b/auto_process_ngs/mockqc.py
@@ -39,12 +39,13 @@ from .tenx.cellplex import CellrangerMultiConfigCsv
 from .utils import normalise_organism_name
 from . import mockqcdata
 from . import mock10xdata
+from . import tenx
 
 #######################################################################
 # Constants
 #######################################################################
 
-_DEFAULT_CELLRANGER_VERSION = "6.1.2"
+_DEFAULT_CELLRANGER_VERSION = tenx.DEFAULT_CELLRANGER_VERSION
 
 #######################################################################
 # Class definitions

--- a/auto_process_ngs/qc/cellranger.py
+++ b/auto_process_ngs/qc/cellranger.py
@@ -96,6 +96,10 @@ class CellrangerCount:
             self._web_summary = None
 
     @property
+    def mode(self):
+        return "count"
+
+    @property
     def dir(self):
         """
         Path to the directory with the cellranger count outputs
@@ -290,6 +294,10 @@ class CellrangerMulti:
             self._samples[smpl]['web_summary'] = os.path.join(
                 smpl_dir,
                 "web_summary.html")
+
+    @property
+    def mode(self):
+        return "multi"
 
     @property
     def dir(self):

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -2712,7 +2712,7 @@ class RunCellrangerCount(PipelineTask):
                     if self.args.library_type == "snRNA-seq":
                         # For single nuclei RNA-seq specify the
                         # --include-introns for cellranger 5.0+
-                        if cellranger_major_version == 7:
+                        if cellranger_major_version in (7,8):
                             cmd.add_args("--include-introns",
                                          "true")
                         else:

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -2717,6 +2717,11 @@ class RunCellrangerCount(PipelineTask):
                                          "true")
                         else:
                             cmd.add_args("--include-introns")
+                # Additional options for cellranger 8.0+
+                if cellranger_major_version >= 8:
+                    # --create-bam is compulsory
+                    # Recommended to set to 'true'
+                    cmd.add_args("--create-bam","true")
             elif cellranger_package == "cellranger-atac":
                 # Cellranger-ATAC
                 cmd.add_args("--fastqs",fastq_dir,

--- a/auto_process_ngs/tenx/__init__.py
+++ b/auto_process_ngs/tenx/__init__.py
@@ -57,3 +57,5 @@ CELLRANGER_ASSAY_CONFIGS = {
     'ARC-v1': 'Single Cell Multiome (ATAC+GEX) v1', # Not documented?
 }
 
+# Default Cellranger version
+DEFAULT_CELLRANGER_VERSION = "7.1.0"

--- a/auto_process_ngs/tenx/metrics.py
+++ b/auto_process_ngs/tenx/metrics.py
@@ -366,6 +366,7 @@ class MultiplexSummary(MetricsSummary):
     The following properties are available:
 
     - cells
+    - mean_reads_per_cell
     - median_reads_per_cell
     - median_genes_per_cell
     - total_genes_detected
@@ -402,23 +403,34 @@ class MultiplexSummary(MetricsSummary):
           name (str): name of the metric
           library_type (str): library type to fetch
             the metric for (default: 'Gene Expression')
+
+        Raises:
+          MissingMetricError: if metric not defined
+          KeyError: if library type not found
         """
         metric = self.lookup('Metric Name',name)
         if not metric:
-            raise Exception("Failed to lookup metric '%s'" % name)
+            raise MissingMetricError("metric '%s' not found"
+                                     % name)
         # Pick out the specific library
         for m in metric:
             if m['Library Type'] == library_type:
                 return m['Metric Value']
         # No matching library
-        raise Exception("No value for metric '%s' associated with "
-                        "library type '%s'" % (name,library_type))
+        raise KeyError("No value for metric '%s' associated with "
+                       "library type '%s'" % (name,library_type))
     @property
     def cells(self):
         """
         Returns the number of cells
         """
         return self.fetch('Cells')
+    @property
+    def mean_reads_per_cell(self):
+        """
+        Returns the mean reads per cell
+        """
+        return self.fetch('Mean reads per cell')
     @property
     def median_reads_per_cell(self):
         """
@@ -443,3 +455,8 @@ class MultiplexSummary(MetricsSummary):
         Returns the median UMI counts per cell
         """
         return self.fetch('Median UMI counts per cell')
+
+class MissingMetricError(Exception):
+    """
+    Custom exception class when metrics are not found
+    """

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_chromium_sc.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_chromium_sc.py
@@ -293,6 +293,100 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_makefastqs_10x_chromium_sc_protocol_800(self):
+        """
+        MakeFastqs: '10x_chromium_sc' protocol (Cellranger 8.0.0)
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics Chromium SC indices
+        samplesheet_chromium_sc_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-GA-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_chromium_sc_indices)
+        # Create mock bcl2fastq and cellranger
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        MockCellrangerExe.create(os.path.join(self.bin,
+                                              "cellranger"),
+                                 version="8.0.0")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="10x_chromium_sc")
+        status = p.run(analysis_dir,
+                       poll_interval=POLL_INTERVAL)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,
+                         (os.path.join(self.bin,"cellranger"),
+                          "cellranger",
+                          "8.0.0"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html",):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
     def test_makefastqs_10x_chromium_sc_protocol_non_standard_dir_name(self):
         """
         MakeFastqs: '10x_chromium_sc' protocol (non-standard directory name)

--- a/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
@@ -454,15 +454,23 @@ AB\tAB1,AB2\tAlan Brown\tGEX\t10xGenomics Single Cell Multiome\tHuman\tAudrey Be
                 self.assertFalse(os.path.exists(template_libraries_file),
                                  "Found %s" % template_libraries_file)
 
-    def test_setup_analysis_dirs_10x_cellplex(self):
+    def test_setup_analysis_dirs_10x_cellplex_710(self):
         """
-        setup_analysis_dirs: test create new analysis dir for 10x CellPlex
+        setup_analysis_dirs: create new analysis dir for 10x CellPlex (7.1.0)
         """
         # Make a mock auto-process directory
         mockdir = MockAnalysisDirFactory.bcl2fastq2(
             '170901_M00879_0087_000000000-AGEW9',
             'miseq',
-            metadata={ "instrument_datestamp": "170901" },
+            metadata={ "instrument_datestamp": "170901",
+                "processing_software": {
+                    "cellranger" : (
+                        "/usr/local/cellranger/7.1.0/cellranger",
+                        "cellranger",
+                        "7.1.0"
+                    )
+                }
+            },
             reads=('R1','R2','I1','I2'),
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
@@ -517,20 +525,113 @@ AB\tAB1,AB2\tAlan Brown\tCellPlex scRNA-seq\t10xGenomics Chromium 3'v3\tHuman\tA
                 # Template file should exist
                 self.assertTrue(os.path.exists(template_multi_config_file),
                                 "Missing %s" % template_multi_config_file)
+                # Template should contain '#no-bam'
+                with open(template_multi_config_file,'rt') as fp:
+                    template = fp.read()
+                    self.assertTrue(template.find("\n#no-bam,") != -1)
             else:
                 # No template file
                 self.assertFalse(os.path.exists(template_multi_config_file),
                                  "Found %s" % template_multi_config_file)
 
-    def test_setup_analysis_dirs_10x_flex(self):
+    def test_setup_analysis_dirs_10x_cellplex_800(self):
         """
-        setup_analysis_dirs: test create new analysis dir for 10x Flex
+        setup_analysis_dirs: create new analysis dir for 10x CellPlex (8.0.0)
         """
         # Make a mock auto-process directory
         mockdir = MockAnalysisDirFactory.bcl2fastq2(
             '170901_M00879_0087_000000000-AGEW9',
             'miseq',
-            metadata={ "instrument_datestamp": "170901" },
+            metadata={ "instrument_datestamp": "170901",
+                "processing_software": {
+                    "cellranger" : (
+                        "/usr/local/cellranger/8.0.0/cellranger",
+                        "cellranger",
+                        "8.0.0"
+                    )
+                }
+            },
+            reads=('R1','R2','I1','I2'),
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq")))
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq","AB")))
+        # Add required metadata to 'projects.info'
+        projects_info = os.path.join(mockdir.dirn,"projects.info")
+        with open(projects_info,"w") as fp:
+            fp.write(
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+AB\tAB1,AB2\tAlan Brown\tCellPlex scRNA-seq\t10xGenomics Chromium 3'v3\tHuman\tAudrey Benson\t1% PhiX
+""")
+        # Expected data
+        projects = {
+            "AB": ["AB1_S1_R1_001.fastq.gz",
+                   "AB1_S1_R2_001.fastq.gz",
+                   "AB1_S1_I1_001.fastq.gz",
+                   "AB1_S1_I2_001.fastq.gz",
+                   "AB2_S2_R1_001.fastq.gz",
+                   "AB2_S2_R2_001.fastq.gz",
+                   "AB2_S2_I1_001.fastq.gz",
+                   "AB2_S2_I2_001.fastq.gz"],
+            "undetermined": ["Undetermined_S0_R1_001.fastq.gz",]
+        }
+        # Check project dirs don't exist
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertFalse(os.path.exists(project_dir_path))
+        # Setup the project dirs
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        setup_analysis_dirs(ap)
+        # Check project dirs and contents
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertTrue(os.path.exists(project_dir_path))
+            # Check README.info file
+            readme_file = os.path.join(project_dir_path,
+                                       "README.info")
+            self.assertTrue(os.path.exists(readme_file))
+            # Check Fastqs
+            fastqs_dir = os.path.join(project_dir_path,
+                                      "fastqs")
+            self.assertTrue(os.path.exists(fastqs_dir))
+            for fq in projects[project]:
+                fastq = os.path.join(fastqs_dir,fq)
+                self.assertTrue(os.path.exists(fastq))
+            # Check template 10x_multi_config.csv
+            template_multi_config_file = os.path.join(
+                project_dir_path,
+                "10x_multi_config.csv.template")
+            if project == "AB":
+                # Template file should exist
+                self.assertTrue(os.path.exists(template_multi_config_file),
+                                "Missing %s" % template_multi_config_file)
+                # Template should contain 'create-bam'
+                with open(template_multi_config_file,'rt') as fp:
+                    template = fp.read()
+                    self.assertTrue(template.find("\ncreate-bam,") != -1)
+            else:
+                # No template file
+                self.assertFalse(os.path.exists(template_multi_config_file),
+                                 "Found %s" % template_multi_config_file)
+
+    def test_setup_analysis_dirs_10x_flex_710(self):
+        """
+        setup_analysis_dirs: create new analysis dir for 10x Flex (7.1.0)
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={
+                "instrument_datestamp": "170901",
+                "processing_software": {
+                    "cellranger" : (
+                        "/usr/local/cellranger/7.1.0/cellranger",
+                        "cellranger",
+                        "7.1.0"
+                    )
+                }
+            },
             reads=('R1','R2','I1','I2'),
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
@@ -581,20 +682,109 @@ AB\tAB1\tAlan Brown\tFlex\t10xGenomics Chromium 3'v3\tHuman\tAudrey Benson\t1% P
                 # Template file should exist
                 self.assertTrue(os.path.exists(template_multi_config_file),
                                 "Missing %s" % template_multi_config_file)
+                # Template should contain '#no-bam'
+                with open(template_multi_config_file,'rt') as fp:
+                    template = fp.read()
+                    self.assertTrue(template.find("\n#no-bam,") != -1)
             else:
                 # No template file
                 self.assertFalse(os.path.exists(template_multi_config_file),
                                  "Found %s" % template_multi_config_file)
 
-    def test_setup_analysis_dirs_10x_immune_profiling(self):
+    def test_setup_analysis_dirs_10x_flex_800(self):
         """
-        setup_analysis_dirs: create new analysis dir for 10x Single Cell Immune Profiling
+        setup_analysis_dirs: create new analysis dir for 10x Flex (8.0.0)
         """
         # Make a mock auto-process directory
         mockdir = MockAnalysisDirFactory.bcl2fastq2(
             '170901_M00879_0087_000000000-AGEW9',
             'miseq',
-            metadata={ "instrument_datestamp": "170901" },
+            metadata={
+                "instrument_datestamp": "170901",
+                "processing_software": {
+                    "cellranger" : (
+                        "/usr/local/cellranger/8.0.0/cellranger",
+                        "cellranger",
+                        "8.0.0"
+                    )
+                }
+            },
+            reads=('R1','R2','I1','I2'),
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq")))
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq","AB")))
+        # Add required metadata to 'projects.info'
+        projects_info = os.path.join(mockdir.dirn,"projects.info")
+        with open(projects_info,"w") as fp:
+            fp.write(
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+AB\tAB1\tAlan Brown\tFlex\t10xGenomics Chromium 3'v3\tHuman\tAudrey Benson\t1% PhiX
+""")
+        # Expected data
+        projects = {
+            "AB": ["AB1_S1_R1_001.fastq.gz",
+                   "AB1_S1_R2_001.fastq.gz",
+                   "AB1_S1_I1_001.fastq.gz",
+                   "AB1_S1_I2_001.fastq.gz",],
+            "undetermined": ["Undetermined_S0_R1_001.fastq.gz",]
+        }
+        # Check project dirs don't exist
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertFalse(os.path.exists(project_dir_path))
+        # Setup the project dirs
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        setup_analysis_dirs(ap)
+        # Check project dirs and contents
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertTrue(os.path.exists(project_dir_path))
+            # Check README.info file
+            readme_file = os.path.join(project_dir_path,
+                                       "README.info")
+            self.assertTrue(os.path.exists(readme_file))
+            # Check Fastqs
+            fastqs_dir = os.path.join(project_dir_path,
+                                      "fastqs")
+            self.assertTrue(os.path.exists(fastqs_dir))
+            for fq in projects[project]:
+                fastq = os.path.join(fastqs_dir,fq)
+                self.assertTrue(os.path.exists(fastq))
+            # Check template 10x_multi_config.csv
+            template_multi_config_file = os.path.join(
+                project_dir_path,
+                "10x_multi_config.csv.template")
+            if project == "AB":
+                # Template file should exist
+                self.assertTrue(os.path.exists(template_multi_config_file),
+                                "Missing %s" % template_multi_config_file)
+                # Template should contain 'create-bam'
+                with open(template_multi_config_file,'rt') as fp:
+                    template = fp.read()
+                    self.assertTrue(template.find("\ncreate-bam,") != -1)
+            else:
+                # No template file
+                self.assertFalse(os.path.exists(template_multi_config_file),
+                                 "Found %s" % template_multi_config_file)
+
+    def test_setup_analysis_dirs_10x_immune_profiling_710(self):
+        """
+        setup_analysis_dirs: create new analysis dir for 10x Single Cell Immune Profiling (7.1.0)
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901",
+                "processing_software": {
+                    "cellranger" : (
+                        "/usr/local/cellranger/7.1.0/cellranger",
+                        "cellranger",
+                        "7.1.0"
+                    )
+                }
+            },
             reads=('R1','R2','I1','I2'),
             top_dir=self.dirn)
         mockdir.create(no_project_dirs=True)
@@ -645,6 +835,86 @@ AB\tAB1\tAlan Brown\tSingle Cell Immune Profiling\t10xGenomics Chromium 5'\tMous
                 # Template file should exist
                 self.assertTrue(os.path.exists(template_multi_config_file),
                                 "Missing %s" % template_multi_config_file)
+                # Template should contain '#no-bam'
+                with open(template_multi_config_file,'rt') as fp:
+                    template = fp.read()
+                    self.assertTrue(template.find("\n#no-bam,") != -1)
+            else:
+                # No template file
+                self.assertFalse(os.path.exists(template_multi_config_file),
+                                 "Found %s" % template_multi_config_file)
+
+    def test_setup_analysis_dirs_10x_immune_profiling_800(self):
+        """
+        setup_analysis_dirs: create new analysis dir for 10x Single Cell Immune Profiling (8.0.0)
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901",
+                "processing_software": {
+                    "cellranger" : (
+                        "/usr/local/cellranger/8.0.0/cellranger",
+                        "cellranger",
+                        "8.0.0"
+                    )
+                }
+            },
+            reads=('R1','R2','I1','I2'),
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq")))
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq","AB")))
+        # Add required metadata to 'projects.info'
+        projects_info = os.path.join(mockdir.dirn,"projects.info")
+        with open(projects_info,"w") as fp:
+            fp.write(
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+AB\tAB1\tAlan Brown\tSingle Cell Immune Profiling\t10xGenomics Chromium 5'\tMouse\tAudrey Benson\t1% PhiX
+""")
+        # Expected data
+        projects = {
+            "AB": ["AB1_S1_R1_001.fastq.gz",
+                   "AB1_S1_R2_001.fastq.gz",
+                   "AB1_S1_I1_001.fastq.gz",
+                   "AB1_S1_I2_001.fastq.gz",],
+            "undetermined": ["Undetermined_S0_R1_001.fastq.gz",]
+        }
+        # Check project dirs don't exist
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertFalse(os.path.exists(project_dir_path))
+        # Setup the project dirs
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        setup_analysis_dirs(ap)
+        # Check project dirs and contents
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertTrue(os.path.exists(project_dir_path))
+            # Check README.info file
+            readme_file = os.path.join(project_dir_path,
+                                       "README.info")
+            self.assertTrue(os.path.exists(readme_file))
+            # Check Fastqs
+            fastqs_dir = os.path.join(project_dir_path,
+                                      "fastqs")
+            self.assertTrue(os.path.exists(fastqs_dir))
+            for fq in projects[project]:
+                fastq = os.path.join(fastqs_dir,fq)
+                self.assertTrue(os.path.exists(fastq))
+            # Check template 10x_multi_config.csv
+            template_multi_config_file = os.path.join(
+                project_dir_path,
+                "10x_multi_config.csv.template")
+            if project == "AB":
+                # Template file should exist
+                self.assertTrue(os.path.exists(template_multi_config_file),
+                                "Missing %s" % template_multi_config_file)
+                # Template should contain 'create-bam'
+                with open(template_multi_config_file,'rt') as fp:
+                    template = fp.read()
+                    self.assertTrue(template.find("\ncreate-bam,") != -1)
             else:
                 # No template file
                 self.assertFalse(os.path.exists(template_multi_config_file),

--- a/auto_process_ngs/test/qc/pipeline/test_10x_cellplex.py
+++ b/auto_process_ngs/test/qc/pipeline/test_10x_cellplex.py
@@ -10,8 +10,8 @@ class TestQCPipeline(BaseQCPipelineTestCase):
     Tests for 10xGenomics CellPlex data
     """
     #@unittest.skip("Skipped")
-    def test_qcpipeline_cellplex_with_cellranger_multi(self):
-        """QCPipeline: 10xGenomics Cellplex run with 'cellranger multi'
+    def test_qcpipeline_cellplex_with_cellranger_multi_600(self):
+        """QCPipeline: 10xGenomics Cellplex run with 'cellranger multi' (6.0.0)
         """
         # Make mock QC executables
         MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
@@ -72,7 +72,7 @@ PBB,CMO302,PBB
                            { 'human': self.ref_data['hg38']['bed'] },
                            annotation_gtf_files=
                            { 'human': self.ref_data['hg38']['gtf'] },
-                           cellranger_arc_references=
+                           cellranger_transcriptomes=
                            { 'human':
                              '/data/refdata-cellranger-gex-GRCh38-2020-A' },
                            poll_interval=POLL_INTERVAL,
@@ -147,6 +147,144 @@ PBB,CMO302,PBB
                              "Found %s (shouldn't exist)" % f)
 
     #@unittest.skip("Skipped")
+    def test_qcpipeline_cellplex_with_cellranger_multi_800(self):
+        """
+        QCPipeline: 10xGenomics Cellplex run with 'cellranger multi' (8.0.0)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 multi_outputs="cellplex",
+                                 version="8.0.0")
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x Cellplex analysis project
+        p = MockAnalysisProject("PJB",("PJB1_GEX_S1_R1_001.fastq.gz",
+                                       "PJB1_GEX_S1_R2_001.fastq.gz",
+                                       "PJB2_MC_S2_R1_001.fastq.gz",
+                                       "PJB2_MC_S2_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v3',
+                                           'Library type': 'CellPlex' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv file
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,%s,any,PJB1,gene expression,
+PJB2_MC,%s,any,PJB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+PBA,CMO301,PBA
+PBB,CMO302,PBB
+""" % (fastq_dir,fastq_dir))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_CellPlex"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           cellranger_transcriptomes=
+                           { 'human':
+                             '/data/refdata-cellranger-gex-GRCh38-2024-A' },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"10x_CellPlex")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_CellPlex")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_GEX")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz,"
+                         "PJB2_MC_S2_R1_001.fastq.gz,"
+                         "PJB2_MC_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,"8.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-cellranger-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_multi",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/_cmdline",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBA/web_summary.html",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBA/metrics_summary.csv",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBB/web_summary.html",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBB/metrics_summary.csv",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/multi/multiplexing_analysis/tag_calls_summary.csv",
+                  "cellranger_multi",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/_cmdline",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBA/web_summary.html",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBA/metrics_summary.csv",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBB/web_summary.html",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBB/metrics_summary.csv",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/multi/multiplexing_analysis/tag_calls_summary.csv",
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/_cmdline",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/web_summary.html",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/_cmdline",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/web_summary.html",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+        # Verify missing outputs for multiplex capture samples
+        for f in ("PJB2_MC_S2_R2_001_fastq_strand.txt",
+                  "PJB2_MC_S2_R2_001_screen_model_organisms.txt",
+                  "PJB2_MC_S2_R2_001_screen_other_organisms.txt",
+                  "PJB2_MC_S2_R2_001_screen_rRNA.txt",
+                  "qualimap-rnaseq/human/PJB2_MC_S2_001",):
+            self.assertFalse(os.path.exists(os.path.join(self.wd,
+                                                         "PJB",
+                                                         "qc",
+                                                         f)),
+                             "Found %s (shouldn't exist)" % f)
+
+    #@unittest.skip("Skipped")
     def test_qcpipeline_cellplex_no_10x_multi_config_file(self):
         """QCPipeline: 10xGenomics Cellplex run without '10x_multi_config.csv' file
         """
@@ -189,7 +327,7 @@ PBB,CMO302,PBB
                            { 'human': self.ref_data['hg38']['bed'] },
                            annotation_gtf_files=
                            { 'human': self.ref_data['hg38']['gtf'] },
-                           cellranger_arc_references=
+                           cellranger_transcriptomes=
                            { 'human':
                              '/data/refdata-cellranger-gex-GRCh38-2020-A' },
                            poll_interval=POLL_INTERVAL,

--- a/auto_process_ngs/test/qc/pipeline/test_10x_cellplex.py
+++ b/auto_process_ngs/test/qc/pipeline/test_10x_cellplex.py
@@ -187,6 +187,7 @@ PBB,CMO302,PBB
                                      "fastqs")
             fp.write("""[gene-expression]
 reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+create-bam,true
 
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate

--- a/auto_process_ngs/test/qc/pipeline/test_10x_flex.py
+++ b/auto_process_ngs/test/qc/pipeline/test_10x_flex.py
@@ -10,8 +10,8 @@ class TestQCPipeline(BaseQCPipelineTestCase):
     Tests for 10xGenomics Flex data
     """
     #@unittest.skip("Skipped")
-    def test_qcpipeline_flex_with_cellranger_multi(self):
-        """QCPipeline: 10xGenomics Flex run with 'cellranger multi'
+    def test_qcpipeline_flex_with_cellranger_multi_710(self):
+        """QCPipeline: 10xGenomics Flex run with 'cellranger multi' (7.1.0)
         """
         # Make mock QC executables
         MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
@@ -124,6 +124,126 @@ PB2,BC002,PB2
                   #"cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_Flex/_cmdline",
                   #"cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_Flex/outs/web_summary.html",
                   #"cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_Flex/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+    #@unittest.skip("Skipped")
+    def test_qcpipeline_flex_with_cellranger_multi_800(self):
+        """
+        QCPipeline: 10xGenomics Flex run with 'cellranger multi' (8.0.0)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockSeqtk.create(os.path.join(self.bin,"seqtk"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 multi_outputs="flex",
+                                 version="8.0.0")
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x Flex analysis project
+        p = MockAnalysisProject("PJB",("PJB1_Flex_S1_R1_001.fastq.gz",
+                                       "PJB1_Flex_S1_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v3',
+                                           'Library type': 'Flex' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv file
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+probe-set,/data/Probe_Set_v1.0_GRCh38-2020-A.csv
+no-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_Flex,{fastq_dir},any,PJB1,Gene Expression,
+
+[samples]
+sample_id,probe_barcode_ids,description
+PB1,BC001,PB1
+PB2,BC002,PB2
+""".format(fastq_dir=fastq_dir))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_Flex"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"10x_Flex")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_Flex")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_Flex")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_Flex_S1_R1_001.fastq.gz,"
+                         "PJB1_Flex_S1_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,"8.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-cellranger-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset,
+                         "/data/Probe_Set_v1.0_GRCh38-2020-A.csv")
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_multi",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/_cmdline",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PB1/web_summary.html",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PB1/metrics_summary.csv",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PB2/web_summary.html",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PB2/metrics_summary.csv",
+                  "cellranger_multi",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/_cmdline",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PB1/web_summary.html",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PB1/metrics_summary.csv",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PB2/web_summary.html",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PB2/metrics_summary.csv",
+                  #"qc/cellranger_count",
+                  #"qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_Flex/_cmdline",
+                  #"qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_Flex/outs/web_summary.html",
+                  #"qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_Flex/outs/metrics_summary.csv",
+                  #"cellranger_count",
+                  #"cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_Flex/_cmdline",
+                  #"cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_Flex/outs/web_summary.html",
+                  #"cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_Flex/outs/metrics_summary.csv",
                   "multiqc_report.html"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),

--- a/auto_process_ngs/test/qc/pipeline/test_10x_sc_immune_profiling.py
+++ b/auto_process_ngs/test/qc/pipeline/test_10x_sc_immune_profiling.py
@@ -10,9 +10,9 @@ class TestQCPipeline(BaseQCPipelineTestCase):
     Tests for 10xGenomics single cell immune profiling data
     """
     #@unittest.skip("Skipped")
-    def test_qcpipeline_immune_profiling(self):
+    def test_qcpipeline_immune_profiling_cellranger_710(self):
         """
-        QCPipeline: 10xGenomics single cell immune profiling run
+        QCPipeline: 10xGenomics SC immune profiling run (cellranger 7.1.0)
         """
         # Make mock QC executables
         MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
@@ -117,12 +117,122 @@ PJB1_TCR,%s,any,PJB1,VDJ-T,
                                                         "PJB",f)),
                             "Missing %s" % f)
         # Verify no cellranger count outputs for VDJ-T samples
-        for f in ("qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/_cmdline",
-                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/web_summary.html",
-                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/metrics_summary.csv",
-                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/_cmdline",
-                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/web_summary.html",
-                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/metrics_summary.csv"):
+        for f in ("qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCRe"):
+            self.assertFalse(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Found %s (shouldn't exist)" % f)
+
+    #@unittest.skip("Skipped")
+    def test_qcpipeline_immune_profiling_cellranger_800(self):
+        """
+        QCPipeline: 10xGenomics SC immune profiling run (cellranger 8.0.0)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="8.0.0")
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x single cell immune profiling project
+        p = MockAnalysisProject("PJB",("PJB1_GEX_S1_R1_001.fastq.gz",
+                                       "PJB1_GEX_S1_R2_001.fastq.gz",
+                                       "PJB1_TCR_S2_R1_001.fastq.gz",
+                                       "PJB1_TCR_S2_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 5\'',
+                                           'Library type':
+                                           'Single Cell Immune Profiling' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv file
+        # (This is only used to identify the GEX samples)
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB1.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+
+[vdj]
+reference,/data/refdata-cellranger-vdj-GRCh38-alts-ensembl-7.1.0
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,%s,any,PJB1,gene expression,
+PJB1_TCR,%s,any,PJB1,VDJ-T,
+""" % (fastq_dir,fastq_dir))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_ImmuneProfiling"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"10x_ImmuneProfiling")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_ImmuneProfiling")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_GEX,PJB1_TCR")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz,"
+                         "PJB1_TCR_S2_R1_001.fastq.gz,"
+                         "PJB1_TCR_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/_cmdline",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/web_summary.html",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/_cmdline",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/web_summary.html",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+        # Verify no cellranger count outputs for VDJ-T samples
+        for f in ("qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_TCR",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_TCR"):
             self.assertFalse(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
                             "Found %s (shouldn't exist)" % f)
@@ -267,18 +377,10 @@ PJB2_TCR,%s,any,PJB2,VDJ-T,
                                                         "PJB",f)),
                             "Missing %s" % f)
         # Verify no cellranger counts outputs for VDJ-T samples
-        for f in ("qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/_cmdline",
-                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/web_summary.html",
-                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/metrics_summary.csv",
-                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR/_cmdline",
-                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR/outs/web_summary.html",
-                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR/outs/metrics_summary.csv",
-                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/_cmdline",
-                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/web_summary.html",
-                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR/outs/metrics_summary.csv",
-                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR/_cmdline",
-                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR/outs/web_summary.html",
-                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR/outs/metrics_summary.csv"):
+        for f in ("qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR",
+                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR",
+                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR"):
             self.assertFalse(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
                             "Found %s (shouldn't exist)" % f)

--- a/auto_process_ngs/test/qc/pipeline/test_10x_scrnaseq.py
+++ b/auto_process_ngs/test/qc/pipeline/test_10x_scrnaseq.py
@@ -393,6 +393,102 @@ class TestQCPipeline(BaseQCPipelineTestCase):
                                                         "PJB",f)),
                             "Missing %s" % f)
 
+    def test_qcpipeline_with_cellranger_count_scRNA_seq_800(self):
+        """QCPipeline: single cell RNA-seq QC run with 'cellranger count' (v8.0.0)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="8.0.0",
+                                 assert_include_introns=True)
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v2',
+                                           'Library type': 'scRNA-seq' })
+        p.create(top_dir=self.wd)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_scRNAseq"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           cellranger_transcriptomes=
+                           { 'human': '/data/refdata-gex-GRCh38-2024-A' },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"10x_scRNAseq")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_scRNAseq")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,"8.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB1/_cmdline",
+                  "qc/cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB1/outs/web_summary.html",
+                  "qc/cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB1/outs/metrics_summary.csv",
+                  "qc/cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB2/_cmdline",
+                  "qc/cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB2/outs/web_summary.html",
+                  "qc/cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB2/outs/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB1/_cmdline",
+                  "cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB1/outs/web_summary.html",
+                  "cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB1/outs/metrics_summary.csv",
+                  "cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB2/_cmdline",
+                  "cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB2/outs/web_summary.html",
+                  "cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB2/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
     def test_qcpipeline_with_cellranger_count_snRNA_seq_310(self):
         """QCPipeline: single nuclei RNA-seq QC run with 'cellranger count' (v3.1.0)
         """
@@ -773,6 +869,102 @@ class TestQCPipeline(BaseQCPipelineTestCase):
                   "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/_cmdline",
                   "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/web_summary.html",
                   "cellranger_count/7.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    def test_qcpipeline_with_cellranger_count_snRNA_seq_800(self):
+        """QCPipeline: single nuclei RNA-seq QC run with 'cellranger count' (v8.0.0)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockFastqStrandPy.create(os.path.join(self.bin,"fastq_strand.py"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="8.0.0",
+                                 assert_include_introns=True)
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v2',
+                                           'Library type': 'snRNA-seq' })
+        p.create(top_dir=self.wd)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_snRNAseq"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           cellranger_transcriptomes=
+                           { 'human': '/data/refdata-gex-GRCh38-2024-A' },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"10x_snRNAseq")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_snRNAseq")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,"8.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB1/_cmdline",
+                  "qc/cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB1/outs/web_summary.html",
+                  "qc/cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB1/outs/metrics_summary.csv",
+                  "qc/cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB2/_cmdline",
+                  "qc/cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB2/outs/web_summary.html",
+                  "qc/cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB2/outs/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB1/_cmdline",
+                  "cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB1/outs/web_summary.html",
+                  "cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB1/outs/metrics_summary.csv",
+                  "cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB2/_cmdline",
+                  "cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB2/outs/web_summary.html",
+                  "cellranger_count/8.0.0/refdata-gex-GRCh38-2024-A/PJB2/outs/metrics_summary.csv",
                   "multiqc_report.html"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),

--- a/auto_process_ngs/test/qc/test_cellranger.py
+++ b/auto_process_ngs/test/qc/test_cellranger.py
@@ -46,6 +46,7 @@ class TestCellrangerCount(unittest.TestCase):
         with open(os.path.join(count_dir,"_cmdline"),'wt') as fp:
             fp.write("%s\n" % cmdline)
         cellranger_count = CellrangerCount(count_dir)
+        self.assertEqual(cellranger_count.mode,"count")
         self.assertEqual(cellranger_count.dir,count_dir)
         self.assertEqual(cellranger_count.sample_name,"PJB1")
         self.assertEqual(cellranger_count.metrics_csv,
@@ -74,6 +75,7 @@ class TestCellrangerCount(unittest.TestCase):
         with open(os.path.join(count_dir,"_cmdline"),'wt') as fp:
             fp.write("%s\n" % cmdline)
         cellranger_count = CellrangerCount(count_dir)
+        self.assertEqual(cellranger_count.mode,"count")
         self.assertEqual(cellranger_count.dir,count_dir)
         self.assertEqual(cellranger_count.sample_name,"PJB1")
         self.assertEqual(cellranger_count.metrics_csv,
@@ -103,6 +105,7 @@ class TestCellrangerCount(unittest.TestCase):
         with open(os.path.join(count_dir,"_cmdline"),'wt') as fp:
             fp.write("%s\n" % cmdline)
         cellranger_count = CellrangerCount(count_dir)
+        self.assertEqual(cellranger_count.mode,"count")
         self.assertEqual(cellranger_count.dir,count_dir)
         self.assertEqual(cellranger_count.sample_name,"PJB1")
         self.assertEqual(cellranger_count.metrics_csv,
@@ -132,6 +135,7 @@ class TestCellrangerCount(unittest.TestCase):
         with open(os.path.join(count_dir,"_cmdline"),'wt') as fp:
             fp.write("%s\n" % cmdline)
         cellranger_count = CellrangerCount(count_dir)
+        self.assertEqual(cellranger_count.mode,"count")
         self.assertEqual(cellranger_count.dir,count_dir)
         self.assertEqual(cellranger_count.sample_name,"PJB1")
         self.assertEqual(cellranger_count.metrics_csv,
@@ -164,6 +168,7 @@ class TestCellrangerCount(unittest.TestCase):
             cellranger_exe="/alt/path/to/cellranger",
             version="5.0.1",
             reference_data="/alt/data/refdata-gex-GRCh38-2020-A")
+        self.assertEqual(cellranger_count.mode,"count")
         self.assertEqual(cellranger_count.dir,count_dir)
         self.assertEqual(cellranger_count.sample_name,"PJB1")
         self.assertEqual(cellranger_count.metrics_csv,
@@ -187,6 +192,7 @@ class TestCellrangerCount(unittest.TestCase):
         # Do tests
         count_dir = os.path.join(self.project.qc_dir,"cellranger_count","PJB1")
         cellranger_count = CellrangerCount(count_dir)
+        self.assertEqual(cellranger_count.mode,"count")
         self.assertRaises(OSError,
                           getattr,cellranger_count,'dir')
         self.assertEqual(cellranger_count.sample_name,None)
@@ -250,6 +256,7 @@ PBB,CMO302,PBB
         with open(os.path.join(multi_dir,"_cmdline"),'wt') as fp:
             fp.write("%s\n" % cmdline)
         cellranger_multi = CellrangerMulti(multi_dir)
+        self.assertEqual(cellranger_multi.mode,"multi")
         self.assertEqual(cellranger_multi.dir,multi_dir)
         self.assertEqual(cellranger_multi.sample_names,["PBA","PBB"])
         self.assertEqual(cellranger_multi.metrics_csv('PBA'),
@@ -322,6 +329,7 @@ PBB,BC002,PBB
         with open(os.path.join(multi_dir,"_cmdline"),'wt') as fp:
             fp.write("%s\n" % cmdline)
         cellranger_multi = CellrangerMulti(multi_dir)
+        self.assertEqual(cellranger_multi.mode,"multi")
         self.assertEqual(cellranger_multi.dir,multi_dir)
         self.assertEqual(cellranger_multi.sample_names,["PBA","PBB"])
         self.assertEqual(cellranger_multi.metrics_csv('PBA'),

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -62,6 +62,7 @@ class TestQCOutputs(unittest.TestCase):
                      include_multiqc=True,
                      include_cellranger_count=False,
                      include_cellranger_multi=False,
+                     cellranger_version=None,
                      legacy_screens=False,
                      legacy_cellranger_outs=False,
                      protocol=None):
@@ -89,6 +90,7 @@ class TestQCOutputs(unittest.TestCase):
             include_multiqc=include_multiqc,
             include_cellranger_count=include_cellranger_count,
             include_cellranger_multi=include_cellranger_multi,
+            cellranger_version=cellranger_version,
             legacy_screens=legacy_screens,
             legacy_cellranger_outs=legacy_cellranger_outs)
 
@@ -1174,9 +1176,9 @@ class TestQCOutputs(unittest.TestCase):
             self.assertTrue(os.path.join(qc_dir,f)
                             in qc_outputs.output_files)
 
-    def test_qcoutputs_10x_cellranger_count(self):
+    def test_qcoutputs_10x_cellranger_count_612(self):
         """
-        QCOutputs: 10xGenomics data with cellranger 'count'
+        QCOutputs: 10xGenomics data with cellranger 'count' (6.1.2)
         """
         qc_dir = self._make_qc_dir('qc',
                                    fastq_names=(
@@ -1190,7 +1192,8 @@ class TestQCOutputs(unittest.TestCase):
                                    cellranger_samples=(
                                        'PJB1',
                                        'PJB2',
-                                   ))
+                                   ),
+                                   cellranger_version='6.1.2')
         qc_outputs = QCOutputs(qc_dir)
         self.assertEqual(qc_outputs.outputs,
                          ['cellranger_count',
@@ -1222,6 +1225,140 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '6.1.2' ],
+                           'fastqc': [ '0.11.3' ],
+                           'fastq_screen': [ '0.9.2' ],
+                           'fastq_strand': [ '0.0.4' ],
+                           'multiqc': [ '1.8' ],
+                         })
+        self.assertEqual(qc_outputs.stats.max_seqs,37285443)
+        self.assertEqual(qc_outputs.stats.min_sequence_length,65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length,76)
+        self.assertEqual(sorted(
+            list(qc_outputs.stats.min_sequence_length_read.keys())),
+                         ['r1','r2'])
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r1'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r1'],76)
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r2'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r2'],76)
+        self.assertEqual(qc_outputs.config_files,
+                         ['fastq_strand.conf'])
+
+    def test_qcoutputs_10x_cellranger_count_710(self):
+        """
+        QCOutputs: 10xGenomics data with cellranger 'count' (7.1.2)
+        """
+        qc_dir = self._make_qc_dir('qc',
+                                   fastq_names=(
+                                       'PJB1_S1_R1_001',
+                                       'PJB1_S1_R2_001',
+                                       'PJB2_S2_R1_001',
+                                       'PJB2_S2_R2_001',
+                                   ),
+                                   include_cellranger_count=True,
+                                   cellranger_pipelines=('cellranger',),
+                                   cellranger_samples=(
+                                       'PJB1',
+                                       'PJB2',
+                                   ),
+                                   cellranger_version='7.1.0')
+        qc_outputs = QCOutputs(qc_dir)
+        self.assertEqual(qc_outputs.outputs,
+                         ['cellranger_count',
+                          'fastqc_r1',
+                          'fastqc_r2',
+                          'multiqc',
+                          'screens_r1',
+                          'screens_r2',
+                          'sequence_lengths',
+                          'strandedness'])
+        self.assertEqual(qc_outputs.fastqs,
+                         ['PJB1_S1_R1_001',
+                          'PJB1_S1_R2_001',
+                          'PJB2_S2_R1_001',
+                          'PJB2_S2_R2_001'])
+        self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.bams,[])
+        self.assertEqual(qc_outputs.organisms,[])
+        self.assertEqual(qc_outputs.fastq_screens,
+                         ['model_organisms',
+                          'other_organisms',
+                          'rRNA'])
+        self.assertEqual(qc_outputs.cellranger_references,
+                         ['/data/refdata-cellranger-2020-A'])
+        self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.reads,['r1','r2'])
+        self.assertEqual(qc_outputs.software,
+                         { 'cellranger': [ '7.1.0' ],
+                           'fastqc': [ '0.11.3' ],
+                           'fastq_screen': [ '0.9.2' ],
+                           'fastq_strand': [ '0.0.4' ],
+                           'multiqc': [ '1.8' ],
+                         })
+        self.assertEqual(qc_outputs.stats.max_seqs,37285443)
+        self.assertEqual(qc_outputs.stats.min_sequence_length,65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length,76)
+        self.assertEqual(sorted(
+            list(qc_outputs.stats.min_sequence_length_read.keys())),
+                         ['r1','r2'])
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r1'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r1'],76)
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r2'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r2'],76)
+        self.assertEqual(qc_outputs.config_files,
+                         ['fastq_strand.conf'])
+
+    def test_qcoutputs_10x_cellranger_count_800(self):
+        """
+        QCOutputs: 10xGenomics data with cellranger 'count' (8.0.0)
+        """
+        qc_dir = self._make_qc_dir('qc',
+                                   fastq_names=(
+                                       'PJB1_S1_R1_001',
+                                       'PJB1_S1_R2_001',
+                                       'PJB2_S2_R1_001',
+                                       'PJB2_S2_R2_001',
+                                   ),
+                                   include_cellranger_count=True,
+                                   cellranger_pipelines=('cellranger',),
+                                   cellranger_samples=(
+                                       'PJB1',
+                                       'PJB2',
+                                   ),
+                                   cellranger_version='8.0.0')
+        qc_outputs = QCOutputs(qc_dir)
+        self.assertEqual(qc_outputs.outputs,
+                         ['cellranger_count',
+                          'fastqc_r1',
+                          'fastqc_r2',
+                          'multiqc',
+                          'screens_r1',
+                          'screens_r2',
+                          'sequence_lengths',
+                          'strandedness'])
+        self.assertEqual(qc_outputs.fastqs,
+                         ['PJB1_S1_R1_001',
+                          'PJB1_S1_R2_001',
+                          'PJB2_S2_R1_001',
+                          'PJB2_S2_R2_001'])
+        self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.bams,[])
+        self.assertEqual(qc_outputs.organisms,[])
+        self.assertEqual(qc_outputs.fastq_screens,
+                         ['model_organisms',
+                          'other_organisms',
+                          'rRNA'])
+        self.assertEqual(qc_outputs.cellranger_references,
+                         ['/data/refdata-cellranger-2020-A'])
+        self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.reads,['r1','r2'])
+        self.assertEqual(qc_outputs.software,
+                         { 'cellranger': [ '8.0.0' ],
                            'fastqc': [ '0.11.3' ],
                            'fastq_screen': [ '0.9.2' ],
                            'fastq_strand': [ '0.0.4' ],
@@ -1423,7 +1560,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.multiplexed_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
-                         { 'cellranger': [ '6.1.2' ],
+                         { 'cellranger': [ '7.1.0' ],
                            'cellranger-arc': [ '2.0.0' ],
                            'fastqc': [ '0.11.3' ],
                            'fastq_screen': [ '0.9.2' ],
@@ -1517,9 +1654,9 @@ class TestQCOutputs(unittest.TestCase):
                           'libraries.PJB1.csv',
                           'libraries.PJB2.csv'])
 
-    def test_qcoutputs_10x_cellranger_multi_cellplex(self):
+    def test_qcoutputs_10x_cellranger_multi_cellplex_612(self):
         """
-        QCOutputs: 10xGenomics CellPlex data with 'cellranger multi'
+        QCOutputs: 10xGenomics CellPlex data with 'cellranger multi' (6.1.2)
         """
         qc_dir = self._make_qc_dir('qc',
                                    protocol="10x_CellPlex",
@@ -1538,7 +1675,8 @@ class TestQCOutputs(unittest.TestCase):
                                    cellranger_multi_samples=(
                                        'PJB_CML1',
                                        'PJB_CML2',
-                                   ))
+                                   ),
+                                   cellranger_version="6.1.2")
         qc_outputs = QCOutputs(qc_dir)
         self.assertEqual(qc_outputs.outputs,
                          ['cellranger_multi',
@@ -1590,9 +1728,157 @@ class TestQCOutputs(unittest.TestCase):
                          ['10x_multi_config.csv',
                           'fastq_strand.conf'])
 
-    def test_qcoutputs_10x_cellranger_multi_and_count_cellplex(self):
+    def test_qcoutputs_10x_cellranger_multi_cellplex_710(self):
         """
-        QCOutputs: 10xGenomics CellPlex data with 'cellranger multi' and 'count'
+        QCOutputs: 10xGenomics CellPlex data with 'cellranger multi' (7.1.0)
+        """
+        qc_dir = self._make_qc_dir('qc',
+                                   protocol="10x_CellPlex",
+                                   fastq_names=(
+                                       'PJB1_GEX_S1_R1_001',
+                                       'PJB1_GEX_S1_R2_001',
+                                       'PJB2_MC_S2_R1_001',
+                                       'PJB2_MC_S2_R2_001',
+                                   ),
+                                   include_cellranger_multi=True,
+                                   cellranger_pipelines=('cellranger',),
+                                   cellranger_samples=(
+                                       'PJB1_GEX',
+                                       'PJB2_MC',
+                                   ),
+                                   cellranger_multi_samples=(
+                                       'PJB_CML1',
+                                       'PJB_CML2',
+                                   ),
+                                   cellranger_version="7.1.0")
+        qc_outputs = QCOutputs(qc_dir)
+        self.assertEqual(qc_outputs.outputs,
+                         ['cellranger_multi',
+                          'fastqc_r1',
+                          'fastqc_r2',
+                          'multiqc',
+                          'screens_r2',
+                          'sequence_lengths',
+                          'strandedness'])
+        self.assertEqual(qc_outputs.fastqs,
+                         ['PJB1_GEX_S1_R1_001',
+                          'PJB1_GEX_S1_R2_001',
+                          'PJB2_MC_S2_R1_001',
+                          'PJB2_MC_S2_R2_001'])
+        self.assertEqual(qc_outputs.samples,
+                         ['PJB1_GEX','PJB2_MC'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1_GEX'])
+        self.assertEqual(qc_outputs.bams,[])
+        self.assertEqual(qc_outputs.organisms,[])
+        self.assertEqual(qc_outputs.fastq_screens,
+                         ['model_organisms',
+                          'other_organisms',
+                          'rRNA'])
+        self.assertEqual(qc_outputs.cellranger_references,
+                         ['/data/refdata-cellranger-2020-A'])
+        self.assertEqual(qc_outputs.cellranger_probe_sets,[])
+        self.assertEqual(qc_outputs.multiplexed_samples,
+                         ['PJB_CML1','PJB_CML2'])
+        self.assertEqual(qc_outputs.reads,['r1','r2'])
+        self.assertEqual(qc_outputs.software,
+                         { 'cellranger': [ '7.1.0' ],
+                           'fastqc': [ '0.11.3' ],
+                           'fastq_screen': [ '0.9.2' ],
+                           'fastq_strand': [ '0.0.4' ],
+                           'multiqc': [ '1.8' ],
+                         })
+        self.assertEqual(qc_outputs.stats.max_seqs,37285443)
+        self.assertEqual(qc_outputs.stats.min_sequence_length,65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length,76)
+        self.assertEqual(sorted(
+            list(qc_outputs.stats.min_sequence_length_read.keys())),
+                         ['r1','r2'])
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r1'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r1'],76)
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r2'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r2'],76)
+        self.assertEqual(qc_outputs.config_files,
+                         ['10x_multi_config.csv',
+                          'fastq_strand.conf'])
+
+    def test_qcoutputs_10x_cellranger_multi_cellplex_800(self):
+        """
+        QCOutputs: 10xGenomics CellPlex data with 'cellranger multi' (8.0.0)
+        """
+        qc_dir = self._make_qc_dir('qc',
+                                   protocol="10x_CellPlex",
+                                   fastq_names=(
+                                       'PJB1_GEX_S1_R1_001',
+                                       'PJB1_GEX_S1_R2_001',
+                                       'PJB2_MC_S2_R1_001',
+                                       'PJB2_MC_S2_R2_001',
+                                   ),
+                                   include_cellranger_multi=True,
+                                   cellranger_pipelines=('cellranger',),
+                                   cellranger_samples=(
+                                       'PJB1_GEX',
+                                       'PJB2_MC',
+                                   ),
+                                   cellranger_multi_samples=(
+                                       'PJB_CML1',
+                                       'PJB_CML2',
+                                   ),
+                                   cellranger_version="8.0.0")
+        qc_outputs = QCOutputs(qc_dir)
+        self.assertEqual(qc_outputs.outputs,
+                         ['cellranger_multi',
+                          'fastqc_r1',
+                          'fastqc_r2',
+                          'multiqc',
+                          'screens_r2',
+                          'sequence_lengths',
+                          'strandedness'])
+        self.assertEqual(qc_outputs.fastqs,
+                         ['PJB1_GEX_S1_R1_001',
+                          'PJB1_GEX_S1_R2_001',
+                          'PJB2_MC_S2_R1_001',
+                          'PJB2_MC_S2_R2_001'])
+        self.assertEqual(qc_outputs.samples,
+                         ['PJB1_GEX','PJB2_MC'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1_GEX'])
+        self.assertEqual(qc_outputs.bams,[])
+        self.assertEqual(qc_outputs.organisms,[])
+        self.assertEqual(qc_outputs.fastq_screens,
+                         ['model_organisms',
+                          'other_organisms',
+                          'rRNA'])
+        self.assertEqual(qc_outputs.cellranger_references,
+                         ['/data/refdata-cellranger-2020-A'])
+        self.assertEqual(qc_outputs.cellranger_probe_sets,[])
+        self.assertEqual(qc_outputs.multiplexed_samples,
+                         ['PJB_CML1','PJB_CML2'])
+        self.assertEqual(qc_outputs.reads,['r1','r2'])
+        self.assertEqual(qc_outputs.software,
+                         { 'cellranger': [ '8.0.0' ],
+                           'fastqc': [ '0.11.3' ],
+                           'fastq_screen': [ '0.9.2' ],
+                           'fastq_strand': [ '0.0.4' ],
+                           'multiqc': [ '1.8' ],
+                         })
+        self.assertEqual(qc_outputs.stats.max_seqs,37285443)
+        self.assertEqual(qc_outputs.stats.min_sequence_length,65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length,76)
+        self.assertEqual(sorted(
+            list(qc_outputs.stats.min_sequence_length_read.keys())),
+                         ['r1','r2'])
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r1'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r1'],76)
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r2'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r2'],76)
+        self.assertEqual(qc_outputs.config_files,
+                         ['10x_multi_config.csv',
+                          'fastq_strand.conf'])
+
+    def test_qcoutputs_10x_cellranger_multi_and_count_cellplex_612(self):
+        """
+        QCOutputs: 10xGenomics CellPlex data with 'cellranger multi' and 'count' (6.1.2)
         """
         qc_dir = self._make_qc_dir('qc',
                                    protocol="10x_CellPlex",
@@ -1612,7 +1898,8 @@ class TestQCOutputs(unittest.TestCase):
                                    cellranger_multi_samples=(
                                        'PJB_CML1',
                                        'PJB_CML2',
-                                   ))
+                                   ),
+                                   cellranger_version="6.1.2")
         qc_outputs = QCOutputs(qc_dir)
         self.assertEqual(qc_outputs.outputs,
                          ['cellranger_count',
@@ -1665,9 +1952,161 @@ class TestQCOutputs(unittest.TestCase):
                          ['10x_multi_config.csv',
                           'fastq_strand.conf'])
 
-    def test_qcoutputs_10x_cellranger_multi_flex(self):
+    def test_qcoutputs_10x_cellranger_multi_and_count_cellplex_710(self):
         """
-        QCOutputs: 10xGenomics Flex data with 'cellranger multi'
+        QCOutputs: 10xGenomics CellPlex data with 'cellranger multi' and 'count' (7.1.0)
+        """
+        qc_dir = self._make_qc_dir('qc',
+                                   protocol="10x_CellPlex",
+                                   fastq_names=(
+                                       'PJB1_GEX_S1_R1_001',
+                                       'PJB1_GEX_S1_R2_001',
+                                       'PJB2_MC_S2_R1_001',
+                                       'PJB2_MC_S2_R2_001',
+                                   ),
+                                   include_cellranger_count=True,
+                                   include_cellranger_multi=True,
+                                   cellranger_pipelines=('cellranger',),
+                                   cellranger_samples=(
+                                       'PJB1_GEX',
+                                       'PJB2_MC',
+                                   ),
+                                   cellranger_multi_samples=(
+                                       'PJB_CML1',
+                                       'PJB_CML2',
+                                   ),
+                                   cellranger_version="7.1.0")
+        qc_outputs = QCOutputs(qc_dir)
+        self.assertEqual(qc_outputs.outputs,
+                         ['cellranger_count',
+                          'cellranger_multi',
+                          'fastqc_r1',
+                          'fastqc_r2',
+                          'multiqc',
+                          'screens_r2',
+                          'sequence_lengths',
+                          'strandedness'])
+        self.assertEqual(qc_outputs.fastqs,
+                         ['PJB1_GEX_S1_R1_001',
+                          'PJB1_GEX_S1_R2_001',
+                          'PJB2_MC_S2_R1_001',
+                          'PJB2_MC_S2_R2_001'])
+        self.assertEqual(qc_outputs.samples,
+                         ['PJB1_GEX','PJB2_MC'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1_GEX'])
+        self.assertEqual(qc_outputs.bams,[])
+        self.assertEqual(qc_outputs.organisms,[])
+        self.assertEqual(qc_outputs.fastq_screens,
+                         ['model_organisms',
+                          'other_organisms',
+                          'rRNA'])
+        self.assertEqual(qc_outputs.cellranger_references,
+                         ['/data/refdata-cellranger-2020-A'])
+        self.assertEqual(qc_outputs.cellranger_probe_sets,[])
+        self.assertEqual(qc_outputs.multiplexed_samples,
+                         ['PJB_CML1','PJB_CML2'])
+        self.assertEqual(qc_outputs.reads,['r1','r2'])
+        self.assertEqual(qc_outputs.software,
+                         { 'cellranger': [ '7.1.0' ],
+                           'fastqc': [ '0.11.3' ],
+                           'fastq_screen': [ '0.9.2' ],
+                           'fastq_strand': [ '0.0.4' ],
+                           'multiqc': [ '1.8' ],
+                         })
+        self.assertEqual(qc_outputs.stats.max_seqs,37285443)
+        self.assertEqual(qc_outputs.stats.min_sequence_length,65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length,76)
+        self.assertEqual(sorted(
+            list(qc_outputs.stats.min_sequence_length_read.keys())),
+                         ['r1','r2'])
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r1'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r1'],76)
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r2'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r2'],76)
+        self.assertEqual(qc_outputs.config_files,
+                         ['10x_multi_config.csv',
+                          'fastq_strand.conf'])
+
+    def test_qcoutputs_10x_cellranger_multi_and_count_cellplex_800(self):
+        """
+        QCOutputs: 10xGenomics CellPlex data with 'cellranger multi' and 'count' (8.0.0)
+        """
+        qc_dir = self._make_qc_dir('qc',
+                                   protocol="10x_CellPlex",
+                                   fastq_names=(
+                                       'PJB1_GEX_S1_R1_001',
+                                       'PJB1_GEX_S1_R2_001',
+                                       'PJB2_MC_S2_R1_001',
+                                       'PJB2_MC_S2_R2_001',
+                                   ),
+                                   include_cellranger_count=True,
+                                   include_cellranger_multi=True,
+                                   cellranger_pipelines=('cellranger',),
+                                   cellranger_samples=(
+                                       'PJB1_GEX',
+                                       'PJB2_MC',
+                                   ),
+                                   cellranger_multi_samples=(
+                                       'PJB_CML1',
+                                       'PJB_CML2',
+                                   ),
+                                   cellranger_version="8.0.0")
+        qc_outputs = QCOutputs(qc_dir)
+        self.assertEqual(qc_outputs.outputs,
+                         ['cellranger_count',
+                          'cellranger_multi',
+                          'fastqc_r1',
+                          'fastqc_r2',
+                          'multiqc',
+                          'screens_r2',
+                          'sequence_lengths',
+                          'strandedness'])
+        self.assertEqual(qc_outputs.fastqs,
+                         ['PJB1_GEX_S1_R1_001',
+                          'PJB1_GEX_S1_R2_001',
+                          'PJB2_MC_S2_R1_001',
+                          'PJB2_MC_S2_R2_001'])
+        self.assertEqual(qc_outputs.samples,
+                         ['PJB1_GEX','PJB2_MC'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1_GEX'])
+        self.assertEqual(qc_outputs.bams,[])
+        self.assertEqual(qc_outputs.organisms,[])
+        self.assertEqual(qc_outputs.fastq_screens,
+                         ['model_organisms',
+                          'other_organisms',
+                          'rRNA'])
+        self.assertEqual(qc_outputs.cellranger_references,
+                         ['/data/refdata-cellranger-2020-A'])
+        self.assertEqual(qc_outputs.cellranger_probe_sets,[])
+        self.assertEqual(qc_outputs.multiplexed_samples,
+                         ['PJB_CML1','PJB_CML2'])
+        self.assertEqual(qc_outputs.reads,['r1','r2'])
+        self.assertEqual(qc_outputs.software,
+                         { 'cellranger': [ '8.0.0' ],
+                           'fastqc': [ '0.11.3' ],
+                           'fastq_screen': [ '0.9.2' ],
+                           'fastq_strand': [ '0.0.4' ],
+                           'multiqc': [ '1.8' ],
+                         })
+        self.assertEqual(qc_outputs.stats.max_seqs,37285443)
+        self.assertEqual(qc_outputs.stats.min_sequence_length,65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length,76)
+        self.assertEqual(sorted(
+            list(qc_outputs.stats.min_sequence_length_read.keys())),
+                         ['r1','r2'])
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r1'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r1'],76)
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r2'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r2'],76)
+        self.assertEqual(qc_outputs.config_files,
+                         ['10x_multi_config.csv',
+                          'fastq_strand.conf'])
+
+    def test_qcoutputs_10x_cellranger_multi_flex_612(self):
+        """
+        QCOutputs: 10xGenomics Flex data with 'cellranger multi' (6.1.2)
         """
         qc_dir = self._make_qc_dir('qc',
                                    protocol="10x_Flex",
@@ -1684,7 +2123,8 @@ class TestQCOutputs(unittest.TestCase):
                                    cellranger_multi_samples=(
                                        'PJB_BC1',
                                        'PJB_BC2',
-                                   ))
+                                   ),
+                                   cellranger_version="6.1.2")
         qc_outputs = QCOutputs(qc_dir)
         self.assertEqual(qc_outputs.outputs,
                          ['cellranger_count',
@@ -1736,9 +2176,9 @@ class TestQCOutputs(unittest.TestCase):
                          ['10x_multi_config.csv',
                           'fastq_strand.conf'])
 
-    def test_qcoutputs_10x_cellranger_single_cell_immune_profiling(self):
+    def test_qcoutputs_10x_cellranger_single_cell_immune_profiling_710(self):
         """
-        QCOutputs: 10xGenomics single cell immune profiling
+        QCOutputs: 10xGenomics single cell immune profiling (7.1.0)
         """
         qc_dir = self._make_qc_dir('qc',
                                    protocol="10x_ImmuneProfiling",
@@ -1758,7 +2198,8 @@ class TestQCOutputs(unittest.TestCase):
                                    cellranger_samples=(
                                        'PJB1_GEX',
                                        'PJB2_GEX',
-                                   ))
+                                   ),
+                                   cellranger_version="7.1.0")
         # Make 10x_multi_config.csv files (one for each physical
         # sample)
         fastq_dir = os.path.join(os.path.dirname(qc_dir),'fastqs')
@@ -1827,7 +2268,121 @@ PJB2_TCR,{fastq_dir},any,PJB2,VDJ-T,
         self.assertEqual(qc_outputs.multiplexed_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
-                         { 'cellranger': [ '6.1.2' ],
+                         { 'cellranger': [ '7.1.0' ],
+                           'fastqc': [ '0.11.3' ],
+                           'fastq_screen': [ '0.9.2' ],
+                           'fastq_strand': [ '0.0.4' ],
+                           'multiqc': [ '1.8' ],
+                         })
+        self.assertEqual(qc_outputs.stats.max_seqs,37285443)
+        self.assertEqual(qc_outputs.stats.min_sequence_length,65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length,76)
+        self.assertEqual(sorted(
+            list(qc_outputs.stats.min_sequence_length_read.keys())),
+                         ['r1','r2'])
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r1'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r1'],76)
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r2'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r2'],76)
+        self.assertEqual(qc_outputs.config_files,
+                         ['10x_multi_config.PJB1.csv',
+                          '10x_multi_config.PJB2.csv',
+                          'fastq_strand.conf'])
+
+    def test_qcoutputs_10x_cellranger_single_cell_immune_profiling_800(self):
+        """
+        QCOutputs: 10xGenomics single cell immune profiling (8.0.0)
+        """
+        qc_dir = self._make_qc_dir('qc',
+                                   protocol="10x_ImmuneProfiling",
+                                   fastq_names=(
+                                       'PJB1_GEX_S1_R1_001',
+                                       'PJB1_GEX_S1_R2_001',
+                                       'PJB1_TCR_S2_R1_001',
+                                       'PJB1_TCR_S2_R2_001',
+                                       'PJB2_GEX_S3_R1_001',
+                                       'PJB2_GEX_S3_R2_001',
+                                       'PJB2_TCR_S4_R1_001',
+                                       'PJB2_TCR_S4_R2_001',
+                                   ),
+                                   include_cellranger_multi=False,
+                                   include_cellranger_count=True,
+                                   cellranger_pipelines=('cellranger',),
+                                   cellranger_samples=(
+                                       'PJB1_GEX',
+                                       'PJB2_GEX',
+                                   ),
+                                   cellranger_version="8.0.0")
+        # Make 10x_multi_config.csv files (one for each physical
+        # sample)
+        fastq_dir = os.path.join(os.path.dirname(qc_dir),'fastqs')
+        with open(os.path.join(qc_dir,"10x_multi_config.PJB1.csv"),
+                  'wt') as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+create-bam,true
+
+[vdj]
+reference,/data/refdata-cellranger-vdj-GRCh38-alts-ensembl-7.1.0
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,{fastq_dir},any,PJB1,gene expression,
+PJB1_TCR,{fastq_dir},any,PJB1,VDJ-T,
+""".format(fastq_dir=fastq_dir))
+        with open(os.path.join(qc_dir,"10x_multi_config.PJB2.csv"),
+                  'wt') as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[vdj]
+reference,/data/refdata-cellranger-vdj-GRCh38-alts-ensembl-7.1.0
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB2_GEX,{fastq_dir},any,PJB2,gene expression,
+PJB2_TCR,{fastq_dir},any,PJB2,VDJ-T,
+""".format(fastq_dir=fastq_dir))
+        # Collect and checkout outputs
+        qc_outputs = QCOutputs(qc_dir)
+        self.assertEqual(qc_outputs.outputs,
+                         ['cellranger_count',
+                          'fastqc_r1',
+                          'fastqc_r2',
+                          'multiqc',
+                          'screens_r2',
+                          'sequence_lengths',
+                          'strandedness'])
+        self.assertEqual(qc_outputs.fastqs,
+                         ['PJB1_GEX_S1_R1_001',
+                          'PJB1_GEX_S1_R2_001',
+                          'PJB1_TCR_S2_R1_001',
+                          'PJB1_TCR_S2_R2_001',
+                          'PJB2_GEX_S3_R1_001',
+                          'PJB2_GEX_S3_R2_001',
+                          'PJB2_TCR_S4_R1_001',
+                          'PJB2_TCR_S4_R2_001'])
+        self.assertEqual(qc_outputs.samples,
+                         ['PJB1_GEX',
+                          'PJB1_TCR',
+                          'PJB2_GEX',
+                          'PJB2_TCR'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1_GEX',
+                          'PJB2_GEX'])
+        self.assertEqual(qc_outputs.bams,[])
+        self.assertEqual(qc_outputs.organisms,[])
+        self.assertEqual(qc_outputs.fastq_screens,
+                         ['model_organisms',
+                          'other_organisms',
+                          'rRNA'])
+        self.assertEqual(qc_outputs.cellranger_references,
+                         ['/data/refdata-cellranger-2020-A'])
+        self.assertEqual(qc_outputs.cellranger_probe_sets,[])
+        self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.reads,['r1','r2'])
+        self.assertEqual(qc_outputs.software,
+                         { 'cellranger': [ '8.0.0' ],
                            'fastqc': [ '0.11.3' ],
                            'fastq_screen': [ '0.9.2' ],
                            'fastq_strand': [ '0.0.4' ],

--- a/auto_process_ngs/test/qc/test_reporting.py
+++ b/auto_process_ngs/test/qc/test_reporting.py
@@ -48,6 +48,7 @@ class TestReportFunction(unittest.TestCase):
                                cellranger_pipelines=('cellranger',),
                                cellranger_samples=None,
                                cellranger_multi_samples=None,
+                               cellranger_version=None,
                                legacy_screens=False,
                                legacy_cellranger_outs=False):
         # Create a mock Analysis Project directory
@@ -75,6 +76,7 @@ class TestReportFunction(unittest.TestCase):
             cellranger_pipelines=cellranger_pipelines,
             cellranger_samples=cellranger_samples,
             cellranger_multi_samples=cellranger_multi_samples,
+            cellranger_version=cellranger_version,
             legacy_screens=legacy_screens,
             legacy_cellranger_outs=legacy_cellranger_outs)
 
@@ -124,42 +126,76 @@ class TestReportFunction(unittest.TestCase):
         self.assertTrue(os.path.exists(
             os.path.join(self.top_dir,'report.PE.html')))
 
-    def test_report_paired_end_cellranger_count(self):
+    def test_report_paired_end_cellranger_count_710(self):
         """
-        report: paired-end data with cellranger 'count'
+        report: paired-end data with cellranger 'count' (7.1.0)
         """
         analysis_dir = self._make_analysis_project(
             protocol='10x_scRNAseq',
             include_cellranger_count=True,
             cellranger_pipelines=('cellranger',),
-            cellranger_samples=('PJB1','PJB2',))
+            cellranger_samples=('PJB1','PJB2',),
+            cellranger_version='7.1.0')
         project = AnalysisProject(analysis_dir)
         report((project,),filename=os.path.join(self.top_dir,
                                                 'report.PE.html'))
         self.assertTrue(os.path.exists(
             os.path.join(self.top_dir,'report.PE.html')))
 
-    def test_report_paired_end_cellranger_multi(self):
+    def test_report_paired_end_cellranger_count_800(self):
         """
-        report: paired-end data with cellranger 'multi'
+        report: paired-end data with cellranger 'count' (8.0.0)
+        """
+        analysis_dir = self._make_analysis_project(
+            protocol='10x_scRNAseq',
+            include_cellranger_count=True,
+            cellranger_pipelines=('cellranger',),
+            cellranger_samples=('PJB1','PJB2',),
+            cellranger_version='8.0.0')
+        project = AnalysisProject(analysis_dir)
+        report((project,),filename=os.path.join(self.top_dir,
+                                                'report.PE.html'))
+        self.assertTrue(os.path.exists(
+            os.path.join(self.top_dir,'report.PE.html')))
+
+    def test_report_paired_end_cellranger_multi_710(self):
+        """
+        report: paired-end data with cellranger 'multi' (7.1.0)
         """
         analysis_dir = self._make_analysis_project(
             protocol='10x_CellPlex',
             include_cellranger_multi=True,
-            cellranger_multi_samples=('PJB_CML1','PJB_CML2',))
+            cellranger_multi_samples=('PJB_CML1','PJB_CML2',),
+            cellranger_version='7.1.0')
         project = AnalysisProject(analysis_dir)
         report((project,),filename=os.path.join(self.top_dir,
                                                 'report.PE.html'))
         self.assertTrue(os.path.exists(
             os.path.join(self.top_dir,'report.PE.html')))
 
-    def test_report_paired_end_bad_cellranger_multi(self):
+    def test_report_paired_end_cellranger_multi_800(self):
         """
-        report: paired-end data with 'bad' 'cellranger_multi' subdir
+        report: paired-end data with cellranger 'multi' (8.0.0)
         """
         analysis_dir = self._make_analysis_project(
             protocol='10x_CellPlex',
-            cellranger_multi_samples=('PJB_CML1','PJB_CML2',))
+            include_cellranger_multi=True,
+            cellranger_multi_samples=('PJB_CML1','PJB_CML2',),
+            cellranger_version='8.0.0')
+        project = AnalysisProject(analysis_dir)
+        report((project,),filename=os.path.join(self.top_dir,
+                                                'report.PE.html'))
+        self.assertTrue(os.path.exists(
+            os.path.join(self.top_dir,'report.PE.html')))
+
+    def test_report_paired_end_bad_cellranger_multi_710(self):
+        """
+        report: paired-end data with 'bad' 'cellranger_multi' subdir (7.1.0)
+        """
+        analysis_dir = self._make_analysis_project(
+            protocol='10x_CellPlex',
+            cellranger_multi_samples=('PJB_CML1','PJB_CML2',),
+            cellranger_version='7.1.0')
         # Make a "bad" 'cellranger_multi' dir
         # i.e. doesn't conform to expected format
         bad_cellranger_multi_dir = os.path.join(analysis_dir,
@@ -176,9 +212,33 @@ class TestReportFunction(unittest.TestCase):
         self.assertTrue(os.path.exists(
             os.path.join(self.top_dir,'report.PE.html')))
 
-    def test_report_paired_end_cellranger_count_and_multi(self):
+    def test_report_paired_end_bad_cellranger_multi_800(self):
         """
-        report: paired-end data with cellranger 'count' and 'multi'
+        report: paired-end data with 'bad' 'cellranger_multi' subdir (8.0.0)
+        """
+        analysis_dir = self._make_analysis_project(
+            protocol='10x_CellPlex',
+            cellranger_multi_samples=('PJB_CML1','PJB_CML2',),
+            cellranger_version='8.0.0')
+        # Make a "bad" 'cellranger_multi' dir
+        # i.e. doesn't conform to expected format
+        bad_cellranger_multi_dir = os.path.join(analysis_dir,
+                                                "qc",
+                                                "cellranger_multi",
+                                                "PJB")
+        os.makedirs(bad_cellranger_multi_dir)
+        with open(os.path.join(bad_cellranger_multi_dir,"web_summary.html"),
+                  "wt") as fp:
+            fp.write("Placeholder")
+        project = AnalysisProject(analysis_dir)
+        report((project,),filename=os.path.join(self.top_dir,
+                                                'report.PE.html'))
+        self.assertTrue(os.path.exists(
+            os.path.join(self.top_dir,'report.PE.html')))
+
+    def test_report_paired_end_cellranger_count_and_multi_710(self):
+        """
+        report: paired-end data with cellranger 'count' and 'multi' (7.1.0)
         """
         analysis_dir = self._make_analysis_project(
             protocol='10x_CellPlex',
@@ -187,7 +247,27 @@ class TestReportFunction(unittest.TestCase):
             cellranger_pipelines=('cellranger',),
             # NB only GEX samples
             cellranger_samples=('PJB1_GEX',),
-            cellranger_multi_samples=('PJB_CML1','PJB_CML2',))
+            cellranger_multi_samples=('PJB_CML1','PJB_CML2',),
+            cellranger_version='7.1.0')
+        project = AnalysisProject(analysis_dir)
+        report((project,),filename=os.path.join(self.top_dir,
+                                                'report.PE.html'))
+        self.assertTrue(os.path.exists(
+            os.path.join(self.top_dir,'report.PE.html')))
+
+    def test_report_paired_end_cellranger_count_and_multi_800(self):
+        """
+        report: paired-end data with cellranger 'count' and 'multi' (8.0.0)
+        """
+        analysis_dir = self._make_analysis_project(
+            protocol='10x_CellPlex',
+            include_cellranger_multi=True,
+            include_cellranger_count=True,
+            cellranger_pipelines=('cellranger',),
+            # NB only GEX samples
+            cellranger_samples=('PJB1_GEX',),
+            cellranger_multi_samples=('PJB_CML1','PJB_CML2',),
+            cellranger_version='8.0.0')
         project = AnalysisProject(analysis_dir)
         report((project,),filename=os.path.join(self.top_dir,
                                                 'report.PE.html'))

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -14,6 +14,8 @@ from auto_process_ngs.mock10xdata import ATAC_SUMMARY
 from auto_process_ngs.mock10xdata import ATAC_SUMMARY_2_0_0
 from auto_process_ngs.mock10xdata import METRICS_SUMMARY
 from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY
+from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY_7_1_0
+from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY_8_0_0
 from auto_process_ngs.mock10xdata import MULTIOME_SUMMARY
 from auto_process_ngs.qc.utils import verify_qc
 from auto_process_ngs.qc.utils import report_qc
@@ -670,6 +672,100 @@ Cellranger version\t6.0.0
         self.assertEqual(AnalysisProject("PJB1",
                                          project_dir).info.number_of_cells,
                          10350)
+
+    def test_set_cell_count_for_cellplex_project_710(self):
+        """
+        set_cell_count_for_project: test for multiplexed data (CellPlex 7.1.0)
+        """
+        # Set up mock project
+        project_dir = self._make_mock_analysis_project(
+            "10xGenomics Chromium 3'v3",
+            "CellPlex")
+        # Build mock cellranger multi output directory
+        multi_dir = os.path.join(project_dir,
+                                 "qc",
+                                 "cellranger_multi",
+                                 "7.1.0",
+                                 "refdata-cellranger-gex-GRCh38-2020-A",
+                                 "outs")
+        mkdirs(multi_dir)
+        for sample in ("PBA","PBB",):
+            sample_dir = os.path.join(multi_dir,
+                                      "per_sample_outs",
+                                      sample)
+            mkdirs(sample_dir)
+            summary_file = os.path.join(sample_dir,
+                                        "metrics_summary.csv")
+            with open(summary_file,'wt') as fp:
+                fp.write(CELLPLEX_METRICS_SUMMARY_7_1_0)
+            web_summary = os.path.join(sample_dir,
+                                       "web_summary.html")
+            with open(web_summary,'wt') as fp:
+                fp.write("Placeholder for web_summary.html\n")
+        # Add QC info file
+        with open(os.path.join(project_dir,"qc","qc.info"),'wt') as fp:
+            fp.write("""Cellranger reference datasets\t/data/refdata-cellranger-gex-GRCh38-2020-A
+Cellranger version\t7.1.0
+""")
+        # Check initial cell count
+        print("Checking number of cells")
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         None)
+        # Update the cell counts
+        print("Updating number of cells")
+        set_cell_count_for_project(project_dir,source="multi")
+        # Check updated cell count
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         3138)
+
+    def test_set_cell_count_for_cellplex_project_800(self):
+        """
+        set_cell_count_for_project: test for multiplexed data (CellPlex 8.0.0)
+        """
+        # Set up mock project
+        project_dir = self._make_mock_analysis_project(
+            "10xGenomics Chromium 3'v3",
+            "CellPlex")
+        # Build mock cellranger multi output directory
+        multi_dir = os.path.join(project_dir,
+                                 "qc",
+                                 "cellranger_multi",
+                                 "8.0.0",
+                                 "refdata-cellranger-gex-GRCh38-2020-A",
+                                 "outs")
+        mkdirs(multi_dir)
+        for sample in ("PBA","PBB",):
+            sample_dir = os.path.join(multi_dir,
+                                      "per_sample_outs",
+                                      sample)
+            mkdirs(sample_dir)
+            summary_file = os.path.join(sample_dir,
+                                        "metrics_summary.csv")
+            with open(summary_file,'wt') as fp:
+                fp.write(CELLPLEX_METRICS_SUMMARY_8_0_0)
+            web_summary = os.path.join(sample_dir,
+                                       "web_summary.html")
+            with open(web_summary,'wt') as fp:
+                fp.write("Placeholder for web_summary.html\n")
+        # Add QC info file
+        with open(os.path.join(project_dir,"qc","qc.info"),'wt') as fp:
+            fp.write("""Cellranger reference datasets\t/data/refdata-cellranger-gex-GRCh38-2020-A
+Cellranger version\t8.0.0
+""")
+        # Check initial cell count
+        print("Checking number of cells")
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         None)
+        # Update the cell counts
+        print("Updating number of cells")
+        set_cell_count_for_project(project_dir,source="multi")
+        # Check updated cell count
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         3164)
 
     def test_set_cell_count_for_cellplex_project_with_count(self):
         """

--- a/auto_process_ngs/test/qc/test_verification.py
+++ b/auto_process_ngs/test/qc/test_verification.py
@@ -515,7 +515,7 @@ class TestQCVerifier(unittest.TestCase):
         # Explicitly match version with any reference
         self.assertTrue(qc_verifier.verify_qc_module('cellranger_count',
                                                      samples=('PJB1','PJB2'),
-                                                     cellranger_version='6.1.2',
+                                                     cellranger_version='7.1.0',
                                                      cellranger_refdata='*'))
         # Explicitly match reference with any version
         self.assertTrue(qc_verifier.verify_qc_module('cellranger_count',
@@ -534,7 +534,7 @@ class TestQCVerifier(unittest.TestCase):
         self.assertFalse(
             qc_verifier.verify_qc_module('cellranger_count',
                                          samples=('PJB1','PJB2'),
-                                         cellranger_version='6.1.2',
+                                         cellranger_version='7.1.0',
                                          cellranger_refdata=\
                                          'refdata-cellranger-2.0.0'))
         # Missing outputs for one sample
@@ -547,7 +547,7 @@ class TestQCVerifier(unittest.TestCase):
         self.assertFalse(
             qc_verifier.verify_qc_module('cellranger_count',
                                          samples=('PJB1','PJB2'),
-                                         cellranger_version='6.1.2',
+                                         cellranger_version='7.1.0',
                                          cellranger_refdata=\
                                          'refdata-cellranger-2020-A'))
         # Empty QC dir
@@ -732,7 +732,7 @@ class TestQCVerifier(unittest.TestCase):
         self.assertTrue(qc_verifier.verify_qc_module('cellranger_multi'))
         # Explicitly match version with any reference
         self.assertTrue(qc_verifier.verify_qc_module('cellranger_multi',
-                                                     cellranger_version='6.1.2',
+                                                     cellranger_version='7.1.0',
                                                      cellranger_refdata='*'))
         # Explicitly match reference with any version
         self.assertTrue(qc_verifier.verify_qc_module('cellranger_multi',
@@ -748,7 +748,7 @@ class TestQCVerifier(unittest.TestCase):
         # Fail if reference not found
         self.assertFalse(
             qc_verifier.verify_qc_module('cellranger_multi',
-                                         cellranger_version='6.1.2',
+                                         cellranger_version='7.1.0',
                                          cellranger_refdata=\
                                          'refdata-cellranger-2.0.0'))
         # Missing outputs for one sample
@@ -761,7 +761,7 @@ class TestQCVerifier(unittest.TestCase):
         self.assertFalse(
             qc_verifier.verify_qc_module('cellranger_multi',
                                          samples=('PJB1','PJB2'),
-                                         cellranger_version='6.1.2',
+                                         cellranger_version='7.1.0',
                                          cellranger_refdata=\
                                          'refdata-cellranger-2020-A'))
         # Empty QC dir
@@ -1100,7 +1100,7 @@ class TestQCVerifier(unittest.TestCase):
             fastq_screens=('model_organisms',
                            'other_organisms',
                            'rRNA'),
-            cellranger_version="6.1.2",
+            cellranger_version="7.1.0",
             cellranger_refdata="/data/refdata-cellranger-2020-A"))
 
     def test_qcverifier_verify_10x_cellranger_count_different_version(self):
@@ -1436,7 +1436,7 @@ class TestQCVerifier(unittest.TestCase):
             star_index="/data/star/hg38",
             annotation_bed="/data/annotation/hg38.bed",
             annotation_gtf="/data/annotation/hg38.gtf",
-            cellranger_version="6.1.2",
+            cellranger_version="7.1.0",
             cellranger_refdata="/data/refdata-cellranger-2020-A"))
 
     def test_qcverifier_verify_10x_cellranger_multi_no_config(self):
@@ -1460,7 +1460,7 @@ class TestQCVerifier(unittest.TestCase):
             fastq_screens=('model_organisms',
                            'other_organisms',
                            'rRNA'),
-            cellranger_version="6.1.2",
+            cellranger_version="7.1.0",
             cellranger_refdata="/data/refdata-cellranger-2020-A"))
 
 class TestParseQCModuleSpec(unittest.TestCase):

--- a/auto_process_ngs/test/tenx/test_metrics.py
+++ b/auto_process_ngs/test/tenx/test_metrics.py
@@ -13,6 +13,8 @@ from auto_process_ngs.mock10xdata import ATAC_SUMMARY_2_0_0
 from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY
 from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY_7_1_0
 from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY_CSP_7_1_0
+from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY_8_0_0
+from auto_process_ngs.mock10xdata import FLEX_METRICS_SUMMARY_8_0_0
 from auto_process_ngs.mock10xdata import MULTIOME_SUMMARY
 from auto_process_ngs.mock10xdata import MULTIOME_SUMMARY_2_0_0
 from auto_process_ngs.tenx.metrics import *
@@ -170,6 +172,7 @@ class TestMultiplexSummary(unittest.TestCase):
             fp.write(CELLPLEX_METRICS_SUMMARY)
         m = MultiplexSummary(summary_csv)
         self.assertEqual(m.cells,5175)
+        self.assertEqual(m.mean_reads_per_cell,28322)
         self.assertEqual(m.median_reads_per_cell,20052)
         self.assertEqual(m.median_genes_per_cell,3086)
         self.assertEqual(m.total_genes_detected,21260)
@@ -183,6 +186,7 @@ class TestMultiplexSummary(unittest.TestCase):
             fp.write(CELLPLEX_METRICS_SUMMARY_7_1_0)
         m = MultiplexSummary(summary_csv)
         self.assertEqual(m.cells,1569)
+        self.assertEqual(m.mean_reads_per_cell,52483)
         self.assertEqual(m.median_reads_per_cell,26198)
         self.assertEqual(m.median_genes_per_cell,2468)
         self.assertEqual(m.total_genes_detected,20942)
@@ -196,9 +200,40 @@ class TestMultiplexSummary(unittest.TestCase):
             fp.write(CELLPLEX_METRICS_SUMMARY_CSP_7_1_0)
         m = MultiplexSummary(summary_csv)
         self.assertEqual(m.cells,1582)
+        self.assertEqual(m.mean_reads_per_cell,24975)
         self.assertEqual(m.median_reads_per_cell,18376)
         self.assertEqual(m.median_genes_per_cell,2042)
         self.assertEqual(m.total_genes_detected,23199)
         self.assertEqual(m.median_umi_counts_per_cell,5789)
         self.assertEqual(m.fetch('Median UMI counts per cell',
                                  'Antibody Capture'),2025)
+
+    def test_multiplex_summary_cellranger_8_0_0(self):
+        """MultiplexSummary: extract CellPlex metrics (Cellranger 8.0.0)
+        """
+        summary_csv = os.path.join(self.wd,"metrics_summary.csv")
+        with open(summary_csv,'w') as fp:
+            fp.write(CELLPLEX_METRICS_SUMMARY_8_0_0)
+        m = MultiplexSummary(summary_csv)
+        self.assertEqual(m.cells,1582)
+        self.assertEqual(m.mean_reads_per_cell,20614)
+        self.assertEqual(m.median_genes_per_cell,2042)
+        self.assertEqual(m.total_genes_detected,23199)
+        self.assertEqual(m.median_umi_counts_per_cell,5789)
+        self.assertRaises(MissingMetricError,
+                          getattr,m,"median_reads_per_cell")
+
+    def test_flex_summary_cellranger_8_0_0(self):
+        """MultiplexSummary: extract Flex metrics (Cellranger 8.0.0)
+        """
+        summary_csv = os.path.join(self.wd,"metrics_summary.csv")
+        with open(summary_csv,'w') as fp:
+            fp.write(FLEX_METRICS_SUMMARY_8_0_0)
+        m = MultiplexSummary(summary_csv)
+        self.assertEqual(m.cells,2302)
+        self.assertEqual(m.mean_reads_per_cell,27485)
+        self.assertEqual(m.median_genes_per_cell,2465)
+        self.assertEqual(m.total_genes_detected,15937)
+        self.assertEqual(m.median_umi_counts_per_cell,4202)
+        self.assertRaises(MissingMetricError,
+                          getattr,m,"median_reads_per_cell")

--- a/auto_process_ngs/test/tenx/test_utils.py
+++ b/auto_process_ngs/test/tenx/test_utils.py
@@ -367,6 +367,13 @@ class TestCellrangerInfo(unittest.TestCase):
             fp.write("#!/bin/bash\necho cellranger cellranger-7.1.0")
         os.chmod(cellranger_710,0o775)
         return cellranger_710
+    def _make_mock_cellranger_800(self):
+        # Make a fake cellranger 8.0.0 executable
+        cellranger_800 = os.path.join(self.wd,"cellranger")
+        with open(cellranger_800,'w') as fp:
+            fp.write("#!/bin/bash\necho cellranger cellranger-8.0.0")
+        os.chmod(cellranger_800,0o775)
+        return cellranger_800
     def _make_mock_cellranger_atac_101(self):
         # Make a fake cellranger-atac 1.0.1 executable
         cellranger_atac_101 = os.path.join(self.wd,"cellranger-atac")
@@ -434,6 +441,13 @@ class TestCellrangerInfo(unittest.TestCase):
         cellranger = self._make_mock_cellranger_710()
         self.assertEqual(cellranger_info(path=cellranger),
                          (cellranger,'cellranger','7.1.0'))
+
+    def test_cellranger_800(self):
+        """cellranger_info: collect info for cellranger 8.0.0
+        """
+        cellranger = self._make_mock_cellranger_800()
+        self.assertEqual(cellranger_info(path=cellranger),
+                         (cellranger,'cellranger','8.0.0'))
 
     def test_cellranger_atac_101(self):
         """cellranger_info: collect info for cellranger-atac 1.0.1

--- a/auto_process_ngs/test/tenx/test_utils.py
+++ b/auto_process_ngs/test/tenx/test_utils.py
@@ -646,9 +646,9 @@ MULTIPLEXED_SAMPLE,CMO1|CMO2|...,DESCRIPTION
                                         if not line.startswith('##')])
         self.assertEqual(expected_content,actual_content)
 
-    def test_make_multi_config_template_cellplex(self):
+    def test_make_multi_config_template_cellplex_710(self):
         """
-        make_multi_config_template: check CellPlex template
+        make_multi_config_template: check CellPlex template (7.1.0)
         """
         expected_content = """[gene-expression]
 reference,/data/mm10_transcriptome
@@ -673,16 +673,52 @@ MULTIPLEXED_SAMPLE,CMO1|CMO2|...,DESCRIPTION
                                    reference="/data/mm10_transcriptome",
                                    fastq_dir="/runs/novaseq_50/fastqs",
                                    samples=("PJB_CML","PJB_GEX"),
-                                   library_type="CellPlex")
+                                   library_type="CellPlex",
+                                   cellranger_version="7.0.0")
         self.assertTrue(os.path.exists(out_file))
         with open(out_file,'rt') as fp:
             actual_content = '\n'.join([line for line in fp.read().split('\n')
                                         if not line.startswith('##')])
         self.assertEqual(expected_content,actual_content)
 
-    def test_make_multi_config_template_flex(self):
+    def test_make_multi_config_template_cellplex_800(self):
         """
-        make_multi_config_template: check fixed RNA profiling (Flex) template
+        make_multi_config_template: check CellPlex template (8.0.0)
+        """
+        expected_content = """[gene-expression]
+reference,/data/mm10_transcriptome
+#force-cells,n
+create-bam,true
+#cmo-set,/path/to/custom/cmo/reference
+
+#[feature]
+#reference,/path/to/feature/reference
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB_CML,/runs/novaseq_50/fastqs,any,PJB_CML,[Gene Expression|Multiplexing Capture],
+PJB_GEX,/runs/novaseq_50/fastqs,any,PJB_GEX,[Gene Expression|Multiplexing Capture],
+
+[samples]
+sample_id,cmo_ids,description
+MULTIPLEXED_SAMPLE,CMO1|CMO2|...,DESCRIPTION
+"""
+        out_file = os.path.join(self.wd,"10x_multi_config.csv")
+        make_multi_config_template(out_file,
+                                   reference="/data/mm10_transcriptome",
+                                   fastq_dir="/runs/novaseq_50/fastqs",
+                                   samples=("PJB_CML","PJB_GEX"),
+                                   library_type="CellPlex",
+                                   cellranger_version="8.0.0")
+        self.assertTrue(os.path.exists(out_file))
+        with open(out_file,'rt') as fp:
+            actual_content = '\n'.join([line for line in fp.read().split('\n')
+                                        if not line.startswith('##')])
+        self.assertEqual(expected_content,actual_content)
+
+    def test_make_multi_config_template_flex_700(self):
+        """
+        make_multi_config_template: check Flex template (7.1.0)
         """
         expected_content = """[gene-expression]
 reference,/data/mm10_transcriptome
@@ -709,16 +745,54 @@ MULTIPLEXED_SAMPLE,BC001|BC002|...,DESCRIPTION
                                    fastq_dir="/runs/novaseq_50/fastqs",
                                    samples=("PJB_Flex",),
                                    no_bam=True,
-                                   library_type="Flex")
+                                   library_type="Flex",
+                                   cellranger_version="7.1.0")
         self.assertTrue(os.path.exists(out_file))
         with open(out_file,'rt') as fp:
             actual_content = '\n'.join([line for line in fp.read().split('\n')
                                         if not line.startswith('##')])
         self.assertEqual(expected_content,actual_content)
 
-    def test_make_multi_config_template_immune_profiling(self):
+    def test_make_multi_config_template_flex_800(self):
         """
-        make_multi_config_template: check Single Cell Immune Profiling template
+        make_multi_config_template: check Flex template (8.0.0)
+        """
+        expected_content = """[gene-expression]
+reference,/data/mm10_transcriptome
+probe-set,/data/mm10_probe_set.csv
+#force-cells,n
+create-bam,false
+#cmo-set,/path/to/custom/cmo/reference
+
+#[feature]
+#reference,/path/to/feature/reference
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB_Flex,/runs/novaseq_50/fastqs,any,PJB_Flex,[Gene Expression|Antibody Capture],
+
+[samples]
+sample_id,probe_barcode_ids,description
+MULTIPLEXED_SAMPLE,BC001|BC002|...,DESCRIPTION
+"""
+        out_file = os.path.join(self.wd,"10x_multi_config.csv")
+        make_multi_config_template(out_file,
+                                   reference="/data/mm10_transcriptome",
+                                   probe_set="/data/mm10_probe_set.csv",
+                                   fastq_dir="/runs/novaseq_50/fastqs",
+                                   samples=("PJB_Flex",),
+                                   no_bam=True,
+                                   library_type="Flex",
+                                   cellranger_version="8.0.0")
+        self.assertTrue(os.path.exists(out_file))
+        with open(out_file,'rt') as fp:
+            actual_content = '\n'.join([line for line in fp.read().split('\n')
+                                        if not line.startswith('##')])
+        self.assertEqual(expected_content,actual_content)
+
+    def test_make_multi_config_template_immune_profiling_710(self):
+        """
+        make_multi_config_template: check Single Cell Immune Profiling template (7.0.0)
         """
         expected_content = """[gene-expression]
 reference,/data/mm10_transcriptome
@@ -742,7 +816,42 @@ PJB_GEX,/runs/novaseq_50/fastqs,any,PJB_GEX,[Gene Expression|Antibody Capture|VD
                                    reference="/data/mm10_transcriptome",
                                    fastq_dir="/runs/novaseq_50/fastqs",
                                    samples=("PJB_CML","PJB_GEX"),
-                                   library_type="Single Cell Immune Profiling")
+                                   library_type="Single Cell Immune Profiling",
+                                   cellranger_version="7.1.0")
+        self.assertTrue(os.path.exists(out_file))
+        with open(out_file,'rt') as fp:
+            actual_content = '\n'.join([line for line in fp.read().split('\n')
+                                        if not line.startswith('##')])
+        self.assertEqual(expected_content,actual_content)
+
+    def test_make_multi_config_template_immune_profiling_800(self):
+        """
+        make_multi_config_template: check Single Cell Immune Profiling template (8.0.0)
+        """
+        expected_content = """[gene-expression]
+reference,/data/mm10_transcriptome
+#force-cells,n
+create-bam,true
+#cmo-set,/path/to/custom/cmo/reference
+
+#[feature]
+#reference,/path/to/feature/reference
+
+#[vdj]
+#reference,/path/to/vdj/reference
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB_CML,/runs/novaseq_50/fastqs,any,PJB_CML,[Gene Expression|Antibody Capture|VDJ-B|VDJ-T],
+PJB_GEX,/runs/novaseq_50/fastqs,any,PJB_GEX,[Gene Expression|Antibody Capture|VDJ-B|VDJ-T],
+"""
+        out_file = os.path.join(self.wd,"10x_multi_config.csv")
+        make_multi_config_template(out_file,
+                                   reference="/data/mm10_transcriptome",
+                                   fastq_dir="/runs/novaseq_50/fastqs",
+                                   samples=("PJB_CML","PJB_GEX"),
+                                   library_type="Single Cell Immune Profiling",
+                                   cellranger_version="8.0.0")
         self.assertTrue(os.path.exists(out_file))
         with open(out_file,'rt') as fp:
             actual_content = '\n'.join([line for line in fp.read().split('\n')


### PR DESCRIPTION
Updates to the Fastq generation and QC pipelines and supporting functions, for compatibility with Cellranger 8.0.0.

Significant changes in Cellranger 8.0.0 which need to be accommodated in the QC pipeline are:

* `cellranger count` now has a required `--create-bam` command line option, which must be set to either `true` or `false`. Recommended default is `true` (i.e. BAM file will be created) if unsure;
* `cellranger multi` replaces the `no-bam` configuration option with a new `create-bam` option (which is essentially the same as the `--create-bam` command line option for `count`)

Creating BAM files will produce larger overall output sizes and can also result in longer compute times, but may not be particularly advantageous in all cases, specifically for Flex datasets it is recommended to disable BAM file creation (see https://kb.10xgenomics.com/hc/en-us/articles/24292856143885-Understanding-the-create-bam-Parameter-in-Cell-Ranger-v8-0).

The multi config template generation code has therefore been updated to take the target Cellranger version as optional input; the `setup_analysis_dirs` command supplies the version from the processing pipeline when generating templates (which should be consistent in most cases).

There is also a minor change to the per-sample `metrics.csv` files produced by 8.0.0 compared to earlier versions, in that 8.0.0 no longer outputs a `median_reads_per_cell` value (which is currently reported as part of the QC reporting); the `mean_reads_per_cell` value will be reported instead for version 8.0.0.

Finally, although this PR implements compatibility with Cellranger 8.0.0, the default version for testing remains at 7.1.0.