### PR TITLE
'make_fastqs ': fix handling of read length truncation

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -2188,9 +2188,9 @@ class IdentifyPlatform(PipelineTask):
             flow_cell_mode = illumina_run.\
                              runparameters.\
                              flowcell_mode
-        if flow_cell_mode:
-            print("Flow cell mode identified as '%s'" % flow_cell_mode)
-            self.output.flow_cell_mode.set(flow_cell_mode)
+            if flow_cell_mode:
+                print("Flow cell mode identified as '%s'" % flow_cell_mode)
+                self.output.flow_cell_mode.set(flow_cell_mode)
         else:
             print("Unable to identify flow cell mode")
 

--- a/auto_process_ngs/bcl2fastq/utils.py
+++ b/auto_process_ngs/bcl2fastq/utils.py
@@ -473,8 +473,8 @@ def get_bases_mask(run_info_xml,sample_sheet_file=None,r1=None,r2=None):
         print("Bases mask: %s (updated for barcode sequence '%s')" %
               (bases_mask,example_barcode))
     # Truncate reads if specified
-    lengths = (r1,r2)
-    if r1 is not None:
+    if not (r1 is None and r2 is None):
+        lengths = (r1,r2)
         reads = []
         read_number = 0
         for read in bases_mask.split(','):
@@ -489,6 +489,8 @@ def get_bases_mask(run_info_xml,sample_sheet_file=None,r1=None,r2=None):
                 read_length = int(read[1:])
                 if rlen < read_length:
                     new_read = "y%dn%d" % (rlen,read_length-rlen)
+                else:
+                    new_read = read
                 reads.append(new_read)
             else:
                 reads.append(read)

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_chromium_sc.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_chromium_sc.py
@@ -482,6 +482,103 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_makefastqs_10x_chromium_sc_protocol_truncate_reads(self):
+        """
+        MakeFastqs: '10x_chromium_sc' protocol (truncate reads)
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics Chromium SC indices
+        samplesheet_chromium_sc_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-GA-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_chromium_sc_indices)
+        # Create mock bcl2fastq and cellranger
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        MockCellrangerExe.create(os.path.join(self.bin,
+                                              "cellranger"),
+                                 version="8.0.0",
+                                 assert_bases_mask="y28n48,I6,y50n26")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="10x_chromium_sc",
+                       r1_length=28,
+                       r2_length=50)
+        status = p.run(analysis_dir,
+                       poll_interval=POLL_INTERVAL)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,
+                         (os.path.join(self.bin,"cellranger"),
+                          "cellranger",
+                          "8.0.0"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html",):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
     def test_makefastqs_10x_chromium_sc_protocol_rerun_completed_pipeline(self):
         """
         MakeFastqs: '10x_chromium_sc' protocol: rerun completed pipeline

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_multiome.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_multiome.py
@@ -392,6 +392,130 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_makefastqs_10x_multiome_protocol_refuse_to_truncate_reads_gex_data(self):
+        """
+        MakeFastqs: '10x_multiome' protocol (refuse to truncate reads for GEX data)
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics indices
+        samplesheet_10x_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-GA-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_10x_indices)
+        # Create mock bcl2fastq and cellranger-arc
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        Mock10xPackageExe.create(os.path.join(self.bin,
+                                              "cellranger-arc"),
+                                 version="2.0.0",
+                                 multiome_data="GEX")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the tests
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet,protocol="10x_multiome",
+                          r1_length=16)
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet,protocol="10x_multiome",
+                          r2_length=16)
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet,protocol="10x_multiome",
+                          r1_length=16,
+                          r2_length=16)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_10x_multiome_protocol_refuse_to_truncate_reads_atac_data(self):
+        """
+        MakeFastqs: '10x_multiome' protocol (refuse to truncate reads for ATAC data)
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics indices
+        samplesheet_10x_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-GA-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_10x_indices)
+        # Create mock bcl2fastq and cellranger-arc
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        Mock10xPackageExe.create(os.path.join(self.bin,
+                                              "cellranger-arc"),
+                                 version="2.0.0",
+                                 multiome_data="ATAC")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the tests
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet,protocol="10x_multiome",
+                          r1_length=16)
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet,protocol="10x_multiome",
+                          r2_length=16)
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet,protocol="10x_multiome",
+                          r1_length=16,
+                          r2_length=16)
+
+    #@unittest.skip("Skipped")
     def test_makefastqs_10x_multiome_atac(self):
         """
         MakeFastqs: '10x_multiome_atac' protocol
@@ -489,6 +613,68 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_makefastqs_10x_multiome_atac_refuse_to_truncate_reads(self):
+        """
+        MakeFastqs: '10x_multiome_atac' protocol (refuse to truncate reads)
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics indices
+        samplesheet_10x_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-GA-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_10x_indices)
+        # Create mock bcl2fastq and cellranger-arc
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        Mock10xPackageExe.create(os.path.join(self.bin,
+                                              "cellranger-arc"),
+                                 version="2.0.0",
+                                 multiome_data="ATAC")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the tests
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet,protocol="10x_multiome_atac",
+                          r1_length=16)
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet,protocol="10x_multiome_atac",
+                          r2_length=16)
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet,protocol="10x_multiome_atac",
+                          r1_length=16,
+                          r2_length=16)
+
+    #@unittest.skip("Skipped")
     def test_makefastqs_10x_multiome_gex(self):
         """
         MakeFastqs: '10x_multiome_gex' protocol
@@ -584,3 +770,65 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
+    def test_makefastqs_10x_multiome_gex_refuse_to_truncate_reads(self):
+        """
+        MakeFastqs: '10x_multiome_gex' protocol (refuse to truncate reads)
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics indices
+        samplesheet_10x_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-GA-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_10x_indices)
+        # Create mock bcl2fastq and cellranger-arc
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        Mock10xPackageExe.create(os.path.join(self.bin,
+                                              "cellranger-arc"),
+                                 version="2.0.0",
+                                 multiome_data="GEX")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the tests
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet,protocol="10x_multiome_gex",
+                          r1_length=16)
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet,protocol="10x_multiome_gex",
+                          r2_length=16)
+        self.assertRaises(Exception,
+                          MakeFastqs,
+                          run_dir,
+                          sample_sheet,protocol="10x_multiome_gex",
+                          r1_length=16,
+                          r2_length=16)

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_visium.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_visium.py
@@ -387,6 +387,103 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_makefastqs_10x_visium_protocol_truncate_reads(self):
+        """
+        MakeFastqs: '10x_visium' protocol (truncate reads)
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics Chromium SC indices
+        samplesheet_visium_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+smpl1,smpl1,,,SI-TT-A1,SI-TT-A1,SI-TT-A1,SI-TT-A1,10xGenomics,
+smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_visium_indices)
+        # Create mock bcl2fastq and spaceranger
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        Mock10xPackageExe.create(os.path.join(self.bin,
+                                              "spaceranger"),
+                                 version='3.0.0',
+                                 assert_bases_mask="y28n48,I6,y50n26")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="10x_visium",
+                       r1_length=28,
+                       r2_length=50)
+        status = p.run(analysis_dir,
+                       poll_interval=POLL_INTERVAL)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.spaceranger_info,
+                         (os.path.join(self.bin,"spaceranger"),
+                          "spaceranger",
+                          "3.0.0"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "processing_qc.html",):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
     def test_makefastqs_10x_visium_protocol_forward_strand_workflow_A(self):
         """
         MakeFastqs: '10x_visium' protocol (forward strand workflow 'A')

