### PR TITLE
Update pipelines for Cellranger 9.0.0

### DIFF
--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1,5 +1,5 @@
 #     mock.py: module providing mock Illumina data for testing
-#     Copyright (C) University of Manchester 2012-2024 Peter Briggs
+#     Copyright (C) University of Manchester 2012-2025 Peter Briggs
 #
 ########################################################################
 
@@ -2195,8 +2195,8 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
                                required=True)
             count.add_argument("--chemistry",action="store")
             count.add_argument("--force-cells",action="store",type=int)
-            if version[0] in (7,8):
-                # Cellranger 7,8: include introns on by default
+            if version[0] >= 7:
+                # Cellranger 7+: include introns on by default
                 count.add_argument("--include-introns",
                                    choices=['true','false'],
                                    default='true')
@@ -2207,8 +2207,8 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
             if version[0] >= 5:
                 count.add_argument("--r1-length",action="store")
                 count.add_argument("--r2-length",action="store")
-            if version[0] == 8:
-                # Cellranger 8: explicitly specify BAM creation
+            if version[0] >= 8:
+                # Cellranger 8+: explicitly specify BAM creation
                 count.add_argument("--create-bam",
                                    choices=['true','false'],
                                    required=True)
@@ -2460,6 +2460,8 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
                 metrics_data = mock10xdata.CELLPLEX_METRICS_SUMMARY_7_1_0
             elif version[0] == 8:
                 metrics_data = mock10xdata.CELLPLEX_METRICS_SUMMARY_8_0_0
+            elif version[0] == 9:
+                metrics_data = mock10xdata.CELLPLEX_METRICS_SUMMARY_9_0_0
             else:
                 raise Exception("%s: unsupported version" % self._version)
             for sample in config.sample_names:

--- a/auto_process_ngs/mock10xdata.py
+++ b/auto_process_ngs/mock10xdata.py
@@ -1,5 +1,5 @@
 #     mock.py: module providing mock 10xGenomics data for testing
-#     Copyright (C) University of Manchester 2018-2024 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2025 Peter Briggs
 #
 ########################################################################
 
@@ -734,6 +734,91 @@ Library,Gene Expression,Probe barcode ID,BC015,UMIs per probe barcode,"51,216,16
 Library,Gene Expression,Probe barcode ID,BC016,Cells per probe barcode,"3,661 (8.32%)"
 Library,Gene Expression,Probe barcode ID,BC016,Sample ID,JMF16
 Library,Gene Expression,Probe barcode ID,BC016,UMIs per probe barcode,"52,394,225 (8.24%)"
+"""
+
+CELLPLEX_METRICS_SUMMARY_9_0_0 = """Category,Library Type,Grouped By,Group Name,Metric Name,Metric Value
+Cells,Gene Expression,,,Cells,"1,571"
+Cells,Gene Expression,,,Confidently mapped antisense,3.7%
+Cells,Gene Expression,,,Confidently mapped to exonic regions,65.8%
+Cells,Gene Expression,,,Confidently mapped to genome,92.8%
+Cells,Gene Expression,,,Confidently mapped to intergenic regions,4.7%
+Cells,Gene Expression,,,Confidently mapped to intronic regions,22.4%
+Cells,Gene Expression,,,Confidently mapped to transcriptome,84.2%
+Cells,Gene Expression,,,Mapped to genome,96.3%
+Cells,Gene Expression,,,Mean reads per cell,"39,445"
+Cells,Gene Expression,,,Median UMI counts per cell,"6,692"
+Cells,Gene Expression,,,Median genes per cell,"2,472"
+Cells,Gene Expression,,,Number of reads from cells called from this sample,"61,968,623"
+Cells,Gene Expression,,,Total genes detected,"20,944"
+Cells,Gene Expression,Physical library ID,SC_GE,Cell-associated barcodes identified as multiplets,"1,218 (8.3%)"
+Cells,Gene Expression,Physical library ID,SC_GE,Cell-associated barcodes not assigned any CMOs,"4,345 (29.6%)"
+Cells,Gene Expression,Physical library ID,SC_GE,Cells assigned to other samples,"7,545 (51.4%)"
+Cells,Gene Expression,Physical library ID,SC_GE,Cells assigned to this sample,"1,571 (10.7%)"
+Library,Gene Expression,Fastq ID,SC_GE,Number of reads,"771,660,546"
+Library,Gene Expression,Fastq ID,SC_GE,Number of short reads skipped,0
+Library,Gene Expression,Fastq ID,SC_GE,Q30 RNA read,92.8%
+Library,Gene Expression,Fastq ID,SC_GE,Q30 UMI,95.7%
+Library,Gene Expression,Fastq ID,SC_GE,Q30 barcodes,96.2%
+Library,Gene Expression,Physical library ID,SC_GE,Cell-associated barcodes identified as multiplets,"1,218 (8.3%)"
+Library,Gene Expression,Physical library ID,SC_GE,Cell-associated barcodes not assigned any CMOs,"4,345 (29.6%)"
+Library,Gene Expression,Physical library ID,SC_GE,Cells,"14,679"
+Library,Gene Expression,Physical library ID,SC_GE,Cells assigned to a sample,"9,116 (62.1%)"
+Library,Gene Expression,Physical library ID,SC_GE,Confidently mapped antisense,3.4%
+Library,Gene Expression,Physical library ID,SC_GE,Confidently mapped reads in cells,96.9%
+Library,Gene Expression,Physical library ID,SC_GE,Confidently mapped to exonic regions,69.0%
+Library,Gene Expression,Physical library ID,SC_GE,Confidently mapped to genome,91.9%
+Library,Gene Expression,Physical library ID,SC_GE,Confidently mapped to intergenic regions,4.0%
+Library,Gene Expression,Physical library ID,SC_GE,Confidently mapped to intronic regions,18.9%
+Library,Gene Expression,Physical library ID,SC_GE,Confidently mapped to transcriptome,84.1%
+Library,Gene Expression,Physical library ID,SC_GE,Mapped to genome,95.3%
+Library,Gene Expression,Physical library ID,SC_GE,Mean reads per cell,"52,569"
+Library,Gene Expression,Physical library ID,SC_GE,Number of reads,"771,660,546"
+Library,Gene Expression,Physical library ID,SC_GE,Number of reads in the library,"771,660,546"
+Library,Gene Expression,Physical library ID,SC_GE,Sequencing saturation,69.0%
+Library,Gene Expression,Physical library ID,SC_GE,Valid UMIs,99.9%
+Library,Gene Expression,Physical library ID,SC_GE,Valid barcodes,97.6%
+Library,Multiplexing Capture,,,Cell-associated barcodes identified as multiplets,"1,218 (8.3%)"
+Library,Multiplexing Capture,,,Cell-associated barcodes not assigned any CMOs,"4,345 (29.6%)"
+Library,Multiplexing Capture,,,Cells assigned to a sample,"9,116 (62.1%)"
+Library,Multiplexing Capture,,,Estimated number of cell-associated barcodes,"14,679"
+Library,Multiplexing Capture,,,Median CMO UMI Counts per cell assigned to a sample,"2,987"
+Library,Multiplexing Capture,,,Number of samples assigned at least one cell,5
+Library,Multiplexing Capture,,,Singlet capture ratio,0.69
+Library,Multiplexing Capture,CMO Name,CMO301,CMO signal-to-noise ratio,4.25
+Library,Multiplexing Capture,CMO Name,CMO301,Cells per CMO,"1,571 (17.2%)"
+Library,Multiplexing Capture,CMO Name,CMO301,Fraction reads in cell-associated barcodes,72.4%
+Library,Multiplexing Capture,CMO Name,CMO301,Sample ID,SC1
+Library,Multiplexing Capture,CMO Name,CMO302,CMO signal-to-noise ratio,2.70
+Library,Multiplexing Capture,CMO Name,CMO302,Cells per CMO,"1,204 (13.2%)"
+Library,Multiplexing Capture,CMO Name,CMO302,Fraction reads in cell-associated barcodes,49.7%
+Library,Multiplexing Capture,CMO Name,CMO302,Sample ID,SC2
+Library,Multiplexing Capture,CMO Name,CMO303,CMO signal-to-noise ratio,3.50
+Library,Multiplexing Capture,CMO Name,CMO303,Cells per CMO,"2,487 (27.3%)"
+Library,Multiplexing Capture,CMO Name,CMO303,Fraction reads in cell-associated barcodes,71.9%
+Library,Multiplexing Capture,CMO Name,CMO303,Sample ID,SC3
+Library,Multiplexing Capture,CMO Name,CMO304,CMO signal-to-noise ratio,4.60
+Library,Multiplexing Capture,CMO Name,CMO304,Cells per CMO,"1,313 (14.4%)"
+Library,Multiplexing Capture,CMO Name,CMO304,Fraction reads in cell-associated barcodes,66.8%
+Library,Multiplexing Capture,CMO Name,CMO304,Sample ID,SC4
+Library,Multiplexing Capture,CMO Name,CMO305,CMO signal-to-noise ratio,3.34
+Library,Multiplexing Capture,CMO Name,CMO305,Cells per CMO,"2,541 (27.9%)"
+Library,Multiplexing Capture,CMO Name,CMO305,Fraction reads in cell-associated barcodes,73.0%
+Library,Multiplexing Capture,CMO Name,CMO305,Sample ID,SC5
+Library,Multiplexing Capture,Fastq ID,SC_CML,Number of reads,"204,261,166"
+Library,Multiplexing Capture,Fastq ID,SC_CML,Number of short reads skipped,0
+Library,Multiplexing Capture,Fastq ID,SC_CML,Q30 RNA read,96.9%
+Library,Multiplexing Capture,Fastq ID,SC_CML,Q30 UMI,96.4%
+Library,Multiplexing Capture,Fastq ID,SC_CML,Q30 barcodes,96.3%
+Library,Multiplexing Capture,Physical library ID,SC_CML,Fraction CMO reads,97.7%
+Library,Multiplexing Capture,Physical library ID,SC_CML,Fraction CMO reads usable,65.0%
+Library,Multiplexing Capture,Physical library ID,SC_CML,Fraction reads from multiplets,16.0%
+Library,Multiplexing Capture,Physical library ID,SC_CML,Fraction reads in cell-associated barcodes,67.0%
+Library,Multiplexing Capture,Physical library ID,SC_CML,Fraction unrecognized CMO,2.3%
+Library,Multiplexing Capture,Physical library ID,SC_CML,Mean reads per cell-associated barcode,"13,915"
+Library,Multiplexing Capture,Physical library ID,SC_CML,Number of reads,"204,261,166"
+Library,Multiplexing Capture,Physical library ID,SC_CML,Sequencing saturation,29.5%
+Library,Multiplexing Capture,Physical library ID,SC_CML,Valid UMIs,100.0%
+Library,Multiplexing Capture,Physical library ID,SC_CML,Valid barcodes,99.2%
 """
 
 MULTIOME_LIBRARIES = """#Local sample\tLinked sample

