### PR TITLE
Handle multiple CellPlex/Flex config files when determining sequence data samples

### DIFF
--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -296,7 +296,8 @@ class QCOutputs:
         for cf in self.config_files:
             # Implicitly defined in 10x multi config file(s) as GEX data
             if cf.startswith('10x_multi_config.'):
-                cf = CellrangerMultiConfigCsv(os.path.join(self.qc_dir,cf))
+                cf = CellrangerMultiConfigCsv(os.path.join(self.qc_dir,cf),
+                                              strict=False)
                 self.seq_data_samples.extend([s for s in cf.gex_libraries
                                               if s in samples])
         if not self.seq_data_samples:

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -351,6 +351,8 @@ def get_seq_data_samples(project_dir,fastq_attrs=None):
             else:
                 bio_samples.append(s)
         return bio_samples
+    # Initial sample list
+    samples = sorted([s.name for s in project.samples])
     # 10x Genomics CellPlex
     single_cell_platform = project.info.single_cell_platform
     if single_cell_platform:
@@ -393,7 +395,8 @@ def get_seq_data_samples(project_dir,fastq_attrs=None):
                             samples_.extend([s for s in
                                              config_csv.libraries(feature_type)
                                              if s in samples])
-            samples = sorted(samples_)
+            if samples_:
+                samples = sorted(samples_)
     return samples
 
 def filter_fastqs(reads,fastqs,fastq_attrs=AnalysisFastq):

--- a/auto_process_ngs/qc/verification.py
+++ b/auto_process_ngs/qc/verification.py
@@ -285,12 +285,18 @@ class QCVerifier(QCOutputs):
         Returns:
           List: subset of sample names with sequence data.
         """
-        # Check for 10x_multi_config.csv
-        if "10x_multi_config.csv" in self.config_files:
-            # Get GEX sample names from multi config file
-            cf = CellrangerMultiConfigCsv(
-                os.path.join(self.qc_dir,"10x_multi_config.csv"))
-            seq_data = [s for s in cf.gex_libraries if s in samples]
+        # Check for 10x_multi_config.*.csv files
+        config_files = [cf for cf in self.config_files
+                        if cf.startswith("10x_multi_config.") and
+                        cf.endswith(".csv")]
+        if config_files:
+            seq_data = []
+            for cf in config_files:
+                # Get GEX sample names from multi config file
+                cf = CellrangerMultiConfigCsv(
+                    os.path.join(self.qc_dir, cf),
+                    strict=False)
+                seq_data.extend([s for s in cf.gex_libraries if s in samples])
         else:
             seq_data = [s for s in samples]
         return seq_data

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -316,6 +316,57 @@ PBB,CMO302,PBB
         self.assertEqual(get_seq_data_samples(project_dir),
                          ["PJB1"])
 
+    def test_get_seq_data_samples_10x_cellplex_multiple_configs(self):
+        """
+        get_seq_data_samples: 10x CellPlex project (multiple configs)
+        """
+        # Set up mock project
+        project_dir = self._make_mock_analysis_project(
+            "CellPlex",
+            single_cell_platform="10xGenomics Chromium 3'v3",
+            fastq_names=("PJB1_GEX_S1_L001_R1_001.fastq.gz",
+                         "PJB1_GEX_S1_L001_R2_001.fastq.gz",
+                         "PJB1_CML_S2_L001_R1_001.fastq.gz",
+                         "PJB1_CML_S2_L001_R2_001.fastq.gz",
+                         "PJB2_GEX_S3_L001_R1_001.fastq.gz",
+                         "PJB2_GEX_S3_L001_R2_001.fastq.gz",
+                         "PJB2_CML_S4_L001_R1_001.fastq.gz",
+                         "PJB2_CML_S4_L001_R2_001.fastq.gz",))
+        # Make 10x_multi_config.csv files
+        with open(os.path.join(project_dir,"10x_multi_config.PJB1.csv"),
+                  'wt') as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,{fastq_dir},any,PJB1,gene expression,
+PJB1_CML,{fastq_dir},any,PJB1,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+PBA,CMO301,PBA
+PBB,CMO302,PBB
+""".format(fastq_dir=os.path.join(project_dir,'fastqs')))
+        with open(os.path.join(project_dir,"10x_multi_config.PJB2.csv"),
+                  'wt') as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB2_GEX,{fastq_dir},any,PJB2,gene expression,
+PJB2_CML,{fastq_dir},any,PJB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+PBC,CMO303,PBC
+PBD,CMO304,PBD
+""".format(fastq_dir=os.path.join(project_dir,'fastqs')))
+        # Check sequence data samples
+        self.assertEqual(get_seq_data_samples(project_dir),
+                         ["PJB1_GEX", "PJB2_GEX"])
+
     def test_get_seq_data_samples_10x_flex(self):
         """
         get_seq_data_samples: 10x Flex project


### PR DESCRIPTION
Makes various updates to enable handling of multiple 10x multi config files:

* Updates the `get_seq_data_samples` function in `qc/utils` to handle multiple 10x multi config files when determining which samples hold sequence (biological) data for CellPlex & Flex experiments.
* Updates the `QCVerifier` class in `qc/verification` to deal with multiple configs when extracting sequence data samples

Note that the pipeline itself is still unable to deal with multiple config files (so when multiple configs are present `cellranger multi` must be run manually).

The PR also fixes a bug in the `QCOutputs` class when handling an invalid 10x multi config file.