### PR TITLE
Detect errors in 'cellranger multi' CSV config files

### DIFF
--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -214,10 +214,13 @@ def setup_analysis_dirs(ap,
             print("-- looking up transcriptome for '%s'" % organism)
             try:
                 organism_id = normalise_organism_name(organism)
-                print("-- using ID '%s'" % organism_id)
+                print("-- ...using ID '%s'" % organism_id)
                 reference_dataset = ap.settings.organisms[organism_id].\
                                     cellranger_reference
-                print("-- found %s" % reference_dataset)
+                if reference_dataset:
+                    print("-- ...found %s" % reference_dataset)
+                else:
+                    print("-- ...no matching transcriptome data")
             except Exception as ex:
                 logger.warning("Failed to locate 10xGenomics reference "
                                "transcriptome for project '%s': %s" %
@@ -228,10 +231,13 @@ def setup_analysis_dirs(ap,
                 print("-- looking up probe set for '%s'" % organism)
                 try:
                     organism_id = normalise_organism_name(organism)
-                    print("-- using ID '%s'" % organism_id)
+                    print("-- ...using ID '%s'" % organism_id)
                     probe_set = ap.settings.organisms[organism_id].\
                                 cellranger_probe_set
-                    print("-- found %s" % probe_set)
+                    if probe_set:
+                        print("-- ...found %s" % probe_set)
+                    else:
+                        print("-- ...no matching probe set")
                 except Exception as ex:
                     logger.warning("Failed to locate 10xGenomics reference "
                                    "probe set for project '%s': %s" %

--- a/auto_process_ngs/qc/modules/cellranger_multi.py
+++ b/auto_process_ngs/qc/modules/cellranger_multi.py
@@ -378,7 +378,12 @@ class GetCellrangerMultiConfig(PipelineFunctionTask):
         for config_file in config_files:
             # Extract information from each config.csv file
             print("Reading '%s'" % os.path.basename(config_file))
-            config_csv = CellrangerMultiConfigCsv(config_file)
+            try:
+                config_csv = CellrangerMultiConfigCsv(config_file)
+            except Exception as ex:
+                self.fail(message=f"problems with 10x multi config "
+                          f"file {config_file}: {ex}")
+                return
             reference_data_path = config_csv.reference_data_path
             probe_set_path = config_csv.probe_set_path
             samples.extend(config_csv.sample_names)

--- a/auto_process_ngs/qc/modules/cellranger_multi.py
+++ b/auto_process_ngs/qc/modules/cellranger_multi.py
@@ -378,11 +378,14 @@ class GetCellrangerMultiConfig(PipelineFunctionTask):
         for config_file in config_files:
             # Extract information from each config.csv file
             print("Reading '%s'" % os.path.basename(config_file))
-            try:
-                config_csv = CellrangerMultiConfigCsv(config_file)
-            except Exception as ex:
+            config_csv = CellrangerMultiConfigCsv(config_file,
+                                                  strict=False)
+            if not config_csv.is_valid:
+                print("Errors found in config.csv file:")
+                for err in config_csv.get_errors():
+                    print(f"- {err}")
                 self.fail(message=f"problems with 10x multi config "
-                          f"file {config_file}: {ex}")
+                          f"file {config_file}")
                 return
             reference_data_path = config_csv.reference_data_path
             probe_set_path = config_csv.probe_set_path

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1175,8 +1175,13 @@ class GetSequenceDataSamples(PipelineTask):
         self.add_output('seq_data_samples',list())
     def setup(self):
         # Identify samples with biological data
-        seq_data_samples = get_seq_data_samples(self.args.project.dirn,
-                                                self.args.fastq_attrs)
+        try:
+            seq_data_samples = get_seq_data_samples(self.args.project.dirn,
+                                                    self.args.fastq_attrs)
+        except Exception as ex:
+            self.fail(message=f"failed to identify sequence data samples: "
+                      f"{ex}")
+            return
         # Report
         print("Samples with sequence data:")
         for sample in seq_data_samples:

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -362,9 +362,18 @@ def get_seq_data_samples(project_dir,fastq_attrs=None):
             config_file = os.path.join(project.dirn,
                                        "10x_multi_config.csv")
             if os.path.exists(config_file):
-                config_csv = CellrangerMultiConfigCsv(config_file)
-                samples = sorted([s for s in config_csv.gex_libraries
-                                  if s in samples])
+                config_csv = CellrangerMultiConfigCsv(config_file,
+                                                      strict=False)
+                if config_csv.is_valid:
+                    samples = sorted([s for s in config_csv.gex_libraries
+                                      if s in samples])
+                else:
+                    print(f"Invalid cellranger multi config file: "
+                          f"{config_file}")
+                    for err in config_csv.get_errors():
+                        print(f"- {err}")
+                    raise Exception(f"Invalid cellranger multi config file: "
+                                    f"{config_file}")
         elif single_cell_platform.startswith("10xGenomics Chromium") and \
              project.info.library_type == "Single Cell Immune Profiling":
             # Single Cell Immune Profiling
@@ -375,7 +384,12 @@ def get_seq_data_samples(project_dir,fastq_attrs=None):
                                 f.endswith(".csv"))]
             samples_ = []
             for config_file in config_files:
-                config_csv = CellrangerMultiConfigCsv(config_file)
+                config_csv = CellrangerMultiConfigCsv(config_file,
+                                                      strict=False)
+                if not config_csv.is_valid:
+                    logger.warning(f"Invalid cellranger multi config file: "
+                                   f"{config_file} (skipped)")
+                    continue
                 for feature_type in ("gene_expression",
                                      "vdj_b",
                                      "vdj_t"):

--- a/auto_process_ngs/tenx/cellplex.py
+++ b/auto_process_ngs/tenx/cellplex.py
@@ -111,6 +111,7 @@ class CellrangerMultiConfigCsv:
         logger.debug("Reading data from '%s'" % self._filen)
         sections = set()
         cmo_list = set()
+        feature_type_list = set()
         with open(self._filen,'rt') as config_csv:
             current_section = None
             for lineno, line in enumerate(config_csv, start=1):
@@ -218,7 +219,13 @@ class CellrangerMultiConfigCsv:
                         if feature_name not in KNOWN_FEATURE_TYPES:
                             self._error("libraries",
                                         f"L{lineno}: '{feature_type}': "
-                                        "unrecognised feature type")
+                                        "unrecognised feature type for "
+                                        f"sample '{name}'")
+                        elif feature_type.lower() in feature_type_list:
+                            self._error("libraries",
+                                        f"L{lineno}: '{feature_type}': "
+                                        "duplicated feature type for "
+                                        f"sample '{name}'")
                         # Store Fastq dir
                         self._fastq_dirs[name] = fastqs
                         # Store library