--- a/auto_process_ngs/mock10xdata.py
+++ b/auto_process_ngs/mock10xdata.py
@@ -821,6 +821,98 @@ Library,Multiplexing Capture,Physical library ID,SC_CML,Valid UMIs,100.0%
 Library,Multiplexing Capture,Physical library ID,SC_CML,Valid barcodes,99.2%
 """
 
+FLEX_METRICS_SUMMARY_9_0_0 = """Category,Library Type,Grouped By,Group Name,Metric Name,Metric Value
+Cells,Gene Expression,,,Cells,"13,958"
+Cells,Gene Expression,,,Confidently mapped reads in cells,94.3%
+Cells,Gene Expression,,,Estimated UMIs from genomic DNA,0.0%
+Cells,Gene Expression,,,Estimated UMIs from genomic DNA per unspliced probe,1
+Cells,Gene Expression,,,Mean reads per cell,"15,434"
+Cells,Gene Expression,,,Median UMI counts per cell,"3,159"
+Cells,Gene Expression,,,Median genes per cell,"1,956"
+Cells,Gene Expression,,,Number of reads from cells called from this sample,"215,425,674"
+Cells,Gene Expression,,,Reads confidently mapped to filtered probe set,95.7%
+Cells,Gene Expression,,,Reads confidently mapped to probe set,97.7%
+Cells,Gene Expression,,,Reads half-mapped to probe set,0.2%
+Cells,Gene Expression,,,Reads mapped to probe set,98.4%
+Cells,Gene Expression,,,Reads split-mapped to probe set,0.5%
+Cells,Gene Expression,,,Total genes detected,"15,480"
+Cells,Gene Expression,Physical library ID,MS_Flex,Cells detected in other samples,"33,694 (70.7%)"
+Cells,Gene Expression,Physical library ID,MS_Flex,Cells detected in this sample,"13,958 (29.3%)"
+Library,Gene Expression,,,Estimated UMIs from genomic DNA,0.0%
+Library,Gene Expression,,,Estimated UMIs from genomic DNA per unspliced probe,1
+Library,Gene Expression,Fastq ID,MS_Flex,Number of reads,"955,352,059"
+Library,Gene Expression,Fastq ID,MS_Flex,Number of short reads skipped,0
+Library,Gene Expression,Fastq ID,MS_Flex,Q30 GEM barcodes,96.8%
+Library,Gene Expression,Fastq ID,MS_Flex,Q30 RNA read,95.8%
+Library,Gene Expression,Fastq ID,MS_Flex,Q30 UMI,96.5%
+Library,Gene Expression,Fastq ID,MS_Flex,Q30 barcodes,96.0%
+Library,Gene Expression,Fastq ID,MS_Flex,Q30 probe barcodes,94.5%
+Library,Gene Expression,Physical library ID,MS_Flex,Cells,"47,652"
+Library,Gene Expression,Physical library ID,MS_Flex,Confidently mapped reads in cells,94.0%
+Library,Gene Expression,Physical library ID,MS_Flex,Fraction of initial cell barcodes passing high occupancy GEM filtering,98.0%
+Library,Gene Expression,Physical library ID,MS_Flex,Mean reads per cell,"20,049"
+Library,Gene Expression,Physical library ID,MS_Flex,Number of reads,"955,352,059"
+Library,Gene Expression,Physical library ID,MS_Flex,Number of reads in the library,"955,352,059"
+Library,Gene Expression,Physical library ID,MS_Flex,Reads confidently mapped to filtered probe set,93.8%
+Library,Gene Expression,Physical library ID,MS_Flex,Reads confidently mapped to probe set,96.1%
+Library,Gene Expression,Physical library ID,MS_Flex,Reads half-mapped to probe set,0.5%
+Library,Gene Expression,Physical library ID,MS_Flex,Reads mapped to probe set,97.3%
+Library,Gene Expression,Physical library ID,MS_Flex,Reads split-mapped to probe set,0.6%
+Library,Gene Expression,Physical library ID,MS_Flex,Sequencing saturation,64.8%
+Library,Gene Expression,Physical library ID,MS_Flex,Valid GEM barcodes,98.5%
+Library,Gene Expression,Physical library ID,MS_Flex,Valid UMIs,100.0%
+Library,Gene Expression,Physical library ID,MS_Flex,Valid barcodes,96.3%
+Library,Gene Expression,Physical library ID,MS_Flex,Valid probe barcodes,97.3%
+Library,Gene Expression,Probe barcode ID,BC001,Cells per probe barcode,"6,306 (13.2%)"
+Library,Gene Expression,Probe barcode ID,BC001,Sample ID,Donor7_PBMC
+Library,Gene Expression,Probe barcode ID,BC001,UMIs per probe barcode,"42,932,288 (13.6%)"
+Library,Gene Expression,Probe barcode ID,BC002,Cells per probe barcode,"3,542 (7.4%)"
+Library,Gene Expression,Probe barcode ID,BC002,Sample ID,Donor7_PBMC
+Library,Gene Expression,Probe barcode ID,BC002,UMIs per probe barcode,"21,794,816 (6.9%)"
+Library,Gene Expression,Probe barcode ID,BC003,Cells per probe barcode,"4,963 (10.4%)"
+Library,Gene Expression,Probe barcode ID,BC003,Sample ID,Donor7_PBMC
+Library,Gene Expression,Probe barcode ID,BC003,UMIs per probe barcode,"34,932,055 (11.1%)"
+Library,Gene Expression,Probe barcode ID,BC004,Cells per probe barcode,"2,974 (6.2%)"
+Library,Gene Expression,Probe barcode ID,BC004,Sample ID,Donor7_PBMC
+Library,Gene Expression,Probe barcode ID,BC004,UMIs per probe barcode,"20,758,295 (6.6%)"
+Library,Gene Expression,Probe barcode ID,BC005,Cells per probe barcode,"4,591 (9.6%)"
+Library,Gene Expression,Probe barcode ID,BC005,Sample ID,Donor7_CD4
+Library,Gene Expression,Probe barcode ID,BC005,UMIs per probe barcode,"22,568,914 (7.1%)"
+Library,Gene Expression,Probe barcode ID,BC006,Cells per probe barcode,"3,300 (6.9%)"
+Library,Gene Expression,Probe barcode ID,BC006,Sample ID,Donor7_CD4
+Library,Gene Expression,Probe barcode ID,BC006,UMIs per probe barcode,"19,687,385 (6.2%)"
+Library,Gene Expression,Probe barcode ID,BC007,Cells per probe barcode,"3,688 (7.7%)"
+Library,Gene Expression,Probe barcode ID,BC007,Sample ID,Donor7_CD4
+Library,Gene Expression,Probe barcode ID,BC007,UMIs per probe barcode,"21,783,905 (6.9%)"
+Library,Gene Expression,Probe barcode ID,BC008,Cells per probe barcode,"2,379 (5.0%)"
+Library,Gene Expression,Probe barcode ID,BC008,Sample ID,Donor7_CD4
+Library,Gene Expression,Probe barcode ID,BC008,UMIs per probe barcode,"14,639,323 (4.6%)"
+Library,Gene Expression,Probe barcode ID,BC009,Cells per probe barcode,"2,901 (6.1%)"
+Library,Gene Expression,Probe barcode ID,BC009,Sample ID,Donor8_PBMC
+Library,Gene Expression,Probe barcode ID,BC009,UMIs per probe barcode,"24,641,156 (7.8%)"
+Library,Gene Expression,Probe barcode ID,BC010,Cells per probe barcode,"2,535 (5.3%)"
+Library,Gene Expression,Probe barcode ID,BC010,Sample ID,Donor8_PBMC
+Library,Gene Expression,Probe barcode ID,BC010,UMIs per probe barcode,"22,730,019 (7.2%)"
+Library,Gene Expression,Probe barcode ID,BC011,Cells per probe barcode,"1,419 (3.0%)"
+Library,Gene Expression,Probe barcode ID,BC011,Sample ID,Donor8_PBMC
+Library,Gene Expression,Probe barcode ID,BC011,UMIs per probe barcode,"12,149,027 (3.8%)"
+Library,Gene Expression,Probe barcode ID,BC012,Cells per probe barcode,"2,671 (5.6%)"
+Library,Gene Expression,Probe barcode ID,BC012,Sample ID,Donor8_PBMC
+Library,Gene Expression,Probe barcode ID,BC012,UMIs per probe barcode,"23,912,642 (7.6%)"
+Library,Gene Expression,Probe barcode ID,BC013,Cells per probe barcode,"3,499 (7.3%)"
+Library,Gene Expression,Probe barcode ID,BC013,Sample ID,Donor8_CD4
+Library,Gene Expression,Probe barcode ID,BC013,UMIs per probe barcode,"17,752,112 (5.6%)"
+Library,Gene Expression,Probe barcode ID,BC014,Cells per probe barcode,924 (1.9%)
+Library,Gene Expression,Probe barcode ID,BC014,Sample ID,Donor8_CD4
+Library,Gene Expression,Probe barcode ID,BC014,UMIs per probe barcode,"5,149,789 (1.6%)"
+Library,Gene Expression,Probe barcode ID,BC015,Cells per probe barcode,803 (1.7%)
+Library,Gene Expression,Probe barcode ID,BC015,Sample ID,Donor8_CD4
+Library,Gene Expression,Probe barcode ID,BC015,UMIs per probe barcode,"4,174,363 (1.3%)"
+Library,Gene Expression,Probe barcode ID,BC016,Cells per probe barcode,"1,157 (2.4%)"
+Library,Gene Expression,Probe barcode ID,BC016,Sample ID,Donor8_CD4
+Library,Gene Expression,Probe barcode ID,BC016,UMIs per probe barcode,"6,380,271 (2.0%)"
+"""
+
 MULTIOME_LIBRARIES = """#Local sample\tLinked sample
 PB2_ATAC\tNEXTSEQ_210111/12:PB_GEX/PB2_GEX
 PB1_ATAC\tNEXTSEQ_210111/12:PB_GEX/PB1_GEX

--- a/auto_process_ngs/mockqc.py
+++ b/auto_process_ngs/mockqc.py
@@ -1,5 +1,5 @@
 #     mockqc.py: module providing mock Illumina QC data for testing
-#     Copyright (C) University of Manchester 2016-2024 Peter Briggs
+#     Copyright (C) University of Manchester 2016-2025 Peter Briggs
 #
 ########################################################################
 
