### PR TITLE
Add functools.wrap() to 'add_command' decorator

### DIFF
--- a/auto_process_ngs/decorators.py
+++ b/auto_process_ngs/decorators.py
@@ -14,6 +14,7 @@ Implements decorators for use with the ``AutoProcessor`` class.
 
 import time
 import logging
+from functools import wraps
 
 # Module specific logger
 logger = logging.getLogger(__name__)
@@ -66,6 +67,7 @@ def add_command(name,f):
         argument of the callable must be an
         AutoProcessor-like class
     """
+    @wraps(f)
     def wrapped_func(*args,**kws):
         # Wraps execution of the supplied
         # function to trap exceptions and


### PR DESCRIPTION
Updates the `add_command` decorator (in the `decorators` module) to use `functools.wrap()`, which should make tracebacks relate back to the actual Python code when commands raise an exception (without the update they relate back to the decorator, which is less helpful).