@@ -229,6 +236,7 @@ class CellrangerMultiConfigCsv:
                             'feature_type': feature_type,
                             'subsample_rate': subsample_rate
                         }
+                        feature_type_list.add(feature_type.lower())
         self._sections = sorted(list(sections))
         if not self.is_valid:
             if strict:

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -392,6 +392,36 @@ PJB2_TCR,{fastq_dir},any,PJB2,VDJ-T,
         self.assertEqual(get_seq_data_samples(project_dir),
                          ["PJB1_GEX","PJB1_TCR","PJB2_GEX","PJB2_TCR"])
 
+    def test_get_seq_data_samples_bad_cellranger_multi_config(self):
+        """
+        get_seq_data_samples: exception for 'bad' Cellranger multi config file
+        """
+        # Set up mock project
+        project_dir = self._make_mock_analysis_project(
+            "CellPlex",
+            single_cell_platform="10xGenomics Chromium 3'v3")
+        # Make 10x_multi_config.csv file
+        with open(os.path.join(project_dir,"10x_multi_config.csv"),
+                  'wt') as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1,{fastq_dir},any,PJB1,[Gene expression|Multiplexing Capture],
+PJB2,{fastq_dir},any,PJB2,[Gene expression|Multiplexing Capture],
+
+[samples]
+sample_id,cmo_ids,description
+MULTIPLEXED_SAMPLE,CMO301|CMO302|...,DESCRIPTION
+PBA,CMO301,PBA
+PBB,CMO302,PBB
+""".format(fastq_dir=os.path.join(project_dir,'fastqs')))
+        # Raises exception when fetching sequence data samples
+        self.assertRaises(Exception,
+                          get_seq_data_samples,
+                          project_dir)
+
 class TestFilterFastqs(unittest.TestCase):
 
     def test_filter_fastqs(self):

--- a/auto_process_ngs/test/tenx/test_cellplex.py
+++ b/auto_process_ngs/test/tenx/test_cellplex.py
@@ -277,6 +277,78 @@ PBB,CMO302
         self.assertEqual(config_csv.pretty_print_samples(),
                          "PBA, PBB")
 
+    def test_cellranger_multi_config_csv_duplicated_sample(self):
+        """
+        CellrangerMultiConfigCsv: raise exception for duplicated sample
+        """
+        with open(os.path.join(self.wd,"10x_multi_config.csv"),'wt') as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[vdj]
+reference,/data/vdj_ref.csv
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,/data/runs/fastqs_gex,any,PJB1,Gene Expression,
+PJB2_CML,/data/runs/fastqs_cml,any,PJB2,Multiplexing Capture,
+
+[samples]
+PB1,CMO1,PB1
+PB2,CMO2,PB2
+PB1,CMO3,PB1
+""")
+        self.assertRaises(Exception,
+                          CellrangerMultiConfigCsv,
+                          os.path.join(self.wd,"10x_multi_config.csv"))
+
+    def test_cellranger_multi_config_csv_duplicated_cmo(self):
+        """
+        CellrangerMultiConfigCsv: raise exception for duplicated CMO
+        """
+        with open(os.path.join(self.wd,"10x_multi_config.csv"),'wt') as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[vdj]
+reference,/data/vdj_ref.csv
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,/data/runs/fastqs_gex,any,PJB1,Gene Expression,
+PJB2_CML,/data/runs/fastqs_cml,any,PJB2,Multiplexing Capture,
+
+[samples]
+PB1,CMO1|CMO2,PB1
+PB2,CMO2|CMO3,PB2
+""")
+        self.assertRaises(Exception,
+                          CellrangerMultiConfigCsv,
+                          os.path.join(self.wd,"10x_multi_config.csv"))
+
+    def test_cellranger_multi_config_csv_bad_cmo(self):
+        """
+        CellrangerMultiConfigCsv: raise exception for "bad" CMO
+        """
+        with open(os.path.join(self.wd,"10x_multi_config.csv"),'wt') as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[vdj]
+reference,/data/vdj_ref.csv
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,/data/runs/fastqs_gex,any,PJB1,Gene Expression,
+PJB2_CML,/data/runs/fastqs_cml,any,PJB2,Multiplexing Capture,
+
+[samples]
+PB1,CMO1|CMO2...,PB1
+""")
+        self.assertRaises(Exception,
+                          CellrangerMultiConfigCsv,
+                          os.path.join(self.wd,"10x_multi_config.csv"))
+
     def test_cellranger_multi_config_csv_unknown_feature_type(self):
         """
         CellrangerMultiConfigCsv: raise exception for unknown feature type

--- a/auto_process_ngs/test/tenx/test_cellplex.py
+++ b/auto_process_ngs/test/tenx/test_cellplex.py
@@ -70,6 +70,7 @@ PBB,CMO302,PBB
                          })
         self.assertEqual(config_csv.pretty_print_samples(),
                          "PBA, PBB")
+        self.assertTrue(config_csv.is_valid)
 
     def test_cellranger_multi_config_csv_frp(self):
         """