@@ -462,6 +462,8 @@ Fraction of reads explained by "1+-,1-+,2++,2--": 0.4925
             metrics_summary = mock10xdata.CELLPLEX_METRICS_SUMMARY_7_1_0
         elif version == 8:
             metrics_summary = mock10xdata.CELLPLEX_METRICS_SUMMARY_8_0_0
+        elif version == 9:
+            metrics_summary = mock10xdata.CELLPLEX_METRICS_SUMMARY_9_0_0
         else:
             raise Exception("%s: unsupported Cellranger "
                             "version" % cellranger_version)

--- a/auto_process_ngs/qc/modules/cellranger_count.py
+++ b/auto_process_ngs/qc/modules/cellranger_count.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 #     cellranger_count: implements 'cellranger_count' QC module
-#     Copyright (C) University of Manchester 2024 Peter Briggs
+#     Copyright (C) University of Manchester 2024-2025 Peter Briggs
 
 """
 Implements the 'cellranger_count' QC module:
@@ -743,11 +743,14 @@ class RunCellrangerCount(PipelineTask):
                     cmd.add_args("--r1-length=26")
                     if self.args.library_type == "snRNA-seq":
                         # For single nuclei RNA-seq specify the
-                        # --include-introns for cellranger 5.0+
-                        if cellranger_major_version in (7,8):
+                        if cellranger_major_version >= 7:
+                            # Syntax is --include-introns {true|false}
+                            # for cellranger 7.0+
                             cmd.add_args("--include-introns",
                                          "true")
                         else:
+                            # Other versions use --include-introns
+                            # (no other arguments)
                             cmd.add_args("--include-introns")
                 # Additional options for cellranger 8.0+
                 if cellranger_major_version >= 8:

--- a/auto_process_ngs/tenx/__init__.py
+++ b/auto_process_ngs/tenx/__init__.py
@@ -87,7 +87,7 @@ CELLRANGER_ASSAY_CONFIGS = {
     'SC3Pv3LT': 'Single Cell 3\' v3 LT',
     'SC3Pv3HT': 'Single Cell 3\' v3 HT',
     'SC5P-PE': 'Single Cell 5\' paired-end (both R1 and R2 are used for alignment)',
-    'SC5P-PE-v3': 'Single Cell 5\' paired-end (both R1 and R2 are used for alignment) v3'
+    'SC5P-PE-v3': 'Single Cell 5\' paired-end (both R1 and R2 are used for alignment) v3',
     'SC5P-R2': 'Single Cell 5\' R2-only (where only R2 is used for alignment)',
     'SC5P-R2-v3': 'Single Cell 5\' R2-only (where only R2 is used for alignment)',
     'ARC-v1': 'Single Cell Multiome (ATAC+GEX) v1 (cannot be autodetected)'

--- a/auto_process_ngs/tenx/__init__.py
+++ b/auto_process_ngs/tenx/__init__.py
@@ -83,9 +83,14 @@ CELLRANGER_ASSAY_CONFIGS = {
     'SC3Pv1': 'Single Cell 3\' v1',
     'SC3Pv2': 'Single Cell 3\' v2',
     'SC3Pv3': 'Single Cell 3\' v3',
+    'SC3Pv4': 'Single Cell 3\' v4',
+    'SC3Pv3LT': 'Single Cell 3\' v3 LT',
+    'SC3Pv3HT': 'Single Cell 3\' v3 HT',
     'SC5P-PE': 'Single Cell 5\' paired-end (both R1 and R2 are used for alignment)',
+    'SC5P-PE-v3': 'Single Cell 5\' paired-end (both R1 and R2 are used for alignment) v3'
     'SC5P-R2': 'Single Cell 5\' R2-only (where only R2 is used for alignment)',
-    'ARC-v1': 'Single Cell Multiome (ATAC+GEX) v1', # Not documented?
+    'SC5P-R2-v3': 'Single Cell 5\' R2-only (where only R2 is used for alignment)',
+    'ARC-v1': 'Single Cell Multiome (ATAC+GEX) v1 (cannot be autodetected)'
 }
 
 # Default Cellranger version

--- a/auto_process_ngs/tenx/utils.py
+++ b/auto_process_ngs/tenx/utils.py
@@ -568,6 +568,13 @@ def make_multi_config_template(f,reference=None,probe_set=None,
         cellranger_version = DEFAULT_CELLRANGER_VERSION
     else:
         cellranger_version = str(cellranger_version)
+    # Major version
+    try:
+        cellranger_major_version = int(cellranger_version.split(".")[0])
+    except Exception as ex:
+        raise Exception(f"'{cellranger_version}': unable to extract "
+                        f"Cellranger major  version from version string: "
+                        f"{ex}")
     # Normalise and check supplied library type
     if library_type.startswith("CellPlex"):
         library_type = "cellplex"
@@ -605,14 +612,14 @@ def make_multi_config_template(f,reference=None,probe_set=None,
                      (probe_set if probe_set
                       else "/path/to/probe/set"))
         fp.write("#force-cells,n\n")
-        if cellranger_version.startswith("7."):
+        if cellranger_major_version == 7:
             # Cellranger 7.* targetted
             if no_bam is not None:
                 fp.write("no-bam,%s\n" % str(no_bam).lower())
             else:
                 fp.write("#no-bam,true|false\n")
-        elif cellranger_version.startswith("8."):
-            # Cellranger 8.* targetted
+        elif cellranger_major_version in (8, 9):
+            # Cellranger 8.* or 9.* targetted
             if no_bam is not None:
                 fp.write("create-bam,%s\n" % str(not no_bam).lower())
             else:

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_chromium_sc.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_10x_chromium_sc.py
@@ -403,6 +403,104 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_makefastqs_10x_chromium_sc_protocol_900(self):
+        """
+        MakeFastqs: '10x_chromium_sc' protocol (Cellranger 9.0.0)
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet with 10xGenomics Chromium SC indices
+        samplesheet_chromium_sc_indices = """[Header]
+IEMFileVersion,4
+Assay,Nextera XT
+
+[Reads]
+76
+76
+
+[Settings]
+ReverseComplement,0
+Adapter,CTGTCTCTTATACACATCT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+smpl1,smpl1,,,A001,SI-GA-A1,10xGenomics,
+smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
+"""
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'w') as fp:
+            fp.write(samplesheet_chromium_sc_indices)
+        # Create mock bcl2fastq and cellranger
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"))
+        MockCellrangerExe.create(os.path.join(self.bin,
+                                              "cellranger"),
+                                 version="9.0.0")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="10x_chromium_sc")
+        status = p.run(analysis_dir,
+                       poll_interval=POLL_INTERVAL)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,
+                         (os.path.join(self.bin,"cellranger"),
+                          "cellranger",
+                          "9.0.0"))
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
+                      "processing_qc.html",):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+
+    #@unittest.skip("Skipped")
     def test_makefastqs_10x_chromium_sc_protocol_non_standard_dir_name(self):
         """
         MakeFastqs: '10x_chromium_sc' protocol (non-standard directory name)

--- a/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
@@ -675,6 +675,86 @@ AB\tAB1,AB2\tAlan Brown\tCellPlex scRNA-seq\t10xGenomics Chromium 3'v3\tHuman\tA
                 self.assertFalse(os.path.exists(template_multi_config_file),
                                  "Found %s" % template_multi_config_file)
 
+    def test_setup_analysis_dirs_10x_cellplex_900(self):
+        """
+        setup_analysis_dirs: create new analysis dir for 10x CellPlex (9.0.0)
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901",
+                "processing_software": {
+                    "cellranger" : (
+                        "/usr/local/cellranger/9.0.0/cellranger",
+                        "cellranger",
+                        "9.0.0"
+                    )
+                }
+            },
+            reads=('R1','R2','I1','I2'),
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq")))
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq","AB")))
+        # Add required metadata to 'projects.info'
+        projects_info = os.path.join(mockdir.dirn,"projects.info")
+        with open(projects_info,"w") as fp:
+            fp.write(
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+AB\tAB1,AB2\tAlan Brown\tCellPlex scRNA-seq\t10xGenomics Chromium 3'v3\tHuman\tAudrey Benson\t1% PhiX
+""")
+        # Expected data
+        projects = {
+            "AB": ["AB1_S1_R1_001.fastq.gz",
+                   "AB1_S1_R2_001.fastq.gz",
+                   "AB1_S1_I1_001.fastq.gz",
+                   "AB1_S1_I2_001.fastq.gz",
+                   "AB2_S2_R1_001.fastq.gz",
+                   "AB2_S2_R2_001.fastq.gz",
+                   "AB2_S2_I1_001.fastq.gz",
+                   "AB2_S2_I2_001.fastq.gz"],
+            "undetermined": ["Undetermined_S0_R1_001.fastq.gz",]
+        }
+        # Check project dirs don't exist
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertFalse(os.path.exists(project_dir_path))
+        # Setup the project dirs
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        setup_analysis_dirs(ap)
+        # Check project dirs and contents
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertTrue(os.path.exists(project_dir_path))
+            # Check README.info file
+            readme_file = os.path.join(project_dir_path,
+                                       "README.info")
+            self.assertTrue(os.path.exists(readme_file))
+            # Check Fastqs
+            fastqs_dir = os.path.join(project_dir_path,
+                                      "fastqs")
+            self.assertTrue(os.path.exists(fastqs_dir))
+            for fq in projects[project]:
+                fastq = os.path.join(fastqs_dir,fq)
+                self.assertTrue(os.path.exists(fastq))
+            # Check template 10x_multi_config.csv
+            template_multi_config_file = os.path.join(
+                project_dir_path,
+                "10x_multi_config.csv.template")
+            if project == "AB":
+                # Template file should exist
+                self.assertTrue(os.path.exists(template_multi_config_file),
+                                "Missing %s" % template_multi_config_file)
+                # Template should contain 'create-bam'
+                with open(template_multi_config_file,'rt') as fp:
+                    template = fp.read()
+                    self.assertTrue(template.find("\ncreate-bam,") != -1)
+            else:
+                # No template file
+                self.assertFalse(os.path.exists(template_multi_config_file),
+                                 "Found %s" % template_multi_config_file)
+
     def test_setup_analysis_dirs_10x_flex_710(self):
         """
         setup_analysis_dirs: create new analysis dir for 10x Flex (7.1.0)
@@ -829,6 +909,83 @@ AB\tAB1\tAlan Brown\tFlex\t10xGenomics Chromium 3'v3\tHuman\tAudrey Benson\t1% P
                 self.assertFalse(os.path.exists(template_multi_config_file),
                                  "Found %s" % template_multi_config_file)
 
+    def test_setup_analysis_dirs_10x_flex_900(self):
+        """
+        setup_analysis_dirs: create new analysis dir for 10x Flex (9.0.0)
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={
+                "instrument_datestamp": "170901",
+                "processing_software": {
+                    "cellranger" : (
+                        "/usr/local/cellranger/9.0.0/cellranger",
+                        "cellranger",
+                        "9.0.0"
+                    )
+                }
+            },
+            reads=('R1','R2','I1','I2'),
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq")))
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq","AB")))
+        # Add required metadata to 'projects.info'
+        projects_info = os.path.join(mockdir.dirn,"projects.info")
+        with open(projects_info,"w") as fp:
+            fp.write(
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+AB\tAB1\tAlan Brown\tFlex\t10xGenomics Chromium 3'v3\tHuman\tAudrey Benson\t1% PhiX
+""")
+        # Expected data
+        projects = {
+            "AB": ["AB1_S1_R1_001.fastq.gz",
+                   "AB1_S1_R2_001.fastq.gz",
+                   "AB1_S1_I1_001.fastq.gz",
+                   "AB1_S1_I2_001.fastq.gz",],
+            "undetermined": ["Undetermined_S0_R1_001.fastq.gz",]
+        }
+        # Check project dirs don't exist
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertFalse(os.path.exists(project_dir_path))
+        # Setup the project dirs
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        setup_analysis_dirs(ap)
+        # Check project dirs and contents
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertTrue(os.path.exists(project_dir_path))
+            # Check README.info file
+            readme_file = os.path.join(project_dir_path,
+                                       "README.info")
+            self.assertTrue(os.path.exists(readme_file))
+            # Check Fastqs
+            fastqs_dir = os.path.join(project_dir_path,
+                                      "fastqs")
+            self.assertTrue(os.path.exists(fastqs_dir))
+            for fq in projects[project]:
+                fastq = os.path.join(fastqs_dir,fq)
+                self.assertTrue(os.path.exists(fastq))
+            # Check template 10x_multi_config.csv
+            template_multi_config_file = os.path.join(
+                project_dir_path,
+                "10x_multi_config.csv.template")
+            if project == "AB":
+                # Template file should exist
+                self.assertTrue(os.path.exists(template_multi_config_file),
+                                "Missing %s" % template_multi_config_file)
+                # Template should contain 'create-bam'
+                with open(template_multi_config_file,'rt') as fp:
+                    template = fp.read()
+                    self.assertTrue(template.find("\ncreate-bam,") != -1)
+            else:
+                # No template file
+                self.assertFalse(os.path.exists(template_multi_config_file),
+                                 "Found %s" % template_multi_config_file)
+
     def test_setup_analysis_dirs_10x_immune_profiling_710(self):
         """
         setup_analysis_dirs: create new analysis dir for 10x Single Cell Immune Profiling (7.1.0)
@@ -919,6 +1076,82 @@ AB\tAB1\tAlan Brown\tSingle Cell Immune Profiling\t10xGenomics Chromium 5'\tMous
                         "/usr/local/cellranger/8.0.0/cellranger",
                         "cellranger",
                         "8.0.0"
+                    )
+                }
+            },
+            reads=('R1','R2','I1','I2'),
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq")))
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq","AB")))
+        # Add required metadata to 'projects.info'
+        projects_info = os.path.join(mockdir.dirn,"projects.info")
+        with open(projects_info,"w") as fp:
+            fp.write(
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+AB\tAB1\tAlan Brown\tSingle Cell Immune Profiling\t10xGenomics Chromium 5'\tMouse\tAudrey Benson\t1% PhiX
+""")
+        # Expected data
+        projects = {
+            "AB": ["AB1_S1_R1_001.fastq.gz",
+                   "AB1_S1_R2_001.fastq.gz",
+                   "AB1_S1_I1_001.fastq.gz",
+                   "AB1_S1_I2_001.fastq.gz",],
+            "undetermined": ["Undetermined_S0_R1_001.fastq.gz",]
+        }
+        # Check project dirs don't exist
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertFalse(os.path.exists(project_dir_path))
+        # Setup the project dirs
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        setup_analysis_dirs(ap)
+        # Check project dirs and contents
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertTrue(os.path.exists(project_dir_path))
+            # Check README.info file
+            readme_file = os.path.join(project_dir_path,
+                                       "README.info")
+            self.assertTrue(os.path.exists(readme_file))
+            # Check Fastqs
+            fastqs_dir = os.path.join(project_dir_path,
+                                      "fastqs")
+            self.assertTrue(os.path.exists(fastqs_dir))
+            for fq in projects[project]:
+                fastq = os.path.join(fastqs_dir,fq)
+                self.assertTrue(os.path.exists(fastq))
+            # Check template 10x_multi_config.csv
+            template_multi_config_file = os.path.join(
+                project_dir_path,
+                "10x_multi_config.csv.template")
+            if project == "AB":
+                # Template file should exist
+                self.assertTrue(os.path.exists(template_multi_config_file),
+                                "Missing %s" % template_multi_config_file)
+                # Template should contain 'create-bam'
+                with open(template_multi_config_file,'rt') as fp:
+                    template = fp.read()
+                    self.assertTrue(template.find("\ncreate-bam,") != -1)
+            else:
+                # No template file
+                self.assertFalse(os.path.exists(template_multi_config_file),
+                                 "Found %s" % template_multi_config_file)
+
+    def test_setup_analysis_dirs_10x_immune_profiling_900(self):
+        """
+        setup_analysis_dirs: create new analysis dir for 10x Single Cell Immune Profiling (9.0.0)
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '170901_M00879_0087_000000000-AGEW9',
+            'miseq',
+            metadata={ "instrument_datestamp": "170901",
+                "processing_software": {
+                    "cellranger" : (
+                        "/usr/local/cellranger/9.0.0/cellranger",
+                        "cellranger",
+                        "9.0.0"
                     )
                 }
             },

--- a/auto_process_ngs/test/qc/modules/test_cellranger_count.py
+++ b/auto_process_ngs/test/qc/modules/test_cellranger_count.py
@@ -486,6 +486,97 @@ class TestQCPipelineCellrangerCount(BaseQCPipelineTestCase):
                                                         "PJB",f)),
                             "Missing %s" % f)
 
+    def test_qcpipeline_qc_modules_cellranger_count_scrnaseq_900(self):
+        """
+        QCPipeline: 'cellranger_count' QC module (scRNA-seq, Cellranger v9.0.0)
+        """
+        # Make mock QC executables
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="9.0.0",
+                                 assert_include_introns=True)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v2',
+                                           'Library type': 'scRNA-seq' })
+        p.create(top_dir=self.wd)
+        # QC protocol
+        protocol = QCProtocol(name="cellranger_count",
+                              description="Cellranger_count test",
+                              seq_data_reads=['r2',],
+                              index_reads=['r1'],
+                              qc_modules=("cellranger_count",))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol)
+        status = runqc.run(cellranger_transcriptomes=
+                           { 'human':
+                             '/data/refdata-gex-GRCh38-2020-A' },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check outputs
+        project_dir = os.path.join(self.wd,"PJB")
+        for f in (
+                "qc/cellranger_count",
+                "qc/cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB1/_cmdline",
+                "qc/cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/web_summary.html",
+                "qc/cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/metrics_summary.csv",
+                "qc/cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB2/_cmdline",
+                "qc/cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/web_summary.html",
+                "qc/cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/metrics_summary.csv",
+                "cellranger_count",
+                "cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB1/_cmdline",
+                "cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/web_summary.html",
+                "cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/metrics_summary.csv",
+                "cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB2/_cmdline",
+                "cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/web_summary.html",
+                "cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/metrics_summary.csv"):
+            self.assertTrue(os.path.exists(os.path.join(project_dir,f)),
+                            "%s: missing" % f)
+        # Check number of cells
+        project_metadata = AnalysisProjectInfo(
+            os.path.join(self.wd,"PJB","README.info"))
+        self.assertEqual(project_metadata.number_of_cells,11058)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"cellranger_count")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,None)
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,None)
+        self.assertEqual(qc_info.cellranger_version,"9.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-gex-GRCh38-2020-A")
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
     def test_qcpipeline_qc_modules_cellranger_count_snrnaseq_310(self):
         """
         QCPipeline: 'cellranger_count' QC module (snRNA-seq, Cellranger v3.1.0)
