### PR TITLE
Enable 'cellranger_multi' QC module to handle multiple config files for more than one physical sample

### DIFF
--- a/auto_process_ngs/qc/modules/cellranger_count.py
+++ b/auto_process_ngs/qc/modules/cellranger_count.py
@@ -268,7 +268,7 @@ class CellrangerCount(QCModule):
                         and f.endswith(".csv")]
             if not cf_files:
                 # No multi config files so no outputs expected
-                return True
+                return None
             # Get GEX sample names and reference dataset from
             # multi config files
             samples = []

--- a/auto_process_ngs/qc/modules/cellranger_count.py
+++ b/auto_process_ngs/qc/modules/cellranger_count.py
@@ -261,17 +261,21 @@ class CellrangerCount(QCModule):
             from the 'collect_qc_outputs' method
         """
         if params.cellranger_use_multi_config:
-            # Take parameters from 10x_multi_config.csv
-            cf_file = os.path.join(params.qc_dir,
-                                   "10x_multi_config.csv")
-            if not os.path.exists(cf_file):
-                # No multi config file so no outputs expected
+            # Fetch 10x_multi_config CSV files
+            cf_files = [os.path.join(params.qc_dir, f)
+                        for f in os.listdir(params.qc_dir)
+                        if f.startswith("10x_multi_config.")
+                        and f.endswith(".csv")]
+            if not cf_files:
+                # No multi config files so no outputs expected
                 return True
             # Get GEX sample names and reference dataset from
-            # multi config file
-            cf = CellrangerMultiConfigCsv(cf_file)
-            samples = cf.gex_libraries
-            cellranger_refdata = cf.reference_data_path
+            # multi config files
+            samples = []
+            for cf_file in cf_files:
+                cf = CellrangerMultiConfigCsv(cf_file)
+                samples.extend(cf.gex_libraries)
+                cellranger_refdata = cf.reference_data_path
         else:
             # Use supplied parameters
             samples = params.samples

--- a/auto_process_ngs/qc/modules/cellranger_multi.py
+++ b/auto_process_ngs/qc/modules/cellranger_multi.py
@@ -219,7 +219,7 @@ class CellrangerMulti(QCModule):
                         and f.endswith(".csv")]
         if not config_files:
             # No multi config files so no outputs expected
-            return True
+            return None
         # Verification paramters
         cellranger_version = None
         if params.cellranger_version != "*":

--- a/auto_process_ngs/qc/modules/cellranger_multi.py
+++ b/auto_process_ngs/qc/modules/cellranger_multi.py
@@ -9,6 +9,7 @@ Implements the 'cellranger_multi' QC module:
 * CellrangerMulti: core QCModule class
 * GetCellrangerMultiConfig: pipeline task to acquire multi config file
 * RunCellrangerMulti: pipeline task to run 'cellranger multi'
+* expected_outputs: helper function for handling 'cellranger multi' outputs
 
 Also imports the following pipeline tasks:
 
@@ -658,3 +659,38 @@ class RunCellrangerMulti(PipelineTask):
         self.output.cellranger_refdata.set(self.args.reference_data_path)
         self.output.cellranger_probeset.set(self.args.probe_set_path)
         self.output.cellranger_version.set(self.args.cellranger_version)
+
+#######################################################################
+# Helper functions
+#######################################################################
+
+def expected_outputs(config_csv, prefix=None):
+    """
+    Generate expected output file paths from 10x multi config
+
+    Arguments:
+      config_csv (str): path to the 10x multi config file
+        to generate the output file names for
+      prefix (str): optional path to prepend to the
+        expected file paths
+
+    Returns:
+      List: list of paths to expected output files.
+    """
+    # Load config file
+    config = CellrangerMultiConfigCsv(config_csv)
+    # Generate list of expected files
+    expected_files = ["_cmdline",]
+    for sample in config.sample_names:
+        for f in ("web_summary.html",
+                  "metrics_summary.csv"):
+            # Per-sample outputs
+            expected_files.append(os.path.join("outs",
+                                               "per_sample_outs",
+                                               sample,
+                                               f))
+    # Prepend prefix if supplied
+    if prefix:
+        expected_files = [os.path.join(prefix, f)
+                          for f in expected_files]
+    return expected_files

--- a/auto_process_ngs/qc/modules/cellranger_multi.py
+++ b/auto_process_ngs/qc/modules/cellranger_multi.py
@@ -567,7 +567,7 @@ class RunCellrangerMulti(PipelineTask):
             # Set prefix
             prefix = multi_dir
             if config.physical_sample:
-                prefix = os.path.join(prefix)
+                prefix = os.path.join(prefix, config.physical_sample)
             # Check whether outputs already exist
             for f in expected_outputs(config_csv, prefix=prefix):
                 if not os.path.exists(f):

--- a/auto_process_ngs/qc/modules/cellranger_multi.py
+++ b/auto_process_ngs/qc/modules/cellranger_multi.py
@@ -303,17 +303,17 @@ class CellrangerMulti(QCModule):
                    envmodules=envmodules)
         check_cellranger_multi_requires.append(get_cellranger)
 
-        # Locate config.csv file for 'cellranger multi'
-        get_cellranger_multi_config = GetCellrangerMultiConfig(
-            "%s: get config file for 'cellranger multi'" %
+        # Locate config.csv files for 'cellranger multi'
+        get_cellranger_multi_configs = GetCellrangerMultiConfigs(
+            "%s: get config files for 'cellranger multi'" %
             project_name,
             project,
             qc_dir
         )
-        p.add_task(get_cellranger_multi_config,
+        p.add_task(get_cellranger_multi_configs,
                    requires=required_tasks)
         check_cellranger_multi_requires.append(
-            get_cellranger_multi_config)
+            get_cellranger_multi_configs)
 
         # Parent directory for cellranger multi outputs
         # Set to project directory unless the 'cellranger_out_dir'
@@ -330,10 +330,10 @@ class CellrangerMulti(QCModule):
             (project_name,
              project.info.library_type),
             project,
-            get_cellranger_multi_config.output.config_csvs,
-            get_cellranger_multi_config.output.samples,
-            get_cellranger_multi_config.output.reference_data_path,
-            get_cellranger_multi_config.output.probe_set_path,
+            get_cellranger_multi_configs.output.config_csvs,
+            get_cellranger_multi_configs.output.samples,
+            get_cellranger_multi_configs.output.reference_data_path,
+            get_cellranger_multi_configs.output.probe_set_path,
             cellranger_out_dir,
             qc_dir=qc_dir,
             working_dir=working_dir,
@@ -348,7 +348,7 @@ class CellrangerMulti(QCModule):
         )
         p.add_task(run_cellranger_multi,
                    requires=(get_cellranger,
-                             get_cellranger_multi_config,),
+                             get_cellranger_multi_configs,),
                    runner=cellranger_runner,
                    envmodules=envmodules)
         return run_cellranger_multi
@@ -357,7 +357,7 @@ class CellrangerMulti(QCModule):
 # Pipeline tasks
 #######################################################################
 
-class GetCellrangerMultiConfig(PipelineFunctionTask):
+class GetCellrangerMultiConfigs(PipelineFunctionTask):
     """
     Locate 'config.csv' files for cellranger multi
     """
@@ -457,7 +457,7 @@ class RunCellrangerMulti(PipelineTask):
           probe_set_path (str): path to the probe set
             reference dataset from the config.csv file
           out_dir (str): top-level directory to copy all
-            final 'count' outputs into. Outputs won't be
+            final 'multi' outputs into. Outputs won't be
             copied if no value is supplied
           qc_dir (str): top-level QC directory to put
             'count' QC outputs (e.g. metrics CSV and summary

--- a/auto_process_ngs/qc/modules/cellranger_multi.py
+++ b/auto_process_ngs/qc/modules/cellranger_multi.py
@@ -421,10 +421,10 @@ class GetCellrangerMultiConfigs(PipelineFunctionTask):
         self.add_output('probe_set_path',Param(type=str))
     def setup(self):
         # Check for top-level multi config files
-        config_files = [os.path.join(self.args.project.dirn,f)
-                        for f in os.listdir(self.args.project.dirn)
-                        if f.startswith("10x_multi_config.")
-                        and f.endswith(".csv")]
+        config_files = sorted([os.path.join(self.args.project.dirn,f)
+                               for f in os.listdir(self.args.project.dirn)
+                               if f.startswith("10x_multi_config.")
+                               and f.endswith(".csv")])
         if not config_files:
             # No configs found
             print("No 10x multi config files found: nothing to do")

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -63,7 +63,7 @@ from .modules.cellranger_atac_count import CellrangerAtacCount
 from .modules.cellranger_arc_count import CellrangerArcCount
 from .modules.cellranger_count import CellrangerCount
 from .modules.cellranger_multi import CellrangerMulti
-from .modules.cellranger_multi import GetCellrangerMultiConfig
+from .modules.cellranger_multi import GetCellrangerMultiConfigs
 from .modules.fastqc import Fastqc
 from .modules.fastq_screen import FastqScreen
 from .modules.picard_insert_size_metrics import PicardInsertSizeMetrics
@@ -638,18 +638,18 @@ class QCPipeline(Pipeline):
                 except KeyError:
                     cellranger_use_multi_config = False
                 if cellranger_use_multi_config:
-                    get_cellranger_multi_config = GetCellrangerMultiConfig(
-                        "%s: get config file for 'cellranger multi'" %
+                    get_cellranger_multi_configs = GetCellrangerMultiConfigs(
+                        "%s: get config files for 'cellranger multi'" %
                         project_name,
                         project,
                         qc_dir
                     )
-                    self.add_task(get_cellranger_multi_config,
+                    self.add_task(get_cellranger_multi_configs,
                                   requires=startup_tasks)
-                    samples = get_cellranger_multi_config.output.gex_libraries
-                    fastq_dirs = get_cellranger_multi_config.output.fastq_dirs
+                    samples = get_cellranger_multi_configs.output.gex_libraries
+                    fastq_dirs = get_cellranger_multi_configs.output.fastq_dirs
                     reference_dataset = \
-                        get_cellranger_multi_config.output.reference_data_path
+                        get_cellranger_multi_configs.output.reference_data_path
                 else:
                     samples = None
                     fastq_dirs = None

--- a/auto_process_ngs/tenx/cellplex.py
+++ b/auto_process_ngs/tenx/cellplex.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     tenx/cellplex.py: utilities for handling 10xGenomics Cellplex data
-#     Copyright (C) University of Manchester 2023-2024 Peter Briggs
+#     Copyright (C) University of Manchester 2023-2025 Peter Briggs
 #
 
 """
