### PR TITLE
Report "cellranger multi" outputs for multiple physical samples in QC

### DIFF
--- a/auto_process_ngs/qc/outputs.py
+++ b/auto_process_ngs/qc/outputs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     qc/outputs: utilities to predict and check QC pipeline outputs
-#     Copyright (C) University of Manchester 2019-2024 Peter Briggs
+#     Copyright (C) University of Manchester 2019-2025 Peter Briggs
 #
 """
 Provides utility classes and functions for QC outputs.
@@ -81,6 +81,8 @@ class QCOutputs:
       files used with 10x pipelines
     - multiplexed_samples: sorted list of sample names
       for multiplexed samples (e.g. 10x CellPlex)
+    - physical_samples: sorted list of physical sample
+      names for multiplexed datasets (e.g. 10x CellPlex)
     - outputs: list of QC output categories detected (see
       below for valid values)
     - output_files: list of absolute paths to QC output
@@ -272,6 +274,9 @@ class QCOutputs:
                 self.cellranger_references.append(reference_data)
         self.cellranger_references = sorted(self.cellranger_references)
         self.cellranger_probe_sets = cellranger_multi.probe_sets
+        # Physical sample names for multiplexed datasets
+        self.physical_samples = sorted(cellranger_multi.physical_samples,
+                                       key=lambda s: split_sample_name(s))
         # Fastqs
         self.fastqs = sorted(list(self.fastqs))
         # BAMs

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -286,7 +286,10 @@ SUMMARY_FIELD_DESCRIPTIONS = {
                       'Reference dataset used for the analysis'),
     '10x_web_summary': ('HTML report','Link to the web_summary.html report'),
     'linked_sample': ('Linked sample',
-                      'Corresponding sample for single cell multiome analysis')
+                      'Corresponding sample for single cell multiome analysis'),
+    'physical_sample': ('Physical sample',
+                        'Name of physical sample associated with the '
+                        'multiplexed sample')
 }
 
 # Fields that are only applicable for biological data
@@ -2388,6 +2391,7 @@ class SampleQCReporter:
         - 10x_reference
         - 10x_web_summary
         - linked_sample
+        - physical_sample
 
         Arguments:
           field (str): name of the field to report; if the
@@ -2403,7 +2407,12 @@ class SampleQCReporter:
         """
         if field == "sample":
             return
