### PR TITLE
Explicitly store list of multiplexed samples in project metadata

### DIFF
--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -454,6 +454,12 @@ def archive(ap,archive_dir=None,platform=None,year=None,
                               project.name)
                     except FileNotFoundError:
                         pass
+                elif project.info.single_cell_platform == "Parse Evercode":
+                    # Set to unknown for Parse data
+                    project.info['multiplexed_samples'] = '?'
+                    project_info_updated = True
+                    print("Project '%s': updated multiplexed sample info" %
+                          project.name)
             # Save the updated information
             if project_info_updated:
                 project.info.save()

--- a/auto_process_ngs/metadata.py
+++ b/auto_process_ngs/metadata.py
@@ -417,6 +417,7 @@ class AnalysisProjectInfo(MetadataDict):
     primary_fastq_dir: the primary subdir with FASTQ files
     samples: textual description of the samples in the project
     biological_samples: comma-separated sample names with biological data
+    multiplexed_samples: comma-separated names of multiplexed samples
     comments: free-text comments
 
     """
@@ -445,6 +446,7 @@ class AnalysisProjectInfo(MetadataDict):
                                   'primary_fastq_dir':'Primary fastqs',
                                   'samples':'Samples',
                                   'biological_samples': 'Biological samples',
+                                  'multiplexed_samples': 'Multiplexed samples',
                                   'comments':'Comments',
                               },
                               order = (

--- a/auto_process_ngs/test/commands/test_archive_cmd.py
+++ b/auto_process_ngs/test/commands/test_archive_cmd.py
@@ -677,6 +677,105 @@ poll_interval = 0.5
             f = os.path.join(final_archive_dir,f)
             self.assertTrue(os.path.exists(f))
 
+    def test_archive_updates_cellplex_multiplexed_sample_metadata(self):
+        """archive: test archiving updates multiplexed sample metadata for 10x Cellplex
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901" },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "CellPlex",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Single cell platform": "10xGenomics Chromium 3'v3",
+                        "Multiplexed samples": ".",
+                        "Number of cells": 1311 },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston",
+                         "Multiplexed samples": "." }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add a cellranger multi config.csv file
+        with open(os.path.join(mockdir.dirn,
+                               "AB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(mockdir.dirn,
+                                     "AB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+AB1,%s,any,AB1,gene expression,
+AB2,%s,any,AB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+ABM1,CMO301,ABM1
+ABM2,CMO302,ABM2
+ABM3,CMO303,ABM3
+ABM4,CMO304,ABM4
+""" % (fastq_dir,fastq_dir))
+        # Make a mock archive directory
+        archive_dir = os.path.join(self.dirn,"archive")
+        final_dir = os.path.join(archive_dir,
+                                 "2017",
+                                 "miseq")
+        os.makedirs(final_dir)
+        self.assertTrue(os.path.isdir(final_dir))
+        self.assertEqual(len(os.listdir(final_dir)),0)
+        # Make autoprocess instance and set required metadata
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=self.settings)
+        ap.set_metadata("source","testing")
+        ap.set_metadata("run_number","87")
+        # Add QC outputs to projects
+        for p in ap.get_analysis_projects():
+            UpdateAnalysisProject(p).add_qc_outputs()
+        # Do archiving op
+        status = archive(ap,
+                         archive_dir=archive_dir,
+                         year='2017',platform='miseq',
+                         read_only_fastqs=False,
+                         final=True)
+        self.assertEqual(status,0)
+        # Check that final dir exists
+        final_archive_dir = os.path.join(
+            final_dir,
+            "170901_M00879_0087_000000000-AGEW9_analysis")
+        self.assertTrue(os.path.exists(final_archive_dir))
+        self.assertEqual(len(os.listdir(final_dir)),1)
+        # Check the multiplexed sample information
+        dirs = ("AB","CDE")
+        for d in dirs:
+            metadata_file = os.path.join(final_archive_dir,
+                                         d,
+                                         "README.info")
+            got_multiplexed_samples = False
+            with open(metadata_file,'rt') as fp:
+                for line in fp:
+                    if line.startswith("Multiplexed samples"):
+                        got_multiplexed_samples = True
+                        line = line.rstrip('\n')
+                        if d == "AB":
+                            self.assertEqual(
+                                line,
+                                "Multiplexed samples\tABM1,ABM2,ABM3,ABM4")
+                        else:
+                            self.assertEqual(
+                                line,
+                                "Multiplexed samples\t.")
+                        break
+            self.assertTrue(got_multiplexed_samples,
+                            "No multiplexed sample info for '%s'" % d)
+
     def test_archive_rewrites_qc_info_fastq_dir(self):
         """archive: test archiving rewrites the Fastq dir in 'qc.info'
         """

--- a/auto_process_ngs/test/commands/test_archive_cmd.py
+++ b/auto_process_ngs/test/commands/test_archive_cmd.py
@@ -678,7 +678,7 @@ poll_interval = 0.5
             self.assertTrue(os.path.exists(f))
 
     def test_archive_updates_cellplex_multiplexed_sample_metadata(self):
-        """archive: test archiving updates multiplexed sample metadata for 10x Cellplex
+        """archive: archiving updates multiplexed sample metadata for 10x Cellplex
         """
         # Make a mock auto-process directory
         mockdir = MockAnalysisDirFactory.bcl2fastq2(
@@ -768,6 +768,104 @@ ABM4,CMO304,ABM4
                             self.assertEqual(
                                 line,
                                 "Multiplexed samples\tABM1,ABM2,ABM3,ABM4")
+                        else:
+                            self.assertEqual(
+                                line,
+                                "Multiplexed samples\t.")
+                        break
+            self.assertTrue(got_multiplexed_samples,
+                            "No multiplexed sample info for '%s'" % d)
+
+    def test_archive_updates_parse_multiplexed_sample_metadata(self):
+        """archive: archiving updates multiplexed sample metadata for Parse Evercode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901" },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "scRNA-seq",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Single cell platform": "Parse Evercode",
+                        "Multiplexed samples": "." },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston",
+                         "Multiplexed samples": "." }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add a cellranger multi config.csv file
+        with open(os.path.join(mockdir.dirn,
+                               "AB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(mockdir.dirn,
+                                     "AB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+AB1,%s,any,AB1,gene expression,
+AB2,%s,any,AB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+ABM1,CMO301,ABM1
+ABM2,CMO302,ABM2
+ABM3,CMO303,ABM3
+ABM4,CMO304,ABM4
+""" % (fastq_dir,fastq_dir))
+        # Make a mock archive directory
+        archive_dir = os.path.join(self.dirn,"archive")
+        final_dir = os.path.join(archive_dir,
+                                 "2017",
+                                 "miseq")
+        os.makedirs(final_dir)
+        self.assertTrue(os.path.isdir(final_dir))
+        self.assertEqual(len(os.listdir(final_dir)),0)
+        # Make autoprocess instance and set required metadata
+        ap = AutoProcess(analysis_dir=mockdir.dirn,
+                         settings=self.settings)
+        ap.set_metadata("source","testing")
+        ap.set_metadata("run_number","87")
+        # Add QC outputs to projects
+        for p in ap.get_analysis_projects():
+            UpdateAnalysisProject(p).add_qc_outputs()
+        # Do archiving op
+        status = archive(ap,
+                         archive_dir=archive_dir,
+                         year='2017',platform='miseq',
+                         read_only_fastqs=False,
+                         final=True)
+        self.assertEqual(status,0)
+        # Check that final dir exists
+        final_archive_dir = os.path.join(
+            final_dir,
+            "170901_M00879_0087_000000000-AGEW9_analysis")
+        self.assertTrue(os.path.exists(final_archive_dir))
+        self.assertEqual(len(os.listdir(final_dir)),1)
+        # Check the multiplexed sample information
+        dirs = ("AB","CDE")
+        for d in dirs:
+            metadata_file = os.path.join(final_archive_dir,
+                                         d,
+                                         "README.info")
+            got_multiplexed_samples = False
+            with open(metadata_file,'rt') as fp:
+                for line in fp:
+                    if line.startswith("Multiplexed samples"):
+                        got_multiplexed_samples = True
+                        line = line.rstrip('\n')
+                        if d == "AB":
+                            self.assertEqual(
+                                line,
+                                "Multiplexed samples\t?")
                         else:
                             self.assertEqual(
                                 line,

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -451,6 +451,199 @@ Summary of data in 'bcl2fastq' dir:
                        expected.split('\n')):
             self.assertEqual(o,e)
 
+    def test_report_info_explicit_multiplexed_samples(self):
+        """report: report run with multiplexed samples in 'info' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87, },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "RNA-seq",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Multiplexed samples": "M1,M2,M3,M4" },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate concise report
+        expected = """Run ID       : MISEQ_170901#87
+Directory    : %s
+Platform     : miseq
+Unaligned dir: bcl2fastq
+
+Summary of data in 'bcl2fastq' dir:
+
+- AB: AB1-2 (2 paired end samples)
+- CDE: CDE3-4 (2 paired end samples)
+
+3 analysis projects:
+
+- AB
+  --
+  User    : Alison Bell
+  PI      : Audrey Bower
+  Library : RNA-seq
+  SC Plat.: None
+  Organism: Human
+  Dir     : AB
+  #samples: 4 multiplexed (2 physical)
+  #cells  : 
+  Samples : M1-4 (AB1-2)
+  QC      : not verified
+  Comments: None
+
+- CDE
+  ---
+  User    : Charles David Edwards
+  PI      : Colin Delaney Eccleston
+  Library : ChIP-seq
+  SC Plat.: None
+  Organism: Mouse
+  Dir     : CDE
+  #samples: 2
+  #cells  : 
+  Samples : CDE3-4
+  QC      : not verified
+  Comments: None
+
+- undetermined
+  ------------
+  User    : None
+  PI      : None
+  Library : None
+  SC Plat.: None
+  Organism: None
+  Dir     : undetermined
+  #samples: 1
+  #cells  : 
+  Samples : Undetermined
+  QC      : not verified
+  Comments: None""" % mockdir.dirn
+        for o,e in zip(report_info(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
+    def test_report_info_no_projects(self):
+        """report: report run with no projects in 'info' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87, },
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate concise report
+        expected = """Run ID       : MISEQ_170901#87
+Directory    : %s
+Platform     : miseq
+Unaligned dir: bcl2fastq
+
+Summary of data in 'bcl2fastq' dir:
+
+- AB: AB1-2 (2 paired end samples)
+- CDE: CDE3-4 (2 paired end samples)
+
+No analysis projects found""" % mockdir.dirn
+        for o,e in zip(report_info(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
+    def test_report_info_explicit_unknown_multiplexed_samples(self):
+        """report: report run with "unknown" multiplexed samples in 'info' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87, },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "RNA-seq",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Multiplexed samples": "?" },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate concise report
+        expected = """Run ID       : MISEQ_170901#87
+Directory    : %s
+Platform     : miseq
+Unaligned dir: bcl2fastq
+
+Summary of data in 'bcl2fastq' dir:
+
+- AB: AB1-2 (2 paired end samples)
+- CDE: CDE3-4 (2 paired end samples)
+
+3 analysis projects:
+
+- AB
+  --
+  User    : Alison Bell
+  PI      : Audrey Bower
+  Library : RNA-seq
+  SC Plat.: None
+  Organism: Human
+  Dir     : AB
+  #samples: ? multiplexed (2 physical)
+  #cells  : 
+  Samples : ? (AB1-2)
+  QC      : not verified
+  Comments: None
+
+- CDE
+  ---
+  User    : Charles David Edwards
+  PI      : Colin Delaney Eccleston
+  Library : ChIP-seq
+  SC Plat.: None
+  Organism: Mouse
+  Dir     : CDE
+  #samples: 2
+  #cells  : 
+  Samples : CDE3-4
+  QC      : not verified
+  Comments: None
+
+- undetermined
+  ------------
+  User    : None
+  PI      : None
+  Library : None
+  SC Plat.: None
+  Organism: None
+  Dir     : undetermined
+  #samples: 1
+  #cells  : 
+  Samples : Undetermined
+  QC      : not verified
+  Comments: None""" % mockdir.dirn
+        for o,e in zip(report_info(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
     def test_report_info_no_projects(self):
         """report: report run with no projects in 'info' mode
         """
@@ -612,7 +805,7 @@ ABM4,CMO304,ABM4
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Generate concise report
         self.assertEqual(report_concise(ap),
-                         "Paired end: 'AB': Alison Bell, Human 10xGenomics Chromium 3'v3 CellPlex (PI: Audrey Bower) (4 samples/1311 cells); 'CDE': Charles David Edwards, Mouse ChIP-seq (PI: Colin Delaney Eccleston) (2 samples)")
+                         "Paired end: 'AB': Alison Bell, Human 10xGenomics Chromium 3'v3 CellPlex (PI: Audrey Bower) (4 multiplexed samples/1311 cells); 'CDE': Charles David Edwards, Mouse ChIP-seq (PI: Colin Delaney Eccleston) (2 samples)")
 
     def test_report_concise_10x_flex(self):
         """report: report 10xGenomics Flex run in 'concise' mode
@@ -664,7 +857,69 @@ ABF4,BC004,ABF4
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Generate concise report
         self.assertEqual(report_concise(ap),
-                         "Paired end: 'AB': Alison Bell, Human 10xGenomics Chromium 3'v3 Flex (PI: Audrey Bower) (4 samples/1311 cells); 'CDE': Charles David Edwards, Mouse ChIP-seq (PI: Colin Delaney Eccleston) (2 samples)")
+                         "Paired end: 'AB': Alison Bell, Human 10xGenomics Chromium 3'v3 Flex (PI: Audrey Bower) (4 multiplexed samples/1311 cells); 'CDE': Charles David Edwards, Mouse ChIP-seq (PI: Colin Delaney Eccleston) (2 samples)")
+
+    def test_report_concise_multiplexed_samples(self):
+        """report: report run with multiplexed samples in 'concise' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "sequencer_model": "MiSeq" },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "RNA-seq",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Sequencer model": "MiSeq",
+                        "Multiplexed samples": "M1,M2,M3,M4" },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "MiSeq" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate concise report
+        self.assertEqual(report_concise(ap),
+                         "Paired end: 'AB': Alison Bell, Human RNA-seq (PI: Audrey Bower) (4 multiplexed samples); 'CDE': Charles David Edwards, Mouse ChIP-seq (PI: Colin Delaney Eccleston) (2 samples)")
+
+    def test_report_concise_unknown_multiplexed_samples(self):
+        """report: report run with "unknown" multiplexed samples in 'concise' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "sequencer_model": "MiSeq" },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "RNA-seq",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Sequencer model": "MiSeq",
+                        "Multiplexed samples": "?" },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "MiSeq" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate concise report
+        self.assertEqual(report_concise(ap),
+                         "Paired end: 'AB': Alison Bell, Human RNA-seq (PI: Audrey Bower) (? multiplexed samples); 'CDE': Charles David Edwards, Mouse ChIP-seq (PI: Colin Delaney Eccleston) (2 samples)")
 
     def test_report_concise_no_projects(self):
         """report: report run with no projects in 'concise' mode
@@ -926,8 +1181,8 @@ Bcl2fastq : bcl2fastq 2.17.1.14
 Cellranger: cellranger 3.0.1
 
 2 projects:
-- 'AB':  Alison Bell           Human CellPlex (10xGenomics Chromium 3'v3) 4 samples/1311 cells (PI Audrey Bower)           
-- 'CDE': Charles David Edwards Mouse ChIP-seq                             2 samples            (PI Colin Delaney Eccleston)
+- 'AB':  Alison Bell           Human CellPlex (10xGenomics Chromium 3'v3) 4 multiplexed samples/1311 cells (PI Audrey Bower)           
+- 'CDE': Charles David Edwards Mouse ChIP-seq                             2 samples                        (PI Colin Delaney Eccleston)
 
 Additional notes/comments:
 - CDE: Repeat of previous run
@@ -1003,8 +1258,108 @@ Bcl2fastq : bcl2fastq 2.17.1.14
 Cellranger: cellranger 3.0.1
 
 2 projects:
-- 'AB':  Alison Bell           Human Flex (10xGenomics Chromium 3'v3) 4 samples/1311 cells (PI Audrey Bower)           
-- 'CDE': Charles David Edwards Mouse ChIP-seq                         2 samples            (PI Colin Delaney Eccleston)
+- 'AB':  Alison Bell           Human Flex (10xGenomics Chromium 3'v3) 4 multiplexed samples/1311 cells (PI Audrey Bower)           
+- 'CDE': Charles David Edwards Mouse ChIP-seq                         2 samples                        (PI Colin Delaney Eccleston)
+
+Additional notes/comments:
+- CDE: Repeat of previous run
+""" % mockdir.dirn
+        for o,e in zip(report_summary(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
+    def test_report_summary_multiplexed_samples(self):
+        """report: report run with multiplexed samples in 'summary' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "sequencer_model": "MiSeq" },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "RNA-seq",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Sequencer model": "MiSeq",
+                        "Multiplexed samples": "M1,M2,M3,M4" },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "MiSeq",
+                         "Comments": "Repeat of previous run" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate summary report
+        expected = """MISEQ run #87 datestamped 170901
+================================
+Run name : 170901_M00879_0087_000000000-AGEW9
+Reference: MISEQ_170901#87
+Platform : MISEQ
+Sequencer: MiSeq
+Directory: %s
+Endedness: Paired end
+Bcl2fastq: Unknown
+
+2 projects:
+- 'AB':  Alison Bell           Human RNA-seq  4 multiplexed samples (PI Audrey Bower)           
+- 'CDE': Charles David Edwards Mouse ChIP-seq 2 samples             (PI Colin Delaney Eccleston)
+
+Additional notes/comments:
+- CDE: Repeat of previous run
+""" % mockdir.dirn
+        for o,e in zip(report_summary(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
+    def test_report_summary_unknown_multiplexed_samples(self):
+        """report: report run with "unknown" multiplexed samples in 'summary' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "sequencer_model": "MiSeq" },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "RNA-seq",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Sequencer model": "MiSeq",
+                        "Multiplexed samples": "?" },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "MiSeq",
+                         "Comments": "Repeat of previous run" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate summary report
+        expected = """MISEQ run #87 datestamped 170901
+================================
+Run name : 170901_M00879_0087_000000000-AGEW9
+Reference: MISEQ_170901#87
+Platform : MISEQ
+Sequencer: MiSeq
+Directory: %s
+Endedness: Paired end
+Bcl2fastq: Unknown
+
+2 projects:
+- 'AB':  Alison Bell           Human RNA-seq  ? multiplexed samples (PI Audrey Bower)           
+- 'CDE': Charles David Edwards Mouse ChIP-seq 2 samples             (PI Colin Delaney Eccleston)
 
 Additional notes/comments:
 - CDE: Repeat of previous run
@@ -1443,6 +1798,76 @@ ABF4,BC004,ABF4
         # Generate projects report
         expected = """NOVASEQ_240213#87\t87\ttesting\t\tAlison Bell\tAudrey Bower\tFlex\t10xGenomics Chromium 3'v3\tHuman\tNOVASEQ\t4\t1311\tyes\tABF1-4
 NOVASEQ_240213#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\tChIP-seq\t\tMouse\tNOVASEQ\t2\t\tyes\tCDE3-4