@@ -57,6 +57,8 @@ class CellrangerMultiConfigCsv:
     - vdj_reference_path: path to the V(D)J-compatible reference
     - gex_libraries: list of Fastq IDs associated
       with GEX data
+    - physical_sample: physical sample name extracted from
+      the config file name if present (otherwise None)
     - is_valid: indicates whether the file appears to be valid
 
     Provides the following methods:
@@ -95,6 +97,7 @@ class CellrangerMultiConfigCsv:
         self._filen = os.path.abspath(filen)
         self._sections = []
         self._samples = {}
+        self._physical_sample = None
         self._reference_data_path = None
         self._probe_set_path = None
         self._feature_reference_path = None
@@ -109,6 +112,9 @@ class CellrangerMultiConfigCsv:
         Internal: read in data from a multiplex 'config.csv' file
         """
         logger.debug("Reading data from '%s'" % self._filen)
+        psample = ".".join(os.path.basename(self._filen).split(".")[1:-1])
+        if psample:
+            self._physical_sample = psample
         sections = set()
         cmo_list = set()
         feature_type_list = set()
@@ -276,6 +282,21 @@ class CellrangerMultiConfigCsv:
         Samples are listed in the '[samples]' section.
         """
         return sorted(list(self._samples.keys()))
+
+    @property
+    def physical_sample(self):
+        """
+        Return the physical sample from config.csv name
+
+        Physical sample name is extracted from config file
+        names of the form:
+
+        10x_multi_config[.SAMPLE].csv
+
+        If no physical sample name is present in the name
+        then returns 'None'.
+        """
+        return self._physical_sample
 
     @property
     def sections(self):

--- a/auto_process_ngs/test/qc/modules/test_cellranger_count.py
+++ b/auto_process_ngs/test/qc/modules/test_cellranger_count.py
@@ -2064,6 +2064,154 @@ PBB,CMO302,PBB
                                                         "PJB",f)),
                             "Missing %s" % f)
 
