### PR TITLE
'run_qc.py': enable user to specify or customise QC protocols

### DIFF
--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -63,6 +63,22 @@ logger.addHandler(logging.NullHandler())
 # Data
 #######################################################################
 
+# QC modules
+
+QC_MODULES = [
+    'cellranger_count',
+    'cellranger-arc_count',
+    'cellranger-atac_count',
+    'cellranger_multi',
+    'fastqc',
+    'fastq_screen',
+    'picard_insert_size_metrics',
+    'qualimap_rnaseq',
+    'rseqc_genebody_coverage',
+    'sequence_lengths',
+    'strandedness'
+]
+
 # QC protocol definitions
 
 QC_PROTOCOLS = {
@@ -402,13 +418,51 @@ class QCProtocol:
         self.name = str(name)
         self.description = (str(description) if description is not None
                             else "")
-        self.qc_modules = (sorted([m for m in qc_modules])
-                           if qc_modules is not None else [])
+        self.seq_data_reads = []
+        self.index_reads = []
+        self.qc_modules = []
+        self.update(seq_data_reads=seq_data_reads,
+                    index_reads=index_reads,
+                    qc_modules=qc_modules)
+
+    def update(self,seq_data_reads=None,index_reads=None,
+                 qc_modules=None):
+        """
+        Update the reads and QC modules for the protocol
+
+        Allows the sequence data reads, index reads and QC
+        modules associated with the protocol to be updated.
+        Checks that values are valid and that internal data
+        is also correctly updated.
+
+        Arguments:
+          seq_data_reads (list): read names associated
+            with sequence data (if not supplied then
+            existing read data will be kept)
+          index_reads (list): read names associated
+            with index data (if not supplied then existing
+            read data will be kept)
+          qc_modules (list): list of names of associated
+            QC modules (if not supplied then existing
+            modules data will be kept)
+        """
+        # Store QC modules
+        if qc_modules is not None:
+            self.qc_modules = (sorted([m for m in qc_modules])
+                               if qc_modules is not None else [])
+            # Check QC modules are valid
+            for m in self.qc_modules:
+                name = m.split('(')[0]
+                if name not in QC_MODULES:
+                    raise QCProtocolError("'%s': unrecognised QC module"
+                                          % name)
         # Store supplied reads
-        self.seq_data_reads = [str(r).lower() for r in seq_data_reads] \
-                              if seq_data_reads else []
-        self.index_reads = [str(r).lower() for r in index_reads] \
-                           if index_reads else []
+        if seq_data_reads is not None:
+            self.seq_data_reads = [str(r).lower() for r in seq_data_reads] \
+                                  if seq_data_reads else []
+        if index_reads is not None:
+            self.index_reads = [str(r).lower() for r in index_reads] \
+                               if index_reads else []
         # Normalise and store supplied read names
         self.reads = AttributeDictionary(
             seq_data=self.__reads(self.seq_data_reads),
@@ -423,10 +477,14 @@ class QCProtocol:
             qc=self.__read_numbers(self.reads.qc))
         # Extract and store sequence ranges for reads
         self.read_range = AttributeDictionary()
-        if not seq_data_reads:
+        if not self.seq_data_reads:
             seq_data_reads = tuple()
+        else:
+            seq_data_reads = self.seq_data_reads
         if not index_reads:
             index_reads = tuple()
+        else:
+            index_reads = self.index_reads
         for r in list(seq_data_reads) + list(index_reads):
             rd,rng = self.__parse_read_defn(r)
             self.read_range[rd] = rng

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -12,6 +12,7 @@ from auto_process_ngs.qc.protocols import QCProtocol
 from auto_process_ngs.qc.protocols import determine_qc_protocol
 from auto_process_ngs.qc.protocols import fetch_protocol_definition
 from auto_process_ngs.qc.protocols import parse_protocol_spec
+from auto_process_ngs.qc.protocols import QCProtocolError
 from auto_process_ngs.qc.protocols import QCProtocolParseSpecError
 
 # Set to False to keep test output dirs
@@ -80,6 +81,45 @@ class TestQCProtocol(unittest.TestCase):
                                           "qc_modules=[fastq_screen,"
                                           "fastqc,sequence_lengths]")
         self.assertEqual(p,q)
