### PR TITLE
Replace defunct 'ubuntu-20.04' runner for CI tests & update Python versions

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,9 +8,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    # Switched from ubuntu-latest to ubuntu-20.04 as former
-    # doesn't support Python 3.6
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -9,10 +9,8 @@ Supported Python versions
 *************************
 
 The package consists predominantly of code written in Python, and the
-following versions are supported:
+following versions are officially supported:
 
-* Python 3.6
-* Python 3.7
 * Python 3.8
 
 .. _software_dependencies:

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -9,9 +9,14 @@ Supported Python versions
 *************************
 
 The package consists predominantly of code written in Python, and the
-following versions are officially supported:
+following versions are formally supported via continuous integration
+testing:
 
 * Python 3.8
+* Python 3.9
+* Python 3.10
+
+Other versions may also work but have not been formally tested.
 
 .. _software_dependencies:
 


### PR DESCRIPTION
Updates the workflow for the CI testing via GitHub Actions, to replace the `ubuntu-20.04` hosted runner (which closes down in April 2025) with the `ubuntu-24.04` runner.

As Python 3.6 and 3.7 are not available for the newer runner, these have been dropped from the CI testing matrix, and versions 3.9 and 3.10 have been added (closes #758).