+    def test_qcpipeline_qc_modules_cellranger_count_multiple_multi_configs(self):
+        """
+        QCPipeline: 'cellranger_count' QC module (use multiple cellranger multi configs)
+        """
+        # Make mock QC executables
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="8.0.0")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x Cellplex analysis project
+        p = MockAnalysisProject("PJB",("PJB1_GEX_S1_R1_001.fastq.gz",
+                                       "PJB1_GEX_S1_R2_001.fastq.gz",
+                                       "PJB1_CML_S2_R1_001.fastq.gz",
+                                       "PJB1_CML_S2_R2_001.fastq.gz",
+                                       "PJB2_GEX_S3_R1_001.fastq.gz",
+                                       "PJB2_GEX_S3_R2_001.fastq.gz",
+                                       "PJB2_CML_S4_R1_001.fastq.gz",
+                                       "PJB2_CML_S4_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v3',
+                                           'Library type': 'CellPlex' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv files
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB1.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+create-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,%s,any,PJB1,gene expression,
+PJB1_CML,%s,any,PJB1,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+PBA,CMO301,PBA
+PBB,CMO302,PBB
+""" % (fastq_dir,fastq_dir))
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB2.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+create-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB2_GEX,%s,any,PJB2,gene expression,
+PJB2_CML,%s,any,PJB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+PBC,CMO303,PBC
+PBD,CMO304,PBD
+""" % (fastq_dir,fastq_dir))
+        # QC protocol
+        protocol = QCProtocol(name="cellranger_count",
+                              description="Cellranger_count test",
+                              seq_data_reads=['r2',],
+                              index_reads=['r1'],
+                              qc_modules=(
+                                  "cellranger_count(cellranger_use_multi_config=true)",))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol)
+        status = runqc.run(cellranger_transcriptomes=
+                           { 'human':
+                             '/data/refdata-gex-GRCh38-2024-A' },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check outputs
+        project_dir = os.path.join(self.wd,"PJB")
+        for f in (
+                "qc/cellranger_count",
+                "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/_cmdline",
+                "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/web_summary.html",
+                "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/metrics_summary.csv",
+                "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/_cmdline",
+                "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/outs/web_summary.html",
+                "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/outs/metrics_summary.csv",
+                "cellranger_count",
+                "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/_cmdline",
+                "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/web_summary.html",
+                "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/metrics_summary.csv",
+                "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/_cmdline",
+                "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/outs/web_summary.html",
+                "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/outs/metrics_summary.csv"):
+            self.assertTrue(os.path.exists(os.path.join(project_dir,f)),
+                            "%s: missing" % f)
+        for f in (
+                "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_CML",
+                "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_CML",
+                "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_CML"
+                "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_CML"):
+            self.assertFalse(os.path.exists(os.path.join(project_dir,f)),
+                             "%s: present" % f)
+        # Check number of cells
+        project_metadata = AnalysisProjectInfo(
+            os.path.join(self.wd,"PJB","README.info"))
+        ##self.assertEqual(project_metadata.number_of_cells,5529)
+        self.assertEqual(project_metadata.number_of_cells,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"cellranger_count")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_GEX,PJB2_GEX")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_CML_S2_R1_001.fastq.gz,"
+                         "PJB1_CML_S2_R2_001.fastq.gz,"
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz,"
+                         "PJB2_CML_S4_R1_001.fastq.gz,"
+                         "PJB2_CML_S4_R2_001.fastq.gz,"
+                         "PJB2_GEX_S3_R1_001.fastq.gz,"
+                         "PJB2_GEX_S3_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,None)
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,None)
+        self.assertEqual(qc_info.cellranger_version,"8.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-cellranger-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
     def test_qcpipeline_qc_modules_cellranger_count_multi_config_no_file(self):
         """
         QCPipeline: 'cellranger_count' QC module (use cellranger multi config, no file)

--- a/auto_process_ngs/test/qc/modules/test_cellranger_multi.py
+++ b/auto_process_ngs/test/qc/modules/test_cellranger_multi.py
@@ -361,6 +361,157 @@ PBB,CMO302,PBB
                                                         "PJB",f)),
                             "Missing %s" % f)
 
+    def test_qcpipeline_qc_modules_cellranger_multi_cellplex_multiple_physical_samples(self):
+        """
+        QCPipeline: 'cellranger_multi' QC module (Cellplex, multiple physical samples)
+        """
+        # Make mock QC executables
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 multi_outputs="cellplex",
+                                 version="9.0.0")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x Cellplex analysis project
+        p = MockAnalysisProject("PJB",("PJB1_GEX_S1_R1_001.fastq.gz",
+                                       "PJB1_GEX_S1_R2_001.fastq.gz",
+                                       "PJB1_MC_S2_R1_001.fastq.gz",
+                                       "PJB1_MC_S2_R2_001.fastq.gz",
+                                       "PJB2_GEX_S3_R1_001.fastq.gz",
+                                       "PJB2_GEX_S3_R2_001.fastq.gz",
+                                       "PJB2_MC_S4_R1_001.fastq.gz",
+                                       "PJB2_MC_S4_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v3',
+                                           'Library type': 'CellPlex' })
+        p.create(top_dir=self.wd)
+        # Add cellranger multi config.csv files for two physical
+        # samples (PJB1 and PJB2)
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB1.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,%s,any,PJB1,gene expression,
+PJB1_MC,%s,any,PJB1,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+PBA,CMO301,PBA
+PBB,CMO302,PBB
+""" % (fastq_dir,fastq_dir))
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB2.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB2_GEX,%s,any,PJB2,gene expression,
+PJB2_MC,%s,any,PJB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+PBC,CMO303,PBC
+PBD,CMO304,PBD
+""" % (fastq_dir,fastq_dir))
+        # QC protocol
+        protocol = QCProtocol(name="cellranger_multi",
+                              description="Cellranger_multi test",
+                              seq_data_reads=['r2',],
+                              index_reads=['r1'],
+                              qc_modules=("cellranger_multi",))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol)
+        status = runqc.run(cellranger_transcriptomes=
+                           { 'human':
+                             '/data/refdata-cellranger-gex-GRCh38-2020-A' },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check outputs
+        project_dir = os.path.join(self.wd,"PJB")
+        for f in (
+                "qc/cellranger_multi",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/_cmdline",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBA/web_summary.html",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBA/metrics_summary.csv",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBB/web_summary.html",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBB/metrics_summary.csv",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/multi/multiplexing_analysis/tag_calls_summary.csv",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/_cmdline",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBC/web_summary.html",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBC/metrics_summary.csv",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBD/web_summary.html",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBD/metrics_summary.csv",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/multi/multiplexing_analysis/tag_calls_summary.csv",
+                "cellranger_multi",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/_cmdline",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBA/web_summary.html",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBA/metrics_summary.csv",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBB/web_summary.html",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBB/metrics_summary.csv",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/multi/multiplexing_analysis/tag_calls_summary.csv",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/_cmdline",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBC/web_summary.html",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBC/metrics_summary.csv",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBD/web_summary.html",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBD/metrics_summary.csv",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/multi/multiplexing_analysis/tag_calls_summary.csv"):
+            self.assertTrue(os.path.exists(os.path.join(project_dir,f)),
+                            "%s: missing" % f)
+        # Check number of cells
+        project_metadata = AnalysisProjectInfo(
+            os.path.join(self.wd,"PJB","README.info"))
+        self.assertEqual(project_metadata.number_of_cells, 6284)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"cellranger_multi")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_GEX,PJB2_GEX")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz,"
+                         "PJB1_MC_S2_R1_001.fastq.gz,"
+                         "PJB1_MC_S2_R2_001.fastq.gz,"
+                         "PJB2_GEX_S3_R1_001.fastq.gz,"
+                         "PJB2_GEX_S3_R2_001.fastq.gz,"
+                         "PJB2_MC_S4_R1_001.fastq.gz,"
+                         "PJB2_MC_S4_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,None)
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,None)
+        self.assertEqual(qc_info.cellranger_version,"9.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-cellranger-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
     def test_qcpipeline_qc_modules_cellranger_multi_cellplex_no_config_file(self):
         """
         QCPipeline: 'cellranger_multi' QC module (CellPlex, no config file)
@@ -850,6 +1001,145 @@ PB2,BC002,PB2
         self.assertEqual(qc_info.fastqs,
                          "PJB1_Flex_S1_R1_001.fastq.gz,"
                          "PJB1_Flex_S1_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,None)
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,None)
+        self.assertEqual(qc_info.cellranger_version,"9.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-cellranger-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset,
+                         "/data/Probe_Set_v1.0_GRCh38-2020-A.csv")
+        # Check output and reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    def test_qcpipeline_qc_modules_cellranger_multi_flex_multiple_physical_samples(self):
+        """
+        QCPipeline: 'cellranger_multi' QC module (Flex, multiple physical samples)
+        """
+        # Make mock QC executables
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 multi_outputs="flex",
+                                 version="9.0.0")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x Flex analysis project
+        p = MockAnalysisProject("PJB",("PJB1_Flex_S1_R1_001.fastq.gz",
+                                       "PJB1_Flex_S1_R2_001.fastq.gz",
+                                       "PJB2_Flex_S2_R1_001.fastq.gz",
+                                       "PJB2_Flex_S2_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v3',
+                                           'Library type': 'Flex' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv files for two physical
+        # samples (PJB1 and PJB2)
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB1.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+probe-set,/data/Probe_Set_v1.0_GRCh38-2020-A.csv
+no-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_Flex,{fastq_dir},any,PJB1,Gene Expression,
+
+[samples]
+sample_id,probe_barcode_ids,description
+PB1,BC001,PB1
+PB2,BC002,PB2
+""".format(fastq_dir=fastq_dir))
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB2.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+probe-set,/data/Probe_Set_v1.0_GRCh38-2020-A.csv
+no-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB2_Flex,{fastq_dir},any,PJB2,Gene Expression,
+
+[samples]
+sample_id,probe_barcode_ids,description
+PB3,BC001,PB3
+PB4,BC002,PB4
+""".format(fastq_dir=fastq_dir))
+        # QC protocol
+        protocol = QCProtocol(name="cellranger_multi",
+                              description="Cellranger_multi test",
+                              seq_data_reads=['r2',],
+                              index_reads=['r1'],
+                              qc_modules=("cellranger_multi",))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol)
+        status = runqc.run(poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check outputs
+        project_dir = os.path.join(self.wd,"PJB")
+        for f in (
+                "qc/cellranger_multi",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/_cmdline",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PB1/web_summary.html",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PB1/metrics_summary.csv",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PB2/web_summary.html",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PB2/metrics_summary.csv",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/_cmdline",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PB3/web_summary.html",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PB3/metrics_summary.csv",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PB4/web_summary.html",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PB4/metrics_summary.csv",
+                "cellranger_multi",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/_cmdline",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PB1/web_summary.html",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PB1/metrics_summary.csv",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PB2/web_summary.html",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PB2/metrics_summary.csv",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/_cmdline",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PB3/web_summary.html",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PB3/metrics_summary.csv",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PB4/web_summary.html",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PB4/metrics_summary.csv"):
+            self.assertTrue(os.path.exists(os.path.join(project_dir,f)),
+                            "%s: missing" % f)
+        # Check number of cells
+        project_metadata = AnalysisProjectInfo(
+            os.path.join(self.wd,"PJB","README.info"))
+        self.assertEqual(project_metadata.number_of_cells, 6284)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"cellranger_multi")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_Flex,PJB2_Flex")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_Flex_S1_R1_001.fastq.gz,"
+                         "PJB1_Flex_S1_R2_001.fastq.gz,"
+                         "PJB2_Flex_S2_R1_001.fastq.gz,"
+                         "PJB2_Flex_S2_R2_001.fastq.gz")
         self.assertEqual(qc_info.fastqs_split_by_lane,False)
         self.assertEqual(qc_info.fastq_screens,None)
         self.assertEqual(qc_info.star_index,None)

--- a/auto_process_ngs/test/qc/protocols/test_10x_cellplex.py
+++ b/auto_process_ngs/test/qc/protocols/test_10x_cellplex.py
@@ -148,6 +148,190 @@ PBB,CMO302,PBB
                              "Found %s (shouldn't exist)" % f)
 
     #@unittest.skip("Skipped")
