### PR TITLE
Add support for RSeQC 'infer_experiment.py' as explicit QC module

### DIFF
--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -270,6 +270,7 @@ class QCPipeline(Pipeline):
         require_bam_files = False
         for qc_module in ('picard_insert_size_metrics',
                           'rseqc_genebody_coverage',
+                          'rseqc_infer_experiment',
                           'qualimap_rnaseq'):
             if qc_module in qc_modules:
                 require_bam_files = True
@@ -522,6 +523,7 @@ class QCPipeline(Pipeline):
                 reference_gene_model_file,
                 os.path.join(qc_dir,'rseqc_infer_experiment',organism_name))
             self.add_task(rseqc_infer_experiment)
+            verify_qc.requires(rseqc_infer_experiment)
 
         ################
         # Add QC modules

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -75,6 +75,7 @@ QC_MODULES = [
     'picard_insert_size_metrics',
     'qualimap_rnaseq',
     'rseqc_genebody_coverage',
+    'rseqc_infer_experiment',
     'sequence_lengths',
     'strandedness'
 ]

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -627,6 +627,7 @@ class QCProtocol:
                              'strandedness',
                              'picard_insert_size_metrics',
                              'rseqc_genebody_coverage',
+                             'rseqc_infer_experiment',
                              'qualimap_rnaseq'):
                 mapped_metrics.append(qc_module)
         return mapped_metrics

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -94,6 +94,7 @@ QC_PROTOCOLS = {
             'fastq_screen',
             'sequence_lengths',
             'rseqc_genebody_coverage',
+            'rseqc_infer_experiment',
             'qualimap_rnaseq'
         ]
     },
@@ -110,6 +111,7 @@ QC_PROTOCOLS = {
             'sequence_lengths',
             'picard_insert_size_metrics',
             'rseqc_genebody_coverage',
+            'rseqc_infer_experiment',
             'qualimap_rnaseq'
         ]
     },
@@ -125,6 +127,7 @@ QC_PROTOCOLS = {
             'fastq_screen',
             'sequence_lengths',
             'rseqc_genebody_coverage',
+            'rseqc_infer_experiment',
             'qualimap_rnaseq',
             'cellranger_count'
         ]
@@ -141,6 +144,7 @@ QC_PROTOCOLS = {
             'fastq_screen',
             'sequence_lengths',
             'rseqc_genebody_coverage',
+            'rseqc_infer_experiment',
             'qualimap_rnaseq',
             'cellranger_count'
         ]
@@ -158,6 +162,7 @@ QC_PROTOCOLS = {
             'sequence_lengths',
             'picard_insert_size_metrics',
             'rseqc_genebody_coverage',
+            'rseqc_infer_experiment',
             'qualimap_rnaseq',
             'cellranger-atac_count'
         ]
