### PR TITLE
'make_fastqs': enable R1/R2 read truncation to be specified on command line

### DIFF
--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     cli/auto_process.py: command line interface for auto_process_ngs
-#     Copyright (C) University of Manchester 2013-2023 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2024 Peter Briggs
 #
 #########################################################################
 #
@@ -475,24 +475,18 @@ def add_make_fastqs_command(cmdparser):
                           dest="no_adapter_trimming",default=False,
                           help="turn off adapter trimming even if "
                           "adapter sequences are supplied")
-    # ICELL8 options
-    icell8 = p.add_argument_group('ICELL8 options (ICELL8 data only)')
-    icell8.add_argument("--well-list",
-                        dest="icell8_well_list",
-                        default=None,
-                        help="specify ICELL8 well list file")
-    icell8.add_argument('--swap-i1-and-i2',
-                        action='store_true',
-                        dest="icell8_swap_i1_and_i2",
-                        help="swap supplied I1 and I2 Fastqs when matching "
-                        "ATAC barcodes against well list")
-    icell8.add_argument('--reverse-complement',
-                        choices=['i1','i2','both'],
-                        dest="icell8_reverse_complement",
-                        default=None,
-                        help="can be 'i1','i2', or 'both'; reverse complement "
-                        "the specified indices from the well list when "
-                        "matching ATAC barcodes against well list")
+    # Standard/mirna options
+    standard = p.add_argument_group('Standard/miRNA options')
+    standard.add_argument('--r1-length',action="store",
+                          dest="r1_length",default=None,type=int,
+                          help="truncate R1 reads to R1_LENGTH  (ignored if "
+                          "--use-bases-mask is explicitly set; only "
+                          "applies to 'standard' and 'miRNA' protocols)")
+    standard.add_argument('--r2-length',action="store",
+                          dest="r2_length",default=None,type=int,
+                          help="truncate R2 reads to R2_LENGTH (ignored if "
+                          "--use-bases-mask is explicitly set; only "
+                          "applies to 'standard' and 'miRNA' protocols)")
     # 10x Genomics options
     default_cellranger_localcores = __settings['10xgenomics'].\
                                     cellranger_localcores
@@ -567,6 +561,24 @@ def add_make_fastqs_command(cmdparser):
                              "(Workflow A) / older NovaSeq Reagent Kits. "
                              "If unset then workflow will be determined "
                              "automatically (recommended)")