+
+    def test_qcprotocol_update(self):
+        """
+        QCProtocol: check protocol can be updated
+        """
+        p = QCProtocol(name="example",
+                       description="Example protocol",
+                       seq_data_reads=['r1','r2'],
+                       index_reads=None,
+                       qc_modules=("fastqc",
+                                   "fastq_screen",
+                                   "sequence_lengths"))
+        self.assertEqual(p.seq_data_reads,['r1','r2'])
+        self.assertEqual(p.index_reads,[])
+        self.assertEqual(p.qc_modules,["fastq_screen",
+                                       "fastqc",
+                                       "sequence_lengths"])
+        p.update(seq_data_reads=['r2'],
+                 index_reads=['r1'],
+                 qc_modules=["sequence_lengths","fastqc"])
+        self.assertEqual(p.seq_data_reads,['r2'])
+        self.assertEqual(p.index_reads,['r1'])
+        self.assertEqual(p.qc_modules,["fastqc",
+                                       "sequence_lengths"])
+
+    def test_qcprotocol_unrecognised_module(self):
+        """
+        QCProtocol: raise exception for unrecognised QC module
+        """
+        self.assertRaises(QCProtocolError,
+                          QCProtocol,
+                          name="example",
+                          description="Example protocol",
+                          seq_data_reads=['r1','r2'],
+                          index_reads=None,
+                          qc_modules=("fastqc",
+                                      "doesnt_exist",
+                                      "fastq_screen",
+                                      "sequence_lengths"))
 
     def test_qcprotocol_null_protocol(self):
         """

--- a/docs/source/reference/qc_protocol_specification.rst
+++ b/docs/source/reference/qc_protocol_specification.rst
@@ -70,6 +70,8 @@ Optionally, descriptions can be enclosed in matching quotes
 description includes special characters such as colons or
 quotes.
 
+.. _qc_protocols_seq_and_index_reads:
+
 -----------------------------
 Sequence data and index reads
 -----------------------------
@@ -90,6 +92,8 @@ Subsequences can be specified by ranges attached to reads,
 for example in this case ``seq_reads=[r2:1-50]``, and tell
 the pipeline to only use these portions of the the reads
 when running the mapped metrics.
+
+.. _qc_protocols_qc_modules:
 
 ----------
 QC modules

--- a/docs/source/using/run_qc_standalone.rst
+++ b/docs/source/using/run_qc_standalone.rst
@@ -50,8 +50,6 @@ Specifying the QC metadata
 The following options specify metadata for the QC which will
 determine which metrics are run:
 
-* ``--protocol``: specify the QC protocol (see :doc:`run_qc`
-  for a complete list, or use the ``--info`` option)
 * ``--organism``: specify the organism(s) (e.g. ``human``,
   ``mouse`` etc; use the ``--info`` option to list the
   organisms available in the current configuration)
@@ -223,3 +221,39 @@ This results in per-lane QC metrics, which can be useful for
 diagnostic purposes when handling Fastqs which have been merged
 across multiple lanes (for example, to determine whether
 contanimation is confined to a single lane).
+
+Specifying and customising the QC protocols
+-------------------------------------------
+
+If a QC protocol is not specified explicitly then by default
+``run_qc.py`` will determine which protocol to use based on the
+metadata; see :doc:`run_qc` for a complete list of the built-in
+protocols (or use ``run_qc.py``'s ``--info`` option).
+
+This behaviour can be overridden in a number of ways:
+
+* The ``--protocol`` option can be used to explicitly specify
+  one of the built-in QC protocols to use, or
+* The ``--protocol-spec`` option can be used to fully specify
+  a custom QC protocol using a specification string (see
+  :doc:`qc_protocol_specification` for details of protocol
+  specification strings), or
+* A combination of the ``--sequence-reads``, ``--index-reads``
+  and/or ``--qc-modules`` can be used to customise or specify
+  the QC protocol.
+
+The ``--sequence-reads`` and ``--index-reads`` options specify
+which reads contain biological data and which contain only
+"index" data; the ``--qc-modules`` option specify which QC
+metrics will be generated and reported.
+
+.. note::
+
+   Details of the available QC modules can be found in
+   :ref:`qc_protocols_qc_modules`.
+
+.. note::
+
+   Using ``--sequence-reads``, ``--index-reads`` and
+   ``--qc-modules`` will override the relevant parts of the
+   specified or automatically determined QC protocol.


### PR DESCRIPTION
Updates the standalone QC runner utility `run_qc.py` to allow the user to specify a custom QC protocol, or to customise an existing protocol. via the command line.

The new options are:

* `--protocol-spec`: allows a full QC protocol specification to be supplied
* `--sequence-reads` and `--index-reads`: allows the reads in a pre-defined protocol to be changed
* `--qc-modules`: allows the QC modules in a pre-defined protocol to be changed

These changes would address some of the issues in #666 (implement QC pipeline as 'mini-protocols') and #638 (enable just the Cellranger `count` part of a pipeline to be run).