### PR TITLE
Add Bio-Rad ddSEQ Single-Cell ATAC as a single cell platform

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -118,7 +118,8 @@ PROTOCOLS = ('standard',
              '10x_multiome',
              '10x_multiome_atac',
              '10x_multiome_gex',
-             'parse_evercode',)
+             'parse_evercode',
+             'biorad_ddseq',)
 
 # 10xGenomics protocols
 PROTOCOLS_10X = ('10x_chromium_sc',
@@ -637,6 +638,11 @@ class MakeFastqs(Pipeline):
                                     trim_adapters=False)
             elif protocol == 'parse_evercode':
                 # Parse Evercode
+                # Disable adapter trimming
+                self._update_subset(s,
+                                    trim_adapters=False)
+            elif protocol == 'biorad_ddseq':
+                # Bio-Rad ddSEQ
                 # Disable adapter trimming
                 self._update_subset(s,
                                     trim_adapters=False)
@@ -1216,7 +1222,8 @@ class MakeFastqs(Pipeline):
             # Standard protocols
             if protocol in ("standard",
                             "mirna",
-                            "parse_evercode"):
+                            "parse_evercode",
+                            "biorad_ddseq"):
 
                 if converter == "bcl2fastq":
                     # Get bcl2fastq information

--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     setup_analysis_dirs_cmd.py: implement 'setup_analysis_dirs' command
-#     Copyright (C) University of Manchester 2018-2024 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2025 Peter Briggs
 #
 #########################################################################
 
@@ -111,7 +111,8 @@ def setup_analysis_dirs(ap,
         if sc_platform and sc_platform != '.':
             if not sc_platform in tenx.PLATFORMS and \
                not sc_platform in icell8.PLATFORMS and \
-               not sc_platform in ('Parse Evercode',):
+               not sc_platform in ('Parse Evercode',) and \
+               not sc_platform in ('Bio-Rad ddSEQ Single Cell ATAC',):
                 logger.error("Unknown single cell platform for '%s': "
                              "'%s'" % (line['Project'],sc_platform))
                 raise Exception("Unknown single cell platform")

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -348,6 +348,22 @@ QC_PROTOCOLS = {
         ]
     },
 
+    "BioRad_ddSEQ_ATAC": {
+        "description": "Bio-Rad ddSEQ Single Cell ATAC data",
+        "reads": {
+            "seq_data": ('r1:79-118', 'r2',),
+            "index": ()
+        },
+        "qc_modules": [
+            'fastqc',
+            'fastq_screen',
+            'sequence_lengths',
+            'rseqc_genebody_coverage',
+            'rseqc_infer_experiment',
+            'qualimap_rnaseq'
+        ]
+    },
+
     "singlecell": {
         "description": "ICELL8 single cell RNA-seq",
         "reads": {
@@ -782,6 +798,12 @@ def determine_qc_protocol_from_metadata(library_type,
                                 "WT scRNA-seq"):
                 # Parse Evercode snRNAseq
                 protocol = "ParseEvercode"
+        # Bio-Rad ATAC
+        elif single_cell_platform == "Bio-Rad ddSEQ Single Cell ATAC":
+            if library_type in ("scATAC-seq",
+                                "snATAC-seq",):
+                # 10xGenomics scATAC-seq
+                protocol = "BioRad_ddSEQ_ATAC"
         # ICELL8
         elif single_cell_platform == "ICELL8":
             # ICELL8 data

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_biorad_ddseq.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_biorad_ddseq.py
@@ -1,0 +1,98 @@
+##############################################################
+# Unit tests for bcl2fastq/pipeline.py (biorad_ddseq protocol)
+##############################################################
+
+# All imports declared in __init__.py file
+from . import *
+
+class TestMakeFastqs(BaseMakeFastqsTestCase):
+    """
+    Tests for MakeFastqs pipeline (parse_evercode protocol)
+    """
+    #@unittest.skip("Skipped")
+    def test_makefastqs_biorad_ddseq_protocol(self):
+        """
+        MakeFastqs: 'biorad_ddseq' protocol
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_NB500968_00002_AHGXXXX",
+            "nextseq",
+            bases_mask="y76,I8,I8,y86",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write("""[Settings]
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT
+
+[Data]
+Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description
+Sample1,Sample1,,,D701,CGTGTAGG,D501,GACCTGTA,,
+Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin,
+                                              "bcl2fastq"),
+                                 version='2.20.0.422',
+                                 assert_bases_mask="y76,I8,I8,y86",
+                                 assert_adapter='',
+                                 assert_adapter2='')
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,protocol="biorad_ddseq")
+        status = p.run(analysis_dir,
+                       poll_interval=POLL_INTERVAL)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"nextseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_NB500968_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_NB500968_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)

