### PR TITLE
'make_fastqs': expose option to ignore missing or corrupt BCLS ('bcl2fastq' --ignore-missing-bcls option)

### DIFF
--- a/auto_process_ngs/applications.py
+++ b/auto_process_ngs/applications.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     applications.py: utilities for running command line applications
-#     Copyright (C) University of Manchester 2013-2023 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2025 Peter Briggs
 #
 ########################################################################
 #
@@ -132,7 +132,7 @@ class bcl2fastq:
     def bcl2fastq2(run_dir,sample_sheet,output_dir="Unaligned",
                    mismatches=None,
                    bases_mask=None,
-                   ignore_missing_bcl=False,
+                   ignore_missing_bcls=False,
                    no_lane_splitting=False,
                    minimum_trimmed_read_length=None,
                    mask_short_adapter_reads=None,
@@ -162,7 +162,7 @@ class bcl2fastq:
             will be derived automatically from the bases mask string)
           bases_mask: optional, specify string indicating how to treat
             each cycle within each read e.g. 'y101,I6,y101'
-          ignore_missing_bcl: optional, if True then interpret missing bcl
+          ignore_missing_bcls: optional, if True then interpret missing bcl
             files as no call (default is False)
           no_lane_splitting: optional, if True then don't split FASTQ
             files by lane (--no-lane-splitting) (default is False)
@@ -210,7 +210,7 @@ class bcl2fastq:
             if bases_mask is not None:
                 bcl2fastq_cmd.add_args('--barcode-mismatches',
                                        get_nmismatches(bases_mask))