@@ -174,6 +179,7 @@ QC_PROTOCOLS = {
             'fastq_screen',
             'sequence_lengths',
             'rseqc_genebody_coverage',
+            'rseqc_infer_experiment',
             'qualimap_rnaseq',
             'cellranger-arc_count',
             # Also run Cellranger
@@ -200,6 +206,7 @@ QC_PROTOCOLS = {
             'sequence_lengths',
             'picard_insert_size_metrics',
             'rseqc_genebody_coverage',
+            'rseqc_infer_experiment',
             'qualimap_rnaseq',
             'cellranger-arc_count',
             # Also run Cellranger ATAC
@@ -225,6 +232,7 @@ QC_PROTOCOLS = {
             'fastq_screen',
             'sequence_lengths',
             'rseqc_genebody_coverage',
+            'rseqc_infer_experiment',
             'qualimap_rnaseq',
             'cellranger_count(cellranger_use_multi_config=True;'
                              'set_cell_count=false;'
@@ -244,6 +252,7 @@ QC_PROTOCOLS = {
             'fastq_screen',
             'sequence_lengths',
             'rseqc_genebody_coverage',
+            'rseqc_infer_experiment',
             'qualimap_rnaseq',
             'cellranger_multi'
         ]
@@ -260,6 +269,7 @@ QC_PROTOCOLS = {
             'fastq_screen',
             'sequence_lengths',
             'rseqc_genebody_coverage',
+            'rseqc_infer_experiment',
             'qualimap_rnaseq',
             'cellranger_count(cellranger_use_multi_config=True;'
                              'set_cell_count=false;'
@@ -279,6 +289,7 @@ QC_PROTOCOLS = {
             'fastq_screen',
             'sequence_lengths',
             'rseqc_genebody_coverage',
+            'rseqc_infer_experiment',
             'qualimap_rnaseq'
         ]
     },
@@ -294,6 +305,7 @@ QC_PROTOCOLS = {
             'fastq_screen',
             'sequence_lengths',
             'rseqc_genebody_coverage',
+            'rseqc_infer_experiment',
             'qualimap_rnaseq'
         ]
     },
@@ -321,6 +333,7 @@ QC_PROTOCOLS = {
             'fastq_screen',
             'sequence_lengths',
             'rseqc_genebody_coverage',
+            'rseqc_infer_experiment',
             'qualimap_rnaseq'
         ]
     },
@@ -336,6 +349,7 @@ QC_PROTOCOLS = {
             'fastq_screen',
             'sequence_lengths',
             'rseqc_genebody_coverage',
+            'rseqc_infer_experiment',
             'qualimap_rnaseq'
         ]
     },

--- a/auto_process_ngs/qc/verification.py
+++ b/auto_process_ngs/qc/verification.py
@@ -379,6 +379,32 @@ class QCVerifier(QCOutputs):
                 return False
             return True
 
+        elif name == "rseqc_infer_experiment":
+            if not seq_data_fastqs:
+                # Nothing to check
+                return None
+            if not organism:
+                # No organism specified
+                return None
+            if not star_index or not annotation_bed:
+                # No STAR index or annotation
+                return None
+            if "rseqc_infer_experiment" not in self.outputs:
+                # No RSeQC infer_experiment.py output present
+                return False
+            if normalise_organism_name(organism) not in \
+               self.data('rseqc_infer_experiment').organisms:
+                return False
+            # Filter Fastq names and convert to BAM names
+            bams = [get_bam_basename(fq)
+                    for fq in self.filter_fastqs(seq_data_reads[:1],
+                                                 seq_data_fastqs)]
+            # Check that outputs exist for every BAM
+            for bam in bams:
+                if bam not in self.data('rseqc_infer_experiment').bam_files:
+                    return False
+            return True
+
         elif name == "picard_insert_size_metrics":
             if not seq_data_fastqs:
                 # Nothing to check

