### PR TITLE
Add 'cellranger_multi' QC module to protocol for 10x single cell immune profiling

### DIFF
--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -2481,7 +2481,12 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
                 metrics_data = mock10xdata.CELLPLEX_METRICS_SUMMARY_9_0_0
             else:
                 raise Exception("%s: unsupported version" % self._version)
-            for sample in config.sample_names:
+            sample_names = config.sample_names
+            if not config.sample_names:
+                # No multiplexed samples - make a single "sample"
+                # named after --id argument
+                sample_names = [args.id]
+            for sample in sample_names:
                 sample_dir = os.path.join(outs_dir,
                                           "per_sample_outs",
                                           sample)

--- a/auto_process_ngs/mockqc.py
+++ b/auto_process_ngs/mockqc.py
@@ -809,7 +809,17 @@ def make_mock_qc_dir(qc_dir,fastq_names,fastq_dir=None,
             if physical_sample:
                 multi_dir = os.path.join(multi_dir, physical_sample)
             # Make outputs
-            MockQCOutputs.cellranger_multi(multi_samples,
+            if multi_samples:
+                # Mimick multiplexed sample outputs
+                multi_samples_ = multi_samples
+            else:
+                # Mimick single 'pseduo-sample' output
+                # when there are no multiplexed samples
+                if physical_sample:
+                    multi_samples_ = (physical_sample,)
+                else:
+                    multi_samples_ = (project_name,)
+            MockQCOutputs.cellranger_multi(multi_samples_,
                                            qc_dir,
                                            config_csv=multi_config,
                                            prefix=multi_dir,

--- a/auto_process_ngs/qc/modules/cellranger_multi.py
+++ b/auto_process_ngs/qc/modules/cellranger_multi.py
@@ -719,13 +719,16 @@ class RunCellrangerMulti(PipelineTask):
 # Helper functions
 #######################################################################
 
-def expected_outputs(config_csv, prefix=None):
+def expected_outputs(config_csv, multi_id=None, prefix=None):
     """
     Generate expected output file paths from 10x multi config
 
     Arguments:
       config_csv (str): path to the 10x multi config file
         to generate the output file names for
+      multi_id (str): optional, the ID of the multi run
+        (supplied via the --id argument), used if the config
+        file doesn't define multiplexed samples
       prefix (str): optional path to prepend to the
         expected file paths
 
@@ -736,7 +739,12 @@ def expected_outputs(config_csv, prefix=None):
     config = CellrangerMultiConfigCsv(config_csv)
     # Generate list of expected files
     expected_files = ["_cmdline",]
-    for sample in config.sample_names:
+    sample_names = config.sample_names
+    if not sample_names:
+        # No multiplexed samples
+        if multi_id:
+            sample_names = [multi_id]
+    for sample in sample_names:
         for f in ("web_summary.html",
                   "metrics_summary.csv"):
             # Per-sample outputs

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     qc.pipeline.py: pipelines for running QC
-#     Copyright (C) University of Manchester 2019-2024 Peter Briggs
+#     Copyright (C) University of Manchester 2019-2025 Peter Briggs
 #
 
 """
@@ -734,6 +734,14 @@ class QCPipeline(Pipeline):
             ################################
             if qc_module_name == "cellranger_multi":
 
+                # Required Cellranger version
+                try:
+                    cellranger_required_version = \
+                        qc_module_params['cellranger_required_version']
+                except KeyError:
+                    cellranger_required_version = None
+
+                # Running cellranger multi
                 run_cellranger_multi = CellrangerMulti.add_to_pipeline(
                     self,
                     project_name,
@@ -748,6 +756,7 @@ class QCPipeline(Pipeline):
                     cellranger_jobinterval=self.params.cellranger_jobinterval,
                     cellranger_localcores=self.params.cellranger_localcores,
                     cellranger_localmem=self.params.cellranger_localmem,
+                    cellranger_required_version=cellranger_required_version,
                     required_tasks=startup_tasks,
                     cellranger_runner=self.runners['cellranger_multi_runner'],
                     envmodules=self.envmodules['cellranger'],

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -23,6 +23,7 @@ Pipeline task classes:
 - GetReferenceDataset
 - GetBAMFile
 - ConvertGTFToBed
+- VerifyQC
 - ReportQC
 """
 
@@ -74,10 +75,10 @@ from .modules.sequence_lengths import SequenceLengths
 from .modules.strandedness import Strandedness
 from .protocols import determine_qc_protocol
 from .protocols import fetch_protocol_definition
+from .protocols import parse_qc_module_spec
 from .utils import get_bam_basename
 from .utils import get_seq_data_samples
 from .utils import set_cell_count_for_project
-from .verification import parse_qc_module_spec
 from .verification import verify_project
 
 # Module specific logger

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -1051,7 +1051,7 @@ def parse_qc_module_spec(module_spec):
                 # Start of a new key
                 current_key = c
             elif current_value is None:
-                if c is "=":
+                if c == "=":
                     # End of key, start of a new value
                     current_value = ""
                 else:

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -1039,23 +1039,73 @@ def parse_qc_module_spec(module_spec):
     # Extract the module name and associated parameter list
     name = items[0]
     params = {}
+    # Extract the key-value pairs from the parameters
     try:
-        for item in items[1].rstrip(')').split(';'):
-            key,value = item.split('=')
-            if value[0] in ('\'','"'):
-                # Quoted string
-                if value[-1] == value[-1]:
-                    value = value[1:-1]
-            elif value in ('True','true'):
-                # Boolean true
-                value = True
-            elif value in ('False','false'):
-                # Boolean false
-                value = False
-            params[key] = value
+        current_key = None
+        current_value = None
+        param_str = items[1].rstrip(')')
+        value_quote = None
+        # Need to handle string character-by-character
+        for c in param_str:
+            if current_key is None:
+                # Start of a new key
+                current_key = c
+            elif current_value is None:
+                if c is "=":
+                    # End of key, start of a new value
+                    current_value = ""
+                else:
+                    # Still processing the key
+                    current_key += c
+            elif not current_value and not value_quote:
+                # First character in new value
+                if c in ("'", "\""):
+                    # Value is quoted
+                    value_quote = c
+                # Store full value (including quotes)
+                current_value = c
+            else:
+                # Inside a value string
+                if value_quote:
+                    # Inside a quoted string
+                    if c == value_quote:
+                        # End of the quoted string
+                        value_quote = None
+                    # Append to current value (including quotes)
+                    current_value += c
+                elif c == ";":
+                    # End of value, store extracted
+                    # key-value pair
+                    params[current_key] = current_value
+                    # Reset for next pair
+                    current_key = None
+                    current_value = None
+                else:
+                    # Still part of current value
+                    current_value += c
+        # Store any final key-value pair
+        if current_key and current_value:
+            params[current_key] = current_value
+        else:
+            # Encountered an error
+            raise Exception(f"Error parsing parameters: {param_str}")
     except IndexError:
+        # No closing ")"
         pass
-    return (name,params)
+    # Post-process values
+    for key in params:
+        value = params[key]
+        if value[0] in ("'", "\"") and value[0] == value[-1]:
+            # Strip quotes
+            value = value[1:-1]
+        elif value in ("True", "true"):
+            # Boolean true
+            value = True
+        elif value in ("False", "false"):
+            # Boolean false
+            value = False
+        params[key] = value
+    return (name, params)
 
 ######################################################################
 # Custom exceptions

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -264,7 +264,7 @@ QC_PROTOCOLS = {
             'cellranger_count(cellranger_use_multi_config=True;'
                              'set_cell_count=false;'
                              'set_metadata=False)',
-            #'cellranger_multi'
+            'cellranger_multi(cellranger_required_version=">=9")'
         ]
     },
 

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -486,7 +486,8 @@ def set_cell_count_for_project(project_dir,qc_dir=None,
     if single_cell_platform:
         if single_cell_platform.startswith("10xGenomics Chromium 3'") or \
            single_cell_platform.startswith("10xGenomics Chromium GEM-X 3'") or \
-           single_cell_platform.startswith("10xGenomics Chromium Next GEM 3'"):
+           single_cell_platform.startswith("10xGenomics Chromium Next GEM 3'") or \
+           single_cell_platform.startswith("10xGenomics Chromium 5'"):
             pipeline = "cellranger"
         elif single_cell_platform == "10xGenomics Single Cell ATAC":
             pipeline = "cellranger-atac"

--- a/auto_process_ngs/qc/verification.py
+++ b/auto_process_ngs/qc/verification.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     verification: utilities for verification of QC outputs
-#     Copyright (C) University of Manchester 2022-2024 Peter Briggs
+#     Copyright (C) University of Manchester 2022-2025 Peter Briggs
 #
 
 """
@@ -88,6 +88,7 @@ class QCVerifier(QCOutputs):
                annotation_bed=None,annotation_gtf=None,
                cellranger_version=None,cellranger_refdata=None,
                cellranger_use_multi_config=None,
+               cellranger_required_version=None,
                seq_data_samples=None):
         """
         Verify QC outputs for Fastqs against specified protocol
@@ -109,6 +110,9 @@ class QCVerifier(QCOutputs):
             cellranger count verification will attempt to
             use data (GEX samples and reference dataset) from
             the '10x_multi_config.csv' file
+          cellranger_required_version (str): specifies which
+            versions of 10x package pipeline are required
+            (e.g. ">=9", "=7" etc)
           seq_data_samples (list): list of sample names with
             sequence (i.e. biological) data
 
@@ -151,7 +155,8 @@ class QCVerifier(QCOutputs):
             annotation_gtf=annotation_gtf,
             cellranger_version=cellranger_version,
             cellranger_refdata=cellranger_refdata,
-            cellranger_use_multi_config=cellranger_use_multi_config
+            cellranger_use_multi_config=cellranger_use_multi_config,
+            cellranger_required_version=cellranger_required_version
         )
 
         # Perform verification

--- a/auto_process_ngs/test/qc/apps/test_cellranger.py
+++ b/auto_process_ngs/test/qc/apps/test_cellranger.py
@@ -948,6 +948,66 @@ class TestFetchCellrangerMultiOutputDirsFunction(unittest.TestCase):
             fetch_cellranger_multi_output_dirs(qc_dir),
             [os.path.join(qc_dir, d) for d in expected_output_dirs])
 
+    def test_fetch_cellranger_multi_output_dirs_single_multiplexed_sample(self):
+        """
+        fetch_cellranger_multi_output_dirs: single multiplexed sample
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB", ("PJB1_GEX_S1_R1_001.fastq.gz",
+                                        "PJB1_GEX_S1_R2_001.fastq.gz",
+                                        "PJB1_MC_S2_R1_001.fastq.gz",
+                                        "PJB1_MC_S2_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # Add qc directory
+        project = AnalysisProject(os.path.join(self.wd, "PJB"))
+        qc_dir = os.path.join(project.dirn, "qc")
+        os.mkdir(qc_dir)
+        # Add 10x multi output dir
+        MockQCOutputs.cellranger_multi(("PJB",),
+                                       qc_dir,
+                                       config_csv=None,
+                                       prefix='cellranger_multi')
+        # Do the test
+        self.assertEqual(
+            fetch_cellranger_multi_output_dirs(qc_dir),
+            [os.path.join(qc_dir, "cellranger_multi")])
+
+    def test_fetch_cellranger_multi_output_dirs_single_multiplexed_sample_with_physical_sample(self):
+        """
+        fetch_cellranger_multi_output_dirs: single multiplexed sample (with physical sample)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB", ("PJB1_GEX_S1_R1_001.fastq.gz",
+                                        "PJB1_GEX_S1_R2_001.fastq.gz",
+                                        "PJB1_MC_S2_R1_001.fastq.gz",
+                                        "PJB1_MC_S2_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human' })
+        p.create(top_dir=self.wd)
+        # Add qc directory
+        project = AnalysisProject(os.path.join(self.wd, "PJB"))
+        qc_dir = os.path.join(project.dirn, "qc")
+        os.mkdir(qc_dir)
+        # Add 10x multi output dir
+        MockQCOutputs.cellranger_multi(
+            ("PJB",),
+            qc_dir,
+            config_csv=None,
+            prefix=os.path.join(
+                "cellranger_multi",
+                "8.0.0",
+                "refdata-cellranger-gex-GRCh38-2020-A",
+                "PJB"))
+        # Do the test
+        self.assertEqual(
+            fetch_cellranger_multi_output_dirs(qc_dir),
+            [os.path.join(qc_dir,
+                          "cellranger_multi",
+                          "8.0.0",
+                          "refdata-cellranger-gex-GRCh38-2020-A",
+                          "PJB")])
+
+
 class TestExtractPathDataFunction(unittest.TestCase):
 
     def test_extract_path_data_with_version_and_refdata(self):

--- a/auto_process_ngs/test/qc/modules/test_cellranger_multi.py
+++ b/auto_process_ngs/test/qc/modules/test_cellranger_multi.py
@@ -1315,3 +1315,24 @@ PJB1_CML,/path/to/fastqs,any,PJB1,Multiplexing Capture,
         # Generate expected outputs
         self.assertEqual(expected_outputs(cf_file),
                          ["_cmdline"])
+
+    def test_expected_outputs_no_multiplexed_samples_with_multi_id(self):
+        """
+        expected_outputs: 10x multi config file (no multiplexed samples, multi ID specified)
+        """
+        # Make a 10x_multi_config.csv file
+        cf_file = os.path.join(self.wd, "10x_multi_config.PJB.csv")
+        with open(cf_file, "wt") as fp:
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,/path/to/fastqs,any,PJB1,gene expression,
+PJB1_CML,/path/to/fastqs,any,PJB1,Multiplexing Capture,
+""")
+        # Generate expected outputs
+        self.assertEqual(expected_outputs(cf_file, "PJB"),
+                         ["_cmdline",
+                          "outs/per_sample_outs/PJB/web_summary.html",
+                          "outs/per_sample_outs/PJB/metrics_summary.csv"])

--- a/auto_process_ngs/test/qc/modules/test_cellranger_multi.py
+++ b/auto_process_ngs/test/qc/modules/test_cellranger_multi.py
@@ -1228,6 +1228,346 @@ PB4,BC002,PB4
                                                         "PJB",f)),
                             "Missing %s" % f)
 