@@ -120,6 +121,7 @@ PB2,BC002,PB2
                          })
         self.assertEqual(config_csv.pretty_print_samples(),
                          "PB1-2")
+        self.assertTrue(config_csv.is_valid)
 
     def test_cellranger_multi_config_csv_feature_ref(self):
         """
@@ -173,6 +175,7 @@ PBB,CMO302,PBB
                          })
         self.assertEqual(config_csv.pretty_print_samples(),
                          "PBA, PBB")
+        self.assertTrue(config_csv.is_valid)
 
     def test_cellranger_multi_config_csv_vdj_t_ref(self):
         """
@@ -228,6 +231,7 @@ PJB2_TCR,/data/runs/fastqs_vdj_t,any,PJB2,VDJ-T,
                            'PJB2_TCR': '/data/runs/fastqs_vdj_t'
                          })
         self.assertEqual(config_csv.pretty_print_samples(),"")
+        self.assertTrue(config_csv.is_valid)
 
     def test_cellranger_multi_config_csv_reduced_fields(self):
         """
@@ -276,10 +280,11 @@ PBB,CMO302
                          })
         self.assertEqual(config_csv.pretty_print_samples(),
                          "PBA, PBB")
+        self.assertTrue(config_csv.is_valid)
 
     def test_cellranger_multi_config_csv_duplicated_sample(self):
         """