--- a/auto_process_ngs/qc/verification.py
+++ b/auto_process_ngs/qc/verification.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     verification: utilities for verification of QC outputs
-#     Copyright (C) University of Manchester 2022-2023 Peter Briggs
+#     Copyright (C) University of Manchester 2022-2024 Peter Briggs
 #
 
 """
@@ -396,9 +396,13 @@ class QCVerifier(QCOutputs):
                self.data('rseqc_infer_experiment').organisms:
                 return False
             # Filter Fastq names and convert to BAM names
-            bams = [get_bam_basename(fq)
-                    for fq in self.filter_fastqs(seq_data_reads[:1],
-                                                 seq_data_fastqs)]
+            if seq_data_reads:
+                fastqs = self.filter_fastqs(seq_data_reads[:1],
+                                            seq_data_fastqs)
+            else:
+                # No Fastqs to get BAM names from
+                return None
+            bams = [get_bam_basename(fq) for fq in fastqs]
             # Check that outputs exist for every BAM
             for bam in bams:
                 if bam not in self.data('rseqc_infer_experiment').bam_files:

--- a/auto_process_ngs/test/qc/qc_modules/test_rseqc_infer_experiment.py
+++ b/auto_process_ngs/test/qc/qc_modules/test_rseqc_infer_experiment.py
@@ -1,0 +1,504 @@
+#######################################################################
+# Unit tests for qc/pipeline.py ('rseqc_infer_experiment' QC module)
+#######################################################################
+
+# All imports declared in __init__.py file
+from . import *
+
+class TestQCPipelineRSeQCInferExperiment(BaseQCPipelineTestCase):
+    """
+    Tests for '' QC module
+    """
+    def test_qcpipeline_qc_modules_rseqc_infer_experiment_pe(self):
+        """
+        QCPipeline: 'rseqc_infer_experiment' QC module (PE data)
+        """
+        # Make mock QC executables
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # QC protocol
+        protocol = QCProtocol(name="rseqc_infer_experiment",
+                              description="RSeQC_infer_experiment test",
+                              seq_data_reads=['r1','r2'],
+                              index_reads=None,
+                              qc_modules=("rseqc_infer_experiment",))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol)
+        status = runqc.run(star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check outputs
+        qc_dir = os.path.join(self.wd,"PJB","qc")
+        infer_expt_dir = os.path.join(qc_dir,"rseqc_infer_experiment","human")
+        for f in ("PJB1_S1_001.infer_experiment.log",
+                  "PJB2_S2_001.infer_experiment.log"):
+            self.assertTrue(os.path.exists(os.path.join(infer_expt_dir,f)),
+                            "%s: missing" % f)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"rseqc_infer_experiment")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    def test_qcpipeline_qc_modules_rseqc_infer_experiment_pe_with_r1_index_reads(self):
+        """
+        QCPipeline: 'rseqc_infer_experiment' QC module (PE data, R1 as index reads)
+        """
+        # Make mock QC executables
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # QC protocol
+        protocol = QCProtocol(name="rseqc_infer_experiment",
+                              description="RSeQC_infer_experiment test",
+                              seq_data_reads=['r1','r2'],
+                              index_reads=None,
+                              qc_modules=("rseqc_infer_experiment",))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol)
+        status = runqc.run(star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check outputs
+        qc_dir = os.path.join(self.wd,"PJB","qc")
+        infer_expt_dir = os.path.join(qc_dir,"rseqc_infer_experiment","human")
+        for f in ("PJB1_S1_001.infer_experiment.log",
+                  "PJB2_S2_001.infer_experiment.log"):
+            self.assertTrue(os.path.exists(os.path.join(infer_expt_dir,f)),
+                            "%s: missing" % f)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"rseqc_infer_experiment")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    def test_qcpipeline_qc_modules_rseqc_infer_experiment_se(self):
+        """
+        QCPipeline: 'rseqc_infer_experiment' QC module (SE data)
+        """
+        # Make mock QC executables
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # QC protocol
+        protocol = QCProtocol(name="rseqc_infer_experiment",
+                              description="RSeQC_infer_experiment test",
+                              seq_data_reads=['r1','r2'],
+                              index_reads=None,
+                              qc_modules=("rseqc_infer_experiment",))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol)
+        status = runqc.run(star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check outputs
+        qc_dir = os.path.join(self.wd,"PJB","qc")
+        infer_expt_dir = os.path.join(qc_dir,"rseqc_infer_experiment","human")
+        for f in ("PJB1_S1_001.infer_experiment.log",
+                  "PJB2_S2_001.infer_experiment.log"):
+            self.assertTrue(os.path.exists(os.path.join(infer_expt_dir,f)),
+                            "%s: missing" % f)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"rseqc_infer_experiment")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    def test_qcpipeline_qc_modules_rseqc_infer_experiment_se_with_biological_samples(self):
+        """
+        QCPipeline: 'rseqc_infer_experiment' QC module (SE data with biological samples)
+        """
+        # Make mock QC executables
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Biological samples': 'PJB1' })
+        p.create(top_dir=self.wd)
+        # QC protocol
+        protocol = QCProtocol(name="rseqc_infer_experiment",
+                              description="RSeQC_infer_experiment test",
+                              seq_data_reads=['r1','r2'],
+                              index_reads=None,
+                              qc_modules=("rseqc_infer_experiment",))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol)
+        status = runqc.run(star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check outputs
+        qc_dir = os.path.join(self.wd,"PJB","qc")
+        infer_expt_dir = os.path.join(qc_dir,"rseqc_infer_experiment","human")
+        for f in ("PJB1_S1_001.infer_experiment.log",):
+            self.assertTrue(os.path.exists(os.path.join(infer_expt_dir,f)),
+                            "%s: missing" % f)
+        infer_expt_dir = os.path.join(qc_dir,"rseqc_infer_experiment","human")
+        for f in ("PJB2_S2_001.infer_experiment.log",):
+            self.assertFalse(os.path.exists(os.path.join(infer_expt_dir,f)),
+                            "%s: present" % f)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"rseqc_infer_experiment")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    def test_qcpipeline_qc_modules_rseqc_infer_experiment_se_split_lanes(self):
+        """
+        QCPipeline: 'rseqc_infer_experiment' QC module (SE data, split by lane)
+        """
+        # Make mock QC executables
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # QC protocol
+        protocol = QCProtocol(name="rseqc_infer_experiment",
+                              description="RSeQC_infer_experiment test",
+                              seq_data_reads=['r1','r2'],
+                              index_reads=None,
+                              qc_modules=("rseqc_infer_experiment",))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol,
+                          split_fastqs_by_lane=True)
+        status = runqc.run(star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check outputs
+        qc_dir = os.path.join(self.wd,"PJB","qc")
+        infer_expt_dir = os.path.join(qc_dir,"rseqc_infer_experiment","human")
+        for f in ("PJB1_S1_L001_001.infer_experiment.log",
+                  "PJB2_S2_L001_001.infer_experiment.log"):
+            self.assertTrue(os.path.exists(os.path.join(infer_expt_dir,f)),
+                            "%s: missing" % f)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"rseqc_infer_experiment")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_L001_R1_001.fastq.gz,"
+                         "PJB2_S2_L001_R1_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,True)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    def test_qcpipeline_qc_modules_rseqc_infer_experiment_missing_star_index(self):
+        """
+        QCPipeline: 'rseqc_infer_experiment' QC module (no STAR index)
+        """
+        # Make mock QC executables
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # QC protocol
+        protocol = QCProtocol(name="rseqc_infer_experiment",
+                              description="RSeQC_infer_experiment test",
+                              seq_data_reads=['r1','r2'],
+                              index_reads=None,
+                              qc_modules=("rseqc_infer_experiment",))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol)
+        status = runqc.run(annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        self.assertEqual(status,0)
+        # Check outputs
+        qc_dir = os.path.join(self.wd,"PJB","qc")
+        infer_expt_dir = os.path.join(qc_dir,"rseqc_infer_experiment","human")
+        for f in ("PJB1_S1_001.infer_experiment.log",
+                  "PJB2_S2_001.infer_experiment.log"):
+            self.assertFalse(os.path.exists(os.path.join(infer_expt_dir,f)),
+                            "%s: present" % f)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"rseqc_infer_experiment")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,None)
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    def test_qcpipeline_qc_modules_rseqc_infer_experiment_missing_gtf_file(self):
+        """
+        QCPipeline: 'rseqc_infer_experiment' QC module (no GTF file)
+        """
+        # Make mock QC executables
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # QC protocol
+        protocol = QCProtocol(name="rseqc_infer_experiment",
+                              description="RSeQC_infer_experiment test",
+                              seq_data_reads=['r1','r2'],
+                              index_reads=None,
+                              qc_modules=("rseqc_infer_experiment",))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol)
+        status = runqc.run(star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        self.assertEqual(status,0)
+        # Check outputs
+        qc_dir = os.path.join(self.wd,"PJB","qc")
+        infer_expt_dir = os.path.join(qc_dir,"rseqc_infer_experiment","human")
+        for f in ("PJB1_S1_001.infer_experiment.log",
+                  "PJB2_S2_001.infer_experiment.log"):
+            self.assertFalse(os.path.exists(os.path.join(infer_expt_dir,f)),
+                            "%s: present" % f)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"rseqc_infer_experiment")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,None)
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -896,6 +896,7 @@ class TestFetchProtocolDefinition(unittest.TestCase):
                                        'picard_insert_size_metrics',
                                        'qualimap_rnaseq',
                                        'rseqc_genebody_coverage',
+                                       'rseqc_infer_experiment',
                                        'sequence_lengths'])
 
     def test_fetch_protocol_definition_unknown_protocol_name(self):

--- a/auto_process_ngs/test/qc/test_verification.py
+++ b/auto_process_ngs/test/qc/test_verification.py
@@ -324,6 +324,76 @@ class TestQCVerifier(unittest.TestCase):
             star_index="/data/indexes/STAR",
             annotation_bed="/data/annot/human.bed"))
 
+    def test_qcverifier_verify_qc_module_rseqc_infer_experiment(self):
+        """
+        QCVerifier: verify QC module 'rseqc_infer_experiment'
+        """
+        fastq_names=('PJB1_S1_R1_001.fastq.gz',
+                     'PJB1_S1_R2_001.fastq.gz',
+                     'PJB2_S2_R1_001.fastq.gz',
+                     'PJB2_S2_R2_001.fastq.gz',)
+        # All outputs present
+        qc_dir = self._make_qc_dir('qc.ok',
+                                   fastq_names=fastq_names,
+                                   organisms=('human',),
+                                   include_rseqc_infer_experiment=True)
+        qc_verifier = QCVerifier(qc_dir)
+        self.assertTrue(qc_verifier.verify_qc_module(
+            'rseqc_infer_experiment',
+            fastqs=fastq_names,
+            organism="Human",
+            star_index="/data/indexes/STAR",
+            annotation_gtf="/data/annot/human.gtf",
+            annotation_bed="/data/annot/human.bed"))
+        # Returns None if organism, STAR index or annotation
+        # is not supplied
+        self.assertEqual(None,
+                         qc_verifier.verify_qc_module(
+                             'rseqc_infer_experiment',
+                             fastqs=fastq_names,
+                             star_index="/data/indexes/STAR",
+                             annotation_gtf="/data/annot/human.gtf",
+                             annotation_bed="/data/annot/human.bed"))
+        self.assertEqual(None,
+                         qc_verifier.verify_qc_module(
+                             'rseqc_infer_experiment',
+                             fastqs=fastq_names,
+                             organism="Human",
+                             annotation_gtf="/data/annot/human.gtf",
+                             annotation_bed="/data/annot/human.bed"))
+        self.assertEqual(None,
+                         qc_verifier.verify_qc_module(
+                             'rseqc_infer_experiment',
+                             fastqs=fastq_names,
+                             organism="Human",
+                             star_index="/data/indexes/STAR"))
+        # Organism name contains spaces
+        qc_dir = self._make_qc_dir('qc.homo_sapiens',
+                                   fastq_names=fastq_names[:-2],
+                                   organisms=('Homo sapiens',),
+                                   include_rseqc_infer_experiment=True)
+        qc_verifier = QCVerifier(qc_dir)
+        self.assertTrue(qc_verifier.verify_qc_module(
+            'rseqc_infer_experiment',
+            fastqs=fastq_names,
+            organism="Homo sapiens",
+            star_index="/data/indexes/STAR",
+            annotation_gtf="/data/annot/human.gtf",
+            annotation_bed="/data/annot/human.bed"))
+        # Empty QC directory
+        qc_dir = self._make_qc_dir('qc.empty',
+                                   fastq_names=fastq_names,
+                                   organisms=('human',),
+                                   include_rseqc_infer_experiment=False)
+        qc_verifier = QCVerifier(qc_dir)
+        self.assertFalse(qc_verifier.verify_qc_module(
+            'rseqc_infer_experiment',
+            fastqs=fastq_names,
+            organism="Human",
+            star_index="/data/indexes/STAR",
+            annotation_gtf="/data/annot/human.gtf",
+            annotation_bed="/data/annot/human.bed"))
+
     def test_qcverifier_verify_qc_module_picard_insert_size_metrics(self):
         """
         QCVerifier: verify QC module 'picard_insert_size_metrics'