+    def test_qcpipeline_qc_modules_cellranger_multi_immune_profiling_800(self):
+        """
+        QCPipeline: 'cellranger_multi' QC module (immune profiling, Cellranger v8.0.0)
+        """
+        # Make mock QC executables
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="8.0.0")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x Flex analysis project
+        p = MockAnalysisProject("PJB",("PJB1_GEX_S1_R1_001.fastq.gz",
+                                       "PJB1_GEX_S1_R2_001.fastq.gz",
+                                       "PJB1_CSP_S2_R1_001.fastq.gz",
+                                       "PJB1_CSP_S2_R2_001.fastq.gz",
+                                       "PJB1_BCR_S3_R1_001.fastq.gz",
+                                       "PJB1_BCR_S3_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v3',
+                                           'Library type': 'Single Cell Immune Profiling' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv file
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+probe-set,/data/Probe_Set_v1.0_GRCh38-2020-A.csv
+no-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,{fastq_dir},any,PJB1,Gene Expression,
+PJB1_CSP,{fastq_dir},any,PJB1,Antibody Capture,
+PJB1_BCR,{fastq_dir},any,PJB1,VDJ-B,
+""".format(fastq_dir=fastq_dir))
+        # QC protocol
+        protocol = QCProtocol(
+            name="cellranger_multi",
+            description="Cellranger_multi test",
+            seq_data_reads=['r2',],
+            index_reads=['r1'],
+            qc_modules=(
+                "cellranger_multi(cellranger_required_version='>=9'",)
+        )
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol)
+        status = runqc.run(poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check outputs
+        project_dir = os.path.join(self.wd,"PJB")
+        for f in ("cellranger_multi", "qc/cellranger_multi"):
+            self.assertFalse(os.path.exists(os.path.join(project_dir,f)),
+                             "%s: shouldn't be present" % f)
+        # Check number of cells
+        project_metadata = AnalysisProjectInfo(
+            os.path.join(self.wd,"PJB","README.info"))
+        self.assertEqual(project_metadata.number_of_cells, None)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"cellranger_multi")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_BCR,PJB1_GEX")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_BCR_S3_R1_001.fastq.gz,"
+                         "PJB1_BCR_S3_R2_001.fastq.gz,"
+                         "PJB1_CSP_S2_R1_001.fastq.gz,"
+                         "PJB1_CSP_S2_R2_001.fastq.gz,"
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,None)
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,None)
+        self.assertEqual(qc_info.cellranger_version, None)
+        self.assertEqual(qc_info.cellranger_refdata, None)
+        self.assertEqual(qc_info.cellranger_probeset, None)
+        # Check output and reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    def test_qcpipeline_qc_modules_cellranger_multi_immune_profiling_900(self):
+        """
+        QCPipeline: 'cellranger_multi' QC module (immune profiling, Cellranger v9.0.0)
+        """
+        # Make mock QC executables
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="9.0.0")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x Flex analysis project
+        p = MockAnalysisProject("PJB",("PJB1_GEX_S1_R1_001.fastq.gz",
+                                       "PJB1_GEX_S1_R2_001.fastq.gz",
+                                       "PJB1_CSP_S2_R1_001.fastq.gz",
+                                       "PJB1_CSP_S2_R2_001.fastq.gz",
+                                       "PJB1_BCR_S3_R1_001.fastq.gz",
+                                       "PJB1_BCR_S3_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v3',
+                                           'Library type': 'Single Cell Immune Profiling' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv file
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+probe-set,/data/Probe_Set_v1.0_GRCh38-2020-A.csv
+no-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,{fastq_dir},any,PJB1,Gene Expression,
+PJB1_CSP,{fastq_dir},any,PJB1,Antibody Capture,
+PJB1_BCR,{fastq_dir},any,PJB1,VDJ-B,
+""".format(fastq_dir=fastq_dir))
+        # QC protocol
+        protocol = QCProtocol(name="cellranger_multi",
+                              description="Cellranger_multi test",
+                              seq_data_reads=['r2',],
+                              index_reads=['r1'],
+                              qc_modules=("cellranger_multi",))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol)
+        status = runqc.run(poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check outputs
+        project_dir = os.path.join(self.wd,"PJB")
+        for f in (
+                "qc/cellranger_multi",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/_cmdline",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PJB/web_summary.html",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PJB/metrics_summary.csv",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/_cmdline",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PJB/web_summary.html",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PJB/metrics_summary.csv"):
+            self.assertTrue(os.path.exists(os.path.join(project_dir,f)),
+                            "%s: missing" % f)
+        # Check number of cells
+        project_metadata = AnalysisProjectInfo(
+            os.path.join(self.wd,"PJB","README.info"))
+        self.assertEqual(project_metadata.number_of_cells, 1571)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"cellranger_multi")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_BCR,PJB1_GEX")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_BCR_S3_R1_001.fastq.gz,"
+                         "PJB1_BCR_S3_R2_001.fastq.gz,"
+                         "PJB1_CSP_S2_R1_001.fastq.gz,"
+                         "PJB1_CSP_S2_R2_001.fastq.gz,"
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,None)
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,None)
+        self.assertEqual(qc_info.cellranger_version,"9.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-cellranger-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset,
+                         "/data/Probe_Set_v1.0_GRCh38-2020-A.csv")
+        # Check output and reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    def test_qcpipeline_qc_modules_cellranger_multi_immune_profiling_multiple_physical_samples(self):
+        """
+        QCPipeline: 'cellranger_multi' QC module (immune profiling, multiple physical samples)
+        """
+        # Make mock QC executables
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="9.0.0")
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x Flex analysis project
+        p = MockAnalysisProject("PJB",("PJB1_GEX_S1_R1_001.fastq.gz",
+                                       "PJB1_GEX_S1_R2_001.fastq.gz",
+                                       "PJB1_CSP_S2_R1_001.fastq.gz",
+                                       "PJB1_CSP_S2_R2_001.fastq.gz",
+                                       "PJB1_BCR_S3_R1_001.fastq.gz",
+                                       "PJB1_BCR_S3_R2_001.fastq.gz",
+                                       "PJB2_GEX_S4_R1_001.fastq.gz",
+                                       "PJB2_GEX_S4_R2_001.fastq.gz",
+                                       "PJB2_CSP_S5_R1_001.fastq.gz",
+                                       "PJB2_CSP_S5_R2_001.fastq.gz",
+                                       "PJB2_BCR_S6_R1_001.fastq.gz",
+                                       "PJB2_BCR_S6_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 3\'v3',
+                                           'Library type': 'Single Cell Immune Profiling' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv files for two physical
+        # samples (PJB1 and PJB2)
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB1.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+probe-set,/data/Probe_Set_v1.0_GRCh38-2020-A.csv
+no-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,{fastq_dir},any,PJB1,Gene Expression,
+PJB1_CSP,{fastq_dir},any,PJB1,Antibody Capture,
+PJB1_BCR,{fastq_dir},any,PJB1,VDJ-B,
+""".format(fastq_dir=fastq_dir))
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB2.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+probe-set,/data/Probe_Set_v1.0_GRCh38-2020-A.csv
+no-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB2_GEX,{fastq_dir},any,PJB2,Gene Expression,
+PJB2_CSP,{fastq_dir},any,PJB2,Antibody Capture,
+PJB2_BCR,{fastq_dir},any,PJB2,VDJ-B,
+""".format(fastq_dir=fastq_dir))
+        # QC protocol
+        protocol = QCProtocol(name="cellranger_multi",
+                              description="Cellranger_multi test",
+                              seq_data_reads=['r2',],
+                              index_reads=['r1'],
+                              qc_modules=("cellranger_multi",))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol)
+        status = runqc.run(poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check outputs
+        project_dir = os.path.join(self.wd,"PJB")
+        for f in (
+                "qc/cellranger_multi",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/_cmdline",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PJB1/web_summary.html",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PJB1/metrics_summary.csv",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/_cmdline",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PJB2/web_summary.html",
+                "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PJB2/metrics_summary.csv",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/_cmdline",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PJB1/web_summary.html",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PJB1/metrics_summary.csv",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/_cmdline",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PJB2/web_summary.html",
+                "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PJB2/metrics_summary.csv"):
+            self.assertTrue(os.path.exists(os.path.join(project_dir,f)),
+                            "%s: missing" % f)
+        # Check number of cells
+        project_metadata = AnalysisProjectInfo(
+            os.path.join(self.wd,"PJB","README.info"))
+        self.assertEqual(project_metadata.number_of_cells, 3142)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"cellranger_multi")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,
+                         "PJB1_BCR,PJB1_GEX,PJB2_BCR,PJB2_GEX")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_BCR_S3_R1_001.fastq.gz,"
+                         "PJB1_BCR_S3_R2_001.fastq.gz,"
+                         "PJB1_CSP_S2_R1_001.fastq.gz,"
+                         "PJB1_CSP_S2_R2_001.fastq.gz,"
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz,"
+                         "PJB2_BCR_S6_R1_001.fastq.gz,"
+                         "PJB2_BCR_S6_R2_001.fastq.gz,"
+                         "PJB2_CSP_S5_R1_001.fastq.gz,"
+                         "PJB2_CSP_S5_R2_001.fastq.gz,"
+                         "PJB2_GEX_S4_R1_001.fastq.gz,"
+                         "PJB2_GEX_S4_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,None)
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,None)
+        self.assertEqual(qc_info.cellranger_version,"9.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-cellranger-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset,
+                         "/data/Probe_Set_v1.0_GRCh38-2020-A.csv")
+        # Check output and reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
 class TestExpectedOutputs(unittest.TestCase):
     """
     Tests for the 'expected_outputs' function

--- a/auto_process_ngs/test/qc/protocols/test_10x_sc_immune_profiling.py
+++ b/auto_process_ngs/test/qc/protocols/test_10x_sc_immune_profiling.py
@@ -12,7 +12,7 @@ class TestQCPipeline(BaseQCPipelineTestCase):
     #@unittest.skip("Skipped")
     def test_qcpipeline_10x_immune_profiling_data(self):
         """