+    def test_qcpipeline_with_10x_cellplex_data_multiple_samples(self):
+        """
+        QCPipeline: 10xGenomics Cellplex run (10x_CellPlex, multiple samples)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 multi_outputs="cellplex",
+                                 version="8.0.0")
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x Cellplex analysis project
+        p = MockAnalysisProject("PJB",("PJB1_GEX_S1_R1_001.fastq.gz",
+                                       "PJB1_GEX_S1_R2_001.fastq.gz",
+                                       "PJB1_CML_S2_R1_001.fastq.gz",
+                                       "PJB1_CML_S2_R2_001.fastq.gz",
+                                       "PJB2_GEX_S3_R1_001.fastq.gz",
+                                       "PJB2_GEX_S3_R2_001.fastq.gz",
+                                       "PJB2_CML_S4_R1_001.fastq.gz",
+                                       "PJB2_CML_S4_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v3',
+                                           'Library type': 'CellPlex' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv files
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB1.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+create-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,%s,any,PJB1,gene expression,
+PJB1_CML,%s,any,PJB1,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+PBA,CMO301,PBA
+PBB,CMO302,PBB
+""" % (fastq_dir,fastq_dir))
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB2.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+create-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB2_GEX,%s,any,PJB2,gene expression,
+PJB2_CML,%s,any,PJB2,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+PBC,CMO301,PBC
+PBD,CMO302,PBD
+""" % (fastq_dir,fastq_dir))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_CellPlex"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           cellranger_transcriptomes=
+                           { 'human':
+                             '/data/refdata-cellranger-gex-GRCh38-2024-A' },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"10x_CellPlex")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_CellPlex")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_GEX,PJB2_GEX")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_CML_S2_R1_001.fastq.gz,"
+                         "PJB1_CML_S2_R2_001.fastq.gz,"
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz,"
+                         "PJB2_CML_S4_R1_001.fastq.gz,"
+                         "PJB2_CML_S4_R2_001.fastq.gz,"
+                         "PJB2_GEX_S3_R1_001.fastq.gz,"
+                         "PJB2_GEX_S3_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,"8.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-cellranger-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_multi",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/_cmdline",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBA/web_summary.html",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBA/metrics_summary.csv",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBB/web_summary.html",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBB/metrics_summary.csv",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/multi/multiplexing_analysis/tag_calls_summary.csv",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/_cmdline",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBC/web_summary.html",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBC/metrics_summary.csv",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBD/web_summary.html",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBD/metrics_summary.csv",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/multi/multiplexing_analysis/tag_calls_summary.csv",
+                  "cellranger_multi",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/_cmdline",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBA/web_summary.html",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBA/metrics_summary.csv",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBB/web_summary.html",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBB/metrics_summary.csv",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/multi/multiplexing_analysis/tag_calls_summary.csv",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/_cmdline",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBC/web_summary.html",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBC/metrics_summary.csv",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBD/web_summary.html",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBD/metrics_summary.csv",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/multi/multiplexing_analysis/tag_calls_summary.csv",
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/_cmdline",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/web_summary.html",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/metrics_summary.csv",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/_cmdline",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/outs/web_summary.html",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/outs/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/_cmdline",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/web_summary.html",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/metrics_summary.csv",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/_cmdline",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/outs/web_summary.html",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+        # Verify missing outputs for multiplex capture samples
+        for f in ("PJB2_MC_S2_R2_001_fastq_strand.txt",
+                  "PJB2_MC_S2_R2_001_screen_model_organisms.txt",
+                  "PJB2_MC_S2_R2_001_screen_other_organisms.txt",
+                  "PJB2_MC_S2_R2_001_screen_rRNA.txt",
+                  "qualimap-rnaseq/human/PJB2_MC_S2_001",):
+            self.assertFalse(os.path.exists(os.path.join(self.wd,
+                                                         "PJB",
+                                                         "qc",
+                                                         f)),
+                             "Found %s (shouldn't exist)" % f)
+
+    #@unittest.skip("Skipped")
     def test_qcpipeline_with_cellplex_data_no_multi_config_file(self):
         """
         QCPipeline: 10xGenomics Cellplex run (10x_CellPlex, no multi config)

--- a/auto_process_ngs/test/qc/protocols/test_10x_flex.py
+++ b/auto_process_ngs/test/qc/protocols/test_10x_flex.py
@@ -130,6 +130,161 @@ PB2,BC002,PB2
                             "Missing %s" % f)
 
     #@unittest.skip("Skipped")
+    def test_qcpipeline_with_10x_flex_data_multiple_samples(self):
+        """
+        QCPipeline: 10xGenomics Flex run (10x_Flex, multiple samples)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockSeqtk.create(os.path.join(self.bin,"seqtk"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 multi_outputs="flex",
+                                 version="8.0.0")
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x Flex analysis project
+        p = MockAnalysisProject("PJB",("PJB1_Flex_S1_R1_001.fastq.gz",
+                                       "PJB1_Flex_S1_R2_001.fastq.gz",
+                                       "PJB2_Flex_S2_R1_001.fastq.gz",
+                                       "PJB2_Flex_S2_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v3',
+                                           'Library type': 'Flex' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv files
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB1.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+probe-set,/data/Probe_Set_v1.0_GRCh38-2020-A.csv
+no-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_Flex,{fastq_dir},any,PJB1,Gene Expression,
+
+[samples]
+sample_id,probe_barcode_ids,description
+PB1,BC001,PB1
+PB2,BC002,PB2
+""".format(fastq_dir=fastq_dir))
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB2.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+probe-set,/data/Probe_Set_v1.0_GRCh38-2020-A.csv
+no-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB2_Flex,{fastq_dir},any,PJB2,Gene Expression,
+
+[samples]
+sample_id,probe_barcode_ids,description
+PB3,BC001,PB3
+PB4,BC002,PB4
+""".format(fastq_dir=fastq_dir))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_Flex"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"10x_Flex")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_Flex")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_Flex,PJB2_Flex")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_Flex_S1_R1_001.fastq.gz,"
+                         "PJB1_Flex_S1_R2_001.fastq.gz,"
+                         "PJB2_Flex_S2_R1_001.fastq.gz,"
+                         "PJB2_Flex_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,"8.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-cellranger-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset,
+                         "/data/Probe_Set_v1.0_GRCh38-2020-A.csv")
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_multi",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/_cmdline",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PB1/web_summary.html",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PB1/metrics_summary.csv",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PB2/web_summary.html",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PB2/metrics_summary.csv",
+                  "cellranger_multi",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/_cmdline",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PB1/web_summary.html",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PB1/metrics_summary.csv",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PB2/web_summary.html",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PB2/metrics_summary.csv",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/_cmdline",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PB3/web_summary.html",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PB3/metrics_summary.csv",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PB4/web_summary.html",
+                  "qc/cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PB4/metrics_summary.csv",
+                  "cellranger_multi",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/_cmdline",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PB3/web_summary.html",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PB3/metrics_summary.csv",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PB4/web_summary.html",
+                  "cellranger_multi/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PB4/metrics_summary.csv",
+                  #"qc/cellranger_count",
+                  #"qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_Flex/_cmdline",
+                  #"qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_Flex/outs/web_summary.html",
+                  #"qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_Flex/outs/metrics_summary.csv",
+                  #"cellranger_count",
+                  #"cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_Flex/_cmdline",
+                  #"cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_Flex/outs/web_summary.html",
+                  #"cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_Flex/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    #@unittest.skip("Skipped")
     def test_qcpipeline_with_10x_flex_data_no_multi_config_file(self):
         """
         QCPipeline: 10xGenomics Flex run (10x_Flex, no multi config file)

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -904,6 +904,59 @@ Cellranger version\t6.0.0
                                          project_dir).info.number_of_cells,
                          10350)
 