--- a/auto_process_ngs/test/qc/test_verification.py
+++ b/auto_process_ngs/test/qc/test_verification.py
@@ -1449,6 +1449,7 @@ class TestQCVerifier(unittest.TestCase):
                                    fastq_names=fastq_names,
                                    seq_data_samples=("PJB1_GEX",),
                                    include_rseqc_genebody_coverage=True,
+                                   include_rseqc_infer_experiment=True,
                                    include_qualimap_rnaseq=True,
                                    include_cellranger_count=True,
                                    include_cellranger_multi=True,
@@ -1695,6 +1696,7 @@ class TestVerifyProject(unittest.TestCase):
                                include_seqlens=True,
                                include_picard_insert_size_metrics=True,
                                include_rseqc_genebody_coverage=True,
+                               include_rseqc_infer_experiment=True,
                                include_qualimap_rnaseq=True,
                                include_multiqc=True,
                                include_cellranger_count=False,
@@ -1725,6 +1727,8 @@ class TestVerifyProject(unittest.TestCase):
             include_picard_insert_size_metrics,
             include_rseqc_genebody_coverage=\
             include_rseqc_genebody_coverage,
+            include_rseqc_infer_experiment=\
+            include_rseqc_infer_experiment,
             include_qualimap_rnaseq=include_qualimap_rnaseq,
             include_multiqc=include_multiqc,
             include_cellranger_count=include_cellranger_count,