-        QCPipeline: 10xGenomics SC immune profiling run (10x_ImmuneProfiling)
+        QCPipeline: 10xGenomics SC immune profiling run (10x_ImmuneProfiling, CellRanger 8.0.0)
         """
         # Make mock QC executables
         MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
@@ -121,11 +121,17 @@ PJB1_TCR,%s,any,PJB1,VDJ-T,
             self.assertFalse(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
                             "Found %s (shouldn't exist)" % f)
+        # Verify no cellranger multi outputs
+        for f in ("qc/cellranger_multi",
+                  "cellranger_multi"):
+            self.assertFalse(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                             "Found %s (shouldn't exist)" % f)
 
     #@unittest.skip("Skipped")
-    def test_qcpipeline_10x_immune_profiling_data_multiple_samples(self):
+    def test_qcpipeline_10x_immune_profiling_data_900(self):
         """
-        QCPipeline: 10xGenomics SC immune profiling run (10x_ImmuneProfiling, multiple samples)
+        QCPipeline: 10xGenomics SC immune profiling run (10x_ImmuneProfiling, CellRanger 9.0.0)
         """
         # Make mock QC executables
         MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
@@ -138,7 +144,126 @@ PJB1_TCR,%s,any,PJB1,VDJ-T,
         MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
         MockQualimap.create(os.path.join(self.bin,"qualimap"))
         MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
-                                 version="7.1.0")
+                                 version="9.0.0")
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x single cell immune profiling project
+        p = MockAnalysisProject("PJB",("PJB1_GEX_S1_R1_001.fastq.gz",
+                                       "PJB1_GEX_S1_R2_001.fastq.gz",
+                                       "PJB1_TCR_S2_R1_001.fastq.gz",
+                                       "PJB1_TCR_S2_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 5\'',
+                                           'Library type':
+                                           'Single Cell Immune Profiling' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv file
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+
+[vdj]
+reference,/data/refdata-cellranger-vdj-GRCh38-alts-ensembl-7.1.0
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,%s,any,PJB1,gene expression,
+PJB1_TCR,%s,any,PJB1,VDJ-T,
+""" % (fastq_dir,fastq_dir))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_ImmuneProfiling"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"10x_ImmuneProfiling")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_ImmuneProfiling")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_GEX,PJB1_TCR")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz,"
+                         "PJB1_TCR_S2_R1_001.fastq.gz,"
+                         "PJB1_TCR_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version, "9.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-cellranger-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset, None)
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/_cmdline",
+                  "qc/cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/web_summary.html",
+                  "qc/cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/metrics_summary.csv",
+                  "qc/cellranger_multi",
+                  "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PJB/web_summary.html",
+                  "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PJB/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/_cmdline",
+                  "cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/web_summary.html",
+                  "cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/metrics_summary.csv",
+                  "cellranger_multi",
+                  "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PJB/web_summary.html",
+                  "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PJB/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+        # Verify no cellranger count outputs for VDJ-T samples
+        for f in ("qc/cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_TCR",
+                  "cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_TCR"):
+            self.assertFalse(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Found %s (shouldn't exist)" % f)
+
+    #@unittest.skip("Skipped")
+    def test_qcpipeline_10x_immune_profiling_data_multiple_samples_800(self):
+        """
+        QCPipeline: 10xGenomics SC immune profiling run (10x_ImmuneProfiling, multiple samples, CellRanger 8.0.0)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="8.0.0")
         MockMultiQC.create(os.path.join(self.bin,"multiqc"))
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
@@ -243,28 +368,192 @@ PJB2_TCR,%s,any,PJB2,VDJ-T,
                   "qc_report.html",
                   "qc_report.PJB.zip",
                   "qc/cellranger_count",
-                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/_cmdline",
-                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/outs/web_summary.html",
-                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/outs/metrics_summary.csv",
-                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/_cmdline",
-                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/outs/web_summary.html",
-                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/outs/metrics_summary.csv",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/_cmdline",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/outs/web_summary.html",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/outs/metrics_summary.csv",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/_cmdline",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/outs/web_summary.html",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/outs/metrics_summary.csv",
                   "cellranger_count",
-                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/_cmdline",
-                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/outs/web_summary.html",
-                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/outs/metrics_summary.csv",
-                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/_cmdline",
-                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/outs/web_summary.html",
-                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/outs/metrics_summary.csv",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/_cmdline",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/outs/web_summary.html",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_GEX/outs/metrics_summary.csv",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/_cmdline",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/outs/web_summary.html",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_GEX/outs/metrics_summary.csv",
                   "multiqc_report.html"):
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
                             "Missing %s" % f)
         # Verify no cellranger counts outputs for VDJ-T samples
-        for f in ("qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR",
-                  "qc/cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR",
-                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR",
-                  "cellranger_count/7.1.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR"):
+        for f in ("qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR",
+                  "qc/cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR",
+                  "cellranger_count/8.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR"):
+            self.assertFalse(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Found %s (shouldn't exist)" % f)
+        # Verify no cellranger multi outputs
+        for f in ("qc/cellranger_multi",
+                  "cellranger_multi"):
+            self.assertFalse(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                             "Found %s (shouldn't exist)" % f)
+
+    #@unittest.skip("Skipped")
+    def test_qcpipeline_10x_immune_profiling_data_multiple_samples_900(self):
+        """
+        QCPipeline: 10xGenomics SC immune profiling run (10x_ImmuneProfiling, multiple samples, CellRanger 9.0.0)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="9.0.0")
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x single cell immune profiling project
+        p = MockAnalysisProject("PJB",("PJB1_GEX_S1_R1_001.fastq.gz",
+                                       "PJB1_GEX_S1_R2_001.fastq.gz",
+                                       "PJB1_TCR_S2_R1_001.fastq.gz",
+                                       "PJB1_TCR_S2_R2_001.fastq.gz",
+                                       "PJB2_GEX_S3_R1_001.fastq.gz",
+                                       "PJB2_GEX_S3_R2_001.fastq.gz",
+                                       "PJB2_TCR_S4_R1_001.fastq.gz",
+                                       "PJB2_TCR_S4_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10xGenomics Chromium 5\'',
+                                           'Library type':
+                                           'Single Cell Immune Profiling' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv files
+        # (This is only used to identify the GEX samples)
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB1.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+
+[vdj]
+reference,/data/refdata-cellranger-vdj-GRCh38-alts-ensembl-7.1.0
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_GEX,%s,any,PJB1,gene expression,
+PJB1_TCR,%s,any,PJB1,VDJ-T,
+""" % (fastq_dir,fastq_dir))
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB2.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+
+[vdj]
+reference,/data/refdata-cellranger-vdj-GRCh38-alts-ensembl-7.1.0
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB2_GEX,%s,any,PJB2,gene expression,
+PJB2_TCR,%s,any,PJB2,VDJ-T,
+""" % (fastq_dir,fastq_dir))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_ImmuneProfiling"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"10x_ImmuneProfiling")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_ImmuneProfiling")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,
+                         "PJB1_GEX,PJB1_TCR,PJB2_GEX,PJB2_TCR")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_GEX_S1_R1_001.fastq.gz,"
+                         "PJB1_GEX_S1_R2_001.fastq.gz,"
+                         "PJB1_TCR_S2_R1_001.fastq.gz,"
+                         "PJB1_TCR_S2_R2_001.fastq.gz,"
+                         "PJB2_GEX_S3_R1_001.fastq.gz,"
+                         "PJB2_GEX_S3_R2_001.fastq.gz,"
+                         "PJB2_TCR_S4_R1_001.fastq.gz,"
+                         "PJB2_TCR_S4_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version, "9.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-cellranger-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset, None)
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/_cmdline",
+                  "qc/cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/web_summary.html",
+                  "qc/cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/metrics_summary.csv",
+                  "qc/cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/_cmdline",
+                  "qc/cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/outs/web_summary.html",
+                  "qc/cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/outs/metrics_summary.csv",
+                  "qc/cellranger_multi",
+                  "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PJB1/web_summary.html",
+                  "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PJB1/metrics_summary.csv",
+                  "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PJB2/web_summary.html",
+                  "qc/cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PJB2/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/_cmdline",
+                  "cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/web_summary.html",
+                  "cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_GEX/outs/metrics_summary.csv",
+                  "cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/_cmdline",
+                  "cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/outs/web_summary.html",
+                  "cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_GEX/outs/metrics_summary.csv",
+                  "cellranger_multi",
+                  "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PJB1/web_summary.html",
+                  "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PJB1/metrics_summary.csv",
+                  "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PJB2/web_summary.html",
+                  "cellranger_multi/9.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PJB2/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+        # Verify no cellranger counts outputs for VDJ-T samples
+        for f in ("qc/cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR",
+                  "qc/cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR",
+                  "cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB1_TCR",
+                  "cellranger_count/9.0.0/refdata-cellranger-gex-GRCh38-2020-A/PJB2_TCR"):
             self.assertFalse(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
                             "Found %s (shouldn't exist)" % f)

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -1711,6 +1711,9 @@ class TestParseQCModuleSpec(unittest.TestCase):
         self.assertEqual(
             parse_qc_module_spec("module(s='\"hello\"')"),
             ('module',{ 's': '"hello"' }))