+    def test_set_cell_count_for_cellplex_project_multiple_physical_samples(self):
+        """
+        set_cell_count_for_project: test for multiplexed data (CellPlex, multiple physical samples)
+        """
+        # Set up mock project
+        project_dir = self._make_mock_analysis_project(
+            "10xGenomics Chromium 3'v3",
+            "CellPlex")
+        # Build mock cellranger multi output directory
+        multi_dir = os.path.join(project_dir,
+                                 "qc",
+                                 "cellranger_multi",
+                                 "9.0.0",
+                                 "refdata-cellranger-gex-GRCh38-2020-A")
+        mkdirs(multi_dir)
+        for sample in ("PJB1", "PJB2"):
+            if sample == "PJB1":
+                multiplexed_samples = ("PBA", "PBB")
+            elif sample == "PJB2":
+                multiplexed_samples = ("PBC", "PBD")
+            for multiplexed_sample in multiplexed_samples:
+                sample_dir = os.path.join(multi_dir,
+                                          sample,
+                                          "outs",
+                                          "per_sample_outs",
+                                          multiplexed_sample)
+                mkdirs(sample_dir)
+                summary_file = os.path.join(sample_dir,
+                                            "metrics_summary.csv")
+                with open(summary_file,'wt') as fp:
+                    fp.write(CELLPLEX_METRICS_SUMMARY)
+                web_summary = os.path.join(sample_dir,
+                                           "web_summary.html")
+                with open(web_summary,'wt') as fp:
+                    fp.write("Placeholder for web_summary.html\n")
+        # Add QC info file
+        with open(os.path.join(project_dir,"qc","qc.info"),'wt') as fp:
+            fp.write("""Cellranger reference datasets\t/data/refdata-cellranger-gex-GRCh38-2020-A
+Cellranger version\t9.0.0
+""")
+        # Check initial cell count
+        print("Checking number of cells")
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         None)
+        # Update the cell counts
+        print("Updating number of cells")
+        set_cell_count_for_project(project_dir,source="multi")
+        # Check updated cell count
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         20700)
+
     def test_set_cell_count_for_cellplex_project_710(self):
         """
         set_cell_count_for_project: test for multiplexed data (CellPlex 7.1.0)

--- a/auto_process_ngs/test/qc/test_verification.py
+++ b/auto_process_ngs/test/qc/test_verification.py
@@ -912,15 +912,16 @@ class TestQCVerifier(unittest.TestCase):
                                      cellranger_refdata=\
                                      'refdata-cellranger-2020-A')))
         # Empty QC dir
-        # NB this will verify as True because the 10x multi CSV config
+        # NB this will verify as None because the 10x multi CSV config
         # file is missing (so no outputs are expected)
         qc_dir = self._make_qc_dir('qc.empty',
                                    fastq_names=fastq_names,
                                    include_cellranger_multi=False)
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify_qc_module(
+        self.assertEqual(qc_verifier.verify_qc_module(
             'cellranger_multi',
-            self._create_params_dict(qc_dir=qc_dir)))
+            self._create_params_dict(qc_dir=qc_dir)),
+                         None)
 
     def test_qcverifier_verify_qc_module_cellranger_multi_multiple_samples(self):
         """
@@ -990,15 +991,16 @@ class TestQCVerifier(unittest.TestCase):
                                      cellranger_refdata=\
                                      'refdata-cellranger-2020-A')))
         # Empty QC dir
-        # NB this will verify as True because the 10x multi CSV config
+        # NB this will verify as None because the 10x multi CSV config
         # file is missing (so no outputs are expected)
         qc_dir = self._make_qc_dir('qc.empty',
                                    fastq_names=fastq_names,
                                    include_cellranger_multi=False)
         qc_verifier = QCVerifier(qc_dir)
-        self.assertTrue(qc_verifier.verify_qc_module(
+        self.assertEqual(qc_verifier.verify_qc_module(
             'cellranger_multi',
-            self._create_params_dict(qc_dir=qc_dir)))
+            self._create_params_dict(qc_dir=qc_dir)),
+                         None)
 
     def test_qcverifier_verify_single_end(self):
         """

--- a/auto_process_ngs/test/qc/test_verification.py
+++ b/auto_process_ngs/test/qc/test_verification.py
@@ -922,6 +922,84 @@ class TestQCVerifier(unittest.TestCase):
             'cellranger_multi',
             self._create_params_dict(qc_dir=qc_dir)))
 
+    def test_qcverifier_verify_qc_module_cellranger_multi_multiple_samples(self):
+        """
+        QCVerifier: verify QC module 'cellranger_multi' (multiple samples)
+        """
+        fastq_names = ("PJB1_GEX_S1_R1_001.fastq.gz",
+                       "PJB1_GEX_S1_R2_001.fastq.gz",
+                       "PJB1_CML_S2_R1_001.fastq.gz",
+                       "PJB1_CML_S2_R2_001.fastq.gz",
+                       "PJB2_GEX_S3_R1_001.fastq.gz",
+                       "PJB2_GEX_S3_R2_001.fastq.gz",
+                       "PJB2_CML_S4_R1_001.fastq.gz",
+                       "PJB2_CML_S4_R2_001.fastq.gz",)
+        # QC dir with cellranger multi outputs
+        qc_dir = self._make_qc_dir('qc',
+                                   fastq_names=fastq_names,
+                                   include_cellranger_multi=True,
+                                   cellranger_pipelines=('cellranger',),
+                                   cellranger_multi_samples={
+                                       "PJB1": ("PB1", "PB2"),
+                                       "PJB2": ("PB3", "PB4")
+                                   })
+        qc_verifier = QCVerifier(qc_dir)
+        # Implicitly match any version and reference
+        self.assertTrue(qc_verifier.verify_qc_module(
+            'cellranger_multi',
+            self._create_params_dict(qc_dir=qc_dir)))
+        # Explicitly match version with any reference
+        self.assertTrue(qc_verifier.verify_qc_module(
+            'cellranger_multi',
+            self._create_params_dict(qc_dir=qc_dir,
+                                     cellranger_version='8.0.0',
+                                     cellranger_refdata='*')))
+        # Explicitly match reference with any version
+        self.assertTrue(qc_verifier.verify_qc_module(
+            'cellranger_multi',
+            self._create_params_dict(qc_dir=qc_dir,
+                                     cellranger_version='*',
+                                     cellranger_refdata=\
+                                     'refdata-cellranger-2020-A')))
+        # Fail if version not found
+        self.assertFalse(qc_verifier.verify_qc_module(
+            'cellranger_multi',
+            self._create_params_dict(qc_dir=qc_dir,
+                                     cellranger_version='5.0.0',
+                                     cellranger_refdata=\
+                                     'refdata-cellranger-2020-A')))
+        # Fail if reference not found
+        self.assertFalse(qc_verifier.verify_qc_module(
+            'cellranger_multi',
+            self._create_params_dict(qc_dir=qc_dir,
+                                     cellranger_version='7.1.0',
+                                     cellranger_refdata=\
+                                     'refdata-cellranger-2.0.0')))
+        # Missing outputs for one sample
+        qc_dir = self._make_qc_dir('qc.fail',
+                                   fastq_names=fastq_names[:2],
+                                   include_cellranger_multi=True,
+                                   cellranger_pipelines=('cellranger',),
+                                   cellranger_multi_samples=('PJB_CML1',))
+        qc_verifier = QCVerifier(qc_dir)
+        self.assertFalse(qc_verifier.verify_qc_module(
+            'cellranger_multi',
+            self._create_params_dict(qc_dir=qc_dir,
+                                     samples=('PJB1','PJB2'),
+                                     cellranger_version='7.1.0',
+                                     cellranger_refdata=\
+                                     'refdata-cellranger-2020-A')))
+        # Empty QC dir
+        # NB this will verify as True because the 10x multi CSV config
+        # file is missing (so no outputs are expected)
+        qc_dir = self._make_qc_dir('qc.empty',
+                                   fastq_names=fastq_names,
+                                   include_cellranger_multi=False)
+        qc_verifier = QCVerifier(qc_dir)
+        self.assertTrue(qc_verifier.verify_qc_module(
+            'cellranger_multi',
+            self._create_params_dict(qc_dir=qc_dir)))
+
     def test_qcverifier_verify_single_end(self):
         """
 	QCVerifier: verify single-end data (standardSE)
