### PR TITLE
'report' command: fix reporting of 10x multiplexed samples

### DIFF
--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -745,3 +745,35 @@ def default_value(s,default=""):
     if s is None:
         return default
     return s
+
+def get_multiplexed_samples(project):
+    """
+    Return the names of implicit multiplexed samples in a project
+
+    Arguments:
+      project (AnalysisProject): project to get implicit multiplexed
+        samples for
+
+    Returns:
+      List: list of multiplexed sample names, or empty list if
+        project should have multiplexed samples but the cannot be
+        identified. Returns None if project is not of a type to
+        have multiplexed samples.
+    """
+    if project.info.library_type in ("CellPlex",
+                                     "CellPlex scRNA-seq",
+                                     "Flex"):
+        # Fetch implicit multiplexed sample info from config
+        try:
+            multi_config = CellrangerMultiConfigCsv(
+                os.path.join(project.dirn,"10x_multi_config.csv"))
+            # Return multiplexed sample names
+            return multi_config.sample_names
+        except FileNotFoundError:
+            # Multiplexed samples expected but can't be identified
+            # Return empty list
+            return []
+    else:
+        # No multiplexed samples expected
+        # Return None
+        return None

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -165,6 +165,7 @@ def report_info(ap):
                                    info.multiplexed_samples.split(',')),
                                 project.prettyPrintSamples())
         elif project.info.library_type in ("CellPlex",
+                                           "CellPlex scRNA-seq",
                                            "Flex"):
             # Fetch implicit multiplexed sample info from config
             try:
@@ -233,6 +234,7 @@ def report_concise(ap):
                                             split(','))
                 has_multiplexed_samples = True
             elif p.info.library_type in ("CellPlex",
+                                         "CellPlex scRNA-seq",
                                          "Flex"):
                 # Fetch implicit multiplexed sample info from config
                 try:
@@ -465,6 +467,7 @@ def report_summary(ap):
                                             split(','))
                 has_multiplexed_samples = True
             elif project.info.library_type in ("CellPlex",
+                                               "CellPlex scRNA-seq",
                                                "Flex"):
                 # Fetch implicit multiplexed sample info from config
                 try:
@@ -649,6 +652,7 @@ def fetch_value(ap,project,field):
     # 10x CellPlex and Flex data
     multi_config = None
     if project.info.library_type in ("CellPlex",
+                                     "CellPlex scRNA-seq",
                                      "Flex"):
         try:
             multi_config = CellrangerMultiConfigCsv(

--- a/auto_process_ngs/commands/report_cmd.py
+++ b/auto_process_ngs/commands/report_cmd.py
@@ -741,16 +741,16 @@ def get_multiplexed_samples(project):
     if project.info.library_type in ("CellPlex",
                                      "CellPlex scRNA-seq",
                                      "Flex"):
-        # Fetch implicit multiplexed sample info from config
-        try:
-            multi_config = CellrangerMultiConfigCsv(
-                os.path.join(project.dirn,"10x_multi_config.csv"))
-            # Return multiplexed sample names
-            return multi_config.sample_names
-        except FileNotFoundError:
-            # Multiplexed samples expected but can't be identified
-            # Return empty list
-            return []
+        # Fetch implicit multiplexed sample info from configs
+        multiplexed_samples = []
+        for f in os.listdir(project.dirn):
+            if f.startswith("10x_multi_config.") and \
+               f.endswith(".csv"):
+                multi_config = CellrangerMultiConfigCsv(
+                    os.path.join(project.dirn, f))
+                multiplexed_samples.extend(multi_config.sample_names)
+        # Return multiplexed sample names
+        return sorted(multiplexed_samples)
     else:
         # No multiplexed samples expected
         # Return None

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -2512,3 +2512,68 @@ ABM4,CMO304,ABM4
         project = AnalysisProject(os.path.join(mockdir.dirn,'AB'))
         self.assertEqual(get_multiplexed_samples(project),
                          ["ABM1", "ABM2", "ABM3", "ABM4"])
+
+    def test_get_multiplexed_samples_multiple_10x_multi_configs(self):
+        """
+        report: test 'get_multiplexed_samples' (multiple 10x multi configs)
+        """
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "sequencer_model": "MiSeq",
+                       "analysis_number": 2 },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "CellPlex scRNA-seq",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Single cell platform": "10xGenomics Chromium 3'v3",
+                        "Number of cells": None,
+                        "Sequencer model": "MiSeq" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add cellranger multi config.csv files
+        with open(os.path.join(mockdir.dirn,
+                               "AB",
+                               "10x_multi_config.AB1.csv"),'wt') as fp:
+            fastq_dir = os.path.join(mockdir.dirn,
+                                     "AB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+AB1,%s,any,AB1,gene expression,
+AB1,%s,any,AB1,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+ABM1,CMO301,ABM1
+ABM2,CMO302,ABM2
+""" % (fastq_dir,fastq_dir))
+        with open(os.path.join(mockdir.dirn,
+                               "AB",
+                               "10x_multi_config.AB2.csv"),'wt') as fp:
+            fastq_dir = os.path.join(mockdir.dirn,
+                                     "AB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+AB2,%s,any,AB2,gene expression,
+AB2,%s,any,AB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+ABM3,CMO303,ABM3
+ABM4,CMO304,ABM4
+""" % (fastq_dir,fastq_dir))
+        project = AnalysisProject(os.path.join(mockdir.dirn,'AB'))
+        self.assertEqual(get_multiplexed_samples(project),
+                         ["ABM1", "ABM2", "ABM3", "ABM4"])