-        CellrangerMultiConfigCsv: raise exception for duplicated sample
+        CellrangerMultiConfigCsv: handle for duplicated sample
         """
         with open(os.path.join(self.wd,"10x_multi_config.csv"),'wt') as fp:
             fp.write("""[gene-expression]
@@ -298,13 +303,20 @@ PB1,CMO1,PB1
 PB2,CMO2,PB2
 PB1,CMO3,PB1
 """)
+        # Raise exception by default
         self.assertRaises(Exception,
                           CellrangerMultiConfigCsv,
                           os.path.join(self.wd,"10x_multi_config.csv"))
+        # Invalid if loaded with 'strict' turned off
+        config_csv = CellrangerMultiConfigCsv(
+            os.path.join(self.wd,
+                         "10x_multi_config.csv"), strict=False)
+        self.assertFalse(config_csv.is_valid)
+        self.assertEqual(len(config_csv.get_errors()), 1)
 
     def test_cellranger_multi_config_csv_duplicated_cmo(self):
         """
-        CellrangerMultiConfigCsv: raise exception for duplicated CMO
+        CellrangerMultiConfigCsv: handle duplicated CMO
         """
         with open(os.path.join(self.wd,"10x_multi_config.csv"),'wt') as fp:
             fp.write("""[gene-expression]
@@ -322,13 +334,20 @@ PJB2_CML,/data/runs/fastqs_cml,any,PJB2,Multiplexing Capture,
 PB1,CMO1|CMO2,PB1
 PB2,CMO2|CMO3,PB2
 """)
+        # Raise exception by default
         self.assertRaises(Exception,
                           CellrangerMultiConfigCsv,
                           os.path.join(self.wd,"10x_multi_config.csv"))
+        # Invalid if loaded with 'strict' turned off
+        config_csv = CellrangerMultiConfigCsv(
+            os.path.join(self.wd,
+                         "10x_multi_config.csv"), strict=False)
+        self.assertFalse(config_csv.is_valid)
+        self.assertEqual(len(config_csv.get_errors()), 1)
 
     def test_cellranger_multi_config_csv_bad_cmo(self):
         """
-        CellrangerMultiConfigCsv: raise exception for "bad" CMO
+        CellrangerMultiConfigCsv: handle "bad" CMO
         """
         with open(os.path.join(self.wd,"10x_multi_config.csv"),'wt') as fp:
             fp.write("""[gene-expression]
@@ -345,13 +364,20 @@ PJB2_CML,/data/runs/fastqs_cml,any,PJB2,Multiplexing Capture,
 [samples]
 PB1,CMO1|CMO2...,PB1
 """)
+        # Raise exception by default
         self.assertRaises(Exception,
                           CellrangerMultiConfigCsv,
                           os.path.join(self.wd,"10x_multi_config.csv"))
+        # Invalid if loaded with 'strict' turned off
+        config_csv = CellrangerMultiConfigCsv(
+            os.path.join(self.wd,
+                         "10x_multi_config.csv"), strict=False)
+        self.assertFalse(config_csv.is_valid)
+        self.assertEqual(len(config_csv.get_errors()), 1)
 
     def test_cellranger_multi_config_csv_unknown_feature_type(self):
         """