+        self.assertEqual(
+            parse_qc_module_spec("module(s='\"greeting=hello\"')"),
+            ('module',{ 's': '"greeting=hello"' }))
 
     def test_parse_qc_module_spec_boolean(self):
         """
@@ -1734,3 +1737,20 @@ class TestParseQCModuleSpec(unittest.TestCase):
         self.assertEqual(
             parse_qc_module_spec("module(b='false')"),
             ('module',{ 'b': 'false' }))
+
+    def test_parse_qc_module_spec_quoted_special_characters(self):
+        """
+        parse_qc_module_spec: handle quoted special characters
+        """
+        self.assertEqual(
+            parse_qc_module_spec("module(version='>=9')"),
+            ('module',{ 'version': '>=9' }))
+        self.assertEqual(
+            parse_qc_module_spec("module(version=\"==9\")"),
+            ('module',{ 'version': '==9' }))
+        self.assertEqual(
+            parse_qc_module_spec("module(s='semicolon;')"),
+            ('module',{ 's': 'semicolon;' }))
+        self.assertEqual(
+            parse_qc_module_spec("module(s=\";semicolon\")"),
+            ('module',{ 's': ';semicolon' }))

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -1213,6 +1213,94 @@ Cellranger version\t6.0.0
         self.assertEqual(AnalysisProject(project_dir).info.number_of_cells,
                          2272)
 
+    def test_set_cell_count_for_immune_profiling_project(self):
+        """
+        set_cell_count_for_project: test for single cell immune profiling data (Chromium 5')
+        """
+        # Set up mock project
+        project_dir = self._make_mock_analysis_project(
+            "10xGenomics Chromium 5'",
+            "Single Cell Immune Profiling")
+        # Build mock cellranger multi output directory
+        multi_dir = os.path.join(project_dir,
+                                 "qc",
+                                 "cellranger_multi",
+                                 "9.0.0",
+                                 "refdata-cellranger-gex-GRCh38-2020-A",
+                                 "outs",
+                                 "per_sample_outs",
+                                 "PJB1")
+        mkdirs(multi_dir)
+        summary_file = os.path.join(multi_dir, "metrics_summary.csv")
+        with open(summary_file,'wt') as fp:
+            fp.write(CELLPLEX_METRICS_SUMMARY)
+        web_summary = os.path.join(multi_dir, "web_summary.html")
+        with open(web_summary,'wt') as fp:
+            fp.write("Placeholder for web_summary.html\n")
+        # Add QC info file
+        with open(os.path.join(project_dir,"qc","qc.info"),'wt') as fp:
+            fp.write("""Cellranger reference datasets\t/data/refdata-cellranger-gex-GRCh38-2020-A
+Cellranger version\t9.0.0
+""")
+        # Check initial cell count
+        print("Checking number of cells")
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         None)
+        # Update the cell counts
+        print("Updating number of cells")
+        set_cell_count_for_project(project_dir,source="multi")
+        # Check updated cell count
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         5175)
+
+    def test_set_cell_count_for_immune_profiling_project_multiple_physical_samples(self):
+        """
+        set_cell_count_for_project: test for single cell immune profiling data (Chromium 5', multiple physical samples)
+        """
+        # Set up mock project
+        project_dir = self._make_mock_analysis_project(
+            "10xGenomics Chromium 5'",
+            "Single Cell Immune Profiling")
+        # Build mock cellranger multi output directory
+        multi_dir = os.path.join(project_dir,
+                                 "qc",
+                                 "cellranger_multi",
+                                 "9.0.0",
+                                 "refdata-cellranger-gex-GRCh38-2020-A")
+        mkdirs(multi_dir)
+        for sample in ("PJB1", "PJB2"):
+            sub_dir = os.path.join(multi_dir,
+                                   sample,
+                                   "outs",
+                                   "per_sample_outs",
+                                   sample)
+            mkdirs(sub_dir)
+            summary_file = os.path.join(sub_dir, "metrics_summary.csv")
+            with open(summary_file,'wt') as fp:
+                fp.write(CELLPLEX_METRICS_SUMMARY)
+            web_summary = os.path.join(sub_dir, "web_summary.html")
+            with open(web_summary,'wt') as fp:
+                fp.write("Placeholder for web_summary.html\n")
+        # Add QC info file
+        with open(os.path.join(project_dir,"qc","qc.info"),'wt') as fp:
+            fp.write("""Cellranger reference datasets\t/data/refdata-cellranger-gex-GRCh38-2020-A
+Cellranger version\t9.0.0
+""")
+        # Check initial cell count
+        print("Checking number of cells")
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         None)
+        # Update the cell counts
+        print("Updating number of cells")
+        set_cell_count_for_project(project_dir,source="multi")
+        # Check updated cell count
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         10350)
+
     def test_set_cell_count_project_missing_library_type(self):
         """
         set_cell_count_for_project: test for scRNA-seq when library not set

--- a/auto_process_ngs/test/qc/test_verification.py
+++ b/auto_process_ngs/test/qc/test_verification.py
@@ -866,10 +866,14 @@ class TestQCVerifier(unittest.TestCase):
                                        'PJB_CML2',
                                    ))
         qc_verifier = QCVerifier(qc_dir)