@@ -1895,12 +1973,13 @@ class TestVerifyProject(unittest.TestCase):
         verify_project: paired-end data with cellranger 'multi'
         """
         analysis_dir = self._make_analysis_project(
-            protocol='10x_CellPlex',
-            sample_names=('PJB1_GEX','PJB2_CML',),
-            seq_data_samples=('PJB1_GEX',),
+            protocol="10x_CellPlex",
+            sample_names=("PJB1_GEX", "PJB1_CML",),
+            seq_data_samples=("PJB1_GEX",),
             include_cellranger_multi=True,
-            cellranger_multi_samples=('PJB_CML1','PJB_CML2',))
+            cellranger_multi_samples=("PB1", "PB2"))
         project = AnalysisProject(analysis_dir)
+        # Should fail to verify as no cellranger count outputs
         self.assertFalse(verify_project(project))
 
     def test_verify_project_paired_end_cellranger_count_and_multi(self):
@@ -1908,15 +1987,48 @@ class TestVerifyProject(unittest.TestCase):
         verify_project: paired-end data with cellranger 'count' and 'multi'
         """
         analysis_dir = self._make_analysis_project(
-            protocol='10x_CellPlex',
-            sample_names=('PJB1_GEX','PJB2_CML',),
-            seq_data_samples=('PJB1_GEX',),
+            protocol="10x_CellPlex",
+            sample_names=("PJB1_GEX", "PJB1_CML",),
+            seq_data_samples=("PJB1_GEX",),
             include_cellranger_multi=True,
             include_cellranger_count=True,
             cellranger_pipelines=('cellranger',),
             # NB only GEX samples
-            cellranger_samples=('PJB1_GEX',),
-            cellranger_multi_samples=('PJB_CML1','PJB_CML2',))
+            cellranger_samples=("PJB1_GEX",),
+            cellranger_multi_samples=("PB1", "PB2"))
+        project = AnalysisProject(analysis_dir)
+        self.assertTrue(verify_project(project))
+
+    def test_verify_project_paired_end_cellranger_multi_multiple_samples(self):
+        """
+        verify_project: paired-end data with cellranger 'multi' (multiple samples)
+        """
+        analysis_dir = self._make_analysis_project(
+            protocol="10x_CellPlex",
+            sample_names=("PJB1_GEX", "PJB1_CML", "PJB2_GEX", "PJB2_CML"),
+            seq_data_samples=("PJB1_GEX", "PJB2_GEX"),
+            include_cellranger_multi=True,
+            cellranger_multi_samples={ "PJB1": ("PB1", "PB2"),
+                                       "PJB2": ("PB3", "PB4") })
+        project = AnalysisProject(analysis_dir)
+        # Should fail to verify as no cellranger count outputs
+        self.assertFalse(verify_project(project))
+
+    def test_verify_project_paired_end_cellranger_count_and_multi_multiple_samples(self):
+        """
+        verify_project: paired-end data with cellranger 'count' and 'multi' (multiple samples)
+        """
+        analysis_dir = self._make_analysis_project(
+            protocol="10x_CellPlex",
+            sample_names=("PJB1_GEX", "PJB1_CML", "PJB2_GEX", "PJB2_CML"),
+            seq_data_samples=("PJB1_GEX", "PJB2_GEX"),
+            include_cellranger_multi=True,
+            include_cellranger_count=True,
+            cellranger_pipelines=('cellranger',),
+            # NB only GEX samples
+            cellranger_samples=("PJB1_GEX", "PJB2_GEX"),
+            cellranger_multi_samples={ "PJB1": ("PB1", "PB2"),
+                                       "PJB2": ("PB3", "PB4") })
         project = AnalysisProject(analysis_dir)
         self.assertTrue(verify_project(project))
 

--- a/auto_process_ngs/test/tenx/test_cellplex.py
+++ b/auto_process_ngs/test/tenx/test_cellplex.py
@@ -34,7 +34,7 @@ reference,/data/refdata-cellranger-gex-GRCh38-2020-A
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
 PJB1_GEX,/data/runs/fastqs_gex,any,PJB1,Gene Expression,
-PJB2_MC,/data/runs/fastqs_mc,any,PJB2,Multiplexing Capture,
+PJB1_MC,/data/runs/fastqs_mc,any,PJB1,Multiplexing Capture,
 
 [samples]
 sample_id,cmo_ids,description
@@ -66,8 +66,59 @@ PBB,CMO302,PBB
                          })
         self.assertEqual(config_csv.fastq_dirs,
                          { 'PJB1_GEX': '/data/runs/fastqs_gex',
-                           'PJB2_MC': '/data/runs/fastqs_mc'
+                           'PJB1_MC': '/data/runs/fastqs_mc'
                          })
+        self.assertEqual(config_csv.physical_sample, None)
+        self.assertEqual(config_csv.pretty_print_samples(),
+                         "PBA, PBB")
+        self.assertTrue(config_csv.is_valid)
+
+    def test_cellranger_multi_config_csv_with_physical_sample(self):
+        """
+        CellrangerMultiConfigCsv: check physical sample is extracted from file name
+        """
+        with open(os.path.join(self.wd,"10x_multi_config.PJB1.csv"),'wt') as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2020-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,/data/runs/fastqs_gex,any,PJB1,Gene Expression,
+PJB1_MC,/data/runs/fastqs_mc,any,PJB1,Multiplexing Capture,
+
+[samples]
+sample_id,cmo_ids,description
+PBA,CMO301,PBA
+PBB,CMO302,PBB
+""")
+        config_csv = CellrangerMultiConfigCsv(
+            os.path.join(self.wd,
+                         "10x_multi_config.PJB1.csv"))
+        self.assertEqual(config_csv.sample_names,['PBA','PBB'])
+        self.assertEqual(config_csv.sections,['gene-expression',
+                                              'libraries',
+                                              'samples'])
+        self.assertEqual(config_csv.reference_data_path,
+                         "/data/refdata-cellranger-gex-GRCh38-2020-A")
+        self.assertEqual(config_csv.probe_set_path,None)
+        self.assertEqual(config_csv.feature_reference_path,None)
+        self.assertEqual(config_csv.vdj_reference_path,None)
+        self.assertEqual(config_csv.feature_types,
+                         ['gene expression','multiplexing capture'])
+        self.assertEqual(config_csv.gex_libraries,
+                         ['PJB1_GEX',])
+        self.assertEqual(config_csv.gex_library('PJB1_GEX'),
+                         { 'fastqs': '/data/runs/fastqs_gex',
+                           'lanes': 'any',
+                           'library_id': 'PJB1',
+                           'feature_type': 'Gene Expression',
+                           'subsample_rate': ''
+                         })
+        self.assertEqual(config_csv.fastq_dirs,
+                         { 'PJB1_GEX': '/data/runs/fastqs_gex',
+                           'PJB1_MC': '/data/runs/fastqs_mc'
+                         })
+        self.assertEqual(config_csv.physical_sample, "PJB1")
         self.assertEqual(config_csv.pretty_print_samples(),
                          "PBA, PBB")
         self.assertTrue(config_csv.is_valid)
@@ -119,6 +170,7 @@ PB2,BC002,PB2
                          {
                              'PJB1_Flex': '/data/runs/fastqs',
                          })
+        self.assertEqual(config_csv.physical_sample, None)
         self.assertEqual(config_csv.pretty_print_samples(),
                          "PB1-2")
         self.assertTrue(config_csv.is_valid)
@@ -137,7 +189,7 @@ reference,/data/feature_ref.csv
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
 PJB1_GEX,/data/runs/fastqs_gex,any,PJB1,Gene Expression,
-PJB2_MC,/data/runs/fastqs_mc,any,PJB2,Multiplexing Capture,
+PJB1_MC,/data/runs/fastqs_mc,any,PJB1,Multiplexing Capture,
 
 [samples]
 sample_id,cmo_ids,description
@@ -171,8 +223,9 @@ PBB,CMO302,PBB
                          })
         self.assertEqual(config_csv.fastq_dirs,
                          { 'PJB1_GEX': '/data/runs/fastqs_gex',
-                           'PJB2_MC': '/data/runs/fastqs_mc'
+                           'PJB1_MC': '/data/runs/fastqs_mc'
                          })
+        self.assertEqual(config_csv.physical_sample, None)
         self.assertEqual(config_csv.pretty_print_samples(),
                          "PBA, PBB")
         self.assertTrue(config_csv.is_valid)
@@ -191,7 +244,7 @@ reference,/data/vdj_ref.csv
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
 PJB1_GEX,/data/runs/fastqs_gex,any,PJB1,Gene Expression,
-PJB2_TCR,/data/runs/fastqs_vdj_t,any,PJB2,VDJ-T,
+PJB1_TCR,/data/runs/fastqs_vdj_t,any,PJB1,VDJ-T,
 """)
         config_csv = CellrangerMultiConfigCsv(
             os.path.join(self.wd,
@@ -218,18 +271,19 @@ PJB2_TCR,/data/runs/fastqs_vdj_t,any,PJB2,VDJ-T,
                            'subsample_rate': ''
                          })
         self.assertEqual(config_csv.libraries('VDJ-T'),
-                         ['PJB2_TCR',])
-        self.assertEqual(config_csv.library('VDJ-T','PJB2_TCR'),
+                         ['PJB1_TCR',])
+        self.assertEqual(config_csv.library('VDJ-T','PJB1_TCR'),
                          { 'fastqs': '/data/runs/fastqs_vdj_t',
                            'lanes': 'any',
-                           'library_id': 'PJB2',
+                           'library_id': 'PJB1',
                            'feature_type': 'VDJ-T',
                            'subsample_rate': ''
                          })
         self.assertEqual(config_csv.fastq_dirs,
                          { 'PJB1_GEX': '/data/runs/fastqs_gex',
-                           'PJB2_TCR': '/data/runs/fastqs_vdj_t'
+                           'PJB1_TCR': '/data/runs/fastqs_vdj_t'
                          })
