### PR TITLE
'publish_qc': fix QC verification for projects with custom protocols

### DIFF
--- a/auto_process_ngs/commands/publish_qc_cmd.py
+++ b/auto_process_ngs/commands/publish_qc_cmd.py
@@ -328,15 +328,11 @@ def publish_qc(ap,projects=None,location=None,ignore_missing_qc=False,
                   os.path.basename(fastq_dir))
             qc_protocol = project.qc_info(qc_dir).protocol
             print("...associated QC protocol '%s'" % qc_protocol)
-            if qc_protocol is None:
-                qc_protocol = "standardPE"
-                print("...assuming QC protocol '%s'" % qc_protocol)
             # Verify the QC and check for report
             verified = verify_qc(
                 project,
                 fastq_dir=fastq_dir,
                 qc_dir=os.path.join(project.dirn,qc_dir),
-                qc_protocol=qc_protocol,
                 runner=runner,
                 log_dir=ap.log_dir)
             if verified:

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -103,6 +103,26 @@ class TestVerifyQCFunction(unittest.TestCase):
         # Do verification
         self.assertFalse(verify_qc(project))
 
+    def test_verify_qc_custom_protocol(self):
+        """verify_qc: project with custom QC protocol
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"))
+        p.create(top_dir=self.wd)
+        # Add QC outputs
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        UpdateAnalysisProject(project).add_qc_outputs()
+        # Update QC metadata with custom protocol name and specification
+        qc_info = project.qc_info("qc")
+        qc_info['protocol'] = "Custom_QC"
+        qc_info['protocol_specification'] = "Custom_QC:'Custom QC':seq_reads=[r1,r2]:index_reads=[]:qc_modules=[fastq_screen,fastqc,sequence_lengths]"
+        qc_info.save()
+        self.assertTrue(verify_qc(project))
+
 class TestReportQCFunction(unittest.TestCase):
     """
     Tests for report_qc function


### PR DESCRIPTION
Fixes a bug in the `publish_qc` command, when projects have used a custom QC protocol. In these cases the bug meant that QC verification would fail if the stored protocol name was not one of the built-in protocols. (Potentially it could also fail if the stored QC specification differed from that for a built-in protocol with the same name.)

The fix is to the invocation of the `verify_qc` function (in `qc/utils.py`) within the `publish_qc` command, to remove the explicit setting of the QC protocol from the stored name - instead `verify_qc` (and the underlying `report_qc.py` utility) is left to determine the protocol to verify against (where the QC specification will be used if present, ignoring the name).

Closes #979.