### PR TITLE
Update QC pipeline to use MultiQC 1.24

### DIFF
--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -2801,7 +2801,7 @@ sys.exit(MockMultiQC(version=%s,
         if version:
             self._version = version
         else:
-            self._version = "1.21"
+            self._version = "1.24"
         self._no_outputs = no_outputs
         self._exit_code = exit_code
 

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -4055,8 +4055,8 @@ class ReportQC(PipelineTask):
           zip_outputs (bool): if True then also generate
             a ZIP archive of the QC reports
         """
-        self.conda("multiqc=1.21",
-                   "python=3.8",
+        self.conda("multiqc=1.24",
+                   "python=3.12",
                    "pillow")
     def setup(self):
         # Check for 10x multiome libraries file with linked projects

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -203,8 +203,8 @@ def report_qc(project,qc_dir=None,fastq_dir=None,qc_protocol=None,
         # Set up conda wrapper
         conda = CondaWrapper(env_dir=conda_env_dir)
         # Get environment for QC reporting
-        report_qc_conda_pkgs = ("multiqc=1.21",
-                                "python=3.8",
+        report_qc_conda_pkgs = ("multiqc=1.24",
+                                "python=3.12",
                                 "pillow")
         env_name = make_conda_env_name(*report_qc_conda_pkgs)
         try:


### PR DESCRIPTION
Bumps the version of MultiQC used for reporting in the QC pipeline to 1.24, to address a bug in the Qualimap module when "infinity" appears in the Qualimap output.