-        # Implicitly match any version and reference
-        self.assertTrue(qc_verifier.verify_qc_module(
+        # Verification not possible if no version and no reference
+        # explicitly specified
+        self.assertEqual(qc_verifier.verify_qc_module(
             'cellranger_multi',
-            self._create_params_dict(qc_dir=qc_dir)))
+            self._create_params_dict(qc_dir=qc_dir,
+                                     cellranger_version=None,
+                                     cellranger_refdata=None)),
+                         None)
         # Explicitly match version with any reference
         self.assertTrue(qc_verifier.verify_qc_module(
             'cellranger_multi',
@@ -883,6 +887,13 @@ class TestQCVerifier(unittest.TestCase):
                                      cellranger_version='*',
                                      cellranger_refdata=\
                                      'refdata-cellranger-2020-A')))
+        # Explicitly match reference with any version and any
+        # reference
+        self.assertTrue(qc_verifier.verify_qc_module(
+            'cellranger_multi',
+            self._create_params_dict(qc_dir=qc_dir,
+                                     cellranger_version='*',
+                                     cellranger_refdata='*')))
         # Fail if version not found
         self.assertFalse(qc_verifier.verify_qc_module(
             'cellranger_multi',
@@ -897,6 +908,17 @@ class TestQCVerifier(unittest.TestCase):
                                      cellranger_version='7.1.0',
                                      cellranger_refdata=\
                                      'refdata-cellranger-2.0.0')))
