### PR TITLE
Enable use of conda dependency resolution in "make_fastqs" command

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -1871,7 +1871,8 @@ class MakeFastqs(Pipeline):
             cellranger_localmem=None,working_dir=None,log_dir=None,
             log_file=None,batch_size=None,batch_limit=None,max_jobs=1,
             max_slots=None,poll_interval=5,runners=None,
-            default_runner=None,envmodules=None,verbose=False):
+            default_runner=None,enable_conda=False,conda=None,
+            conda_env_dir=None,envmodules=None,verbose=False):
         """
         Run the tasks in the pipeline
 
@@ -1956,6 +1957,11 @@ class MakeFastqs(Pipeline):
             'cellranger_atac_mkfastq'
           default_runner (JobRunner): optional default
             job runner to use
+          enable_conda (bool): if True then enable use of
+            conda environments to satisfy task dependencies
+          conda (str): path to conda
+          conda_env_dir (str): path to non-default
+            directory for conda environments
           verbose (bool): if True then report additional
             information for diagnostics
         """
@@ -2099,6 +2105,9 @@ class MakeFastqs(Pipeline):
                               max_slots=max_slots,
                               runners=runners,
                               default_runner=default_runner,
+                              enable_conda=enable_conda,
+                              conda=conda,
+                              conda_env_dir=conda_env_dir,
                               envmodules=envmodules,
                               verbose=verbose)
 

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     cli/auto_process.py: command line interface for auto_process_ngs
-#     Copyright (C) University of Manchester 2013-2024 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2025 Peter Briggs
 #
 #########################################################################
 #
@@ -616,6 +616,21 @@ def add_make_fastqs_command(cmdparser):
     p.add_argument('analysis_dir',metavar="ANALYSIS_DIR",nargs="?",
                    help="auto_process analysis directory (optional: defaults "
                    "to the current directory)")
+    # Conda options
+    enable_conda = ("yes" if __settings.conda.enable_conda else "no")
+    conda_env_dir = __settings.conda.env_dir
+    conda = p.add_argument_group("Conda dependency resolution")
+    conda.add_argument('--enable-conda',choices=["yes","no"],
+                       dest="enable_conda",default=enable_conda,
+                       help="use conda to resolve task dependencies; can "
+                       "be 'yes' or 'no' (default: %s)" %
+                       ("yes" if enable_conda else "no"))
+    conda.add_argument('--conda-env-dir',action='store',
+                       dest="conda_env_dir",default=conda_env_dir,
+                       help="specify directory for conda enviroments "
+                       "(default: %s)" % ('temporary directory'
+                                          if not conda_env_dir else
+                                          conda_env_dir))
     # Job control options
     job_control = p.add_argument_group("Job control options")
     job_control.add_argument('-j','--maxjobs',type=int,action='store',
@@ -1590,6 +1605,8 @@ def make_fastqs(args):
         max_jobs=args.max_jobs,
         max_cores=args.max_cores,
         batch_limit=args.max_batches,
+        enable_conda=(args.enable_conda == 'yes'),
+        conda_env_dir=args.conda_env_dir,
         working_dir=args.working_dir,
         verbose=args.verbose)
 

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -66,6 +66,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 cellranger_ignore_dual_index=False,
                 spaceranger_rc_i2_override=None,
                 max_jobs=None,max_cores=None,batch_limit=None,
+                enable_conda=None,conda_env_dir=None,
                 verbose=False,working_dir=None):
     """
     Create and summarise FASTQ files
@@ -206,6 +207,10 @@ def make_fastqs(ap,protocol='standard',platform=None,
          exceed this limit
       working_dir (str): path to a working directory (defaults to
          temporary directory in the current directory)
+      enable_conda (bool): if True then use conda to resolve
+        dependencies declared on tasks in the pipeline
+      conda_env_dir (str): path to non-default directory for conda
+        environments
       verbose (bool): if True then report additional information for
          pipeline diagnostics
     """
@@ -385,6 +390,12 @@ def make_fastqs(ap,protocol='standard',platform=None,
             except KeyError:
                 envmodules[envmod] = None
 
+    # Conda dependency resolution
+    if enable_conda is None:
+        enable_conda = ap.settings.conda.enable_conda
+    if conda_env_dir is None:
+        conda_env_dir = ap.settings.conda.env_dir
+
     # Other pipeline settings
     poll_interval = ap.settings.general.poll_interval
 
@@ -442,6 +453,8 @@ def make_fastqs(ap,protocol='standard',platform=None,
                              cellranger_localcores=cellranger_localcores,
                              cellranger_localmem=cellranger_localmem,
                              runners=runners,
+                             enable_conda=enable_conda,
+                             conda_env_dir=conda_env_dir,
                              envmodules=envmodules,
                              log_dir=ap.log_dir,
                              log_file=pipeline_log,

--- a/auto_process_ngs/conda.py
+++ b/auto_process_ngs/conda.py
@@ -326,11 +326,17 @@ def make_conda_env_name(*pkgs):
 
     The name consists of components of the form
     "NAME[@VERSION]" for each package specification
-    "NAME[=VERSION]" (e.g. 'star=2.4.2a' becomes
-    'star@2.4.2a').
+    "NAME[=VERSION]" (e.g. "star=2.4.2a" becomes
+    "star@2.4.2a").
 
-    Components are joined by '+' and are sorted by package
+    Components are joined by "+" and are sorted by package
     name (regardless of the order they are supplied in).
+
+    Channel prefixes (e.g "CHANNEL::NAME[=VERSION]")
+    are also incorporated into the name, by replacing
+    the '::' with an underscore (e.g.
+    "bih-cubi::bcl2fastq2=2.20.04.7" becomes
+    "bih-cubi_bcl2fastq2@2.20.04.7").
 
     Arguments:
       pkgs (list): list of conda package specifiers
@@ -339,4 +345,6 @@ def make_conda_env_name(*pkgs):
       String: environment name constructed from package
         list.
     """
-    return '+'.join(sorted([str(p) for p in pkgs])).replace('=','@')
+    return "+".join(sorted([str(p) for p in pkgs]))\
+              .replace("=","@")\
+              .replace("::","_")

--- a/auto_process_ngs/test/test_conda.py
+++ b/auto_process_ngs/test/test_conda.py
@@ -224,3 +224,10 @@ class TestMakeCondaEnvName(unittest.TestCase):
         self.assertEqual(make_conda_env_name("bowtie=1.2.3",
                                              "fastq-screen=0.14.0"),
                          "bowtie@1.2.3+fastq-screen@0.14.0")
+
+    def test_make_conda_env_name_replace_channel_prefix(self):
+        """
+        make_conda_env_name: replace channel prefix ('::') in package name
+        """
+        self.assertEqual(make_conda_env_name("bih-cubi::bcl2fastq2"),
+                         "bih-cubi_bcl2fastq2")


### PR DESCRIPTION
Updates the `bcl2fastq` Fastq generation pipeline (`bcl2fastq/pipeline.py`) and the `make_fastqs` command to add support for `conda` dependency resolution.

The update includes a fix to generating environment names from package names when the package specifier includes a channel (e.g. `bih-cubi::bcl2fastq2`).

(Note that currently no `conda` packages are specified within the pipeline so this shouldn't make an difference to the pipeline in practice.)