### PR TITLE
Drop 'singlecell' QC protocol as the default for unknown single cell platforms

### DIFF
--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     protocols: define and handle QC protocols
-#     Copyright (C) University of Manchester 2022-2024 Peter Briggs
+#     Copyright (C) University of Manchester 2022-2025 Peter Briggs
 #
 
 """
@@ -734,11 +734,12 @@ def determine_qc_protocol_from_metadata(library_type,
         protocol = "standardSE"
     # Single cell protocols
     if single_cell_platform is not None:
-        # Default/fallback
-        protocol = "singlecell"
+        # 10x Genomics
         if single_cell_platform.startswith('10xGenomics Chromium 3\'') or \
            single_cell_platform.startswith('10xGenomics Chromium GEM-X 3\'') or \
            single_cell_platform.startswith('10xGenomics Chromium Next GEM 3\''):
+            # Default for 10x
+            protocol = "singlecell"
             # 10xGenomics scRNA-seq
             if library_type == "scRNA-seq":
                 protocol = "10x_scRNAseq"

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -1354,6 +1354,24 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
         self.assertEqual(determine_qc_protocol(project),
                          "ParseEvercode")
 
+    def test_determine_qc_protocol_unknown_single_cell_platform(self):
+        """determine_qc_protocol: unknown single cell platform
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={'Single cell platform':
+                                          "NewSCPlatform",
+                                          'Library type':
+                                          "scRNA-seq"})
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        self.assertEqual(determine_qc_protocol(project),
+                         "standardPE")
+
 class TestFetchProtocolDefinition(unittest.TestCase):
 
     def test_fetch_protocol_definition_from_specification(self):


### PR DESCRIPTION
Updates the automatic QC protocol determination (`determine_qc_protocol` function in `qc/protocols`) so that by default it now returns `standardPE` (for paired-end data) or `standardSE` (for single-ended data) for unknown single cell platforms, rather than the `singlecell` protocol.