+        # Verification when no multiplexed samples present
+        qc_dir = self._make_qc_dir('qc.no_multiplexed',
+                                   fastq_names=fastq_names[:2],
+                                   include_cellranger_multi=True,
+                                   cellranger_pipelines=('cellranger',))
+        qc_verifier = QCVerifier(qc_dir)
+        self.assertTrue(qc_verifier.verify_qc_module(
+            'cellranger_multi',
+            self._create_params_dict(qc_dir=qc_dir,
+                                     cellranger_version='8.0.0',
+                                     cellranger_refdata='*')))
         # Missing outputs for one sample
         qc_dir = self._make_qc_dir('qc.fail',
                                    fastq_names=fastq_names[:2],
@@ -945,10 +967,12 @@ class TestQCVerifier(unittest.TestCase):
                                        "PJB2": ("PB3", "PB4")
                                    })
         qc_verifier = QCVerifier(qc_dir)
-        # Implicitly match any version and reference
-        self.assertTrue(qc_verifier.verify_qc_module(
+        # Verification not possible if no version and no reference
+        # were explicitly supplied
+        self.assertEqual(qc_verifier.verify_qc_module(
             'cellranger_multi',
-            self._create_params_dict(qc_dir=qc_dir)))
+            self._create_params_dict(qc_dir=qc_dir)),
+                         None)
         # Explicitly match version with any reference
         self.assertTrue(qc_verifier.verify_qc_module(
             'cellranger_multi',
@@ -962,6 +986,13 @@ class TestQCVerifier(unittest.TestCase):
                                      cellranger_version='*',
                                      cellranger_refdata=\
                                      'refdata-cellranger-2020-A')))