--- a/auto_process_ngs/test/commands/test_report_cmd.py
+++ b/auto_process_ngs/test/commands/test_report_cmd.py
@@ -344,6 +344,112 @@ Summary of data in 'bcl2fastq' dir:
                        expected.split('\n')):
             self.assertEqual(o,e)
 
+    def test_report_info_10x_cellplex_scrnaseq(self):
+        """report: report 10xGenomics CellPlex scRNA-seq run in 'info' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87, },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "CellPlex scRNA-seq",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Single cell platform": "10xGenomics Chromium 3'v3",
+                        "Number of cells": 1311
+                        },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add a cellranger multi config.csv file
+        with open(os.path.join(mockdir.dirn,
+                               "AB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(mockdir.dirn,
+                                     "AB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+AB1,%s,any,AB1,gene expression,
+AB2,%s,any,AB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+ABM1,CMO301,ABM1
+ABM2,CMO302,ABM2
+ABM3,CMO303,ABM3
+ABM4,CMO304,ABM4
+""" % (fastq_dir,fastq_dir))
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate concise report
+        expected = """Run ID       : MISEQ_170901#87
+Directory    : %s
+Platform     : miseq
+Unaligned dir: bcl2fastq
+
+Summary of data in 'bcl2fastq' dir:
+
+- AB: AB1-2 (2 paired end samples)
+- CDE: CDE3-4 (2 paired end samples)
+
+3 analysis projects:
+
+- AB
+  --
+  User    : Alison Bell
+  PI      : Audrey Bower
+  Library : CellPlex scRNA-seq
+  SC Plat.: 10xGenomics Chromium 3'v3
+  Organism: Human
+  Dir     : AB
+  #samples: 4 multiplexed (2 physical)
+  #cells  : 1311
+  Samples : ABM1-4 (AB1-2)
+  QC      : not verified
+  Comments: None
+
+- CDE
+  ---
+  User    : Charles David Edwards
+  PI      : Colin Delaney Eccleston
+  Library : ChIP-seq
+  SC Plat.: None
+  Organism: Mouse
+  Dir     : CDE
+  #samples: 2
+  #cells  : 
+  Samples : CDE3-4
+  QC      : not verified
+  Comments: None
+
+- undetermined
+  ------------
+  User    : None
+  PI      : None
+  Library : None
+  SC Plat.: None
+  Organism: None
+  Dir     : undetermined
+  #samples: 1
+  #cells  : 
+  Samples : Undetermined
+  QC      : not verified
+  Comments: None""" % mockdir.dirn
+        for o,e in zip(report_info(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
     def test_report_info_10x_flex(self):
         """report: report 10xGenomics Flex run in 'info' mode
         """
@@ -807,6 +913,57 @@ ABM4,CMO304,ABM4
         self.assertEqual(report_concise(ap),
                          "Paired end: 'AB': Alison Bell, Human 10xGenomics Chromium 3'v3 CellPlex (PI: Audrey Bower) (4 multiplexed samples/1311 cells); 'CDE': Charles David Edwards, Mouse ChIP-seq (PI: Colin Delaney Eccleston) (2 samples)")
 
+    def test_report_concise_10x_cellplex_scrnaseq(self):
+        """report: report 10xGenomics CellPlex scRNA-seq run in 'concise' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87, },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "CellPlex scRNA-seq",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Single cell platform": "10xGenomics Chromium 3'v3",
+                        "Number of cells": 1311 },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add a cellranger multi config.csv file
+        with open(os.path.join(mockdir.dirn,
+                               "AB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(mockdir.dirn,
+                                     "AB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+AB1,%s,any,AB1,gene expression,
+AB2,%s,any,AB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+ABM1,CMO301,ABM1
+ABM2,CMO302,ABM2
+ABM3,CMO303,ABM3
+ABM4,CMO304,ABM4
+""" % (fastq_dir,fastq_dir))
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate concise report
+        self.assertEqual(report_concise(ap),
+                         "Paired end: 'AB': Alison Bell, Human 10xGenomics Chromium 3'v3 CellPlex scRNA-seq (PI: Audrey Bower) (4 multiplexed samples/1311 cells); 'CDE': Charles David Edwards, Mouse ChIP-seq (PI: Colin Delaney Eccleston) (2 samples)")
+
     def test_report_concise_10x_flex(self):
         """report: report 10xGenomics Flex run in 'concise' mode
         """
@@ -1183,6 +1340,82 @@ Cellranger: cellranger 3.0.1
 2 projects:
 - 'AB':  Alison Bell           Human CellPlex (10xGenomics Chromium 3'v3) 4 multiplexed samples/1311 cells (PI Audrey Bower)           
 - 'CDE': Charles David Edwards Mouse ChIP-seq                             2 samples                        (PI Colin Delaney Eccleston)
+
+Additional notes/comments:
+- CDE: Repeat of previous run
+""" % mockdir.dirn
+        for o,e in zip(report_summary(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
+    def test_report_summary_10x_cellplex_scrnaseq(self):
+        """report: report 10xGenomics CellPlex scRNA-seq run in 'summary' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "bcl2fastq_software":
+                       "('/usr/bin/bcl2fastq', 'bcl2fastq', '2.17.1.14')",
+                       "cellranger_software":
+                       "('/usr/bin/cellranger', 'cellranger', '3.0.1')",
+                       "sequencer_model": "MiSeq" },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "CellPlex scRNA-seq",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Single cell platform": "10xGenomics Chromium 3'v3",
+                        "Number of cells": 1311 },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston",
+                         "Comments": "Repeat of previous run" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add a cellranger multi config.csv file
+        with open(os.path.join(mockdir.dirn,
+                               "AB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(mockdir.dirn,
+                                     "AB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+AB1,%s,any,AB1,gene expression,
+AB2,%s,any,AB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+ABM1,CMO301,ABM1
+ABM2,CMO302,ABM2
+ABM3,CMO303,ABM3
+ABM4,CMO304,ABM4
+""" % (fastq_dir,fastq_dir))
+        # Make autoprocess instance
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate summary report
+        expected = """MISEQ run #87 datestamped 170901
+================================
+Run name  : 170901_M00879_0087_000000000-AGEW9
+Reference : MISEQ_170901#87
+Platform  : MISEQ
+Sequencer : MiSeq
+Directory : %s
+Endedness : Paired end
+Bcl2fastq : bcl2fastq 2.17.1.14
+Cellranger: cellranger 3.0.1
+
+2 projects:
+- 'AB':  Alison Bell           Human CellPlex scRNA-seq (10xGenomics Chromium 3'v3) 4 multiplexed samples/1311 cells (PI Audrey Bower)           
+- 'CDE': Charles David Edwards Mouse ChIP-seq                                       2 samples                        (PI Colin Delaney Eccleston)
 
 Additional notes/comments:
 - CDE: Repeat of previous run
@@ -1738,6 +1971,64 @@ ABM4,CMO304,ABM4
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Generate projects report
         expected = """MISEQ_170901#87\t87\ttesting\t\tAlison Bell\tAudrey Bower\tCellPlex\t10xGenomics Chromium 3'v3\tHuman\tMISEQ\t4\t1311\tyes\tABM1-4
+MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\tChIP-seq\t\tMouse\tMISEQ\t2\t\tyes\tCDE3-4
+"""
+        for o,e in zip(report_projects(ap).split('\n'),
+                       expected.split('\n')):
+            self.assertEqual(o,e)
+
+    def test_report_projects_10x_cellplex_scrnaseq(self):
+        """report: report 10xGenomics CellPlex scRNA-seq run in 'projects' mode
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "source": "testing",
+                       "run_number": 87,
+                       "sequencer_model": "MiSeq" },
+            project_metadata={
+                "AB": { "User": "Alison Bell",
+                        "Library type": "CellPlex scRNA-seq",
+                        "Organism": "Human",
+                        "PI": "Audrey Bower",
+                        "Single cell platform": "10xGenomics Chromium 3'v3",
+                        "Number of cells": 1311,
+                        "Sequencer model": "MiSeq" },
+                "CDE": { "User": "Charles David Edwards",
+                         "Library type": "ChIP-seq",
+                         "Organism": "Mouse",
+                         "PI": "Colin Delaney Eccleston",
+                         "Sequencer model": "MiSeq" }
+            },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Add a cellranger multi config.csv file
+        with open(os.path.join(mockdir.dirn,
+                               "AB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(mockdir.dirn,
+                                     "AB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+AB1,%s,any,AB1,gene expression,
+AB2,%s,any,AB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+ABM1,CMO301,ABM1
+ABM2,CMO302,ABM2
+ABM3,CMO303,ABM3
+ABM4,CMO304,ABM4
+""" % (fastq_dir,fastq_dir))
+        # Make autoprocess instance and set required metadata
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        # Generate projects report
+        expected = """MISEQ_170901#87\t87\ttesting\t\tAlison Bell\tAudrey Bower\tCellPlex scRNA-seq\t10xGenomics Chromium 3'v3\tHuman\tMISEQ\t4\t1311\tyes\tABM1-4
 MISEQ_170901#87\t87\ttesting\t\tCharles David Edwards\tColin Delaney Eccleston\tChIP-seq\t\tMouse\tMISEQ\t2\t\tyes\tCDE3-4
 """
         for o,e in zip(report_projects(ap).split('\n'),


### PR DESCRIPTION
Updates the `report` command to implement fixes and updates required for reporting the names and numbers of multiplexed samples derived from the `10x_multi_config.csv` files in 10xGenomics projects with multiplexed samples.

The fix is to ensure that the `CellPlex scRNA-seq` library type is also recognised as a project with multiplexed samples (previously it was not); the update is to handle the situation where there are multiple `10x_multi_config.csv` files within a project (so they should all be scanned to extract the multiplexed sample information).

As part of these changes the for extracting the multiplexed sample information has been abstracted into a single new function `get_multiplexed_samples` (whereas before the same logic was programmed multiple times, for each different reporting mode). The refactoring should make future updates (e.g. adding new library types) more straightforward.