@@ -931,6 +1022,97 @@ class TestQCPipelineCellrangerCount(BaseQCPipelineTestCase):
         self.assertEqual(qc_info.annotation_bed,None)
         self.assertEqual(qc_info.annotation_gtf,None)
         self.assertEqual(qc_info.cellranger_version,"8.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-gex-GRCh38-2020-A")
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    def test_qcpipeline_qc_modules_cellranger_count_snrnaseq_900(self):
+        """
+        QCPipeline: 'cellranger_count' QC module (snRNA-seq, Cellranger v9.0.0)
+        """
+        # Make mock QC executables
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="9.0.0",
+                                 assert_include_introns=True)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v2',
+                                           'Library type': 'snRNA-seq' })
+        p.create(top_dir=self.wd)
+        # QC protocol
+        protocol = QCProtocol(name="cellranger_count",
+                              description="Cellranger_count test",
+                              seq_data_reads=['r2',],
+                              index_reads=['r1'],
+                              qc_modules=("cellranger_count",))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol)
+        status = runqc.run(cellranger_transcriptomes=
+                           { 'human':
+                             '/data/refdata-gex-GRCh38-2020-A' },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check outputs
+        project_dir = os.path.join(self.wd,"PJB")
+        for f in (
+                "qc/cellranger_count",
+                "qc/cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB1/_cmdline",
+                "qc/cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/web_summary.html",
+                "qc/cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/metrics_summary.csv",
+                "qc/cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB2/_cmdline",
+                "qc/cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/web_summary.html",
+                "qc/cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/metrics_summary.csv",
+                "cellranger_count",
+                "cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB1/_cmdline",
+                "cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/web_summary.html",
+                "cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB1/outs/metrics_summary.csv",
+                "cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB2/_cmdline",
+                "cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/web_summary.html",
+                "cellranger_count/9.0.0/refdata-gex-GRCh38-2020-A/PJB2/outs/metrics_summary.csv"):
+            self.assertTrue(os.path.exists(os.path.join(project_dir,f)),
+                            "%s: missing" % f)
+        # Check number of cells
+        project_metadata = AnalysisProjectInfo(
+            os.path.join(self.wd,"PJB","README.info"))
+        self.assertEqual(project_metadata.number_of_cells,11058)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"cellranger_count")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,None)
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,None)
+        self.assertEqual(qc_info.cellranger_version,"9.0.0")
         self.assertEqual(qc_info.cellranger_refdata,
                          "/data/refdata-gex-GRCh38-2020-A")
         self.assertEqual(qc_info.cellranger_probeset,None)