-        CellrangerMultiConfigCsv: raise exception for unknown feature type
+        CellrangerMultiConfigCsv: handle unknown feature type
         """
         with open(os.path.join(self.wd,"10x_multi_config.csv"),'wt') as fp:
             fp.write("""[gene-expression]
@@ -365,6 +391,13 @@ fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
 PJB1_GEX,/data/runs/fastqs_gex,any,PJB1,Gene Expression,
 PJB2_UNKNOWN,/data/runs/fastqs_unknown,any,PJB2,Unknown,
 """)
+        # Raise exception by default
         self.assertRaises(Exception,
                           CellrangerMultiConfigCsv,
                           os.path.join(self.wd,"10x_multi_config.csv"))
+        # Invalid if loaded with 'strict' turned off
+        config_csv = CellrangerMultiConfigCsv(
+            os.path.join(self.wd,
+                         "10x_multi_config.csv"), strict=False)
+        self.assertFalse(config_csv.is_valid)
+        self.assertEqual(len(config_csv.get_errors()), 1)

--- a/auto_process_ngs/test/tenx/test_cellplex.py
+++ b/auto_process_ngs/test/tenx/test_cellplex.py
@@ -401,3 +401,32 @@ PJB2_UNKNOWN,/data/runs/fastqs_unknown,any,PJB2,Unknown,
                          "10x_multi_config.csv"), strict=False)
         self.assertFalse(config_csv.is_valid)
         self.assertEqual(len(config_csv.get_errors()), 1)
+
+    def test_cellranger_multi_config_csv_duplicated_feature_type(self):
+        """
+        CellrangerMultiConfigCsv: handle duplicated feature type
+        """
+        with open(os.path.join(self.wd,"10x_multi_config.csv"),'wt') as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[vdj]
+reference,/data/vdj_ref.csv
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,/data/runs/fastqs,any,PJB2,Gene Expression,
+PJB1_CML,/data/runs/fastqs,any,PJB2,Multiplexing capture,
+PJB2_GEX,/data/runs/fastqs,any,PJB2,Gene Expression,
+PJB2_CML,/data/runs/fastqs,any,PJB2,Multiplexing capture,
+""")
+        # Raise exception by default
+        self.assertRaises(Exception,
+                          CellrangerMultiConfigCsv,
+                          os.path.join(self.wd,"10x_multi_config.csv"))
+        # Invalid if loaded with 'strict' turned off
+        config_csv = CellrangerMultiConfigCsv(
+            os.path.join(self.wd,
+                         "10x_multi_config.csv"), strict=False)
+        self.assertFalse(config_csv.is_valid)
+        self.assertEqual(len(config_csv.get_errors()), 2)


### PR DESCRIPTION
Updates the `CellrangerMultiConfigCsv` class (in `tenx/cellplex`) to detect a range of problems:

* "Bad" CMO or probe barcode IDs
* Duplicated CMOs or probe barcode IDs
* Duplicated sample names
* Duplicated feature types
* Unsupported feature types

If any of these problems are encountered then by default the class raises an exception ("strict" mode). If "strict" mode is disabled (`strict=False` option) then the class logs a warning but doesn't raise an exception; instead a new `is_valid` property can be checked to see if there were any issues, and the error messages can be accessed via a new `get_errors` method.

The `GetSeqDataSamples` task (in the main QC pipeline in `qc/pipeline`) and the `GetCellrangerMultiConfig` task (in `qc/modules/cellranger_multi`) have been updated to read in the config file with "strict" mode disabled, and then check the validity or otherwise of the input file. An invalid file causes the tasks to fail (rather than leaving it to `cellranger multi` to trip over the errors).

Closes #917.