### PR TITLE
Drop the 'defaults' channel from the default channels used by 'CondaWrapper'

### DIFF
--- a/auto_process_ngs/conda.py
+++ b/auto_process_ngs/conda.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     conda.py: utilities for managing conda environments
-#     Copyright (C) University of Manchester 2021-2022 Peter Briggs
+#     Copyright (C) University of Manchester 2021-2024 Peter Briggs
 #
 """
 Module providing utility classes and functions to help with managing
@@ -40,7 +40,6 @@ logger.addHandler(logging.NullHandler())
 DEFAULT_CONDA_CHANNELS = (
     'conda-forge',
     'bioconda',
-    'defaults',
 )
 
 ######################################################################

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1837,6 +1837,8 @@ class RunFastqScreen(PipelineTask):
         # Also need to specify tbb=2020.2 for bowtie
         # See https://www.biostars.org/p/494922/
         self.conda("tbb=2020.2")
+        # perl-gd seems to be needed explicitly
+        self.conda("perl-gd")
     def setup(self):
         if not self.args.fastqs:
             print("Nothing to do")


### PR DESCRIPTION
Removes the Anaconda `defaults` channel from the list of default conda channels specified in the `conda` module and used by the `CondaWrapper` class.

This is to mitigate potential licensing issues to do with using the Anaconda `defaults` channel (see e.g. https://www.datacamp.com/blog/navigating-anaconda-licensing)

(It is also recommended to use an alternative implementation (e.g. Miniconda  or Mamba) when using conda to resolve pipeline dependencies.)