-        if field == "linked_sample":
+        if field == "physical_sample":
+            value = cellranger_data.physical_sample
+            if not value:
+                # No physical sample information
+                value = "-"
+        elif field == "linked_sample":
             try:
                 value = ','.join(
                     [split_sample_reference(s)[2]

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -1749,6 +1749,8 @@ class QCProject:
     - bams: sorted list of BAM file names
     - multiplexed_samples: sorted list of sample names
       for multiplexed samples (e.g. 10x CellPlex)
+    - physical_samples: sorted list of physical sample
+      names for multiplexed datasets (e.g. 10x CellPlex)
     - organisms: sorted list of organism names
     - outputs: list of QC output categories detected (see
       below for valid values)
@@ -1974,6 +1976,8 @@ class QCProject:
         self.cellranger_probe_sets = qc_outputs.cellranger_probe_sets
         # Multiplexed samples
         self.multiplexed_samples = qc_outputs.multiplexed_samples
+        # Physical samples
+        self.physical_samples = qc_outputs.physical_samples
         # QC outputs
         self.outputs = qc_outputs.outputs
         # Software versions

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -647,12 +647,16 @@ class QCReport(Document):
             if 'cellranger_multi' in project.outputs:
                 # Set up fields for reporting
                 pkg = 'cellranger'
-                multiplex_analysis_fields = ['sample',
-                                             '10x_cells',
-                                             '10x_reads_per_cell',
-                                             '10x_genes_per_cell',
-                                             '10x_genes_detected',
-                                             '10x_umis_per_cell']
+                if project.physical_samples:
+                    multiplex_analysis_fields = ["physical_sample"]
+                else:
+                    multiplex_analysis_fields = []
+                multiplex_analysis_fields.extend(['sample',
+                                                  '10x_cells',
+                                                  '10x_reads_per_cell',
+                                                  '10x_genes_per_cell',
+                                                  '10x_genes_detected',
+                                                  '10x_umis_per_cell'])
                 # Add column for multiple versions
                 if len(project.software[pkg]) > 1:
                     multiplex_analysis_fields.append('10x_pipeline')

--- a/auto_process_ngs/test/qc/apps/test_cellranger.py
+++ b/auto_process_ngs/test/qc/apps/test_cellranger.py
@@ -20,6 +20,7 @@ from auto_process_ngs.qc.apps.cellranger import cellranger_atac_count_output
 from auto_process_ngs.qc.apps.cellranger import cellranger_arc_count_output
 from auto_process_ngs.qc.apps.cellranger import cellranger_multi_output
 from auto_process_ngs.qc.apps.cellranger import fetch_cellranger_multi_output_dirs
+from auto_process_ngs.qc.apps.cellranger import extract_path_data
 
 # Set to False to keep test output dirs
 REMOVE_TEST_OUTPUTS = True
@@ -798,3 +799,49 @@ class TestFetchCellrangerMultiOutputDirsFunction(unittest.TestCase):
         self.assertEqual(
             fetch_cellranger_multi_output_dirs(qc_dir),
             [os.path.join(qc_dir, d) for d in expected_output_dirs])
+
+class TestExtractPathDataFunction(unittest.TestCase):
+
+    def test_extract_path_data_with_version_and_refdata(self):
+        """
+        extract_path_data: version and reference data
+        """
+        self.assertEqual(extract_path_data(
+            "/qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/",
+            "/qc/cellranger_multi/"),
+                         ("8.0.0",
+                          "refdata-cellranger-gex-GRCh38-2020-A",
+                          None))
+
+    def test_extract_path_data_with_version_refdata_sample(self):
+        """
+        extract_path_data: version, reference data and sample
+        """
+        self.assertEqual(extract_path_data(
+            "/qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2020-A/PB1",
+            "/qc/cellranger_multi/"),
+                         ("9.0.0",
+                          "refdata-cellranger-gex-GRCh38-2020-A",
+                          "PB1"))
+
+    def test_extract_path_data_with_no_intermediate_dirs(self):
+        """
+        extract_path_data: no intermediate directories
+        """
+        self.assertEqual(extract_path_data(
+            "/qc/cellranger_multi/",
+            "/qc/cellranger_multi/"),
+                         (None,
+                          None,
+                          None))
+
+    def test_extract_path_data_with_unrecognised_arrangement(self):
+        """
+        extract_path_data: unrecognised directory arrangement
+        """
+        self.assertEqual(extract_path_data(
+            "/qc/cellranger_multi/PB1/PB2/PB3/PB4/PB5",
+            "/qc/cellranger_multi/"),
+                         (None,
+                          None,
+                          None))

--- a/auto_process_ngs/test/qc/test_outputs.py
+++ b/auto_process_ngs/test/qc/test_outputs.py
@@ -109,6 +109,7 @@ class TestQCOutputs(unittest.TestCase):
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -158,6 +159,7 @@ class TestQCOutputs(unittest.TestCase):
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1'])
         self.assertEqual(qc_outputs.software,
                          { 'fastq_screen': [ '0.9.2' ],
@@ -203,6 +205,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.fastq_screens,[])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -251,6 +254,7 @@ class TestQCOutputs(unittest.TestCase):
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -298,6 +302,7 @@ class TestQCOutputs(unittest.TestCase):
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -345,6 +350,7 @@ class TestQCOutputs(unittest.TestCase):
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -394,6 +400,7 @@ class TestQCOutputs(unittest.TestCase):
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -449,6 +456,7 @@ class TestQCOutputs(unittest.TestCase):
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -505,6 +513,7 @@ class TestQCOutputs(unittest.TestCase):
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'fastq_screen': [ '0.9.2' ],
@@ -564,6 +573,7 @@ class TestQCOutputs(unittest.TestCase):
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -624,6 +634,7 @@ class TestQCOutputs(unittest.TestCase):
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -686,6 +697,7 @@ class TestQCOutputs(unittest.TestCase):
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -747,6 +759,7 @@ class TestQCOutputs(unittest.TestCase):
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -801,6 +814,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.fastq_screens,[])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -857,6 +871,7 @@ class TestQCOutputs(unittest.TestCase):
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -904,6 +919,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.bams,[])
         self.assertEqual(qc_outputs.organisms,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -959,6 +975,7 @@ class TestQCOutputs(unittest.TestCase):
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -1016,6 +1033,7 @@ class TestQCOutputs(unittest.TestCase):
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -1074,6 +1092,7 @@ class TestQCOutputs(unittest.TestCase):
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -1135,6 +1154,7 @@ class TestQCOutputs(unittest.TestCase):
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -1206,6 +1226,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.cellranger_references,
                          ['/data/refdata-cellranger-2020-A'])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '6.1.2' ],