-        if ignore_missing_bcl:
+        if ignore_missing_bcls:
             bcl2fastq_cmd.add_args('--ignore-missing-bcls')
         if no_lane_splitting:
             bcl2fastq_cmd.add_args('--no-lane-splitting')

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     bcl2fastq.pipeline.py: pipelines for Fastq generation
-#     Copyright (C) University of Manchester 2020-2024 Peter Briggs
+#     Copyright (C) University of Manchester 2020-2025 Peter Briggs
 #
 
 """
@@ -379,6 +379,7 @@ class MakeFastqs(Pipeline):
         self.add_param('find_adapters_with_sliding_window',value=False,
                        type=bool)
         self.add_param('create_empty_fastqs',value=False,type=bool)
+        self.add_param('ignore_missing_bcls',value=False,type=bool)
         self.add_param('name',type=str)
         self.add_param('stats_file',type=str)
         self.add_param('stats_full',type=str)
@@ -1249,6 +1250,7 @@ class MakeFastqs(Pipeline):
                         find_adapters_with_sliding_window=\
                         find_adapters_with_sliding_window,
                         create_empty_fastqs=self.params.create_empty_fastqs,
+                        ignore_missing_bcls=self.params.ignore_missing_bcls,
                         platform=identify_platform.output.platform,
                         bcl2fastq_exe=get_bcl2fastq.output.bcl2fastq_exe,
                         bcl2fastq_version=\
@@ -1853,8 +1855,9 @@ class MakeFastqs(Pipeline):
             primary_data_dir=None,force_copy_of_primary_data=False,
             no_lane_splitting=None,create_fastq_for_index_read=None,
             find_adapters_with_sliding_window=None,
-            create_empty_fastqs=None,name=None,stats_file=None,
-            stats_full=None,per_lane_stats=None,per_lane_sample_stats=None,
+            create_empty_fastqs=None,ignore_missing_bcls=None,
+            name=None,stats_file=None,stats_full=None,
+            per_lane_stats=None,per_lane_sample_stats=None,
             nprocessors=None,cellranger_jobmode='local',
             cellranger_mempercore=None,cellranger_maxjobs=None,
             cellranger_jobinterval=None,cellranger_localcores=None,
@@ -1888,6 +1891,8 @@ class MakeFastqs(Pipeline):
             sequences (--find-adapters-with-sliding-window)
           create_empty_fastqs (bool): if True then create empty
             "placeholder" Fastqs if not created by bcl2fastq
+          ignore_missing_bcls (bool): if True then ignore missing
+            or corrupted BCL files
           name (str): optional identifier for output
             stats and report files
           stats_file (str): path to statistics output file
@@ -2055,6 +2060,7 @@ class MakeFastqs(Pipeline):
             'find_adapters_with_sliding_window':
             find_adapters_with_sliding_window,
             'create_empty_fastqs': create_empty_fastqs,
+            'ignore_missing_bcls': ignore_missing_bcls,
             'name': name,
             'stats_file': stats_file,
             'stats_full': stats_full,
@@ -2454,7 +2460,7 @@ class RunBcl2Fastq(PipelineTask):
     """
     def init(self,run_dir,out_dir,sample_sheet,bases_mask='auto',
              r1_length=None,r2_length=None,
-             ignore_missing_bcl=False,no_lane_splitting=False,
+             ignore_missing_bcls=False,no_lane_splitting=False,
              minimum_trimmed_read_length=None,
              mask_short_adapter_reads=None,
              create_fastq_for_index_read=False,
@@ -2477,8 +2483,8 @@ class RunBcl2Fastq(PipelineTask):
           r2_length (int): if set then truncate R2 reads in
             bases mask to this length (NB ignored if bases
             mask is already set)
-          ignore_missing_bcl (bool): if True then run
-            bcl2fastq with --ignore-missing-bcl
+          ignore_missing_bcls (bool): if True then run
+            bcl2fastq with --ignore-missing-bcls
           no_lane_splitting (bool): if True then run bcl2fastq
             with --no-lane-splitting
           minimum_trimmed_read_length (int): if set then supply
@@ -2584,7 +2590,7 @@ class RunBcl2Fastq(PipelineTask):
         params = {
             'mismatches': mismatches,
             'bases_mask': bases_mask,
-            'ignore_missing_bcl': self.args.ignore_missing_bcl,
+            'ignore_missing_bcls': self.args.ignore_missing_bcls,
             'no_lane_splitting': self.args.no_lane_splitting,
             'minimum_trimmed_read_length':
             self.args.minimum_trimmed_read_length,
@@ -2629,7 +2635,7 @@ class RunBcl2Fastq(PipelineTask):
         print("%-22s: %s" % ("Create empty Fastqs",self.args.create_empty_fastqs))
         for item,desc in (('bases_mask',"Bases mask"),
                           ('mismatches',"Allowed mismatches",),
-                          ('ignore_missing_bcl',"Ignore missing bcl"),
+                          ('ignore_missing_bcls',"Ignore missing bcls"),
                           ('no_lane_splitting',"No lane splitting"),
                           ('minimum_trimmed_read_length',"Min trimmed read len"),
                           ('mask_short_adapter_reads',"Mask short adptr reads"),

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -435,6 +435,13 @@ def add_make_fastqs_command(cmdparser):
                               dest='create_fastq_for_index_read',
                               default=False,
                               help="also create FASTQs for index reads")
+    # Ignore missing or corrupted BCL files
+    bcl_to_fastq.add_argument("--ignore-missing-bcls", action="store_true",
+                              dest="ignore_missing_bcls", default=False,
+                              help="ignores missing or corrupt BCL files "
+                              "and assumes 'N'/'#' for missing calls "
+                              "(only applies if using bcl2fastq as the "
+                              "BCL conversion software)")
     # Number of processors
     add_nprocessors_option(bcl_to_fastq,None,
                            default_display=(
@@ -1565,6 +1572,7 @@ def make_fastqs(args):
         adapter_sequence=args.adapter_sequence,
         adapter_sequence_read2=args.adapter_sequence_read2,
         create_fastq_for_index_read=args.create_fastq_for_index_read,
+        ignore_missing_bcls=args.ignore_missing_bcls,
         find_adapters_with_sliding_window=\
         args.find_adapters_with_sliding_window,
         stats_file=args.stats_file,

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -53,7 +53,8 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 per_lane_stats_file=None,
                 analyse_barcodes=True,barcode_analysis_dir=None,
                 force_copy_of_primary_data=False,
-                create_empty_fastqs=False,runner=None,
+                create_empty_fastqs=False,
+                ignore_missing_bcls=False,runner=None,
                 icell8_swap_i1_and_i2=False,
                 icell8_reverse_complement=None,
                 cellranger_jobmode=None,
@@ -145,9 +146,12 @@ def make_fastqs(ap,protocol='standard',platform=None,
         sequence to use for read2 instead of any sequences already set
         in the samplesheet (nb will be ignored if 'trim_adapters' is
         False)
-      create_fastq_for_index_reads (boolean): if True then also create
+      create_fastq_for_index_reads (bool): if True then also create
         Fastq files for index reads (default, don't create index read
         Fastqs)
+      ignore_missing_bcls (bool): if True then tell BCL conversion
+        software to ignore missing or corrupted BCLs (default: False,
+        don't ignore missing or corrupted BCL files)
       find_adapters_with_sliding_window (boolean): if True then use
         sliding window algorithm to identify adapter sequences for
         trimming
@@ -340,6 +344,9 @@ def make_fastqs(ap,protocol='standard',platform=None,
     # Create empty Fastqs
     create_empty_fastqs = defaults['create_empty_fastqs']
 
+    # Ignore missing/corrupted BCL files
+    ignore_missing_bcls = defaults['ignore_missing_bcls']
+
     # Set up pipeline runners
     default_runner = ap.settings.general.default_runner
     runners = {
@@ -421,6 +428,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
                              find_adapters_with_sliding_window=\
                              find_adapters_with_sliding_window,
                              create_empty_fastqs=create_empty_fastqs,
+                             ignore_missing_bcls=ignore_missing_bcls,
                              stats_file=stats_file,
                              per_lane_stats=per_lane_stats_file,
                              nprocessors=nprocessors,

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -316,6 +316,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
         'nprocessors': nprocessors,
         'no_lane_splitting': no_lane_splitting,
         'create_empty_fastqs': create_empty_fastqs,
+        'ignore_missing_bcls': ignore_missing_bcls
     }
     for item in ('bcl_converter',
                  'nprocessors',

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1118,6 +1118,8 @@ class MockBcl2fastq2Exe:
     - sliding window algorith for adapter
       trimming can be checked via
       `assert_find_adapters_with_sliding_window`
+    - ignoring missing BCL files can be checked
+      via `assert_ignore_missing_bcls`
     """
 
     @staticmethod
@@ -1129,6 +1131,7 @@ class MockBcl2fastq2Exe:
                assert_mask_short_adapter_reads=None,
                assert_adapter=None,assert_adapter2=None,
                assert_find_adapters_with_sliding_window=None,
+               assert_ignore_missing_bcls=None,
                version='2.20.0.422'):
         """
         Create a "mock" bcl2fastq executable
@@ -1176,6 +1179,10 @@ class MockBcl2fastq2Exe:
             (bool): if set then assert that
             --find-adapters-with-sliding-window
             matches the supplied boolean value
+          assert_ignore_missing_bcls (bool): if
+            set then assert that
+            --ignore-missing-bcls matches the
+            supplied boolean value
           version (str): version of bcl2fastq2
             to imitate
         """
@@ -1198,6 +1205,7 @@ sys.exit(MockBcl2fastq2Exe(exit_code=%s,
                            assert_adapter=%s,
                            assert_adapter2=%s,
                            assert_find_adapters_with_sliding_window=%s,
+                           assert_ignore_missing_bcls=%s,
                            version=%s).main(sys.argv[1:]))
             """ % (exit_code,
                    missing_fastqs,
@@ -1218,6 +1226,7 @@ sys.exit(MockBcl2fastq2Exe(exit_code=%s,
                     if assert_adapter2 is not None
                     else None),
                    assert_find_adapters_with_sliding_window,
+                   assert_ignore_missing_bcls,
                    ("\"%s\"" % version
                     if version is not None
                     else None)))
@@ -1238,6 +1247,7 @@ sys.exit(MockBcl2fastq2Exe(exit_code=%s,
                  assert_adapter=None,
                  assert_adapter2=None,
                  assert_find_adapters_with_sliding_window=None,
+                 assert_ignore_missing_bcls=None,
                  version=None):
         """
         Internal: configure the mock bcl2fastq2
@@ -1257,6 +1267,7 @@ sys.exit(MockBcl2fastq2Exe(exit_code=%s,
         self._assert_adapter2 = assert_adapter2
         self._assert_find_adapters_with_sliding_window = \
                                 assert_find_adapters_with_sliding_window
+        self._assert_ignore_missing_bcls = assert_ignore_missing_bcls
         self._version = version
 
     def main(self,args):
@@ -1328,6 +1339,12 @@ bcl2fastq v%s
                   args.find_adapters_with_sliding_window)
             assert(args.find_adapters_with_sliding_window ==
                    self._assert_find_adapters_with_sliding_window)
+        # Check --ignore-missing-bcls
+        if self._assert_ignore_missing_bcls is not None:
+            print("Checking --ignore-missing-bcls: %s" %
+                  args.ignore_missing_bcls)
+            assert(args.ignore_missing_bcls ==
+                   self._assert_ignore_missing_bcls)
         # Platform
         print("Platform (default): %s" % self._platform)
         # Run folder (input data)

--- a/auto_process_ngs/test/test_applications.py
+++ b/auto_process_ngs/test/test_applications.py
@@ -71,7 +71,7 @@ class TestBcl2Fastq(unittest.TestCase):
             '/runs/150107_NB123000_0001_ABCX',
             'SampleSheet.csv',
             output_dir='run/bcl2fastq',
-            ignore_missing_bcl=True).command_line,
+            ignore_missing_bcls=True).command_line,
                          ['bcl2fastq',
                           '--runfolder-dir','/runs/150107_NB123000_0001_ABCX',
                           '--output-dir','run/bcl2fastq',


### PR DESCRIPTION
Updates the `make_fastqs` command to enable the `--ignore-missing-bcls` option to be supplied to `bcl2fastq` when using that explicitly as the BCL conversion software.

This option causes `bcl2fastq` to ignore missing or corrupt BCL files and assume `N`/`#` for missing calls; it can be specified with the `--ignore-missing-bcls` command line option on the `make_fastqs` command, to address errors from `bcl2fastq` of the form e.g.

    terminate called after throwing an instance of 'boost::exception_detail::clone_impl<bcl2fastq::common::InputDataError>'
      what():  Mismatching cluster count in BCL file: Cycle #26, Tile#2101: bytes_read=1636139 bytes_expected=2045952