+        self.assertEqual(config_csv.physical_sample, None)
         self.assertEqual(config_csv.pretty_print_samples(),"")
         self.assertTrue(config_csv.is_valid)
 
@@ -244,7 +298,7 @@ reference,/data/refdata-cellranger-gex-GRCh38-2020-A
 [libraries]
 fastq_id,fastqs,feature_types
 PJB1_GEX,/data/runs/fastqs_gex,gene expression
-PJB2_MC,/data/runs/fastqs_mc,Multiplexing Capture
+PJB1_MC,/data/runs/fastqs_mc,Multiplexing Capture
 
 [samples]
 sample_id,cmo_ids
@@ -276,8 +330,9 @@ PBB,CMO302
                          })
         self.assertEqual(config_csv.fastq_dirs,
                          { 'PJB1_GEX': '/data/runs/fastqs_gex',
-                           'PJB2_MC': '/data/runs/fastqs_mc'
+                           'PJB1_MC': '/data/runs/fastqs_mc'
                          })
+        self.assertEqual(config_csv.physical_sample, None)
         self.assertEqual(config_csv.pretty_print_samples(),
                          "PBA, PBB")
         self.assertTrue(config_csv.is_valid)
@@ -296,7 +351,7 @@ reference,/data/vdj_ref.csv
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
 PJB1_GEX,/data/runs/fastqs_gex,any,PJB1,Gene Expression,
-PJB2_CML,/data/runs/fastqs_cml,any,PJB2,Multiplexing Capture,
+PJB1_CML,/data/runs/fastqs_cml,any,PJB1,Multiplexing Capture,
 
 [samples]
 PB1,CMO1,PB1
@@ -311,6 +366,7 @@ PB1,CMO3,PB1
         config_csv = CellrangerMultiConfigCsv(
             os.path.join(self.wd,
                          "10x_multi_config.csv"), strict=False)
+        self.assertEqual(config_csv.physical_sample, None)
         self.assertFalse(config_csv.is_valid)
         self.assertEqual(len(config_csv.get_errors()), 1)
 
@@ -328,7 +384,7 @@ reference,/data/vdj_ref.csv
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
 PJB1_GEX,/data/runs/fastqs_gex,any,PJB1,Gene Expression,
-PJB2_CML,/data/runs/fastqs_cml,any,PJB2,Multiplexing Capture,
+PJB1_CML,/data/runs/fastqs_cml,any,PJB1,Multiplexing Capture,
 
 [samples]
 PB1,CMO1|CMO2,PB1
@@ -342,6 +398,7 @@ PB2,CMO2|CMO3,PB2
         config_csv = CellrangerMultiConfigCsv(
             os.path.join(self.wd,
                          "10x_multi_config.csv"), strict=False)
+        self.assertEqual(config_csv.physical_sample, None)
         self.assertFalse(config_csv.is_valid)
         self.assertEqual(len(config_csv.get_errors()), 1)
 
@@ -359,7 +416,7 @@ reference,/data/vdj_ref.csv
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
 PJB1_GEX,/data/runs/fastqs_gex,any,PJB1,Gene Expression,
-PJB2_CML,/data/runs/fastqs_cml,any,PJB2,Multiplexing Capture,
+PJB1_CML,/data/runs/fastqs_cml,any,PJB1,Multiplexing Capture,
 
 [samples]
 PB1,CMO1|CMO2...,PB1
@@ -372,6 +429,7 @@ PB1,CMO1|CMO2...,PB1
         config_csv = CellrangerMultiConfigCsv(
             os.path.join(self.wd,
                          "10x_multi_config.csv"), strict=False)
+        self.assertEqual(config_csv.physical_sample, None)
         self.assertFalse(config_csv.is_valid)
         self.assertEqual(len(config_csv.get_errors()), 1)
 
@@ -399,6 +457,7 @@ PJB2_UNKNOWN,/data/runs/fastqs_unknown,any,PJB2,Unknown,
         config_csv = CellrangerMultiConfigCsv(
             os.path.join(self.wd,
                          "10x_multi_config.csv"), strict=False)
+        self.assertEqual(config_csv.physical_sample, None)
         self.assertFalse(config_csv.is_valid)
         self.assertEqual(len(config_csv.get_errors()), 1)
 
@@ -415,8 +474,8 @@ reference,/data/vdj_ref.csv
 
 [libraries]
 fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