@@ -1273,6 +1294,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.cellranger_references,
                          ['/data/refdata-cellranger-2020-A'])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '7.1.0' ],
@@ -1340,6 +1362,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.cellranger_references,
                          ['/data/refdata-cellranger-2020-A'])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '8.0.0' ],
@@ -1407,6 +1430,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.cellranger_references,
                          ['/data/refdata-cellranger-2020-A'])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '9.0.0' ],
@@ -1474,6 +1498,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.cellranger_references,
                          ['/data/refdata-cellranger-2020-A'])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '?' ],
@@ -1540,6 +1565,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.cellranger_references,
                          ['/data/refdata-cellranger-atac-2020-A'])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r3'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger-atac': [ '2.0.0' ],
@@ -1609,6 +1635,7 @@ class TestQCOutputs(unittest.TestCase):
                          ['/data/refdata-cellranger-2020-A',
                           '/data/refdata-cellranger-arc-2020-A'])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '8.0.0' ],
@@ -1681,6 +1708,7 @@ class TestQCOutputs(unittest.TestCase):
                          ['/data/refdata-cellranger-arc-2020-A',
                           '/data/refdata-cellranger-atac-2020-A'])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r3'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger-arc': [ '2.0.0' ],
@@ -1757,6 +1785,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.cellranger_probe_sets,[])
         self.assertEqual(qc_outputs.multiplexed_samples,
                          ['PJB_CML1','PJB_CML2'])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '6.1.2' ],
@@ -1831,6 +1860,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.cellranger_probe_sets,[])
         self.assertEqual(qc_outputs.multiplexed_samples,
                          ['PJB_CML1','PJB_CML2'])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '7.1.0' ],
@@ -1905,6 +1935,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.cellranger_probe_sets,[])
         self.assertEqual(qc_outputs.multiplexed_samples,
                          ['PJB_CML1','PJB_CML2'])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '8.0.0' ],
@@ -1979,6 +2010,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.cellranger_probe_sets,[])
         self.assertEqual(qc_outputs.multiplexed_samples,
                          ['PJB_CML1','PJB_CML2'])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '9.0.0' ],
@@ -2055,6 +2087,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.cellranger_probe_sets,[])
         self.assertEqual(qc_outputs.multiplexed_samples,
                          ['PJB_CML1','PJB_CML2'])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '6.1.2' ],
@@ -2131,6 +2164,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.cellranger_probe_sets,[])
         self.assertEqual(qc_outputs.multiplexed_samples,
                          ['PJB_CML1','PJB_CML2'])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '7.1.0' ],
@@ -2207,6 +2241,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.cellranger_probe_sets,[])
         self.assertEqual(qc_outputs.multiplexed_samples,
                          ['PJB_CML1','PJB_CML2'])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '8.0.0' ],
@@ -2283,6 +2318,7 @@ class TestQCOutputs(unittest.TestCase):
         self.assertEqual(qc_outputs.cellranger_probe_sets,[])
         self.assertEqual(qc_outputs.multiplexed_samples,
                          ['PJB_CML1','PJB_CML2'])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '9.0.0' ],
