### PR TITLE
'make_fastqs': add sequence length statistics to processing QC

### DIFF
--- a/auto_process_ngs/qc/seqlens.py
+++ b/auto_process_ngs/qc/seqlens.py
@@ -241,20 +241,28 @@ def get_sequence_lengths(fastq,outfile=None,show_progress=False,
                 reads_padded[seqlen] = 1
     # Get statistics
     seqlens = sorted(sequence_length.keys())
-    min_len = min(seqlens)
-    max_len = max(seqlens)
-    mean_len = float(sum([l*sequence_length[l] for l in seqlens]))\
-               /float(nreads)
-    median_read = nreads//2
-    median_len = None
-    read_count = 0
-    for l in seqlens:
-        read_count += sequence_length[l]
-        if read_count >= median_read:
-            median_len = l
-            break
-    frac_reads_masked = float(nreads_masked)/nreads*100.0
-    frac_reads_padded = float(nreads_padded)/nreads*100.0
+    if seqlens:
+        min_len = min(seqlens)
+        max_len = max(seqlens)
+        mean_len = float(sum([l*sequence_length[l] for l in seqlens]))\
+                   /float(nreads)
+        median_read = nreads//2
+        median_len = None
+        read_count = 0
+        for l in seqlens:
+            read_count += sequence_length[l]
+            if read_count >= median_read:
+                median_len = l
+                break
+        frac_reads_masked = float(nreads_masked)/nreads*100.0
+        frac_reads_padded = float(nreads_padded)/nreads*100.0
+    else:
+        min_len = None
+        max_len = None
+        mean_len = None
+        median_len = None
+        frac_reads_masked = None
+        frac_reads_padded = None
     # Build dictionary for output
     stats = dict(fastq=fastq,
                  nreads=nreads,

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_atac.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_atac.py
@@ -83,6 +83,9 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -99,6 +102,7 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",
                       "cellranger-atac_qc_summary.html",):
             self.assertTrue(os.path.isfile(
@@ -179,6 +183,9 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -195,6 +202,7 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -261,6 +269,7 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                   "statistics.info",
                   "per_lane_statistics.info",
                   "per_lane_sample_stats.info",
+                  "seq_len_statistics.info",
                   "processing_qc.html",
                   "cellranger-atac_qc_summary.html",):
             with open(os.path.join(analysis_dir,f),'wt') as fp:
@@ -295,6 +304,9 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -311,6 +323,7 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_chromium_sc.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_chromium_sc.py
@@ -82,6 +82,9 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -98,6 +101,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",
                       "cellranger_qc_summary.html",):
             self.assertTrue(os.path.isfile(
@@ -177,6 +181,9 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -193,6 +200,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -271,6 +279,9 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -287,6 +298,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -365,6 +377,9 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -381,6 +396,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -460,6 +476,9 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "10X_ILLUMINA_RUN"),
@@ -476,6 +495,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -557,6 +577,9 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -573,6 +596,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -637,6 +661,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                   "statistics.info",
                   "per_lane_statistics.info",
                   "per_lane_sample_stats.info",
+                  "seq_len_statistics.info",
                   "processing_qc.html",
                   "cellranger_qc_summary.html",):
             with open(os.path.join(analysis_dir,f),'wt') as fp:
@@ -673,6 +698,9 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -689,6 +717,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_multiome.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_multiome.py
@@ -83,6 +83,9 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -99,6 +102,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",
                       "cellranger-arc_qc_summary.html",):
             self.assertTrue(os.path.isfile(
@@ -179,6 +183,9 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -195,6 +202,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",
                       "cellranger-arc_qc_summary.html",):
             self.assertTrue(os.path.isfile(
@@ -275,6 +283,9 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -291,6 +302,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -370,6 +382,9 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -386,6 +401,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -591,6 +607,9 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -607,6 +626,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -750,6 +770,9 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -766,6 +789,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_visium.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_visium.py
@@ -82,6 +82,9 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -98,6 +101,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",
                       "spaceranger_qc_summary.html",):
             self.assertTrue(os.path.isfile(
@@ -177,6 +181,9 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -193,6 +200,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -271,6 +279,9 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -287,6 +298,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -365,6 +377,9 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -381,6 +396,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -462,6 +478,9 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -478,6 +497,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -559,6 +579,9 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -575,6 +598,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -656,6 +680,9 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -672,6 +699,7 @@ smpl2,smpl2,,,SI-TT-B1,SI-TT-B1,SI-TT-B1,SI-TT-B1,10xGenomics,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html",):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_core.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_core.py
@@ -63,6 +63,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -85,6 +88,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -122,6 +126,8 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                                       "the_per_lane_stats.txt")
         per_lane_sample_stats = os.path.join(analysis_dir,
                                              "the_per_lane_sample_stats.txt")
+        seq_len_statistics = os.path.join(analysis_dir,
+                                          "the_seq_len_statistics.info")
         # Do the test
         p = MakeFastqs(run_dir,sample_sheet)
         status = p.run(analysis_dir,
@@ -224,6 +230,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.test.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.test.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -241,6 +250,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.test.info",
                       "per_lane_statistics.test.info",
                       "per_lane_sample_stats.test.info",
+                      "seq_len_statistics.test.info",
                       "processing_qc_test.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -310,6 +320,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertFalse(os.path.exists(
                 os.path.join(analysis_dir,filen)),
@@ -367,6 +378,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -385,6 +399,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -442,6 +457,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_UNKNOWN_00002_AHGXXXX"),
@@ -458,6 +476,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -515,6 +534,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_UNKNOWN_00002_AHGXXXX"),
@@ -531,6 +553,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -701,6 +724,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_icell8.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_icell8.py
@@ -64,6 +64,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -80,6 +83,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -132,6 +136,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                   "statistics.info",
                   "per_lane_statistics.info",
                   "per_lane_sample_stats.info",
+                  "seq_len_statistics.info",
                   "processing_qc.html",):
             with open(os.path.join(analysis_dir,f),'wt') as fp:
                 fp.write("")
@@ -165,6 +170,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -180,6 +188,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -261,6 +270,9 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,ICELL8_ATAC,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -277,6 +289,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,ICELL8_ATAC,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -355,6 +368,7 @@ Unassigned-Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,ICELL8_ATAC,
                   "statistics.info",
                   "per_lane_statistics.info",
                   "per_lane_sample_stats.info",
+                  "seq_len_statistics.info",
                   "processing_qc.html",):
             with open(os.path.join(analysis_dir,f),'wt') as fp:
                 fp.write("")
@@ -389,6 +403,9 @@ Unassigned-Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,ICELL8_ATAC,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -404,6 +421,7 @@ Unassigned-Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,ICELL8_ATAC,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_mirna.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_mirna.py
@@ -65,6 +65,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -81,6 +84,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -144,6 +148,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -160,6 +167,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_parse_evercode.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_parse_evercode.py
@@ -72,6 +72,9 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -88,6 +91,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_standard_bcl2fastq.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_standard_bcl2fastq.py
@@ -61,6 +61,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -77,6 +80,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -134,6 +138,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -150,6 +157,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -209,6 +217,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -225,6 +236,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -286,6 +298,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -302,6 +317,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -361,6 +377,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -377,6 +396,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -436,6 +456,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -452,6 +475,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -516,6 +540,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -532,6 +559,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -590,6 +618,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -606,6 +637,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -664,6 +696,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -680,6 +715,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -736,6 +772,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
@@ -752,6 +791,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -810,6 +850,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
@@ -826,6 +869,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -883,6 +927,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
@@ -901,6 +948,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -946,6 +994,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                   "statistics.info",
                   "per_lane_statistics.info",
                   "per_lane_sample_stats.info",
+                  "seq_len_statistics.info",
                   "processing_qc.html",):
             with open(os.path.join(analysis_dir,f),'wt') as fp:
                 fp.write("")