--- a/auto_process_ngs/test/qc/modules/test_cellranger_multi.py
+++ b/auto_process_ngs/test/qc/modules/test_cellranger_multi.py
@@ -249,6 +249,117 @@ PBB,CMO302,PBB
                                                         "PJB",f)),
                             "Missing %s" % f)
 
+    def test_qcpipeline_qc_modules_cellranger_multi_cellplex_900(self):
+        """
+        QCPipeline: 'cellranger_multi' QC module (Cellplex, Cellranger v9.0.0)
+        """
+        # Make mock QC executables
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 multi_outputs="cellplex",
+                                 version="9.0.0")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x Cellplex analysis project
+        p = MockAnalysisProject("PJB",("PJB1_GEX_S1_R1_001.fastq.gz",
+                                       "PJB1_GEX_S1_R2_001.fastq.gz",
+                                       "PJB2_MC_S2_R1_001.fastq.gz",
+                                       "PJB2_MC_S2_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v3',
+                                           'Library type': 'CellPlex' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv file
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,%s,any,PJB1,gene expression,
+PJB2_MC,%s,any,PJB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+PBA,CMO301,PBA
+PBB,CMO302,PBB
+""" % (fastq_dir,fastq_dir))
+        # QC protocol
+        protocol = QCProtocol(name="cellranger_multi",
+                              description="Cellranger_multi test",
+                              seq_data_reads=['r2',],
+                              index_reads=['r1'],
+                              qc_modules=("cellranger_multi",))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol)
+        status = runqc.run(cellranger_transcriptomes=
+                           { 'human':
+                             '/data/refdata-cellranger-gex-GRCh38-2020-A' },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check outputs
+        project_dir = os.path.join(self.wd,"PJB")
+        for f in (
+                "qc/cellranger_multi",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/_cmdline",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBA/web_summary.html",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBA/metrics_summary.csv",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBB/web_summary.html",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBB/metrics_summary.csv",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/multi/multiplexing_analysis/tag_calls_summary.csv",
+                "cellranger_multi",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/_cmdline",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBA/web_summary.html",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBA/metrics_summary.csv",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBB/web_summary.html",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBB/metrics_summary.csv",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/multi/multiplexing_analysis/tag_calls_summary.csv"):
+            self.assertTrue(os.path.exists(os.path.join(project_dir,f)),
+                            "%s: missing" % f)
+        # Check number of cells
+        project_metadata = AnalysisProjectInfo(
+            os.path.join(self.wd,"PJB","README.info"))
+        self.assertEqual(project_metadata.number_of_cells,3142)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"cellranger_multi")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_GEX")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz,"
+                         "PJB2_MC_S2_R1_001.fastq.gz,"
+                         "PJB2_MC_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,None)
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,None)
+        self.assertEqual(qc_info.cellranger_version,"9.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-cellranger-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
     def test_qcpipeline_qc_modules_cellranger_multi_cellplex_no_config_file(self):
         """
         QCPipeline: 'cellranger_multi' QC module (CellPlex, no config file)

--- a/auto_process_ngs/test/qc/modules/test_cellranger_multi.py
+++ b/auto_process_ngs/test/qc/modules/test_cellranger_multi.py
@@ -762,6 +762,110 @@ PB2,BC002,PB2
                                                         "PJB",f)),
                             "Missing %s" % f)
 
+    def test_qcpipeline_qc_modules_cellranger_multi_flex_900(self):
+        """
+        QCPipeline: 'cellranger_multi' QC module (Flex, Cellranger v9.0.0)
+        """
+        # Make mock QC executables
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 multi_outputs="flex",
+                                 version="9.0.0")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x Flex analysis project
+        p = MockAnalysisProject("PJB",("PJB1_Flex_S1_R1_001.fastq.gz",
+                                       "PJB1_Flex_S1_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v3',
+                                           'Library type': 'Flex' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv file
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+probe-set,/data/Probe_Set_v1.0_GRCh38-2020-A.csv
+no-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_Flex,{fastq_dir},any,PJB1,Gene Expression,
+
+[samples]
+sample_id,probe_barcode_ids,description
+PB1,BC001,PB1
+PB2,BC002,PB2
+""".format(fastq_dir=fastq_dir))
+        # QC protocol
+        protocol = QCProtocol(name="cellranger_multi",
+                              description="Cellranger_multi test",
+                              seq_data_reads=['r2',],
+                              index_reads=['r1'],
+                              qc_modules=("cellranger_multi",))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol)
+        status = runqc.run(poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check outputs
+        project_dir = os.path.join(self.wd,"PJB")
+        for f in (
+                "qc/cellranger_multi",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/_cmdline",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PB1/web_summary.html",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PB1/metrics_summary.csv",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PB2/web_summary.html",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PB2/metrics_summary.csv",
+                "cellranger_multi",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/_cmdline",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PB1/web_summary.html",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PB1/metrics_summary.csv",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PB2/web_summary.html",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PB2/metrics_summary.csv"):
+            self.assertTrue(os.path.exists(os.path.join(project_dir,f)),
+                            "%s: missing" % f)
+        # Check number of cells
+        project_metadata = AnalysisProjectInfo(
+            os.path.join(self.wd,"PJB","README.info"))
+        self.assertEqual(project_metadata.number_of_cells,3142)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"cellranger_multi")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_Flex")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_Flex_S1_R1_001.fastq.gz,"
+                         "PJB1_Flex_S1_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,None)
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,None)
+        self.assertEqual(qc_info.cellranger_version,"9.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-cellranger-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset,
+                         "/data/Probe_Set_v1.0_GRCh38-2020-A.csv")
+        # Check output and reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
     def test_qcpipeline_qc_modules_cellranger_multi_flex_no_config_file(self):
         """
         QCPipeline: 'cellranger_multi' QC module (Flex, no config file)

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -1361,6 +1361,73 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.config_files,
                          ['fastq_strand.conf'])
 
+    def test_qcoutputs_10x_cellranger_count_900(self):
+        """
+        QCOutputs: 10xGenomics data with cellranger 'count' (9.0.0)
+        """
+        qc_dir = self._make_qc_dir('qc',
+                                   fastq_names=(
+                                       'PJB1_S1_R1_001',
+                                       'PJB1_S1_R2_001',
+                                       'PJB2_S2_R1_001',
+                                       'PJB2_S2_R2_001',
+                                   ),
+                                   include_cellranger_count=True,
+                                   cellranger_pipelines=('cellranger',),
+                                   cellranger_samples=(
+                                       'PJB1',
+                                       'PJB2',
+                                   ),
+                                   cellranger_version='9.0.0')
+        qc_outputs = QCOutputs(qc_dir)
+        self.assertEqual(qc_outputs.outputs,
+                         ['cellranger_count',
+                          'fastqc_r1',
+                          'fastqc_r2',
+                          'multiqc',
+                          'screens_r1',
+                          'screens_r2',
+                          'sequence_lengths',
+                          'strandedness'])
+        self.assertEqual(qc_outputs.fastqs,
+                         ['PJB1_S1_R1_001',
+                          'PJB1_S1_R2_001',
+                          'PJB2_S2_R1_001',
+                          'PJB2_S2_R2_001'])
+        self.assertEqual(qc_outputs.samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1','PJB2'])
+        self.assertEqual(qc_outputs.bams,[])
+        self.assertEqual(qc_outputs.organisms,[])
+        self.assertEqual(qc_outputs.fastq_screens,
+                         ['model_organisms',
+                          'other_organisms',
+                          'rRNA'])
+        self.assertEqual(qc_outputs.cellranger_references,
+                         ['/data/refdata-cellranger-2020-A'])
+        self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.reads,['r1','r2'])
+        self.assertEqual(qc_outputs.software,
+                         { 'cellranger': [ '9.0.0' ],
+                           'fastqc': [ '0.11.3' ],
+                           'fastq_screen': [ '0.9.2' ],
+                           'fastq_strand': [ '0.0.4' ],
+                           'multiqc': [ '1.8' ],
+                         })
+        self.assertEqual(qc_outputs.stats.max_seqs,37285443)
+        self.assertEqual(qc_outputs.stats.min_sequence_length,65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length,76)
+        self.assertEqual(sorted(
+            list(qc_outputs.stats.min_sequence_length_read.keys())),
+                         ['r1','r2'])
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r1'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r1'],76)
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r2'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r2'],76)
+        self.assertEqual(qc_outputs.config_files,
+                         ['fastq_strand.conf'])
+
     def test_qcoutputs_10x_cellranger_count_legacy(self):
         """
         QCOutputs: 10xGenomics data with cellranger 'count' (legacy format)
@@ -1860,6 +1927,80 @@ class TestQCOutputs(unittest.TestCase):
                          ['10x_multi_config.csv',
                           'fastq_strand.conf'])
 
+    def test_qcoutputs_10x_cellranger_multi_cellplex_900(self):
+        """
+        QCOutputs: 10xGenomics CellPlex data with 'cellranger multi' (9.0.0)
+        """
+        qc_dir = self._make_qc_dir('qc',
+                                   protocol="10x_CellPlex",
+                                   fastq_names=(
+                                       'PJB1_GEX_S1_R1_001',
+                                       'PJB1_GEX_S1_R2_001',
+                                       'PJB2_MC_S2_R1_001',
+                                       'PJB2_MC_S2_R2_001',
+                                   ),
+                                   include_cellranger_multi=True,
+                                   cellranger_pipelines=('cellranger',),
+                                   cellranger_samples=(
+                                       'PJB1_GEX',
+                                       'PJB2_MC',
+                                   ),
+                                   cellranger_multi_samples=(
+                                       'PJB_CML1',
+                                       'PJB_CML2',
+                                   ),
+                                   cellranger_version="9.0.0")
+        qc_outputs = QCOutputs(qc_dir)
+        self.assertEqual(qc_outputs.outputs,
+                         ['cellranger_multi',
+                          'fastqc_r1',
+                          'fastqc_r2',
+                          'multiqc',
+                          'screens_r2',
+                          'sequence_lengths',
+                          'strandedness'])
+        self.assertEqual(qc_outputs.fastqs,
+                         ['PJB1_GEX_S1_R1_001',
+                          'PJB1_GEX_S1_R2_001',
+                          'PJB2_MC_S2_R1_001',
+                          'PJB2_MC_S2_R2_001'])
+        self.assertEqual(qc_outputs.samples,
+                         ['PJB1_GEX','PJB2_MC'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1_GEX'])
+        self.assertEqual(qc_outputs.bams,[])
+        self.assertEqual(qc_outputs.organisms,[])
+        self.assertEqual(qc_outputs.fastq_screens,
+                         ['model_organisms',
+                          'other_organisms',
+                          'rRNA'])
+        self.assertEqual(qc_outputs.cellranger_references,
+                         ['/data/refdata-cellranger-2020-A'])
+        self.assertEqual(qc_outputs.cellranger_probe_sets,[])
+        self.assertEqual(qc_outputs.multiplexed_samples,
+                         ['PJB_CML1','PJB_CML2'])
+        self.assertEqual(qc_outputs.reads,['r1','r2'])
+        self.assertEqual(qc_outputs.software,
+                         { 'cellranger': [ '9.0.0' ],
+                           'fastqc': [ '0.11.3' ],
+                           'fastq_screen': [ '0.9.2' ],
+                           'fastq_strand': [ '0.0.4' ],
+                           'multiqc': [ '1.8' ],
+                         })
+        self.assertEqual(qc_outputs.stats.max_seqs,37285443)
+        self.assertEqual(qc_outputs.stats.min_sequence_length,65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length,76)
+        self.assertEqual(sorted(
+            list(qc_outputs.stats.min_sequence_length_read.keys())),
+                         ['r1','r2'])
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r1'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r1'],76)
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r2'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r2'],76)
+        self.assertEqual(qc_outputs.config_files,
+                         ['10x_multi_config.csv',
+                          'fastq_strand.conf'])
+
     def test_qcoutputs_10x_cellranger_multi_and_count_cellplex_612(self):
         """
         QCOutputs: 10xGenomics CellPlex data with 'cellranger multi' and 'count' (6.1.2)