@@ -2355,6 +2391,7 @@ class TestQCOutputs(unittest.TestCase):
                          ['/data/probe-set-2020-A'])
         self.assertEqual(qc_outputs.multiplexed_samples,
                          ['PJB_BC1','PJB_BC2'])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '6.1.2' ],
@@ -2467,6 +2504,7 @@ PJB2_TCR,{fastq_dir},any,PJB2,VDJ-T,
                          ['/data/refdata-cellranger-2020-A'])
         self.assertEqual(qc_outputs.cellranger_probe_sets,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '7.1.0' ],
@@ -2581,6 +2619,7 @@ PJB2_TCR,{fastq_dir},any,PJB2,VDJ-T,
                          ['/data/refdata-cellranger-2020-A'])
         self.assertEqual(qc_outputs.cellranger_probe_sets,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '8.0.0' ],
@@ -2695,6 +2734,7 @@ PJB2_TCR,{fastq_dir},any,PJB2,VDJ-T,
                          ['/data/refdata-cellranger-2020-A'])
         self.assertEqual(qc_outputs.cellranger_probe_sets,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '9.0.0' ],
@@ -2784,6 +2824,8 @@ PJB2_TCR,{fastq_dir},any,PJB2,VDJ-T,
         self.assertEqual(qc_outputs.cellranger_probe_sets,[])
         self.assertEqual(qc_outputs.multiplexed_samples,
                          ["PJB01", "PJB02", "PJB03", "PJB04"])
+        self.assertEqual(qc_outputs.physical_samples,
+                         ["PJB1", "PJB2"])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '9.0.0' ],
@@ -2861,6 +2903,7 @@ PJB2_TCR,{fastq_dir},any,PJB2,VDJ-T,
         self.assertEqual(qc_outputs.cellranger_probe_sets,[])
         self.assertEqual(qc_outputs.multiplexed_samples,
                          ['EX1'])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'cellranger': [ '7.1.0' ],
@@ -2919,6 +2962,7 @@ PJB2_TCR,{fastq_dir},any,PJB2,VDJ-T,
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],
@@ -2976,6 +3020,7 @@ PJB2_TCR,{fastq_dir},any,PJB2,VDJ-T,
                           'rRNA'])
         self.assertEqual(qc_outputs.cellranger_references,[])
         self.assertEqual(qc_outputs.multiplexed_samples,[])
+        self.assertEqual(qc_outputs.physical_samples,[])
         self.assertEqual(qc_outputs.reads,['r1','r2'])
         self.assertEqual(qc_outputs.software,
                          { 'fastqc': [ '0.11.3' ],


### PR DESCRIPTION
Updates the QC reporting to handle `cellranger multi` outputs for multiple physical samples.

Prior to this PR, multiple `cellranger multi` outputs could be stored under the `cellranger_multi` directory only if they were distinguished by version and reference data, i.e. paths that looked like:

    .../PROJECT/qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/outs/...

The PR enables the reporting to detect an optional third subdirectory level below the version and reference data levels, which will be the name associated with a physical sample. For example:

    .../PROJECT/qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/PB1/outs/...

To this end, new functions have been implemented in the `qc/apps/cellranger` module:

* `fetch_cellranger_multi_output_dirs` tries to locate `cellranger multi` output directories under an arbitrary path
* `extract_path_data` tries to extract the version, reference data and physical sample name from the intermediate subdirectory names
* `CellrangerMulti` class has also been updated to enable information about the physical sample name to be stored and retrieved

The `collect_qc_outputs` method of the `CellrangerMulti` QC class (in the `qc/modules/cellranger_multi` module) has been updated to use the new methods above to locate and characterise `cellranger multi` outputs which include a physical sample subdirectory level. It also returns a new attribute `physical_samples` (which lists the names associated with physical sample information, if present), and the `QCOutputs` class (in `qc/outputs`) has been updated to include a new `physical_samples` attribute derived from this information.

Finally the `qc/reporting` module has also been updated to use `fetch_cellranger_multi_output_dirs` and `extract_path_data` when locating `cellranger multi` outputs for reporting. If physical sample information is present then this will now be included in the table reporting `cellranger multi` outputs.