+    # ICELL8 options
+    icell8 = p.add_argument_group('ICELL8 options (ICELL8 data only)')
+    icell8.add_argument("--well-list",
+                        dest="icell8_well_list",
+                        default=None,
+                        help="specify ICELL8 well list file")
+    icell8.add_argument('--swap-i1-and-i2',
+                        action='store_true',
+                        dest="icell8_swap_i1_and_i2",
+                        help="swap supplied I1 and I2 Fastqs when matching "
+                        "ATAC barcodes against well list")
+    icell8.add_argument('--reverse-complement',
+                        choices=['i1','i2','both'],
+                        dest="icell8_reverse_complement",
+                        default=None,
+                        help="can be 'i1','i2', or 'both'; reverse complement "
+                        "the specified indices from the well list when "
+                        "matching ATAC barcodes against well list")
     # Statistics
     statistics = p.add_argument_group('Statistics generation')
     statistics.add_argument('--stats-file',action='store',
@@ -1495,6 +1507,9 @@ def make_fastqs(args):
                     key = "icell8_atac_%s" % key
                 elif key == 'rc_i2_override':
                     key = 'spaceranger_rc_i2_override'
+                # Convert integer values
+                if key in ('r1_length' ,'r2_length'):
+                    value = int(value)
                 # Deal with True/False values
                 # Ignore case and also allow 'yes' and 'no'
                 if value.lower() in ('true','yes'):
@@ -1528,6 +1543,8 @@ def make_fastqs(args):
         unaligned_dir=args.out_dir,
         sample_sheet=args.sample_sheet,
         bases_mask=args.bases_mask,
+        r1_length=args.r1_length,
+        r2_length=args.r2_length,
         lanes=only_include_lanes,lane_subsets=lane_subsets,
         icell8_well_list=args.icell8_well_list,
         icell8_swap_i1_and_i2=args.icell8_swap_i1_and_i2,

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1507,15 +1507,17 @@ def make_fastqs(args):
                     key = "icell8_atac_%s" % key
                 elif key == 'rc_i2_override':
                     key = 'spaceranger_rc_i2_override'
-                # Convert integer values
+                # Convert values where appropriate
                 if key in ('r1_length' ,'r2_length'):
+                    # Convert integer values
                     value = int(value)
-                # Deal with True/False values
-                # Ignore case and also allow 'yes' and 'no'
-                if value.lower() in ('true','yes'):
-                    value = True
-                elif value.lower() in ('false','no'):
-                    value = False
+                else:
+                    # Deal with True/False values
+                    # Ignore case and also allow 'yes' and 'no'
+                    if value.lower() in ('true','yes'):
+                        value = True
+                    elif value.lower() in ('false','no'):
+                        value = False
                 subset_options[key] = value
             # Add the subset to the list
             lane_subsets.append(subset(lanes_,**subset_options))

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     make_fastqs_cmd.py: implement auto process make_fastqs command
-#     Copyright (C) University of Manchester 2018-2023 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2024 Peter Briggs
 #
 #########################################################################
 
@@ -40,7 +40,8 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 name=None,lanes=None,lane_subsets=None,
                 icell8_well_list=None,
                 nprocessors=None,bcl_converter=None,
-                bases_mask=None,no_lane_splitting=None,
+                bases_mask=None,r1_length=None,
+                r2_length=None,no_lane_splitting=None,
                 minimum_trimmed_read_length=None,
                 mask_short_adapter_reads=None,
                 trim_adapters=True,
@@ -119,6 +120,12 @@ def make_fastqs(ap,protocol='standard',platform=None,
         "bcl2fastq>2.0" or "bcl-convert=3.7.5"). Defaults to "bcl2fastq"
       bases_mask (str): if set then use this as an alternative bases
         mask setting
+      r1_length (int): explicitly specify length to truncate R1 reads
+         to (ignored if not using bcl2fastq or bclconvert, or if bases
+         mask is set)
+      r2_length (int): explicitly specify length to truncate R2 reads
+         to (ignored if not using bcl2fastq or bclconvert, or if bases
+         mask is set)
       no_lane_splitting (bool): if True then run bcl2fastq with
         --no-lane-splitting
       minimum_trimmed_read_length (int): if set then specify minimum
@@ -378,6 +385,8 @@ def make_fastqs(ap,protocol='standard',platform=None,
                              ap.params.sample_sheet,
                              protocol=protocol,
                              bases_mask=bases_mask,
+                             r1_length=r1_length,
+                             r2_length=r2_length,
                              bcl_converter=bcl_converter,
                              platform=platform,
                              icell8_well_list=icell8_well_list,

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_standard_bcl2fastq.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_standard_bcl2fastq.py
@@ -555,7 +555,8 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
             fp.write(SampleSheets.miseq)
         # Create mock bcl2fastq
         MockBcl2fastq2Exe.create(os.path.join(self.bin,
-                                              "bcl2fastq"))
+                                              "bcl2fastq"),
+                                 assert_bases_mask="y101,I8,I8,y101")
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         # Make an (empty) analysis directory
@@ -564,6 +565,80 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         # Do the test
         p = MakeFastqs(run_dir,sample_sheet,protocol="standard",
                        bases_mask="y101,I8,I8,y101")