@@ -2069,6 +2210,82 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '8.0.0' ],
+                           'fastqc': [ '0.11.3' ],
+                           'fastq_screen': [ '0.9.2' ],
+                           'fastq_strand': [ '0.0.4' ],
+                           'multiqc': [ '1.8' ],
+                         })
+        self.assertEqual(qc_outputs.stats.max_seqs,37285443)
+        self.assertEqual(qc_outputs.stats.min_sequence_length,65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length,76)
+        self.assertEqual(sorted(
+            list(qc_outputs.stats.min_sequence_length_read.keys())),
+                         ['r1','r2'])
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r1'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r1'],76)
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r2'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r2'],76)
+        self.assertEqual(qc_outputs.config_files,
+                         ['10x_multi_config.csv',
+                          'fastq_strand.conf'])
+
+    def test_qcoutputs_10x_cellranger_multi_and_count_cellplex_900(self):
+        """
+        QCOutputs: 10xGenomics CellPlex data with 'cellranger multi' and 'count' (9.0.0)
+        """
+        qc_dir = self._make_qc_dir('qc',
+                                   protocol="10x_CellPlex",
+                                   fastq_names=(
+                                       'PJB1_GEX_S1_R1_001',
+                                       'PJB1_GEX_S1_R2_001',
+                                       'PJB2_MC_S2_R1_001',
+                                       'PJB2_MC_S2_R2_001',
+                                   ),
+                                   include_cellranger_count=True,
+                                   include_cellranger_multi=True,
+                                   cellranger_pipelines=('cellranger',),
+                                   cellranger_samples=(
+                                       'PJB1_GEX',
+                                       'PJB2_MC',
+                                   ),
+                                   cellranger_multi_samples=(
+                                       'PJB_CML1',
+                                       'PJB_CML2',
+                                   ),
+                                   cellranger_version="9.0.0")
+        qc_outputs = QCOutputs(qc_dir)
+        self.assertEqual(qc_outputs.outputs,
+                         ['cellranger_count',
+                          'cellranger_multi',
+                          'fastqc_r1',
+                          'fastqc_r2',
+                          'multiqc',
+                          'screens_r2',
+                          'sequence_lengths',
+                          'strandedness'])
+        self.assertEqual(qc_outputs.fastqs,
+                         ['PJB1_GEX_S1_R1_001',
+                          'PJB1_GEX_S1_R2_001',
+                          'PJB2_MC_S2_R1_001',
+                          'PJB2_MC_S2_R2_001'])
+        self.assertEqual(qc_outputs.samples,
+                         ['PJB1_GEX','PJB2_MC'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1_GEX'])
+        self.assertEqual(qc_outputs.bams,[])
+        self.assertEqual(qc_outputs.organisms,[])
+        self.assertEqual(qc_outputs.fastq_screens,
+                         ['model_organisms',
+                          'other_organisms',
+                          'rRNA'])
+        self.assertEqual(qc_outputs.cellranger_references,
+                         ['/data/refdata-cellranger-2020-A'])
+        self.assertEqual(qc_outputs.cellranger_probe_sets,[])
+        self.assertEqual(qc_outputs.multiplexed_samples,
+                         ['PJB_CML1','PJB_CML2'])
+        self.assertEqual(qc_outputs.reads,['r1','r2'])
+        self.assertEqual(qc_outputs.software,
+                         { 'cellranger': [ '9.0.0' ],
                            'fastqc': [ '0.11.3' ],
                            'fastq_screen': [ '0.9.2' ],
                            'fastq_strand': [ '0.0.4' ],
@@ -2367,6 +2584,120 @@ PJB2_TCR,{fastq_dir},any,PJB2,VDJ-T,
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '8.0.0' ],
+                           'fastqc': [ '0.11.3' ],
+                           'fastq_screen': [ '0.9.2' ],
+                           'fastq_strand': [ '0.0.4' ],
+                           'multiqc': [ '1.8' ],
+                         })
+        self.assertEqual(qc_outputs.stats.max_seqs,37285443)
+        self.assertEqual(qc_outputs.stats.min_sequence_length,65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length,76)
+        self.assertEqual(sorted(
+            list(qc_outputs.stats.min_sequence_length_read.keys())),
+                         ['r1','r2'])
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r1'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r1'],76)
+        self.assertEqual(qc_outputs.stats.min_sequence_length_read['r2'],65)
+        self.assertEqual(qc_outputs.stats.max_sequence_length_read['r2'],76)
+        self.assertEqual(qc_outputs.config_files,
+                         ['10x_multi_config.PJB1.csv',
+                          '10x_multi_config.PJB2.csv',
+                          'fastq_strand.conf'])
+
+    def test_qcoutputs_10x_cellranger_single_cell_immune_profiling_900(self):
+        """
+        QCOutputs: 10xGenomics single cell immune profiling (9.0.0)
+        """
+        qc_dir = self._make_qc_dir('qc',
+                                   protocol="10x_ImmuneProfiling",
+                                   fastq_names=(
+                                       'PJB1_GEX_S1_R1_001',
+                                       'PJB1_GEX_S1_R2_001',
+                                       'PJB1_TCR_S2_R1_001',
+                                       'PJB1_TCR_S2_R2_001',
+                                       'PJB2_GEX_S3_R1_001',
+                                       'PJB2_GEX_S3_R2_001',
+                                       'PJB2_TCR_S4_R1_001',
+                                       'PJB2_TCR_S4_R2_001',
+                                   ),
+                                   include_cellranger_multi=False,
+                                   include_cellranger_count=True,
+                                   cellranger_pipelines=('cellranger',),
+                                   cellranger_samples=(
+                                       'PJB1_GEX',
+                                       'PJB2_GEX',
+                                   ),
+                                   cellranger_version="9.0.0")
+        # Make 10x_multi_config.csv files (one for each physical
+        # sample)
+        fastq_dir = os.path.join(os.path.dirname(qc_dir),'fastqs')
+        with open(os.path.join(qc_dir,"10x_multi_config.PJB1.csv"),
+                  'wt') as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+create-bam,true
+
+[vdj]
+reference,/data/refdata-cellranger-vdj-GRCh38-alts-ensembl-7.1.0
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,{fastq_dir},any,PJB1,gene expression,
+PJB1_TCR,{fastq_dir},any,PJB1,VDJ-T,
+""".format(fastq_dir=fastq_dir))
+        with open(os.path.join(qc_dir,"10x_multi_config.PJB2.csv"),
+                  'wt') as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[vdj]
+reference,/data/refdata-cellranger-vdj-GRCh38-alts-ensembl-7.1.0
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB2_GEX,{fastq_dir},any,PJB2,gene expression,
+PJB2_TCR,{fastq_dir},any,PJB2,VDJ-T,
+""".format(fastq_dir=fastq_dir))
+        # Collect and checkout outputs
+        qc_outputs = QCOutputs(qc_dir)
+        self.assertEqual(qc_outputs.outputs,
+                         ['cellranger_count',
+                          'fastqc_r1',
+                          'fastqc_r2',
+                          'multiqc',
+                          'screens_r2',
+                          'sequence_lengths',
+                          'strandedness'])
+        self.assertEqual(qc_outputs.fastqs,
+                         ['PJB1_GEX_S1_R1_001',
+                          'PJB1_GEX_S1_R2_001',
+                          'PJB1_TCR_S2_R1_001',
+                          'PJB1_TCR_S2_R2_001',
+                          'PJB2_GEX_S3_R1_001',
+                          'PJB2_GEX_S3_R2_001',
+                          'PJB2_TCR_S4_R1_001',
+                          'PJB2_TCR_S4_R2_001'])
+        self.assertEqual(qc_outputs.samples,
+                         ['PJB1_GEX',
+                          'PJB1_TCR',
+                          'PJB2_GEX',
+                          'PJB2_TCR'])
+        self.assertEqual(qc_outputs.seq_data_samples,
+                         ['PJB1_GEX',
+                          'PJB2_GEX'])
+        self.assertEqual(qc_outputs.bams,[])
+        self.assertEqual(qc_outputs.organisms,[])
+        self.assertEqual(qc_outputs.fastq_screens,
+                         ['model_organisms',
+                          'other_organisms',
+                          'rRNA'])
+        self.assertEqual(qc_outputs.cellranger_references,
+                         ['/data/refdata-cellranger-2020-A'])
+        self.assertEqual(qc_outputs.cellranger_probe_sets,[])
+        self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.reads,['r1','r2'])
+        self.assertEqual(qc_outputs.software,
+                         { 'cellranger': [ '9.0.0' ],
                            'fastqc': [ '0.11.3' ],
                            'fastq_screen': [ '0.9.2' ],
                            'fastq_strand': [ '0.0.4' ],

--- a/auto_process_ngs/test/qc/test_reporting.py
+++ b/auto_process_ngs/test/qc/test_reporting.py
@@ -157,6 +157,22 @@ class TestReportFunction(unittest.TestCase):
         self.assertTrue(os.path.exists(
             os.path.join(self.top_dir,'report.PE.html')))
 
+    def test_report_paired_end_cellranger_count_900(self):
+        """
+        report: paired-end data with cellranger 'count' (9.0.0)
+        """
+        analysis_dir = self._make_analysis_project(
+            protocol='10x_scRNAseq',
+            include_cellranger_count=True,
+            cellranger_pipelines=('cellranger',),
+            cellranger_samples=('PJB1','PJB2',),
+            cellranger_version='9.0.0')
+        project = AnalysisProject(analysis_dir)
+        report((project,),filename=os.path.join(self.top_dir,
+                                                'report.PE.html'))
+        self.assertTrue(os.path.exists(
+            os.path.join(self.top_dir,'report.PE.html')))
+
     def test_report_paired_end_cellranger_multi_710(self):
         """
         report: paired-end data with cellranger 'multi' (7.1.0)
@@ -181,6 +197,21 @@ class TestReportFunction(unittest.TestCase):
             include_cellranger_multi=True,
             cellranger_multi_samples=('PJB_CML1','PJB_CML2',),
             cellranger_version='8.0.0')
+        project = AnalysisProject(analysis_dir)
+        report((project,),filename=os.path.join(self.top_dir,
+                                                'report.PE.html'))
+        self.assertTrue(os.path.exists(
+            os.path.join(self.top_dir,'report.PE.html')))
+
+    def test_report_paired_end_cellranger_multi_900(self):
+        """
+        report: paired-end data with cellranger 'multi' (9.0.0)
+        """
+        analysis_dir = self._make_analysis_project(
+            protocol='10x_CellPlex',
+            include_cellranger_multi=True,
+            cellranger_multi_samples=('PJB_CML1','PJB_CML2',),
+            cellranger_version='9.0.0')
         project = AnalysisProject(analysis_dir)
         report((project,),filename=os.path.join(self.top_dir,
                                                 'report.PE.html'))
@@ -235,6 +266,30 @@ class TestReportFunction(unittest.TestCase):
         self.assertTrue(os.path.exists(
             os.path.join(self.top_dir,'report.PE.html')))
 
+    def test_report_paired_end_bad_cellranger_multi_900(self):
+        """
+        report: paired-end data with 'bad' 'cellranger_multi' subdir (9.0.0)
+        """
+        analysis_dir = self._make_analysis_project(
+            protocol='10x_CellPlex',
+            cellranger_multi_samples=('PJB_CML1','PJB_CML2',),
+            cellranger_version='9.0.0')
+        # Make a "bad" 'cellranger_multi' dir
+        # i.e. doesn't conform to expected format
+        bad_cellranger_multi_dir = os.path.join(analysis_dir,
+                                                "qc",
+                                                "cellranger_multi",
+                                                "PJB")
+        os.makedirs(bad_cellranger_multi_dir)
+        with open(os.path.join(bad_cellranger_multi_dir,"web_summary.html"),
+                  "wt") as fp:
+            fp.write("Placeholder")
+        project = AnalysisProject(analysis_dir)
+        report((project,),filename=os.path.join(self.top_dir,
+                                                'report.PE.html'))
+        self.assertTrue(os.path.exists(
+            os.path.join(self.top_dir,'report.PE.html')))
+
     def test_report_paired_end_cellranger_count_and_multi_710(self):
         """
         report: paired-end data with cellranger 'count' and 'multi' (7.1.0)
@@ -267,6 +322,25 @@ class TestReportFunction(unittest.TestCase):
             cellranger_samples=('PJB1_GEX',),
             cellranger_multi_samples=('PJB_CML1','PJB_CML2',),
             cellranger_version='8.0.0')
+        project = AnalysisProject(analysis_dir)
+        report((project,),filename=os.path.join(self.top_dir,
+                                                'report.PE.html'))
+        self.assertTrue(os.path.exists(
+            os.path.join(self.top_dir,'report.PE.html')))
+
+    def test_report_paired_end_cellranger_count_and_multi_900(self):
+        """
+        report: paired-end data with cellranger 'count' and 'multi' (9.0.0)
+        """
+        analysis_dir = self._make_analysis_project(
+            protocol='10x_CellPlex',
+            include_cellranger_multi=True,
+            include_cellranger_count=True,
+            cellranger_pipelines=('cellranger',),
+            # NB only GEX samples
+            cellranger_samples=('PJB1_GEX',),
+            cellranger_multi_samples=('PJB_CML1','PJB_CML2',),
+            cellranger_version='9.0.0')
         project = AnalysisProject(analysis_dir)
         report((project,),filename=os.path.join(self.top_dir,
                                                 'report.PE.html'))

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -16,6 +16,7 @@ from auto_process_ngs.mock10xdata import METRICS_SUMMARY
 from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY
 from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY_7_1_0
 from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY_8_0_0
+from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY_9_0_0
 from auto_process_ngs.mock10xdata import MULTIOME_SUMMARY
 from auto_process_ngs.qc.utils import verify_qc
 from auto_process_ngs.qc.utils import report_qc
@@ -1043,6 +1044,53 @@ Cellranger version\t8.0.0
         self.assertEqual(AnalysisProject("PJB1",
                                          project_dir).info.number_of_cells,
                          3164)
+
+    def test_set_cell_count_for_cellplex_project_900(self):
+        """
+        set_cell_count_for_project: test for multiplexed data (CellPlex 9.0.0)
+        """
+        # Set up mock project
+        project_dir = self._make_mock_analysis_project(
+            "10xGenomics Chromium 3'v3",
+            "CellPlex")
+        # Build mock cellranger multi output directory
+        multi_dir = os.path.join(project_dir,
+                                 "qc",
+                                 "cellranger_multi",
+                                 "9.0.0",
+                                 "refdata-cellranger-gex-GRCh38-2020-A",
+                                 "outs")
+        mkdirs(multi_dir)
+        for sample in ("PBA","PBB",):
+            sample_dir = os.path.join(multi_dir,
+                                      "per_sample_outs",
+                                      sample)
+            mkdirs(sample_dir)
+            summary_file = os.path.join(sample_dir,
+                                        "metrics_summary.csv")
+            with open(summary_file,'wt') as fp:
+                fp.write(CELLPLEX_METRICS_SUMMARY_9_0_0)
+            web_summary = os.path.join(sample_dir,
+                                       "web_summary.html")
+            with open(web_summary,'wt') as fp:
+                fp.write("Placeholder for web_summary.html\n")
+        # Add QC info file
+        with open(os.path.join(project_dir,"qc","qc.info"),'wt') as fp:
+            fp.write("""Cellranger reference datasets\t/data/refdata-cellranger-gex-GRCh38-2020-A
+Cellranger version\t9.0.0
+""")
+        # Check initial cell count
+        print("Checking number of cells")
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         None)
+        # Update the cell counts
+        print("Updating number of cells")
+        set_cell_count_for_project(project_dir,source="multi")
+        # Check updated cell count
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         3142)
 
     def test_set_cell_count_for_cellplex_project_with_count(self):
         """

--- a/auto_process_ngs/test/tenx/test_metrics.py
+++ b/auto_process_ngs/test/tenx/test_metrics.py
@@ -15,6 +15,7 @@ from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY_7_1_0
 from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY_CSP_7_1_0
 from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY_8_0_0
 from auto_process_ngs.mock10xdata import FLEX_METRICS_SUMMARY_8_0_0
+from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY_9_0_0
 from auto_process_ngs.mock10xdata import MULTIOME_SUMMARY
 from auto_process_ngs.mock10xdata import MULTIOME_SUMMARY_2_0_0
 from auto_process_ngs.tenx.metrics import *
@@ -220,6 +221,22 @@ class TestMultiplexSummary(unittest.TestCase):
         self.assertEqual(m.median_genes_per_cell,2042)
         self.assertEqual(m.total_genes_detected,23199)
         self.assertEqual(m.median_umi_counts_per_cell,5789)
+        self.assertRaises(MissingMetricError,
+                          getattr,m,"median_reads_per_cell")
+
+    def test_multiplex_summary_cellranger_9_0_0(self):
+        """
+        MultiplexSummary: extract CellPlex metrics (Cellranger 9.0.0)
+        """
+        summary_csv = os.path.join(self.wd,"metrics_summary.csv")
+        with open(summary_csv, "wt") as fp:
+            fp.write(CELLPLEX_METRICS_SUMMARY_9_0_0)
+        m = MultiplexSummary(summary_csv)
+        self.assertEqual(m.cells, 1571)
+        self.assertEqual(m.mean_reads_per_cell, 39445)
+        self.assertEqual(m.median_genes_per_cell, 2472)
+        self.assertEqual(m.total_genes_detected, 20944)
+        self.assertEqual(m.median_umi_counts_per_cell, 6692)
         self.assertRaises(MissingMetricError,
                           getattr,m,"median_reads_per_cell")
 

--- a/auto_process_ngs/test/tenx/test_metrics.py
+++ b/auto_process_ngs/test/tenx/test_metrics.py
@@ -16,6 +16,7 @@ from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY_CSP_7_1_0
 from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY_8_0_0
 from auto_process_ngs.mock10xdata import FLEX_METRICS_SUMMARY_8_0_0
 from auto_process_ngs.mock10xdata import CELLPLEX_METRICS_SUMMARY_9_0_0
+from auto_process_ngs.mock10xdata import FLEX_METRICS_SUMMARY_9_0_0
 from auto_process_ngs.mock10xdata import MULTIOME_SUMMARY
 from auto_process_ngs.mock10xdata import MULTIOME_SUMMARY_2_0_0
 from auto_process_ngs.tenx.metrics import *
@@ -252,5 +253,20 @@ class TestMultiplexSummary(unittest.TestCase):
         self.assertEqual(m.median_genes_per_cell,2465)
         self.assertEqual(m.total_genes_detected,15937)
         self.assertEqual(m.median_umi_counts_per_cell,4202)
+        self.assertRaises(MissingMetricError,
+                          getattr,m,"median_reads_per_cell")
+
+    def test_flex_summary_cellranger_9_0_0(self):
+        """MultiplexSummary: extract Flex metrics (Cellranger 9.0.0)
+        """
+        summary_csv = os.path.join(self.wd,"metrics_summary.csv")
+        with open(summary_csv,'w') as fp:
+            fp.write(FLEX_METRICS_SUMMARY_9_0_0)
+        m = MultiplexSummary(summary_csv)
+        self.assertEqual(m.cells, 13958)
+        self.assertEqual(m.mean_reads_per_cell, 15434)
+        self.assertEqual(m.median_genes_per_cell, 1956)
+        self.assertEqual(m.total_genes_detected, 15480)
+        self.assertEqual(m.median_umi_counts_per_cell, 3159)
         self.assertRaises(MissingMetricError,
                           getattr,m,"median_reads_per_cell")

--- a/auto_process_ngs/test/tenx/test_utils.py
+++ b/auto_process_ngs/test/tenx/test_utils.py
@@ -754,6 +754,41 @@ MULTIPLEXED_SAMPLE,CMO1|CMO2|...,DESCRIPTION
                                         if not line.startswith('##')])
         self.assertEqual(expected_content,actual_content)
 
+    def test_make_multi_config_template_cellplex_900(self):
+        """
+        make_multi_config_template: check CellPlex template (9.0.0)
+        """
+        expected_content = """[gene-expression]
+reference,/data/mm10_transcriptome
+#force-cells,n
+create-bam,true
+#cmo-set,/path/to/custom/cmo/reference
+
+#[feature]
+#reference,/path/to/feature/reference
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB_CML,/runs/novaseq_50/fastqs,any,PJB_CML,[Gene Expression|Multiplexing Capture],
+PJB_GEX,/runs/novaseq_50/fastqs,any,PJB_GEX,[Gene Expression|Multiplexing Capture],
+
+[samples]
+sample_id,cmo_ids,description
+MULTIPLEXED_SAMPLE,CMO1|CMO2|...,DESCRIPTION
+"""
+        out_file = os.path.join(self.wd,"10x_multi_config.csv")
+        make_multi_config_template(out_file,
+                                   reference="/data/mm10_transcriptome",
+                                   fastq_dir="/runs/novaseq_50/fastqs",
+                                   samples=("PJB_CML","PJB_GEX"),
+                                   library_type="CellPlex",
+                                   cellranger_version="9.0.0")
+        self.assertTrue(os.path.exists(out_file))
+        with open(out_file,'rt') as fp:
+            actual_content = '\n'.join([line for line in fp.read().split('\n')
+                                        if not line.startswith('##')])
+        self.assertEqual(expected_content,actual_content)
+
     def test_make_multi_config_template_cellplex_scrnaseq_800(self):
         """
         make_multi_config_template: check CellPlex scRNA-seq template (8.0.0)