--- a/auto_process_ngs/test/qc/test_verification.py
+++ b/auto_process_ngs/test/qc/test_verification.py
@@ -53,6 +53,7 @@ class TestQCVerifier(unittest.TestCase):
                      include_seqlens=True,
                      include_picard_insert_size_metrics=False,
                      include_rseqc_genebody_coverage=False,
+                     include_rseqc_infer_experiment=False,
                      include_qualimap_rnaseq=False,
                      include_multiqc=False,
                      include_cellranger_count=False,
@@ -79,6 +80,8 @@ class TestQCVerifier(unittest.TestCase):
             include_picard_insert_size_metrics,
             include_rseqc_genebody_coverage=\
             include_rseqc_genebody_coverage,
+            include_rseqc_infer_experiment=\
+            include_rseqc_infer_experiment,
             include_qualimap_rnaseq=include_qualimap_rnaseq,
             include_multiqc=include_multiqc,
             include_cellranger_count=include_cellranger_count,
@@ -341,6 +344,7 @@ class TestQCVerifier(unittest.TestCase):
         self.assertTrue(qc_verifier.verify_qc_module(
             'rseqc_infer_experiment',
             fastqs=fastq_names,
+            seq_data_reads=('r1','r2'),
             organism="Human",
             star_index="/data/indexes/STAR",
             annotation_gtf="/data/annot/human.gtf",
@@ -351,6 +355,7 @@ class TestQCVerifier(unittest.TestCase):
                          qc_verifier.verify_qc_module(
                              'rseqc_infer_experiment',
                              fastqs=fastq_names,
+                             seq_data_reads=('r1','r2'),
                              star_index="/data/indexes/STAR",
                              annotation_gtf="/data/annot/human.gtf",
                              annotation_bed="/data/annot/human.bed"))
@@ -358,6 +363,7 @@ class TestQCVerifier(unittest.TestCase):
                          qc_verifier.verify_qc_module(
                              'rseqc_infer_experiment',
                              fastqs=fastq_names,
+                             seq_data_reads=('r1','r2'),
                              organism="Human",
                              annotation_gtf="/data/annot/human.gtf",
                              annotation_bed="/data/annot/human.bed"))
