### PR TITLE
Handle "reads per cell" in 10xGenomics metrics file being non-integer value when reporting multiplexed QC

### DIFF
--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -2429,7 +2429,14 @@ class SampleQCReporter:
                     # Cellranger 8.0.0 doesn't output median
                     # reads so fall back to mean
                     value = metrics.mean_reads_per_cell
-            value = pretty_print_reads(value)
+            try:
+                # Assume that reads per cell is an
+                # integer and trap if it isn't (e.g.
+                # '---')
+                value = pretty_print_reads(int(value))
+            except ValueError:
+                # Not an integer - report as a string
+                value = str(value)
         elif field == "10x_genes_per_cell":
             value = pretty_print_reads(metrics.median_genes_per_cell)
         elif field == "10x_frac_reads_in_cell":


### PR DESCRIPTION
Handles the special case of the "reads per cell" value in a `cellranger multi` `metrics_summary.csv` file not being an integer when reporting 10x Genomics multiplexed statistics.

For example if no cells were assigned to a multiplexed sample then the `metrics_summary.csv` file might contain the line:

    Cells,Gene Expression,,,Mean reads per cell,---

compared with:

    Cells,Gene Expression,,,Mean reads per cell,"20,614"

Without the bugfix the QC reporting fails as the `SampleQCReporter.get_10x_value()` method in `qc/reporting.py` encounters an untrapped error attempting to format a non-integer value for the `10x_reads_per_cell` field. The fix allows for non-integer values specifically for this field to be return as-is as string instead.