@@ -789,9 +824,9 @@ MULTIPLEXED_SAMPLE,CMO1|CMO2|...,DESCRIPTION
                                         if not line.startswith('##')])
         self.assertEqual(expected_content,actual_content)
 
-    def test_make_multi_config_template_cellplex_900(self):
+    def test_make_multi_config_template_cellplex_scrnaseq_900(self):
         """
-        make_multi_config_template: check CellPlex template (9.0.0)
+        make_multi_config_template: check CellPlex scRNA-seq template (9.0.0)
         """
         expected_content = """[gene-expression]
 reference,/data/mm10_transcriptome
@@ -816,7 +851,7 @@ MULTIPLEXED_SAMPLE,CMO1|CMO2|...,DESCRIPTION
                                    reference="/data/mm10_transcriptome",
                                    fastq_dir="/runs/novaseq_50/fastqs",
                                    samples=("PJB_CML","PJB_GEX"),
-                                   library_type="CellPlex",
+                                   library_type="CellPlex scRNA-seq",
                                    cellranger_version="9.0.0")
         self.assertTrue(os.path.exists(out_file))
         with open(out_file,'rt') as fp:

--- a/auto_process_ngs/test/tenx/test_utils.py
+++ b/auto_process_ngs/test/tenx/test_utils.py
@@ -374,6 +374,13 @@ class TestCellrangerInfo(unittest.TestCase):
             fp.write("#!/bin/bash\necho cellranger cellranger-8.0.0")
         os.chmod(cellranger_800,0o775)
         return cellranger_800
+    def _make_mock_cellranger_900(self):
+        # Make a fake cellranger 9.0.0 executable
+        cellranger_900 = os.path.join(self.wd,"cellranger")
+        with open(cellranger_900,'w') as fp:
+            fp.write("#!/bin/bash\necho cellranger cellranger-9.0.0")
+        os.chmod(cellranger_900,0o775)
+        return cellranger_900
     def _make_mock_cellranger_atac_101(self):
         # Make a fake cellranger-atac 1.0.1 executable
         cellranger_atac_101 = os.path.join(self.wd,"cellranger-atac")
@@ -448,6 +455,13 @@ class TestCellrangerInfo(unittest.TestCase):
         cellranger = self._make_mock_cellranger_800()
         self.assertEqual(cellranger_info(path=cellranger),
                          (cellranger,'cellranger','8.0.0'))
+
+    def test_cellranger_900(self):
+        """cellranger_info: collect info for cellranger 8.0.0
+        """
+        cellranger = self._make_mock_cellranger_900()
+        self.assertEqual(cellranger_info(path=cellranger),
+                         (cellranger,'cellranger','9.0.0'))
 
     def test_cellranger_atac_101(self):
         """cellranger_info: collect info for cellranger-atac 1.0.1