@@ -979,6 +1028,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -994,6 +1046,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -1068,6 +1121,9 @@ AB1,AB1,,,,,AB,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_NB500968_00002_AHGXXXX"),
@@ -1084,6 +1140,7 @@ AB1,AB1,,,,,AB,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -1142,6 +1199,9 @@ AB1,AB1,,,,,AB,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -1158,6 +1218,7 @@ AB1,AB1,,,,,AB,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -1207,6 +1268,7 @@ AB1,AB1,,,,,AB,
         self.assertEqual(p.output.stats_full,None)
         self.assertEqual(p.output.per_lane_stats,None)
         self.assertEqual(p.output.per_lane_sample_stats,None)
+        self.assertEqual(p.output.seq_len_stats,None)
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),):
@@ -1226,6 +1288,7 @@ AB1,AB1,,,,,AB,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertFalse(os.path.exists(
                 os.path.join(analysis_dir,filen)),
@@ -1279,6 +1342,7 @@ AB1,AB1,,,,,AB,
         self.assertEqual(p.output.stats_full,None)
         self.assertEqual(p.output.per_lane_stats,None)
         self.assertEqual(p.output.per_lane_sample_stats,None)
+        self.assertEqual(p.output.seq_len_stats,None)
         self.assertEqual(p.output.missing_fastqs,
                          ["Sample1/Sample1_S1_L001_R1_001.fastq.gz",
                           "Sample1/Sample1_S1_L001_R2_001.fastq.gz"])
@@ -1300,6 +1364,7 @@ AB1,AB1,,,,,AB,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertFalse(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -1360,6 +1425,9 @@ AB1,AB1,,,,,AB,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,
                          ["Sample1/Sample1_S1_L001_R1_001.fastq.gz",
                           "Sample1/Sample1_S1_L001_R2_001.fastq.gz"])
@@ -1378,6 +1446,7 @@ AB1,AB1,,,,,AB,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -1420,6 +1489,7 @@ AB1,AB1,,,,,AB,
         self.assertEqual(p.output.stats_full,None)
         self.assertEqual(p.output.per_lane_stats,None)
         self.assertEqual(p.output.per_lane_sample_stats,None)
+        self.assertEqual(p.output.seq_len_stats,None)
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),):
@@ -1439,6 +1509,7 @@ AB1,AB1,,,,,AB,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertFalse(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -1490,6 +1561,7 @@ AB1,AB1,,,,,AB,
         self.assertEqual(p.output.stats_full,None)
         self.assertEqual(p.output.per_lane_stats,None)
         self.assertEqual(p.output.per_lane_sample_stats,None)
+        self.assertEqual(p.output.seq_len_stats,None)
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),):
@@ -1509,6 +1581,7 @@ AB1,AB1,,,,,AB,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertFalse(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -1568,6 +1641,9 @@ AB1,AB1,,,,,AB,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "221206_A7001250_00042_AHGXXXX"),
@@ -1584,6 +1660,7 @@ AB1,AB1,,,,,AB,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -1643,6 +1720,9 @@ AB1,AB1,,,,,AB,
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -1659,6 +1739,7 @@ AB1,AB1,,,,,AB,
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_standard_bclconvert.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_standard_bclconvert.py
@@ -62,6 +62,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -80,6 +83,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -152,6 +156,9 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -168,6 +175,7 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -245,6 +253,9 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -261,6 +272,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -338,6 +350,9 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -354,6 +369,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -424,6 +440,9 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -440,6 +459,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -510,6 +530,9 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -526,6 +549,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -599,6 +623,9 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -615,6 +642,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -685,6 +713,9 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -701,6 +732,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -771,6 +803,9 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -787,6 +822,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -855,6 +891,9 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -871,6 +910,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -930,6 +970,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
         self.assertEqual(p.output.stats_full,None)
         self.assertEqual(p.output.per_lane_stats,None)
         self.assertEqual(p.output.per_lane_sample_stats,None)