+        status = p.run(analysis_dir,
+                       poll_interval=POLL_INTERVAL)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_truncate_read_lengths(self):
+        """
+        MakeFastqs: standard protocol/bcl2fastq: truncate read lengths
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 assert_bases_mask="y26n75,I8,I8,y76n25")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="standard",
+                       r1_length=26,r2_length=76)
         status = p.run(analysis_dir,
                        poll_interval=POLL_INTERVAL)
         self.assertEqual(status,0)

--- a/auto_process_ngs/test/bcl2fastq/test_utils.py
+++ b/auto_process_ngs/test/bcl2fastq/test_utils.py
@@ -1286,6 +1286,51 @@ SL4,SL4,,,N704,SI-GA-D2,SL,
         self.assertEqual(get_bases_mask(run_info_xml,sample_sheet),
                          "y76,I6,y76")
 
+    def test_get_bases_mask_dual_index_truncate_reads(self):
+        """get_bases_mask: truncate reads (dual index)
+        """
+        # Make a RunInfo.xml file
+        run_info_xml = os.path.join(self.wd,"RunInfo.xml")
+        with open(run_info_xml,'w') as fp:
+            fp.write(RunInfoXml.hiseq("171020_SN7001250_00002_AHGXXXX"))
+        # Make a matching sample sheet
+        sample_sheet_content = """[Header]
+IEMFileVersion,4
+Date,11/23/2015
+Workflow,GenerateFASTQ
+Application,FASTQ Only
+Assay,TruSeq HT
+Description,
+Chemistry,Amplicon
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+
+[Data]
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index,index2,Sample_Project,Description
+1,AB1,AB1,,,D701,CGTGTAGG,D501,GACCTGTA,AB,
+2,AB2,AB2,,,D701,CGTGTAGG,D501,GACCTGTA,AB,
+3,AB1,AB1,,,D701,CGTGTAGG,D501,GACCTGTA,AB,
+4,AB2,AB2,,,D701,CGTGTAGG,D501,GACCTGTA,AB,
+5,CD1,CD1,,,D701,CGTGTAGG,D501,GACCTGTA,CD,
+6,CD2,CD2,,,D701,CGTGTAGG,D501,GACCTGTA,CD,
+7,CD1,CD1,,,D701,CGTGTAGG,D501,GACCTGTA,CD,
+8,CD2,CD2,,,D701,CGTGTAGG,D501,GACCTGTA,CD,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(sample_sheet_content)
+        # Check the bases mask
+        self.assertEqual(get_bases_mask(run_info_xml,sample_sheet,
+                                        r1=26,r2=76),
+                         "y26n75,I8,I8,y76n25")
+
     def test_get_bases_mask_single_index_no_sample_sheet(self):
         """get_bases_mask: handle single index (no samplesheet)
         """

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -34,6 +34,7 @@ Various options are available to skip or control each of these stages;
 more detail on the different usage modes can be found in the
 subsequent sections:
 
+* :ref:`make_fastqs-truncating-reads`
 * :ref:`make_fastqs-adapter-trimming-and-masking`
 * :ref:`make_fastqs-mixed-protocols`
 * :ref:`make_fastqs-bcl-converter`
@@ -152,6 +153,42 @@ Some of the most commonly used options are:
 The full set of options can be found in the
 :ref:`'make_fastqs' <commands_make_fastqs>` section of the command
 reference.
+
+.. _make_fastqs-truncating-reads:
+
+Truncating reads and setting bases mask
+---------------------------------------
+
+Generally it should not be necessary to manually set the bases mask
+(which is used by ``bcl2fastq`` to determine what to do with each
+base within a read) as the Fastq generation will automatically
+set it to the appropriate value to capture the complete sequence
+for each non-index read. It will also adjust the masking used for
+the index reads according to the lengths of the index sequences
+provided in the sample sheet.
+
+In some cases it may be desirable to truncate the lengths of the
+non-index reads, typically to truncate R1 and/or R2 sequences. In
+these cases, the bases mask can be set explicitly to only keep
+the required bases, for example:
+
+::
+
+   y28n48,I8,I8,y76
+
+could be specified to truncate the sequences in the R1 reads to
+28bp whilst keeping all 76bp of the R2 sequences.
+
+Alternatively, if the ``--r1-length`` and/or ``--r2-length``
+options are specified the the bases masking will be adjusted
+automatically to truncate the reads, for example setting
+``--r1-length=28 --use-bases-mask=auto`` would generate the
+masking template above.
+
+.. note::
+
+   The ``--r1-length`` and ``--r2-length`` options are only
+   applied for the ``standard`` and ``mirna`` protocols.
 
 .. _make_fastqs-adapter-trimming-and-masking:
 
@@ -280,6 +317,12 @@ The available options are:
 Option                                Description
 ===================================== ==================================
 ``bases_mask=BASES_MASK``             Set bases mask