@@ -365,17 +371,19 @@ class TestQCVerifier(unittest.TestCase):
                          qc_verifier.verify_qc_module(
                              'rseqc_infer_experiment',
                              fastqs=fastq_names,
+                             seq_data_reads=('r1','r2'),
                              organism="Human",
                              star_index="/data/indexes/STAR"))
         # Organism name contains spaces
         qc_dir = self._make_qc_dir('qc.homo_sapiens',
-                                   fastq_names=fastq_names[:-2],
+                                   fastq_names=fastq_names,
                                    organisms=('Homo sapiens',),
                                    include_rseqc_infer_experiment=True)
         qc_verifier = QCVerifier(qc_dir)
         self.assertTrue(qc_verifier.verify_qc_module(
             'rseqc_infer_experiment',
             fastqs=fastq_names,
+            seq_data_reads=('r1','r2'),
             organism="Homo sapiens",
             star_index="/data/indexes/STAR",
             annotation_gtf="/data/annot/human.gtf",
@@ -389,6 +397,7 @@ class TestQCVerifier(unittest.TestCase):
         self.assertFalse(qc_verifier.verify_qc_module(
             'rseqc_infer_experiment',
             fastqs=fastq_names,
+            seq_data_reads=('r1','r2'),
             organism="Human",
             star_index="/data/indexes/STAR",
             annotation_gtf="/data/annot/human.gtf",

--- a/docs/source/reference/qc_protocol_specification.rst
+++ b/docs/source/reference/qc_protocol_specification.rst
@@ -112,6 +112,7 @@ QC module                      Software                        Metrics
 ``picard_insert_size_metrics`` Picard CollectInsertSizeMetrics Insert sizes
 ``qualimap_rnaseq``            Qualimap 'rnaseq'               Coverage and genomic origin of reads
 ``rseqc_genebody_coverage``    RSeQC geneBody_coverage.py      Coverage
+``rseqc_infer_experiment``     RSeQC infer_experiment.py       Strand-specificity
 ``sequence_lengths``           Built-in                        Sequence length and masking stats
 ``strandedness``               fastq_strand.py                 Strandedness information
 ``cellranger_count``           CellRanger 'count'              Single library analysis

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -61,7 +61,7 @@ QC module                      Details
                                generate gene body coverage plot for all
 			       samples
 ``rseqc_infer_experimemt``     Run `rseqc`_ ``infer_experiment.py`` to
-                               strand-specificity
+                               determine strand-specificity
 ``qualimap_rnaseq``            Runs `qualimap`_ ``rnaseq`` to generate
                                various metrics including coverage and
 			       genomic origin of reads

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -60,6 +60,8 @@ QC module                      Details
 ``rseqc_genebody_coverage``    Runs `rseqc`_ ``geneBody_coverage.py`` to
                                generate gene body coverage plot for all
 			       samples
+``rseqc_infer_experimemt``     Run `rseqc`_ ``infer_experiment.py`` to
+                               strand-specificity
 ``qualimap_rnaseq``            Runs `qualimap`_ ``rnaseq`` to generate
                                various metrics including coverage and
 			       genomic origin of reads


### PR DESCRIPTION
Updates the QC pipeline to add support for `infer_experiment.py` (from the RSeQC package) as an explicit QC module (where previously it was implied whenever BAM files were required to generate a specific metric).

`infer_experiment.py` is now used to generate the strand-specificity metrics (following the removal of the `strandedness` module from the QC protocols #971), however without this update it is not possible to directly request these metrics.