### PR TITLE
bcl2fastq/reporting: fix the barplot for masked/padded reads per Fastq.

### DIFF
--- a/auto_process_ngs/bcl2fastq/reporting.py
+++ b/auto_process_ngs/bcl2fastq/reporting.py
@@ -453,7 +453,7 @@ class ProcessingQCReport(Document):
                         data['Masked'] = "%.2f%%" % masked
                         data['Padded'] = "%.2f%%" % padded
                         plot_data = [masked,
-                                     masked+padded,
+                                     padded,
                                      100.0]
                         data['PropMaskedPadded'] = Img(
                             ustackedbar(plot_data,


### PR DESCRIPTION
Fix a bug in the reporting of masked and padded percentages of reads in each Fastq at the processing stage, in the `add_per_fastq_statistics` method of the `ProcessingQCReport` class - the proportion of padded reads was erroneously shown in the barplot as the sum of the masked and padded reads (so were overrepresented compared to the real data).