--- a/auto_process_ngs/test/tenx/test_utils.py
+++ b/auto_process_ngs/test/tenx/test_utils.py
@@ -789,6 +789,41 @@ MULTIPLEXED_SAMPLE,CMO1|CMO2|...,DESCRIPTION
                                         if not line.startswith('##')])
         self.assertEqual(expected_content,actual_content)
 
+    def test_make_multi_config_template_cellplex_900(self):
+        """
+        make_multi_config_template: check CellPlex template (9.0.0)
+        """
+        expected_content = """[gene-expression]
+reference,/data/mm10_transcriptome
+#force-cells,n
+create-bam,true
+#cmo-set,/path/to/custom/cmo/reference
+
+#[feature]
+#reference,/path/to/feature/reference
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB_CML,/runs/novaseq_50/fastqs,any,PJB_CML,[Gene Expression|Multiplexing Capture],
+PJB_GEX,/runs/novaseq_50/fastqs,any,PJB_GEX,[Gene Expression|Multiplexing Capture],
+
+[samples]
+sample_id,cmo_ids,description
+MULTIPLEXED_SAMPLE,CMO1|CMO2|...,DESCRIPTION
+"""
+        out_file = os.path.join(self.wd,"10x_multi_config.csv")
+        make_multi_config_template(out_file,
+                                   reference="/data/mm10_transcriptome",
+                                   fastq_dir="/runs/novaseq_50/fastqs",
+                                   samples=("PJB_CML","PJB_GEX"),
+                                   library_type="CellPlex",
+                                   cellranger_version="9.0.0")
+        self.assertTrue(os.path.exists(out_file))
+        with open(out_file,'rt') as fp:
+            actual_content = '\n'.join([line for line in fp.read().split('\n')
+                                        if not line.startswith('##')])
+        self.assertEqual(expected_content,actual_content)
+
     def test_make_multi_config_template_flex_700(self):
         """
         make_multi_config_template: check Flex template (7.1.0)
@@ -863,6 +898,43 @@ MULTIPLEXED_SAMPLE,BC001|BC002|...,DESCRIPTION
                                         if not line.startswith('##')])
         self.assertEqual(expected_content,actual_content)
 
+    def test_make_multi_config_template_flex_900(self):
+        """
+        make_multi_config_template: check Flex template (9.0.0)
+        """
+        expected_content = """[gene-expression]
+reference,/data/mm10_transcriptome
+probe-set,/data/mm10_probe_set.csv
+#force-cells,n
+create-bam,false
+#cmo-set,/path/to/custom/cmo/reference
+
+#[feature]
+#reference,/path/to/feature/reference
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB_Flex,/runs/novaseq_50/fastqs,any,PJB_Flex,[Gene Expression|Antibody Capture],
+
+[samples]
+sample_id,probe_barcode_ids,description
+MULTIPLEXED_SAMPLE,BC001|BC002|...,DESCRIPTION
+"""
+        out_file = os.path.join(self.wd,"10x_multi_config.csv")
+        make_multi_config_template(out_file,
+                                   reference="/data/mm10_transcriptome",
+                                   probe_set="/data/mm10_probe_set.csv",
+                                   fastq_dir="/runs/novaseq_50/fastqs",
+                                   samples=("PJB_Flex",),
+                                   no_bam=True,
+                                   library_type="Flex",
+                                   cellranger_version="9.0.0")
+        self.assertTrue(os.path.exists(out_file))
+        with open(out_file,'rt') as fp:
+            actual_content = '\n'.join([line for line in fp.read().split('\n')
+                                        if not line.startswith('##')])
+        self.assertEqual(expected_content,actual_content)
+
     def test_make_multi_config_template_immune_profiling_710(self):
         """
         make_multi_config_template: check Single Cell Immune Profiling template (7.0.0)
@@ -925,6 +997,40 @@ PJB_GEX,/runs/novaseq_50/fastqs,any,PJB_GEX,[Gene Expression|Antibody Capture|VD
                                    samples=("PJB_CML","PJB_GEX"),
                                    library_type="Single Cell Immune Profiling",
                                    cellranger_version="8.0.0")
+        self.assertTrue(os.path.exists(out_file))
+        with open(out_file,'rt') as fp:
+            actual_content = '\n'.join([line for line in fp.read().split('\n')
+                                        if not line.startswith('##')])
+        self.assertEqual(expected_content,actual_content)
+
+    def test_make_multi_config_template_immune_profiling_900(self):
+        """
+        make_multi_config_template: check Single Cell Immune Profiling template (9.0.0)
+        """
+        expected_content = """[gene-expression]
+reference,/data/mm10_transcriptome
+#force-cells,n
+create-bam,true
+#cmo-set,/path/to/custom/cmo/reference
+
+#[feature]
+#reference,/path/to/feature/reference
+
+#[vdj]
+#reference,/path/to/vdj/reference
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB_CML,/runs/novaseq_50/fastqs,any,PJB_CML,[Gene Expression|Antibody Capture|VDJ-B|VDJ-T],
+PJB_GEX,/runs/novaseq_50/fastqs,any,PJB_GEX,[Gene Expression|Antibody Capture|VDJ-B|VDJ-T],
+"""
+        out_file = os.path.join(self.wd,"10x_multi_config.csv")
+        make_multi_config_template(out_file,
+                                   reference="/data/mm10_transcriptome",
+                                   fastq_dir="/runs/novaseq_50/fastqs",
+                                   samples=("PJB_CML","PJB_GEX"),
+                                   library_type="Single Cell Immune Profiling",
+                                   cellranger_version="9.0.0")
         self.assertTrue(os.path.exists(out_file))
         with open(out_file,'rt') as fp:
             actual_content = '\n'.join([line for line in fp.read().split('\n')


### PR DESCRIPTION
Update the pipelines to work with Cellranger version 9.0.0 (addressing issue #1010).

The command line, version string and metrics output from Cellranger 9.0.0 appear to match those from 8.0.0, so minimal updates to the code are required for compatibility. However new tests have been implemented to try and ensure that any minor differences are handled correctly.