### PR TITLE
Update 'set_cell_count_for_project' to recognise 10x Genomics Next GEM 3' and GEM-X 3' platforms

### DIFF
--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -482,7 +482,9 @@ def set_cell_count_for_project(project_dir,qc_dir=None,
     pipeline = None
     single_cell_platform = project.info.single_cell_platform
     if single_cell_platform:
-        if single_cell_platform.startswith("10xGenomics Chromium 3'"):
+        if single_cell_platform.startswith("10xGenomics Chromium 3'") or \
+           single_cell_platform.startswith("10xGenomics Chromium GEM-X 3'") or \
+           single_cell_platform.startswith("10xGenomics Chromium Next GEM 3'"):
             pipeline = "cellranger"
         elif single_cell_platform == "10xGenomics Single Cell ATAC":
             pipeline = "cellranger-atac"

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -544,9 +544,9 @@ class TestSetCellCountForProject(unittest.TestCase):
         m.create(top_dir=self.wd)
         return os.path.join(self.wd,'PJB')
 
-    def test_set_cell_count_for_project(self):
+    def test_set_cell_count_for_project_chromium_3v3(self):
         """
-        set_cell_count_for_project: test for scRNA-seq
+        set_cell_count_for_project: test for scRNA-seq (10x Chromium 3'v3)
         """
         # Set up mock project
         project_dir = self._make_mock_analysis_project(
@@ -556,7 +556,7 @@ class TestSetCellCountForProject(unittest.TestCase):
         counts_dir = os.path.join(project_dir,
                                   "qc",
                                   "cellranger_count",
-                                  "5.0.1",
+                                  "8.0.0",
                                   "refdata-gex-GRCh38-2020-A",
                                   "PJB1",
                                   "outs")
@@ -568,7 +568,85 @@ class TestSetCellCountForProject(unittest.TestCase):
         # Add QC info file
         with open(os.path.join(project_dir,"qc","qc.info"),'wt') as fp:
             fp.write("""Cellranger reference datasets\t/data/refdata-gex-GRCh38-2020-A
-Cellranger version\t5.0.1
+Cellranger version\t8.0.0
+""")
+        # Check initial cell count
+        print("Checking number of cells")
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         None)
+        # Update the cell counts
+        print("Updating number of cells")
+        set_cell_count_for_project(project_dir)
+        # Check updated cell count
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         2272)
+
+    def test_set_cell_count_for_project_chromium_gem_x_3v4(self):
+        """
+        set_cell_count_for_project: test for scRNA-seq (10x Chromium GEM-X 3'v4)
+        """
+        # Set up mock project
+        project_dir = self._make_mock_analysis_project(
+            "10xGenomics Chromium GEM-X 3'v4",
+            "scRNA-seq")
+        # Add metrics_summary.csv
+        counts_dir = os.path.join(project_dir,
+                                  "qc",
+                                  "cellranger_count",
+                                  "8.0.0",
+                                  "refdata-gex-GRCh38-2020-A",
+                                  "PJB1",
+                                  "outs")
+        mkdirs(counts_dir)
+        metrics_summary_file = os.path.join(counts_dir,
+                                            "metrics_summary.csv")
+        with open(metrics_summary_file,'wt') as fp:
+            fp.write(METRICS_SUMMARY)
+        # Add QC info file
+        with open(os.path.join(project_dir,"qc","qc.info"),'wt') as fp:
+            fp.write("""Cellranger reference datasets\t/data/refdata-gex-GRCh38-2020-A
+Cellranger version\t8.0.0
+""")
+        # Check initial cell count
+        print("Checking number of cells")
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         None)
+        # Update the cell counts
+        print("Updating number of cells")
+        set_cell_count_for_project(project_dir)
+        # Check updated cell count
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         2272)
+
+    def test_set_cell_count_for_project_chromium_next_gem_x_3v31(self):
+        """
+        set_cell_count_for_project: test for scRNA-seq (10x Chromium Next GEM 3'v3.1)
+        """
+        # Set up mock project
+        project_dir = self._make_mock_analysis_project(
+            "10xGenomics Chromium Next GEM 3'v3.1",
+            "scRNA-seq")
+        # Add metrics_summary.csv
+        counts_dir = os.path.join(project_dir,
+                                  "qc",
+                                  "cellranger_count",
+                                  "8.0.0",
+                                  "refdata-gex-GRCh38-2020-A",
+                                  "PJB1",
+                                  "outs")
+        mkdirs(counts_dir)
+        metrics_summary_file = os.path.join(counts_dir,
+                                            "metrics_summary.csv")
+        with open(metrics_summary_file,'wt') as fp:
+            fp.write(METRICS_SUMMARY)
+        # Add QC info file
+        with open(os.path.join(project_dir,"qc","qc.info"),'wt') as fp:
+            fp.write("""Cellranger reference datasets\t/data/refdata-gex-GRCh38-2020-A
+Cellranger version\t8.0.0
 """)
         # Check initial cell count
         print("Checking number of cells")
@@ -879,6 +957,53 @@ Cellranger version\t7.1.0
         # Set up mock project
         project_dir = self._make_mock_analysis_project(
             "10xGenomics Chromium 3'v3",
+            "CellPlex")
+        # Build mock cellranger multi output directory
+        multi_dir = os.path.join(project_dir,
+                                 "qc",
+                                 "cellranger_multi",
+                                 "8.0.0",
+                                 "refdata-cellranger-gex-GRCh38-2020-A",
+                                 "outs")
+        mkdirs(multi_dir)
+        for sample in ("PBA","PBB",):
+            sample_dir = os.path.join(multi_dir,
+                                      "per_sample_outs",
+                                      sample)
+            mkdirs(sample_dir)
+            summary_file = os.path.join(sample_dir,
+                                        "metrics_summary.csv")
+            with open(summary_file,'wt') as fp:
+                fp.write(CELLPLEX_METRICS_SUMMARY_8_0_0)
+            web_summary = os.path.join(sample_dir,
+                                       "web_summary.html")
+            with open(web_summary,'wt') as fp:
+                fp.write("Placeholder for web_summary.html\n")
+        # Add QC info file
+        with open(os.path.join(project_dir,"qc","qc.info"),'wt') as fp:
+            fp.write("""Cellranger reference datasets\t/data/refdata-cellranger-gex-GRCh38-2020-A
+Cellranger version\t8.0.0
+""")
+        # Check initial cell count
+        print("Checking number of cells")
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         None)
+        # Update the cell counts
+        print("Updating number of cells")
+        set_cell_count_for_project(project_dir,source="multi")
+        # Check updated cell count
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         3164)
+
+    def test_set_cell_count_for_cellplex_project_next_gem(self):
+        """
+        set_cell_count_for_project: test for multiplexed data (CellPlex with 10x Next GEM)
+        """
+        # Set up mock project
+        project_dir = self._make_mock_analysis_project(
+            "10xGenomics Chromium Next GEM 3'v3.1",
             "CellPlex")
         # Build mock cellranger multi output directory
         multi_dir = os.path.join(project_dir,


### PR DESCRIPTION
Updates the `set_cell_count_for_project` function in the `qc.utils` module so that it also recognises the 10x Genomics Next GEM 3' and GEM-X 3' platforms when extracting the cell count from the `cellranger*` outputs. (Previously the cell counts were not being extracted or reported for either of these platforms.)