+``r1_length=LENGTH``                  Truncate R1 reads to ``LENGTH``
+                                      (``standard`` and ``mirna``
+                                      protocols only)
+``r2_length=LENGTH``                  Truncate R2 reads to ``LENGTH``
+                                      (``standard`` and ``mirna``
+                                      protocols only)
 ``trim_adapters=yes|no``              Turn adapter trimming on or off
 ``adapter=SEQUENCE``                  Set adapter sequence for trimming
 ``adapter_read2=SEQUENCE``            Set read2 adapter sequence

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -34,7 +34,7 @@ Various options are available to skip or control each of these stages;
 more detail on the different usage modes can be found in the
 subsequent sections:
 
-* :ref:`make_fastqs-truncating-reads`
+* :ref:`make_fastqs-truncating-read-lengths`
 * :ref:`make_fastqs-adapter-trimming-and-masking`
 * :ref:`make_fastqs-mixed-protocols`
 * :ref:`make_fastqs-bcl-converter`
@@ -154,41 +154,53 @@ The full set of options can be found in the
 :ref:`'make_fastqs' <commands_make_fastqs>` section of the command
 reference.
 
-.. _make_fastqs-truncating-reads:
+.. _make_fastqs-truncating-read-lengths:
 
-Truncating reads and setting bases mask
----------------------------------------
-
-Generally it should not be necessary to manually set the bases mask
-(which is used by ``bcl2fastq`` to determine what to do with each
-base within a read) as the Fastq generation will automatically
-set it to the appropriate value to capture the complete sequence
-for each non-index read. It will also adjust the masking used for
-the index reads according to the lengths of the index sequences
-provided in the sample sheet.
+Truncating R1/R2 read lengths and setting bases mask
+----------------------------------------------------
 
 In some cases it may be desirable to truncate the lengths of the
-non-index reads, typically to truncate R1 and/or R2 sequences. In
-these cases, the bases mask can be set explicitly to only keep
-the required bases, for example:
+non-index reads, most typically for the R1 and/or R2 sequences.
+In these cases the ``--r1-length`` and/or ``--r2-length`` options
+can be used to specify the maximum length for one or both of the
+R1 and R2 reads.
+
+For example:
 
 ::
 
-   y28n48,I8,I8,y76
+  auto_process.py make_fastqs --r1-length=28
 
-could be specified to truncate the sequences in the R1 reads to
-28bp whilst keeping all 76bp of the R2 sequences.
+would result in R1 sequences with a maximum length of 28bp.
 
-Alternatively, if the ``--r1-length`` and/or ``--r2-length``
-options are specified the the bases masking will be adjusted
-automatically to truncate the reads, for example setting
-``--r1-length=28 --use-bases-mask=auto`` would generate the
-masking template above.
+Maximum read lengths can also be applied to a subset of lanes
+via the ``--lanes`` option, for example:
+
+::
+
+   auto_process.py make_fastqs --lanes=1-2:standard:r1_length=28
+
 
 .. note::
 
    The ``--r1-length`` and ``--r2-length`` options are only
-   applied for the ``standard`` and ``mirna`` protocols.
+   applied for the ``standard`` and ``mirna`` protocols; they
+   are ignored for other protocols.
+
+   The options operate by adjusting the bases mask used to
+   match the required length, so if a bases mask is explicitly
+   provided then these options will also not be applied.
+
+   Alternatively (or in scenarios where more complicated
+   read manipulations are required), the bases mask can be
+   explicitly specified via the ``--use-bases-mask`` option;
+   for example:
+
+   ::
+
+      y28n48,I8,I8,y76
+
+   would also truncate R1 sequences to the first 28bp.
 
 .. _make_fastqs-adapter-trimming-and-masking:
 


### PR DESCRIPTION
Updates the `make_fastqs` command so that R1 and/or R2 reads can be truncated without explicitly specifying the bases mask string (which was how this has been done in the past).

Bases mask can still be specified explicitly, however this PR implements new command line options `--r1-length` and `--r2-length` which the command will now use to adjust the default bases mask.

For example, if the default bases mask was `y107,I10,I10,y107` but only the first 59 bases of the R1 and R2 sequences were needed, then specifying `--r1-length=59` and `--r2-length=59` would automatically adjust the masking to `y59n48,I10,I10,y59n48` (rather than the user needing to manually work out and specify this themselves).

Note that the options are only applied for the `standard` and `mirna` protocols.

This PR close #884.