### PR TITLE
Updates to QC report generation

### DIFF
--- a/auto_process_ngs/cli/reportqc.py
+++ b/auto_process_ngs/cli/reportqc.py
@@ -93,9 +93,10 @@ def main():
                                 "specified)")
     data_dir_group.add_argument('--no-data-dir',action='store_true',
                                 dest='no_data_dir',
-                                help="don't a data directory with copies "
-                                "of QC artefacts (this is the default "
-                                "except for multi-project reports)")
+                                help="don't create a data directory with "
+                                "copies of QC artefacts (this is the "
+                                "default except for multi-project "
+                                "reports)")
     verification = p.add_argument_group('Verification options')
     verification.add_argument('--verify',action='store_true',
                               dest='verify',

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -499,22 +499,22 @@ class QCReport(Document):
                            ', '.join(project.software[package])))
             # Fields to report in summary table
             if not summary_fields:
-                if len(project.reads) > 1:
+                if project.fastqs:
+                    if len(project.reads) > 1:
+                        summary_fields_ = ['sample',
+                                           'fastqs',
+                                           'reads']
+                    else:
+                        summary_fields_ = ['sample',
+                                           'fastq',
+                                           'reads']
+                    summary_fields_.extend(['read_counts',
+                                            'read_lengths',
+                                            'sequence_duplication',
+                                            'adapter_content'])
+                elif project.bams:
                     summary_fields_ = ['sample',
-                                       'fastqs',
-                                       'reads',
-                                       'read_counts',
-                                       'read_lengths',
-                                       'sequence_duplication',
-                                       'adapter_content']
-                else:
-                    summary_fields_ = ['sample',
-                                       'fastq',
-                                       'reads',
-                                       'read_counts',
-                                       'read_lengths',
-                                       'sequence_duplication',
-                                       'adapter_content']
+                                       'bam_file']
                 if 'strandedness' in project.outputs:
                     summary_fields_.append('strandedness')
                 elif 'rseqc_infer_experiment' in project.outputs:

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -2941,7 +2941,9 @@ class FastqGroupQCReporter:
         elif field == "bam_file":
             value = self.bam
         elif field == "reads":
-            if self.reporters[self.reads[0]].sequence_lengths:
+            if not self.reads:
+                value = ''
+            elif self.reporters[self.reads[0]].sequence_lengths:
                 value = pretty_print_reads(
                     self.reporters[self.reads[0]].sequence_lengths.nreads)
             else:

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -2790,10 +2790,9 @@ class FastqGroupQCReporter:
           relpath (str): if set then make link paths
             relative to 'relpath'
         """
-        rd = self.reads[0]
         qualimap_report = document.add_subsection(
             "Qualimap outputs",
-            name="qualimap_rnaseq_%s" % self.reporters[rd].safe_name)
+            name="qualimap_rnaseq_%s" % self.bam)
         # Get Qualimap outputs for each organism
         no_reports = True
         for organism in self.project.organisms:

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -1953,7 +1953,7 @@ class SampleQCReporter:
         for bam in self.bams:
             if bam in [grp.bam for grp in self.fastq_groups
                        if grp.bam is not None]:
-                continueq
+                continue
             self.fastq_groups.append(FastqGroupQCReporter(
                 [],
                 bam_file=bam,

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -1285,7 +1285,9 @@ class QCReport(Document):
                                     fastq_attrs=project.fastq_attrs)
         reads = reporter.reads
         n_fastq_groups = len(reporter.fastq_groups)
-        if len(reads) == 1:
+        if len(reads) == 0:
+            sample_report.add("No associated Fastqs")
+        elif len(reads) == 1:
             sample_report.add("%d %s Fastq%s" %
                               (n_fastq_groups,
                                reads[0].upper(),

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -1715,6 +1715,18 @@ class QCProject:
         else:
             logger.warning("Run metadata file '%s' not found"
                            % run_metadata_file)
+        # Run reference ID
+        try:
+            self.run_id = run_id(self.project.info['run'],
+                                 platform=self.project.info['platform'],
+                                 facility_run_number=
+                                 self.run_metadata['run_number'],
+                                 analysis_number=
+                                 self.run_metadata['analysis_number'])
+        except (AttributeError,TypeError) as ex:
+            logger.warning("'%s': run reference ID can't be "
+                           "determined: %s (ignored)" % (self.name,ex))
+            self.run_id = None
         # Collect processing software metadata
         try:
             self.processing_software = ast.literal_eval(
@@ -1777,30 +1789,6 @@ class QCProject:
         Comments associated with the project
         """
         return self.project.info.comments
-
-    @property
-    def run_id(self):
-        """
-        Identifier for parent run
-
-        This is the standard identifier constructed
-        from the platform, datestamp and facility
-        run number (e.g. ``MINISEQ_201120#22``).
-
-        If an identifier can't be constructed then
-        ``None`` is returned.
-        """
-        try:
-            return run_id(self.info['run'],
-                          platform=self.info['platform'],
-                          facility_run_number=
-                          self.run_metadata['run_number'],
-                          analysis_number=
-                          self.run_metadata['analysis_number'])
-        except (AttributeError,TypeError) as ex:
-            logger.warning("Run reference ID can't be "
-                           "determined: %s (ignored)" % ex)
-            return None
 
     @property
     def is_single_cell(self):


### PR DESCRIPTION
Various updates to the QC reporting:

* Fix issues with summary table when only outputs associated with BAM files are detected (i.e. when the detection doesn't pick up the names of any associated Fastqs); previously this could result in summaries with no data
* Refactor and abstract setting of default fields for reporting into new methods for clarity - fields are set based on available outputs (should also close #106)
* Adds a link to the full Qualimap RNA-seq HTML report in the per-sample reporting
* Minor updates to improve reporting of some missing metrics