+        self.assertEqual(p.output.seq_len_stats,None)
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),):
@@ -949,6 +990,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertFalse(os.path.exists(
                 os.path.join(analysis_dir,filen)),
@@ -1023,6 +1065,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
@@ -1041,6 +1086,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -1172,6 +1218,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
@@ -1190,6 +1239,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -1300,6 +1350,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
@@ -1318,6 +1371,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -1451,6 +1505,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_SN7001250_00002_AHGXXXX"),
@@ -1467,6 +1524,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -1557,6 +1615,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -1575,6 +1636,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),
@@ -1631,6 +1693,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                   "statistics.info",
                   "per_lane_statistics.info",
                   "per_lane_sample_stats.info",
+                  "seq_len_statistics.info",
                   "processing_qc.html",):
             with open(os.path.join(analysis_dir,f),'wt') as fp:
                 fp.write("")
@@ -1667,6 +1730,9 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         self.assertEqual(p.output.per_lane_sample_stats,
                          os.path.join(analysis_dir,
                                       "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
         self.assertEqual(p.output.missing_fastqs,[])
         for subdir in (os.path.join("primary_data",
                                     "171020_M00879_00002_AHGXXXX"),
@@ -1682,6 +1748,7 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
                       "statistics_full.info",
                       "per_lane_statistics.info",
                       "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
                       "processing_qc.html"):
             self.assertTrue(os.path.isfile(
                 os.path.join(analysis_dir,filen)),

--- a/auto_process_ngs/test/bcl2fastq/test_reporting.py
+++ b/auto_process_ngs/test/bcl2fastq/test_reporting.py
@@ -84,6 +84,105 @@ CDE	CDE4	CDE4_S8_R2_001.fastq.gz	1.2G	27283286	Y	2		27283286
 Undetermined_indices	undetermined	Undetermined_S0_R1_001.fastq.gz	22.0G	27596657	Y	1	27596657	27596657
 Undetermined_indices	undetermined	Undetermined_S0_R2_001.fastq.gz	24.0G	27596657	Y	2	27596657	27596657
 """)
+        seq_len_statistics = os.path.join(analysis_dir,
+                                          "seq_len_statistics.info")
+        with open(seq_len_statistics,'w') as fp:
+            fp.write("""#Fastq	min	max	mean	nreads	masked	padded	masked_frac	padded_frac
+AB1_S1_R1_001.fastq.gz	35	76	75.26169877916482	25058003	293	85	0.16576242228118512	0.0480880747232107
+AB1_S1_R2_001.fastq.gz	35	76	75.26169877916482	25058003	293	85	0.16576242228118512	0.0480880747232107
+AB2_S2_R1_001.fastq.gz	35	76	75.26169877916482	22330927	293	85	0.16576242228118512	0.0480880747232107
+AB2_S2_R2_001.fastq.gz	35	76	75.26169877916482	22330927	293	85	0.16576242228118512	0.0480880747232107
+AB3_S3_R1_001.fastq.gz	35	76	75.26169877916482	34509382	293	85	0.16576242228118512	0.0480880747232107
+AB3_S3_R2_001.fastq.gz	35	76	75.26169877916482	34509382	293	85	0.16576242228118512	0.0480880747232107
+AB4_S4_R1_001.fastq.gz	35	76	75.26169877916482	27283286	293	85	0.16576242228118512	0.0480880747232107
+AB4_S4_R2_001.fastq.gz	35	76	75.26169877916482	27283286	293	85	0.16576242228118512	0.0480880747232107
+CDE1_S5_R1_001.fastq.gz	35	76	75.26169877916482	25058003	293	85	0.16576242228118512	0.0480880747232107
+CDE1_S5_R2_001.fastq.gz	35	76	75.26169877916482	25058003	293	85	0.16576242228118512	0.0480880747232107
+CDE2_S6_R1_001.fastq.gz	35	76	75.26169877916482	22330927	293	85	0.16576242228118512	0.0480880747232107
+CDE2_S6_R2_001.fastq.gz	35	76	75.26169877916482	22330927	293	85	0.16576242228118512	0.0480880747232107
+CDE3_S7_R1_001.fastq.gz	35	76	75.26169877916482	34509382	293	85	0.16576242228118512	0.0480880747232107
+CDE3_S7_R2_001.fastq.gz	35	76	75.26169877916482	34509382	293	85	0.16576242228118512	0.0480880747232107
+CDE4_S8_R1_001.fastq.gz	35	76	75.26169877916482	27283286	293	85	0.16576242228118512	0.0480880747232107
+CDE4_S8_R2_001.fastq.gz	35	76	75.26169877916482	27283286	293	85	0.16576242228118512	0.0480880747232107
+Undetermined_S0_R1_001.fastq.gz	35	76	75.26169877916482	27596657	293	85	0.16576242228118512	0.0480880747232107
+Undetermined_S0_R2_001.fastq.gz	35	76	75.26169877916482	27596657	293	85	0.16576242228118512	0.0480880747232107
+""")
+        # Generate QC report
+        output_html = os.path.join(analysis_dir,
+                                   "processing_report.html")
+        self.assertFalse(os.path.exists(output_html))
+        processing_qc_report = ProcessingQCReport(
+            analysis_dir,
+            statistics_full,
+            per_lane_statistics,
+            per_lane_sample_stats,
+            seq_len_statistics
+        )
+        processing_qc_report.write(output_html)
+        self.assertTrue(os.path.exists(output_html))
+        # Check the HTML
+        with open(output_html,'rt') as fp:
+            html = fp.read()
+        # No warnings
+        self.assertTrue(html.find("<p>Status: OK</p>") > -1)
+
+    def test_processing_qc_report_no_seq_len_stats(self):
+        """ProcessingQCReport: handle missing sequence length stats
+        """
+        # Create test data
+        analysis_dir = os.path.join(self.wd,
+                                    "180430_K00311_0001_ABCDEFGHXX_analysis")
+        os.mkdir(analysis_dir)
+        per_lane_sample_stats = os.path.join(analysis_dir,
+                                             "per_lane_sample_stats.info")
+        with open(per_lane_sample_stats,'w') as fp:
+            fp.write("""
+Lane 1
+Total reads = 136778255
+- AB/AB1	25058003	18.3%
+- AB/AB2	22330927	16.3%
+- AB/AB3	34509382	25.2%
+- AB/AB4	27283286	19.9%
+- Undetermined_indices/undetermined	27596657	20.2%
+
+Lane 2
+Total reads = 136778255
+- CDE/CDE1	25058003	18.3%
+- CDE/CDE2	22330927	16.3%
+- CDE/CDE3	34509382	25.2%
+- CDE/CDE4	27283286	19.9%
+- Undetermined_indices/undetermined	27596657	20.2%
+""")
+        per_lane_statistics = os.path.join(analysis_dir,
+                                           "per_lane_statistics.info")
+        with open(per_lane_statistics,'w') as fp:
+            fp.write("""#Lane	Total reads	Assigned reads	Unassigned reads	%assigned	%unassigned
+Lane 1	136778255	109181598	27596657	79.8	20.2
+Lane 2	136778255	109181598	27596657	79.8	20.2
+""")
+        statistics_full = os.path.join(analysis_dir,
+                                       "statistics_full.info")
+        with open(statistics_full,'w') as fp:
+            fp.write("""#Project	Sample	Fastq	Size	Nreads	Paired_end	Read_number	L1	L2
+AB	AB1	AB1_S1_R1_001.fastq.gz	1.0G	25058003	Y	1	25058003	
+AB	AB1	AB1_S1_R2_001.fastq.gz	1.1G	25058003	Y	2	25058003	
+AB	AB2	AB2_S2_R1_001.fastq.gz	941.7M	22330927	Y	1	22330927	
+AB	AB2	AB2_S2_R2_001.fastq.gz	1.0G	22330927	Y	2	22330927	
+AB	AB3	AB3_S3_R1_001.fastq.gz	1.4G	34509382	Y	1	34509382	
+AB	AB3	AB3_S3_R2_001.fastq.gz	1.6G	34509382	Y	2	34509382	
+AB	AB4	AB4_S4_R1_001.fastq.gz	1.1G	27283286	Y	1	27283286	
+AB	AB4	AB4_S4_R2_001.fastq.gz	1.2G	27283286	Y	2	27283286	
+CDE	CDE1	CDE1_S5_R1_001.fastq.gz	1.0G	25058003	Y	1		25058003
+CDE	CDE1	CDE1_S5_R2_001.fastq.gz	1.1G	25058003	Y	2		25058003
+CDE	CDE2	CDE2_S6_R1_001.fastq.gz	941.7M	22330927	Y	1		22330927
+CDE	CDE2	CDE2_S6_R2_001.fastq.gz	1.0G	22330927	Y	2		22330927
+CDE	CDE3	CDE3_S7_R1_001.fastq.gz	1.4G	34509382	Y	1		34509382
+CDE	CDE3	CDE3_S7_R2_001.fastq.gz	1.6G	34509382	Y	2		34509382
+CDE	CDE4	CDE4_S8_R1_001.fastq.gz	1.1G	27283286	Y	1		27283286
+CDE	CDE4	CDE4_S8_R2_001.fastq.gz	1.2G	27283286	Y	2		27283286
+Undetermined_indices	undetermined	Undetermined_S0_R1_001.fastq.gz	22.0G	27596657	Y	1	27596657	27596657
+Undetermined_indices	undetermined	Undetermined_S0_R2_001.fastq.gz	24.0G	27596657	Y	2	27596657	27596657
+""")
         # Generate QC report
         output_html = os.path.join(analysis_dir,
                                    "processing_report.html")

--- a/auto_process_ngs/test/qc/test_seqlens.py
+++ b/auto_process_ngs/test/qc/test_seqlens.py
@@ -1,0 +1,238 @@
+#######################################################################
+# Unit tests for qc/seqlens.py
+#######################################################################
+
+import unittest
+import shutil
+import os
+import tempfile
+
+from auto_process_ngs.qc.seqlens import SeqLens
+from auto_process_ngs.qc.seqlens import get_sequence_lengths
+
+# Set to False to keep test output dirs
+REMOVE_TEST_OUTPUTS = True
+
+class TestSeqLens(unittest.TestCase):
+    """
+    Tests for the SeqLens class
+    """
+    def test_seqlens(self):
+        """
+        SeqLens: load data from dictionary
+        """
+        seq_len_data = {
+            'fastq': '/data/test.fastq',
+            'frac_reads_masked': 10.0,
+            'frac_reads_padded': 10.0,
+            'max_length': 65,
+            'mean_length': 42.3,
+            'median_length': 33,
+            'min_length': 22,
+            'nreads': 10,
+            'nreads_masked': 1,
+            'nreads_padded': 1,
+            'seq_lengths_dist': {22: 2, 29: 1, 33: 2, 41: 1, 48: 1, 65: 3},
+            'seq_lengths_masked_dist': {22: 1},
+            'seq_lengths_padded_dist': {22: 1}
+        }
+        s = SeqLens(data=seq_len_data)
+        self.assertEqual(s.data,seq_len_data)
+        self.assertEqual(s.fastq,"/data/test.fastq")
+        self.assertEqual(s.nreads,10)
+        self.assertEqual(s.min_length,22)
+        self.assertEqual(s.max_length,65)
+        self.assertEqual(s.mean,42.3)
+        self.assertEqual(s.range,"22-65")
+        self.assertEqual(s.nmasked,1)
+        self.assertEqual(s.frac_masked,10.0)
+        self.assertEqual(s.npadded,1)
+        self.assertEqual(s.frac_padded,10.0)
+        self.assertEqual(s.dist,{22: 2, 29: 1, 33: 2, 41: 1, 48: 1, 65: 3})
+        self.assertEqual(s.masked_dist,{22: 1})
+        self.assertTrue(s)
+
+class TestGetSequenceLengths(unittest.TestCase):
+    """
+    Tests for the get_sequence_lengths function
+    """
+    def setUp(self):
+        # Create a temp working dir
+        self.wd = tempfile.mkdtemp(suffix='TestGetSequenceLengths')
+
+    def tearDown(self):
+        # Remove the temporary test directory
+        if REMOVE_TEST_OUTPUTS:
+            shutil.rmtree(self.wd)
+
+    def test_get_sequence_lengths_from_fastq(self):
+        """
+        get_sequence_lengths: test outputs with Fastq file
+        """
+        # Make a test Fastq file
+        fastq = os.path.join(self.wd,"test.fastq")
+        with open(fastq,'wt') as fp:
+            fp.write("""@MISEQ:1:000000000-A2Y1L:1:1101:19264:2433 1:N:0:NAAGGCGATAGATCGC
+AGATAGCCGAAGATAAAGAGNTCATAACCGTAA
++
+?????BBB@BBBB?BBFFFF#66EAFHHHCEFE
+@MISEQ:1:000000000-A2Y1L:1:1101:18667:2435 1:N:0:NAAGGCGATAGATCGC
+ATATATTCATCCGCCATTATNA
++
+?????BBBDDDDADDDE@FF#6
+@MISEQ:1:000000000-A2Y1L:1:1101:17523:2436 1:N:0:NAAGGCGATAGATCGC
+CATCACTACCGCTCAGGAATNTGACGGCA
++
+?<,<?BBBBBBBBBBBFFFF#6ACECCEC
+@MISEQ:1:000000000-A2Y1L:1:1101:15489:2437 1:N:0:NAAGGCGATAGATCGC
+GAGCAGTCGGGCTCAGCGCTNTGCAAATTCTAGTTAGAAACTCACAGT
++
+5====>/<@@@@@@>@CCCE#66>ACEEEEGGGGGGGFFFEFDFFFFF
+@MISEQ:1:000000000-A2Y1L:1:1101:18851:2442 1:N:0:NAAGGCGATAGATCGC
+GGTATCCCCCGGCAGTGAGGATGGAGCCATGGTCTGCATCA
++
+??,<?BBBDDDDDDD<FFF@FC;FFFBEFHHHCDDHHGHHH
+@MISEQ:1:000000000-A2Y1L:1:1101:15290:2442 1:N:0:NAAGGCGATAGATCGC
+AAAATAATCCTAAAAAATAACCTCTATGCCGCC
++
+?????BBBDDDDDDDDGGGGGGIIIHHFFHHHH
+@MISEQ:1:000000000-A2Y1L:1:1101:18106:2444 1:N:0:NAAGGCGATAGATCGC
+GTAGTATTCTCATATCACAAGT
++
+55,,5?9BBBBB<<BBFFFFFF
+/:*:ACE?0:::A::***00::*/?C888??EEE#############
+@MISEQ:1:000000000-A2Y1L:1:1101:15892:2446 1:N:0:NAAGGCGATAGATCGC
+CTTCCCCACGGCCCAGACACAAGAGACGACCTCCATAAATCTTTTAGA
++
+?????BBBDBDDDDDDFFFFFFHIHIHHHHHHIHIFGGHFHHHHIIFH
+@MISEQ:1:000000000-A2Y1L:1:1101:17903:2450 1:N:0:TAAGGCGATAGATCGC
+GTGCAGGGGGTGTGGTCAATCCACACTGTTGCTGAG
++
+=5===<>+5<5<+5=@CC;8CEEEEE;-8ACFDE.7
+@MISEQ:1:000000000-A2Y1L:1:1101:15113:2451 1:N:0:TAAGGCGATAGATCGC
+TCTCAGATGAGCATGCAGCAGCCCAGACTCGCCCCACGCAGTTTGCCA
++
+=,,<=>>>@@@@@9@@CCEE@EE+++6C8-++CECE+>DCC>@@EFFF
+""")
+        # Expected output
+        expected_stats = {
+            'fastq': fastq,
+            'frac_reads_masked': 0.0,
+            'frac_reads_padded': 0.0,
+            'max_length': 65,
+            'mean_length': 42.3,
+            'median_length': 33,
+            'min_length': 22,
+            'nreads': 10,
+            'nreads_masked': 0,
+            'nreads_padded': 0,
+            'seq_lengths_dist': {22: 2, 29: 1, 33: 2, 41: 1, 48: 1, 65: 3},
+            'seq_lengths_masked_dist': {},
+            'seq_lengths_padded_dist': {}
+        }
+        # Get statistics
+        stats = get_sequence_lengths(fastq)
+        # Check against expected
+        self.assertEqual(stats,expected_stats)
+
+    def test_get_sequence_lengths(self):
+        """
+        get_sequence_lengths: Fastq with masking and padding
+        """
+        # Make a test Fastq file
+        fastq = os.path.join(self.wd,"test.fastq")
+        with open(fastq,'wt') as fp:
+            fp.write("""@MISEQ:1:000000000-A2Y1L:1:1101:19264:2433 1:N:0:NAAGGCGATAGATCGC
+AGATAGCCGAAGATAAAGAGNTCATAACCGTAA
++
+?????BBB@BBBB?BBFFFF#66EAFHHHCEFE
+@MISEQ:1:000000000-A2Y1L:1:1101:18667:2435 1:N:0:NAAGGCGATAGATCGC
+NNNNNNNNNNNNNNNNNNNNNN
++
+?????BBBDDDDADDDE@FF#6
+@MISEQ:1:000000000-A2Y1L:1:1101:17523:2436 1:N:0:NAAGGCGATAGATCGC
+CATCACTACCGCTCAGGAATNTGACGGCA
++
+?<,<?BBBBBBBBBBBFFFF#6ACECCEC
+@MISEQ:1:000000000-A2Y1L:1:1101:15489:2437 1:N:0:NAAGGCGATAGATCGC
+GAGCAGTCGGGCTCAGCGCTNTGCAAATTCTAGTTAGAAACTCACAGT
++
+5====>/<@@@@@@>@CCCE#66>ACEEEEGGGGGGGFFFEFDFFFFF
+@MISEQ:1:000000000-A2Y1L:1:1101:18851:2442 1:N:0:NAAGGCGATAGATCGC
+GGTATCCCCCGGCAGTGAGGATGGAGCCATGGTCTGCATCA
++
+??,<?BBBDDDDDDD<FFF@FC;FFFBEFHHHCDDHHGHHH
+@MISEQ:1:000000000-A2Y1L:1:1101:15290:2442 1:N:0:NAAGGCGATAGATCGC
+AAAATAATCCTAAAAAATAACCTCTATGCCGCC
++
+?????BBBDDDDDDDDGGGGGGIIIHHFFHHHH
+@MISEQ:1:000000000-A2Y1L:1:1101:18106:2444 1:N:0:NAAGGCGATAGATCGC
+GTAGTATTCTCATATNNNNNNN
++
+55,,5?9BBBBB<<BBFFFFFF
+/:*:ACE?0:::A::***00::*/?C888??EEE#############
+@MISEQ:1:000000000-A2Y1L:1:1101:15892:2446 1:N:0:NAAGGCGATAGATCGC
+CTTCCCCACGGCCCAGACACAAGAGACGACCTCCATAAATCTTTTAGA
++
+?????BBBDBDDDDDDFFFFFFHIHIHHHHHHIHIFGGHFHHHHIIFH
+@MISEQ:1:000000000-A2Y1L:1:1101:17903:2450 1:N:0:TAAGGCGATAGATCGC
+GTGCAGGGGGTGTGGTCAATCCACACTGTTGCTGAG
++
+=5===<>+5<5<+5=@CC;8CEEEEE;-8ACFDE.7
+@MISEQ:1:000000000-A2Y1L:1:1101:15113:2451 1:N:0:TAAGGCGATAGATCGC
+TCTCAGATGAGCATGCAGCAGCCCAGACTCGCCCCACGCAGTTTGCCA
++
+=,,<=>>>@@@@@9@@CCEE@EE+++6C8-++CECE+>DCC>@@EFFF
+""")
+        # Expected output
+        expected_stats = {
+            'fastq': fastq,
+            'frac_reads_masked': 10.0,
+            'frac_reads_padded': 10.0,
+            'max_length': 65,
+            'mean_length': 42.3,
+            'median_length': 33,
+            'min_length': 22,
+            'nreads': 10,
+            'nreads_masked': 1,
+            'nreads_padded': 1,
+            'seq_lengths_dist': {22: 2, 29: 1, 33: 2, 41: 1, 48: 1, 65: 3},
+            'seq_lengths_masked_dist': {22: 1},
+            'seq_lengths_padded_dist': {22: 1}
+        }
+        # Get statistics
+        stats = get_sequence_lengths(fastq)
+        print(stats['frac_reads_masked'])
+        print(stats['frac_reads_padded'])
+        # Check against expected
+        self.assertEqual(stats,expected_stats)
+
+    def test_get_sequence_lengths_from_empty_fastq(self):
+        """
+        get_sequence_lengths: test outputs with empty Fastq file
+        """
+        # Make a test Fastq file
+        fastq = os.path.join(self.wd,"test.fastq")
+        with open(fastq,'wt') as fp:
+            fp.write("")
+        # Expected output
+        expected_stats = {
+            'fastq': fastq,
+            'frac_reads_masked': None,
+            'frac_reads_padded': None,
+            'max_length': None,
+            'mean_length': None,
+            'median_length': None,
+            'min_length': None,
+            'nreads': 0,
+            'nreads_masked': 0,
+            'nreads_padded': 0,
+            'seq_lengths_dist': {},
+            'seq_lengths_masked_dist': {},
+            'seq_lengths_padded_dist': {}
+        }
+        # Get statistics
+        stats = get_sequence_lengths(fastq)
+        # Check against expected
+        self.assertEqual(stats,expected_stats)
+


### PR DESCRIPTION
Updates the Fastq generation pipeline used by `make_fastqs`, to generate and report statistics on the sequence lengths of the generated Fastq files, as part of the processing QC.

This is useful to check any trimming of reads immediately after Fastq generation, without needing to do the full QC (as is the case at present).

Additionally as the updates re-use the existing code from the QC pipeline, the composition of reads (i.e. percentages of masked and padded reads in each file) is now also reported.