--- a/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/test/commands/test_setup_analysis_dirs_cmd.py
@@ -1214,6 +1214,64 @@ AB\tAB1\tAlan Brown\tSingle Cell Immune Profiling\t10xGenomics Chromium 5'\tMous
                 self.assertFalse(os.path.exists(template_multi_config_file),
                                  "Found %s" % template_multi_config_file)
 
+    def test_setup_analysis_dirs_biorad_ddseq_single_cell_atac(self):
+        """
+        setup_analysis_dirs: create new analysis dir for Bio-Rad ddSEQ Single Cell ATAC
+        """
+        # Make a mock auto-process directory
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '250321_A01899_0263_AHVHGMDRX',
+            'novaseq6000',
+            metadata={ "instrument_datestamp": "250321",
+                "processing_software": {
+                    "bcl2fastq" : (
+                        "/usr/local/bcl2fastq/2.20/bcl2fastq",
+                        "bcl2fastq",
+                        "2.20"
+                    )
+                }
+            },
+            reads=('R1','R2'),
+            top_dir=self.dirn)
+        mockdir.create(no_project_dirs=True)
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq")))
+        print(os.listdir(os.path.join(mockdir.dirn,"bcl2fastq","AB")))
+        # Add required metadata to 'projects.info'
+        projects_info = os.path.join(mockdir.dirn,"projects.info")
+        with open(projects_info,"w") as fp:
+            fp.write(
+"""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+AB\tAB1\tAlan Brown\tscATAC-seq\tBio-Rad ddSEQ Single Cell ATAC\tMouse\tAudrey Benson\t1% PhiX
+""")
+        # Expected data
+        projects = {
+            "AB": ["AB1_S1_R1_001.fastq.gz",
+                   "AB1_S1_R2_001.fastq.gz",],
+            "undetermined": ["Undetermined_S0_R1_001.fastq.gz",]
+        }
+        # Check project dirs don't exist
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertFalse(os.path.exists(project_dir_path))
+        # Setup the project dirs
+        ap = AutoProcess(analysis_dir=mockdir.dirn)
+        setup_analysis_dirs(ap)
+        # Check project dirs and contents
+        for project in projects:
+            project_dir_path = os.path.join(mockdir.dirn,project)
+            self.assertTrue(os.path.exists(project_dir_path))
+            # Check README.info file
+            readme_file = os.path.join(project_dir_path,
+                                       "README.info")
+            self.assertTrue(os.path.exists(readme_file))
+            # Check Fastqs
+            fastqs_dir = os.path.join(project_dir_path,
+                                      "fastqs")
+            self.assertTrue(os.path.exists(fastqs_dir))
+            for fq in projects[project]:
+                fastq = os.path.join(fastqs_dir,fq)
+                self.assertTrue(os.path.exists(fastq))
+
     def test_setup_analysis_dirs_missing_metadata(self):
         """
         setup_analysis_dirs: raise exception if metadata not set

--- a/auto_process_ngs/test/qc/protocols/test_biorad_ddseq.py
+++ b/auto_process_ngs/test/qc/protocols/test_biorad_ddseq.py
@@ -1,0 +1,166 @@
+#######################################################################
+# Unit tests for qc/pipeline.py (Bio-Rad ddSEQ data)
+#######################################################################
+
+# All imports declared in __init__.py file
+from . import *
+
+class TestQCPipeline(BaseQCPipelineTestCase):
+    """
+    Tests for Bio-Rad ddSEQ data
+    """
+    #@unittest.skip("Skipped")
+    def test_qcpipeline_with_biorad_ddseq_scatacseq_data(self):
+        """
+        QCPipeline: single-cell ATAC-seq QC run (Bio-Rad ddSEQ)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockSeqtk.create(os.path.join(self.bin,"seqtk"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           'Bio-Rad ddSEQ Single Cell ATAC',
+                                           'Library type': 'scATAC-seq' })
+        p.create(top_dir=self.wd)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("BioRad_ddSEQ_ATAC"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"BioRad_ddSEQ_ATAC")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("BioRad_ddSEQ_ATAC")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    #@unittest.skip("Skipped")
+    def test_qcpipeline_with_biorad_ddseq_snatacseq_data(self):
+        """
+        QCPipeline: single-nuclei ATAC-seq QC run (Bio-Rad ddSEQ)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockSeqtk.create(os.path.join(self.bin,"seqtk"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           'Bio-Rad ddSEQ Single Cell ATAC',
+                                           'Library type': 'snATAC-seq' })
+        p.create(top_dir=self.wd)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("BioRad_ddSEQ_ATAC"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"BioRad_ddSEQ_ATAC")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("BioRad_ddSEQ_ATAC")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -693,6 +693,23 @@ class TestDetermineQCProtocolFromMetadataFunction(unittest.TestCase):
             paired_end=True),
                          "ParseEvercode")
 
+    def test_determine_qc_protocol_from_metadata_biorad_ddseq_atac(self):
+        """
+        determine_qc_protocol_from_metadata: Bio-Rad ddSEQ Single Cell ATAC data
+        """
+        # scATAC-seq
+        self.assertEqual(determine_qc_protocol_from_metadata(
+            library_type="scATAC-seq",
+            single_cell_platform="Bio-Rad ddSEQ Single Cell ATAC",
+            paired_end=True),
+                         "BioRad_ddSEQ_ATAC")
+        # snATAC-seq
+        self.assertEqual(determine_qc_protocol_from_metadata(
+            library_type="snATAC-seq",
+            single_cell_platform="Bio-Rad ddSEQ Single Cell ATAC",
+            paired_end=True),
+                         "BioRad_ddSEQ_ATAC")
+
 class TestDetermineQCProtocolFunction(unittest.TestCase):
     """
     Tests for determine_qc_protocol function