+"""
+        for o,e in zip(report_projects(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
+    def test_report_projects_multiplexed_samples(self):
+        """report: report run with multiplexed samples in 'projects' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "sequencer_model": "MiSeq" },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "RNA-seq",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Sequencer model": "MiSeq",
+                        "Multiplexed samples": "M1,M2,M3,M4" },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "MiSeq" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Make autoprocess instance and set required metadata
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate projects report
+        expected = """MISEQ_170901#87\t87\ttesting\t\tAlison Bell\tAudrey Bower\tRNA-seq\t\tHuman\tMISEQ\t4\t\tyes\tM1-4
+MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\tChIP-seq\t\tMouse\tMISEQ\t2\t\tyes\tCDE3-4
+"""
+        for o,e in zip(report_projects(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
+    def test_report_projects_unknown_multiplexed_samples(self):
+        """report: report run with "unknown" multiplexed samples in 'projects' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "sequencer_model": "MiSeq" },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "RNA-seq",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Sequencer model": "MiSeq",
+                        "Multiplexed samples": "?" },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "MiSeq" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Make autoprocess instance and set required metadata
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate projects report
+        expected = """MISEQ_170901#87\t87\ttesting\t\tAlison Bell\tAudrey Bower\tRNA-seq\t\tHuman\tMISEQ\t?\t\tyes\t?
+MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\tChIP-seq\t\tMouse\tMISEQ\t2\t\tyes\tCDE3-4
 """
         for o,e in zip(report_projects(ap).split('\n'),
                        expected.split('\n')):

--- a/auto_process_ngs/test/test_metadata.py
+++ b/auto_process_ngs/test/test_metadata.py
@@ -707,5 +707,6 @@ class TestAnalysisProjectInfo(unittest.TestCase):
         self.assertEqual(info.primary_fastq_dir,None)
         self.assertEqual(info.samples,None)
         self.assertEqual(info.biological_samples,None)
+        self.assertEqual(info.multiplexed_samples,None)
         self.assertEqual(info.sequencer_model,None)
         self.assertEqual(info.comments,None)

--- a/docs/source/output/analysis_dirs.rst
+++ b/docs/source/output/analysis_dirs.rst
@@ -172,8 +172,10 @@ The most commonly used metadata items are listed in the table below:
    ======================== =========================================
    **Item**                 **Description**
    ------------------------ -----------------------------------------
+   ``Name``                 Project name
    ``Run``                  Parent run name
-   ``Platform``             Sequencing platform (e.g. ``miseq``)
+   ``Platform``             Sequencing platform (e.g. ``novaseq600``)
+   ``Sequencer model``      Model of sequencer used (e.g. ``NovaSeq 6000``)
    ``User``                 Name of the user(s)
    ``PI``                   Name of PI(s)
    ``Organism``             Organism name(s)
@@ -185,7 +187,18 @@ The most commonly used metadata items are listed in the table below:
                             end
    ``Primary fastqs``       Subdirectory holding the 'primary' set of
                             Fastq files for the project
-   ``Samples``              Number and list of sample names
+   ``Samples``              Number and list of sample names for
+                            physical samples
+   ``Biological samples``   List of subset of physical samples with
+                            biological data (if not set then all
+                            samples assumed to contain biological
+                            information)
+   ``Multiplexed samples``  List of sample names for multiplexed
+                            for 10x Genomics CellPlex and Flex data
+                            and Parse Evercode data (if not set then
+                            there are no multiplexed samples; if set
+                            to ``?`` then there are multiplexed
+                            samples but the names are not known)
    ``Comments``             Any additional comments about the project
    ======================== =========================================
 


### PR DESCRIPTION
Updates to explicitly store the multiplexed sample names in the metadata for each project (using a new `multiplexed_samples` field), and then use this for reporting if it is set.

The metadata item can be either `None` (no multiplexed samples), `?` (multiplexed samples present but no information is known about them) or a comma-separated list of sample names (e.g. `M1,M2,M3`). Numbers of multiplexed samples will be reported as either the number of samples in the list, or as `?` if the information is not known.

For CellPlex and Flex projects, if the multiplexed sample information is not set then by default it will continue to be extracted on the fly from the cellranger multi config file until the run is archived; upon archiving the extracted information will be permanently written to the project metadata.

For Parse Evercode projects, if the multiplexed sample information is not set then it will be updated upon archiving to `?` (i.e. unknown).