+        # Explicitly match reference with any version and any
+        # reference
+        self.assertTrue(qc_verifier.verify_qc_module(
+            'cellranger_multi',
+            self._create_params_dict(qc_dir=qc_dir,
+                                     cellranger_version='*',
+                                     cellranger_refdata='*')))
         # Fail if version not found
         self.assertFalse(qc_verifier.verify_qc_module(
             'cellranger_multi',
@@ -976,6 +1007,21 @@ class TestQCVerifier(unittest.TestCase):
                                      cellranger_version='7.1.0',
                                      cellranger_refdata=\
                                      'refdata-cellranger-2.0.0')))
+        # Verification when no multiplexed samples present
+        qc_dir = self._make_qc_dir('qc.no_multiplexed',
+                                   fastq_names=fastq_names[:2],
+                                   include_cellranger_multi=True,
+                                   cellranger_pipelines=('cellranger',),
+                                   cellranger_multi_samples={
+                                       "PJB1": (),
+                                       "PJB2": ()
+                                   })
+        qc_verifier = QCVerifier(qc_dir)
+        self.assertTrue(qc_verifier.verify_qc_module(
+            'cellranger_multi',
+            self._create_params_dict(qc_dir=qc_dir,
+                                     cellranger_version='8.0.0',
+                                     cellranger_refdata='*')))
         # Missing outputs for one sample
         qc_dir = self._make_qc_dir('qc.fail',
                                    fastq_names=fastq_names[:2],

--- a/auto_process_ngs/test/test_utils.py
+++ b/auto_process_ngs/test/test_utils.py
@@ -1021,6 +1021,36 @@ class TestFindExecutables(unittest.TestCase):
                                           self.info_func,
                                           paths=paths),exes)
 