--- a/auto_process_ngs/test/bcl2fastq/test_utils.py
+++ b/auto_process_ngs/test/bcl2fastq/test_utils.py
@@ -1286,8 +1286,8 @@ SL4,SL4,,,N704,SI-GA-D2,SL,
         self.assertEqual(get_bases_mask(run_info_xml,sample_sheet),
                          "y76,I6,y76")
 
-    def test_get_bases_mask_dual_index_truncate_reads(self):
-        """get_bases_mask: truncate reads (dual index)
+    def test_get_bases_mask_dual_index_truncate_r1_and_r2_reads(self):
+        """get_bases_mask: truncate R1 and R2 reads (dual index)
         """
         # Make a RunInfo.xml file
         run_info_xml = os.path.join(self.wd,"RunInfo.xml")
@@ -1326,10 +1326,26 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index,i
         sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
         with open(sample_sheet,'w') as fp:
             fp.write(sample_sheet_content)
-        # Check the bases mask
+        # Truncate R1 and R2 reads in bases mask
         self.assertEqual(get_bases_mask(run_info_xml,sample_sheet,
                                         r1=26,r2=76),
                          "y26n75,I8,I8,y76n25")
+        # Truncate R1 read only
+        self.assertEqual(get_bases_mask(run_info_xml,sample_sheet,
+                                        r1=26),
+                         "y26n75,I8,I8,y101")
+        # Truncate R2 read only
+        self.assertEqual(get_bases_mask(run_info_xml,sample_sheet,
+                                        r2=26),
+                         "y101,I8,I8,y26n75")
+        # "Truncate" R1 and R2 reads to same length as actual reads
+        self.assertEqual(get_bases_mask(run_info_xml,sample_sheet,
+                                        r1=101,r2=101),
+                         "y101,I8,I8,y101")
+        # "Truncate" R1 and R2 reads to longer lengths than actual reads
+        self.assertEqual(get_bases_mask(run_info_xml,sample_sheet,
+                                        r1=102,r2=102),
+                         "y101,I8,I8,y101")
 
     def test_get_bases_mask_single_index_no_sample_sheet(self):
         """get_bases_mask: handle single index (no samplesheet)

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -184,8 +184,9 @@ via the ``--lanes`` option, for example:
 .. note::
 
    The ``--r1-length`` and ``--r2-length`` options are only
-   applied for the ``standard`` and ``mirna`` protocols; they
-   are ignored for other protocols.
+   applied for the ``standard``, ``mirna``, ``10x_chromium``
+   and ``10x_visium`` protocols; they are ignored for other
+   protocols.
 
    The options operate by adjusting the bases mask used to
    match the required length, so if a bases mask is explicitly


### PR DESCRIPTION
Fixes various bugs and issues in the `make_fastqs` command and underlying Fastq generation pipeline regarding truncating read lengths:

* Fixes a bug when only R2 read length was specified (it was being ignored)
* Fixes a bug when requested read lengths matched or exceeded actual length (caused an exception)
* Updates the pipeline to apply the read length truncation for the `10x_chromium_sc` and `10x_visium` protocols
* Updates the pipeline to raise an exception and halt if read length truncation is requested for the `10x_atac`, `10x_multiome`, `10x_multiome_atac` or `10x_multiome_gex` protocols

Also fixes an unrelated bug with detecting flow cell mode in the platform identification task for older sequencing runs.