-PJB1_GEX,/data/runs/fastqs,any,PJB2,Gene Expression,
-PJB1_CML,/data/runs/fastqs,any,PJB2,Multiplexing capture,
+PJB1_GEX,/data/runs/fastqs,any,PJB1,Gene Expression,
+PJB1_CML,/data/runs/fastqs,any,PJB1,Multiplexing capture,
 PJB2_GEX,/data/runs/fastqs,any,PJB2,Gene Expression,
 PJB2_CML,/data/runs/fastqs,any,PJB2,Multiplexing capture,
 """)
@@ -428,5 +487,6 @@ PJB2_CML,/data/runs/fastqs,any,PJB2,Multiplexing capture,
         config_csv = CellrangerMultiConfigCsv(
             os.path.join(self.wd,
                          "10x_multi_config.csv"), strict=False)
+        self.assertEqual(config_csv.physical_sample, None)
         self.assertFalse(config_csv.is_valid)
         self.assertEqual(len(config_csv.get_errors()), 2)

--- a/docs/source/control_files/10x_multi_config_csv.rst
+++ b/docs/source/control_files/10x_multi_config_csv.rst
@@ -1,8 +1,8 @@
-10x Genomics CellPlex and Flex datasets: ``10x_multi_config[.SAMPLE].csv``
-==========================================================================
+10x Genomics CellRanger ``multi`` pipeline: ``10x_multi_config[.SAMPLE].csv``
+=============================================================================
 
 For certain types of 10x Genomics data, the QC pipeline will
-automatically run the `cellranger`_ ``multi`` command to perform
+automatically run the `cellranger`_ ``multi`` pipeline to perform
 appropriate analyses (for example, multiplexing analyses for
 CellPlex data), provided that:
 
@@ -23,11 +23,11 @@ physical sample in the dataset).
    Currently the physical sample name in the configuration
    file name is arbitrary and doesn't have to match the sample
    names for the Fastq files.
-    
+
 A template version of the file (called
 ``10x_multi_config.csv.template``) is automatically
 generated and partially populated by the
-:doc:`setup_analysis_dirs <setup_analysis_dirs>` command for the
+:doc:`setup_analysis_dirs <../using/setup_analysis_dirs>` command for the
 appropriate single cell data type (see
 :doc:`../single_cell/10x_single_cell`). The template file is
 ignored by the QC pipeline, so it must be manually copied,
@@ -45,14 +45,15 @@ Specifically, at a minimum:
     ``Multiplexing capture`` etc;
  3. The ``samples`` section should be removed or edited as
     appropriate for the type of data being analysed (for example,
-    assigning CMOs tp multiplexed sample names for CellPlex
+    assigning CMOs to multiplexed sample names for CellPlex
     dataset).
 
 Any additional options (for example, forcing numbers of cells)
 can be included if required - details of the format of the
 ``multi`` configuration file for different applications can be
-found via
-`Cell Ranger Multi Config CSV <https://www.10xgenomics.com/support/software/cell-ranger/latest/advanced/cr-multi-config-csv-opts>`_
+found via the CellRanger documentation:
+
+* `Cell Ranger Multi Config CSV <https://www.10xgenomics.com/support/software/cell-ranger/latest/advanced/cr-multi-config-csv-opts>`_.
 
 The QC pipeline will attempt to run ``cellranger multi`` for
 each of the appropriately named configuration files in the project
@@ -62,7 +63,7 @@ types:
  * `CellPlex <https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/multi#cellranger-multicellranger_multi_cellplex>`_
  * `Flex <https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/multi-frp>`_
 
-The following library types are not yet supported:
+The following library types are explicitly (not yet) supported:
 
  * `Single cell immune profiling <https://www.10xgenomics.com/support/software/cell-ranger/latest/analysis/running-pipelines/cr-5p-multi>`_
 

--- a/docs/source/control_files/10x_multi_config_csv.rst
+++ b/docs/source/control_files/10x_multi_config_csv.rst
@@ -1,28 +1,69 @@
-10xGenomics CellPlex and Flex datasets: ``10x_multi_config.csv``
-================================================================
+10x Genomics CellPlex and Flex datasets: ``10x_multi_config[.SAMPLE].csv``
+==========================================================================
 
-For 10xGenomics CellPlex (cell multiplexing) and Flex (fixed RNA
-profiling) data, multiplexing analyses are run using the
-`cellranger`_ ``multi`` command, provided that a
-``10x_multi_config.csv`` file is also present in the project
-directory.
+For certain types of 10x Genomics data, the QC pipeline will
+automatically run the `cellranger`_ ``multi`` command to perform
+appropriate analyses (for example, multiplexing analyses for
+CellPlex data), provided that:
+
+ 1. The ``cellranger_multi`` QC module is specified as part of
+    the protocol, and
+ 2. one or more configuration files for running CellRanger ``multi``
+    are present in the analysis project directory.
+
+The configuration files should be named either
+``10x_multi_config.csv`` (appropriate if there is a single
+physical sample in the dataset) or ``10x_multi_config.<SAMPLE>.csv``
+(the more general form when there is one or more physical
+sample, in which case ``<SAMPLE>`` should be a label for each
+physical sample in the dataset).
 
 .. note::
 
-   Template versions of this file will be automatically and
-   partially populated by the
-   :doc:`setup_analysis_dirs <setup_analysis_dirs>` command
-   for the appropriate single cell data type (see
-   :doc:`../single_cell/10x_single_cell`).
+   Currently the physical sample name in the configuration
+   file name is arbitrary and doesn't have to match the sample
+   names for the Fastq files.
+    
+A template version of the file (called
+``10x_multi_config.csv.template``) is automatically
+generated and partially populated by the
+:doc:`setup_analysis_dirs <setup_analysis_dirs>` command for the
+appropriate single cell data type (see
+:doc:`../single_cell/10x_single_cell`). The template file is
+ignored by the QC pipeline, so it must be manually copied,
+renamed and edited for each physical sample that the ``multi``
+command should be run on.
 
-Depending on the library type, this file should have the format
-and content outlined in the following 10x Genomics documentation:
+Specifically, at a minimum:
 
- * **CellPlex**: `cellranger_multi_cellplex`_
- * **Flex**: `cellranger_multi_frp`_
- * **Single cell immune profiling**: `cellranger_multi
+ 1. The physical sample name should be added into the file name
+    (if there are multiple physical samples);
+ 2. The ``[libraries]`` section should be edited to remove any
+    Fastqs associated with other physical samples, and the
+    ``feature_types`` field for each Fastq ID should be updated
+    to assign the correct feature type (e.g. ``Gene expression``,
+    ``Multiplexing capture`` etc;
+ 3. The ``samples`` section should be removed or edited as
+    appropriate for the type of data being analysed (for example,
+    assigning CMOs tp multiplexed sample names for CellPlex
+    dataset).
+
+Any additional options (for example, forcing numbers of cells)
+can be included if required - details of the format of the
+``multi`` configuration file for different applications can be
+found via
+`Cell Ranger Multi Config CSV <https://www.10xgenomics.com/support/software/cell-ranger/latest/advanced/cr-multi-config-csv-opts>`_
+
+The QC pipeline will attempt to run ``cellranger multi`` for
+each of the appropriately named configuration files in the project
+directory. Currently this is supported for the following library
+types:
+
+ * `CellPlex <https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/multi#cellranger-multicellranger_multi_cellplex>`_
+ * `Flex <https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/multi-frp>`_
+
+The following library types are not yet supported:
+
+ * `Single cell immune profiling <https://www.10xgenomics.com/support/software/cell-ranger/latest/analysis/running-pipelines/cr-5p-multi>`_
 
 .. _cellranger: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/what-is-cell-ranger
-.. _cellranger_multi_cellplex: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/multi#cellranger-multi
-.. _cellranger_multi_frp: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/multi-frp
-.. _cellranger_multi_immune_profing: https://www.10xgenomics.com/support/software/cell-ranger/latest/analysis/running-pipelines/cr-5p-multi

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -86,7 +86,7 @@ at the `University of Manchester <https://www.manchester.ac.uk/>`_.
 
    projects.info <control_files/projects_info>
    10x_multiome_libraries.info <control_files/10x_multiome_libraries_info>
-   10x_multi_config.csv <control_files/10x_multi_config_csv>
+   10x_multi_config[.SAMPLE].csv <control_files/10x_multi_config_csv>
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/single_cell/10x_single_cell.rst
+++ b/docs/source/single_cell/10x_single_cell.rst
@@ -154,15 +154,13 @@ also create template control files for use in subsequent QC runs:
 
  * **CellPlex and Flex**: a template
    :doc:`10x_multi_config.csv <../control_files/10x_multi_config_csv>`
-   file, which should be renamed and populated with information on
-   the feature types, multiplexed samples etc.
+   file, which should be copied, renamed and appropriatedly edited
+   for each physical sample in the dataset.
 
  * **Single Cell immune profiling**: a template
-   :doc:`10x_multi_config.csv <../control_files/10x_multi_config_csv>`,
-   which should be copied for each sample in the project with the
-   name `10x_multi_config.<SAMPLE>.csv`. Each one should then be
-   populated with information on the Fastqs, feature types etc for
-   that sample.
+   :doc:`10x_multi_config.csv <../control_files/10x_multi_config_csv>`
+   file, which should be copied, renamed and appropriatedly edited
+   for each physical sample in the dataset.
 
 The :doc:`run_qc <../using/run_qc>` command
 will then determine the appropriate QC protocol to use based on the

--- a/docs/source/using/run_qc.rst
+++ b/docs/source/using/run_qc.rst
@@ -75,7 +75,7 @@ QC module                      Details
 ``cellranger_multi``           Cell multiplexing and fixed RNA profiling
                                analyses using `cellranger`_ ``multi``
                                (requires
-                               :doc:`10x_multi_config.csv <../control_files/10x_multi_config_csv>`)
+                               :doc:`10x_multi_config[.SAMPLE].csv <../control_files/10x_multi_config_csv>`)
 ============================== ======================
 
 Appropriate reference data must be available (for example,


### PR DESCRIPTION
Updates the `cellranger_multi` QC module (in `qc/modules/cellranger_multi.py`) and supporting code to enable `cellranger multi` to be run for multiple configuration files in the same project. This will remove the limitation that only one config file is recognised, meaning that if a dataset contained more than one physical sample then the module couldn't operate on them.

With this update, 10x multi configuration files which are named using the convention `10x_multi_config[.SAMPLE].csv` will be recognised by the module, and `cellranger multi` will be run for each of them. In the convention `SAMPLE` is used to distinguish different physical samples (the name itself is arbitrary in the current implementation).

The PR builds upon the changes already in PR #1028. The updates include:

* `tenx/cellplex`: `CellrangerMultiConfigCsv` class is now able to extract the physical sample name from the config file name
* `qc/utils`: the `set_cell_count_for_project` function is able to sum the cell counts across multiple `cellranger multi` output directories
* `qc/modules/cellranger_multi`:
  - `CellrangerMulti.verify` method now able to verify outputs from multiple physical samples (i.e. multiple config files)
  - `RunCellrangerMulti` task now runs `cellranger multi` for each physical sample (i.e. config file) present in the project directory