+class TestCheckRequiredVersion(unittest.TestCase):
+    """
+    Tests for the 'check_required_version' function
+    """
+    def test_check_required_version(self):
+        """
+        check_required_version: determines if versions match specification
+        """
+        self.assertTrue(check_required_version("2.17.1.4", ">1.8.4"))
+        self.assertTrue(check_required_version("2.17.1.4", "==2.17.1.4"))
+        self.assertTrue(check_required_version("2.17.1.4", "=2.17.1.4"))
+        self.assertTrue(check_required_version("2.17.1.4", "2.17.1.4"))
+        self.assertTrue(check_required_version("1.8.4", "<2.17.1.4"))
+        self.assertTrue(check_required_version("10.0", ">9.1"))
+        self.assertTrue(check_required_version("1.10", ">1.9.rc1"))
+        self.assertTrue(check_required_version("9.0.0", "9"))
+        self.assertTrue(check_required_version("9.1.0", "9"))
+        self.assertTrue(check_required_version("9.0.0", ">8"))
+        self.assertTrue(check_required_version("9.0.0", ">=9,<=12"))
+        self.assertTrue(check_required_version("9.0.1", "==9.0"))
+        self.assertTrue(check_required_version("9.1.1", ">9.0.2"))
+        self.assertTrue(check_required_version("9.0.2", "<9.1.1"))
+        self.assertTrue(check_required_version("9.0.2", "<9.1.1"))
+        self.assertFalse(check_required_version("8.0.0", "9"))
+        self.assertFalse(check_required_version("9.0.0", "<=8"))
+        self.assertFalse(check_required_version("8.0.0", ">=9,<=12"))
+        self.assertFalse(check_required_version("9.0.1", ">9.0"))
+        self.assertFalse(check_required_version("9.0.0", "==9.1.0"))
+        self.assertFalse(check_required_version("9.0", "==9.0.1"))
+
 class TestParseVersion(unittest.TestCase):
     """Tests for the parse_version function
     """
@@ -1033,20 +1063,6 @@ class TestParseVersion(unittest.TestCase):
                          (1,8,4))
         self.assertEqual(parse_version("1.9.rc1"),
                          (1,9,"rc1"))
-
-    def test_compare_versions(self):
-        """parse_version compares versions correctly
-        """
-        self.assertTrue(
-            parse_version("2.17.1.4") > parse_version("1.8.4"))
-        self.assertTrue(
-            parse_version("2.17.1.4") == parse_version("2.17.1.4"))
-        self.assertTrue(
-            parse_version("1.8.4") < parse_version("2.17.1.4"))
-        self.assertTrue(
-            parse_version("10.0") > parse_version("9.1"))
-        self.assertTrue(
-            parse_version("1.10") > parse_version("1.9.rc1"))
 
     def test_handle_empty_version(self):
         """parse_version handles empty version

--- a/auto_process_ngs/test/test_utils.py
+++ b/auto_process_ngs/test/test_utils.py
@@ -1055,6 +1055,35 @@ class TestParseVersion(unittest.TestCase):
         self.assertTrue(
             parse_version("") < parse_version("1.8.4"))
 
+class TestParseVersionRequirement(unittest.TestCase):
+    """
+    Tests for the parse_version_requirement function
+    """
+    def test_parse_version_requirement(self):
+        """
+        parse_version_requirement: extracts operator function and version string
+        """
+        # No operator
+        self.assertEqual(parse_version_requirement("2.17.1.4"),
+                         (operator.eq, "2.17.1.4"))
+        # Explicit equals
+        self.assertEqual(parse_version_requirement("=2.17.1.4"),
+                         (operator.eq, "2.17.1.4"))
+        self.assertEqual(parse_version_requirement("==2.17.1.4"),
+                         (operator.eq, "2.17.1.4"))
+        # Greater than
+        self.assertEqual(parse_version_requirement(">8.1"),
+                         (operator.gt, "8.1"))
+        # Greater than or equals
+        self.assertEqual(parse_version_requirement(">=9.0"),
+                         (operator.ge, "9.0"))
+        # Less than
+        self.assertEqual(parse_version_requirement("<3.12"),
+                         (operator.lt, "3.12"))
+        # Less than or equals
+        self.assertEqual(parse_version_requirement("<=2.7"),
+                         (operator.le, "2.7"))
+
 class TestParseSampleSheetSpec(unittest.TestCase):
     """Tests for the parse_samplesheet_spec function
     """

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -1008,23 +1008,13 @@ def find_executables(names,info_func,reqs=None,paths=None):
             prog_path = os.path.abspath(os.path.join(path,name))
             if bcf_utils.PathInfo(prog_path).is_executable:
                 available_exes.append(prog_path)
-    # Filter on requirement
+    # Filter on requirements
     if reqs:
-        # Loop over ranges
-        for req in reqs.split(','):
-            logger.debug("Filtering on expression: %s" % req)
-            # Determine operator and version
-            op, req_version = parse_version_requirement(req)
-            # Filter the available executables on version
-            logger.debug("Pre filter: %s" % available_exes)
-            logger.debug("Versions  : %s" % [info_func(x)[2]
-                                              for x in available_exes])
-            available_exes = list(
-                filter(lambda x: op(
-                    parse_version(info_func(x)[2]),
-                    parse_version(req_version)),
-                       available_exes))
-            logger.debug("Post filter: %s" % available_exes)
+        available_exes = list(
+            filter(
+                lambda x: check_required_version(
+                    info_func(x)[2], reqs),
+                available_exes))
         # Sort into version order, highest to lowest
         available_exes.sort(
             key=lambda x: parse_version(info_func(x)[2]),

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -1066,7 +1066,6 @@ def check_required_version(version, required_version):
     """
     for version_spec in required_version.split(","):
         # Check against all version specifications
-        print(f"====> Check {version} against {version_spec}")
         op, req = parse_version_requirement(version_spec)
         # Match lengths of version and requirement strings
         version_ = parse_version(version)


### PR DESCRIPTION
Updates the `10x_ImmuneProfiling` QC protocol to add the `cellranger_multi` module, which should only be run if CellRanger is version 9 or above.

This involves substantial updates to the `cellranger_multi` module to allow arbitrary requirements to be specifed for the CellRanger version, and updates to the pipeline to ensure that version requirements specified in the QC protocol are honoured.

Additional updates were required to deal with `cellranger multi` outputs for non-multiplexed 10x datasets (which includes the single cell immune profiling), and to set the cell counts for 10x Chromium 5' data (again, including single cell immune profiling), including to `cellranger_multi` QC module verification.

Other changes include:

* bug fixes to the code for parsing the QC module specifications (particularly for handling special characters and quoted values)
* bug fixes and expansion of the code for parsing program version requirements, and for filtering versions against these.

Closes #1012.