@@ -1353,6 +1370,48 @@ class TestDetermineQCProtocolFunction(unittest.TestCase):
                                   os.path.join(self.wd,"PJB"))
         self.assertEqual(determine_qc_protocol(project),
                          "ParseEvercode")
+
+    def test_determine_qc_protocol_biorad_ddseq_sc_atac(self):
+        """
+        determine_qc_protocol: single-cell ATAC-seq (Bio-Rad ddSEQ)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz",
+                                       "PJB1_S1_I1_001.fastq.gz",
+                                       "PJB1_S1_I2_001.fastq.gz"),
+                                metadata={'Single cell platform':
+                                          "Bio-Rad ddSEQ Single Cell ATAC",
+                                          'Library type':
+                                          "scATAC-seq"})
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        self.assertEqual(determine_qc_protocol(project),
+                         "BioRad_ddSEQ_ATAC")
+
+    def test_determine_qc_protocol_biorad_ddseq_sn_atac(self):
+        """
+        determine_qc_protocol: single-nuclei ATAC-seq (Bio-Rad ddSEQ)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz",
+                                       "PJB1_S1_I1_001.fastq.gz",
+                                       "PJB1_S1_I2_001.fastq.gz"),
+                                metadata={'Single cell platform':
+                                          "Bio-Rad ddSEQ Single Cell ATAC",
+                                          'Library type':
+                                          "snATAC-seq"})
+        p.create(top_dir=self.wd)
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        self.assertEqual(determine_qc_protocol(project),
+                         "BioRad_ddSEQ_ATAC")
 
     def test_determine_qc_protocol_unknown_single_cell_platform(self):
         """determine_qc_protocol: unknown single cell platform

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -62,6 +62,7 @@ at the `University of Manchester <https://www.manchester.ac.uk/>`_.
 
    10x Genomics single cell data <single_cell/10x_single_cell>
    Parse Evercode data <single_cell/parse>
+   Bio-Rad ddSEQ single cell data <single_cell/bio_rad>
    Takara Bio ICELL8 data <single_cell/icell8>
 
 .. _spatial-docs:

--- a/docs/source/single_cell/bio_rad.rst
+++ b/docs/source/single_cell/bio_rad.rst
@@ -44,3 +44,30 @@ command will automatically transfer these values into the project
 metadata on creation. The :doc:`run_qc <../using/run_qc>` command
 will then determine the appropriate QC protocol to use based on the
 metadata values.
+
+Appendix: position of DNA insert sequences for QC (ddSEQ ATAC)
+--------------------------------------------------------------
+
+The Bio-Rad SureCell ATAC library configuration for R1 reads is assumed
+to look like:
+
+* 7bp barcode
+* 0-4bp "phase block"
+* Fixed sequence ``TATGCATGAC`` (10bp)
+* 7bp barcode
+* Fixed sequence ``AGTCACTGAG`` (10bp)
+* 7bp barcode
+* Fixed sequence ``TCGTCGGCAGCGTCAGATGTGTATAAGAGACAG`` (33bp)
+* DNA insert (remainder of the sequence, 40-44bp)
+
+The DNA insert in any individual read sequence is therefore expected
+to start between positions 75 and 79 (depending on the size of the
+variable length phase block sequence).
+
+For the R2 reads it is assumed to look like:
+
+* DNA insert (40bp)
+* 6bp TI adapter
+
+Based on this, for the ``BioRad_ddSEQ_ATAC`` QC protocol the mapped
+metrics are calculated using R1 positions 79-118 and all of R2.

--- a/docs/source/single_cell/bio_rad.rst
+++ b/docs/source/single_cell/bio_rad.rst
@@ -1,0 +1,53 @@
+Processing Bio-Rad ddSEQ single cell data
+=========================================
+
+Background
+----------
+
+Bio-Rad provides ddSEQ Single-Cell ATAC-seq and ddSEQ Single-Cell 3'
+RNA-seq kits. This document outlines using the ``auto-process-ngs``
+pipeline to perform Fastq generation and QC for ddSEQ Single-Cell
+ATAC-seq data (there is no support currently for ddSEQ single cell
+RNA-seq data).
+
+Requirements
+------------
+
+No additional external software is required for the Fastq generation
+or QC.
+
+Fastq generation
+----------------
+
+The ``standard`` Fastq generation protocol should be used for
+Bio-Rad's ddSEQ Single-Cell ATAC-seq data when running the
+:doc:`make_fastqs <../using/make_fastqs>` command.
+
+.. note::
+
+   It is unclear whether Bio-Rad's Omnition downstream analysis
+   software requires that adapters are not trimmed. Adapter
+   trimming can be explicitly disabled using the
+   ``--no-adapter-trimming`` option of ``make_fastqs``.
+
+
+Analysis project setup and QC
+-----------------------------
+
+Once Fastqs have been successfully generated, the ``SC_platform``
+and ``Library`` metadata items should be set to the appropriate values
+for the Parse Evercode project(s) in the ``projects.info`` control file.
+
+The following values are valid options:
+
+===================================== =================================
+Single cell platform                  Library types
+===================================== =================================
+``Bio-Rad ddSEQ Single Cell ATAC``    ``scATAC-seq``, ``snATAC-seq``
+===================================== =================================
+
+Running the :doc:`setup_analysis_dirs <../using/setup_analysis_dirs>`
+command will automatically transfer these values into the project
+metadata on creation. The :doc:`run_qc <../using/run_qc>` command
+will then determine the appropriate QC protocol to use based on the
+metadata values.

--- a/docs/source/single_cell/bio_rad.rst
+++ b/docs/source/single_cell/bio_rad.rst
@@ -19,16 +19,9 @@ or QC.
 Fastq generation
 ----------------
 
-The ``standard`` Fastq generation protocol should be used for
+The ``biorad_ddseq`` Fastq generation protocol should be used for
 Bio-Rad's ddSEQ Single-Cell ATAC-seq data when running the
 :doc:`make_fastqs <../using/make_fastqs>` command.
-
-.. note::
-
-   It is unclear whether Bio-Rad's Omnition downstream analysis
-   software requires that adapters are not trimmed. Adapter
-   trimming can be explicitly disabled using the
-   ``--no-adapter-trimming`` option of ``make_fastqs``.
 
 
 Analysis project setup and QC

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -83,6 +83,7 @@ Protocol option          Used for
                          GEX data only (run with pooled GEX
                          and ATAC data)
 ``parse_evercode``       Parse Evercode single cell data
+``biorad_ddseq``         Bio-Rad ddSEQ single cell data
 ``icell8``               ICELL8 single-cell RNA-seq data
 ``icell8_atac``          ICELL8 single-cell ATAC-seq data
 ======================== =====================================
@@ -113,6 +114,7 @@ Fastq generation protocols should be used:
 * :doc:`10x Genomics single cell data <../single_cell/10x_single_cell>`
 * :doc:`10x Genomics spatial data <../spatial/10x_visium>`
 * :doc:`Parse Evercode single cell data <../single_cell/parse>`
+* :doc:`Bio-Rad single cell data <../single_cell/bio_rad>`
 * :doc:`ICELL single cell data <../single_cell/icell8>`
 
 .. _make_fastqs-commonly-used-options:


### PR DESCRIPTION
Adds basic support for Bio-Rad ddSEQ Single-Cell ATAC-seq data (https://www.bio-rad.com/en-uk/product/ddseq-single-cell-atac-seq-kit-omnition-analysis-software?ID=PEXSR1MC1ORV) by adding it as a known platform for the `setup_analysis_dirs` command.

`Bio-Rad ddSEQ Single Cell ATAC` should be used as the platform name when setting up the project metadata in `projects.info`, with either `scATAC-seq` or `snATAC-seq` as the library type.

Other updates associated with this new platform include:

* New Fastq generation protocol `biorad_ddseq` (disables adapter trimming);
* New QC protocol `BioRad_ddSEQ_ATAC` specifically for these data (uses positions 79-118 from the R1 read sequences together the complete R2 sequences when generating mapped QC metrics)