### PR TITLE
Fix missing MultiQC reports when running QC pipeline via standalone 'run_qc.py' utility

### DIFF
--- a/auto_process_ngs/cli/run_qc.py
+++ b/auto_process_ngs/cli/run_qc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     cli/run_qc.py: command line interface for standalone QC pipeline
-#     Copyright (C) University of Manchester 2017-2024 Peter Briggs
+#     Copyright (C) University of Manchester 2017-2025 Peter Briggs
 #
 #########################################################################
 #
@@ -957,13 +957,15 @@ def main():
     qc_info_file = os.path.join(qc_dir,"qc.info")
 
     # Output file name
-    if args.filename is None:
-        out_file = "%s_report.html" % os.path.basename(qc_dir)
-    else:
+    if args.filename:
+        # Handle setting output report name explicitly
         out_file = args.filename
-    if not os.path.isabs(out_file):
-        out_file = os.path.join(out_dir,out_file)
-    print("Output report: %s" % out_file)
+        if not os.path.isabs(out_file):
+            out_file = os.path.join(out_dir, out_file)
+        print("Output report: %s" % out_file)
+    else:
+        # Use the defaults
+        out_file = None
 
     # Build and populate a temporary project directory
     announce("Building temporary project directory")

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -1877,9 +1877,8 @@ class RunMultiQC(PipelineTask):
         # MultiQC report file
         project = self.args.project
         qc_base = os.path.basename(self.args.qc_dir)
-        self.multiqc_report = os.path.join(project.dirn,
-                                           "multi%s_report.html" %
-                                           qc_base)
+        self.multiqc_report = os.path.join(os.path.dirname(self.args.qc_dir),
+                                           f"multi{qc_base}_report.html")
         # Report title
         if project.info.run is None:
             title = "%s" % project.name
@@ -1889,13 +1888,14 @@ class RunMultiQC(PipelineTask):
         if self.args.fastq_dir is not None:
             title = "%s (%s)" % (title,self.args.fastq_dir)
         # Add the command
+        multiqc_cmd = Command("multiqc",
+                              "--title",title,
+                              "--filename",self.multiqc_report,
+                              "--force",
+                              self.args.qc_dir)
         self.add_cmd(PipelineCommandWrapper(
             "Run MultiQC",
-            "multiqc",
-            "--title",title,
-            "--filename",self.multiqc_report,
-            "--force",
-            self.args.qc_dir))
+            *multiqc_cmd.command_line))
     def finish(self):
         # Check report was generated
         if not os.path.exists(self.multiqc_report):
@@ -1947,7 +1947,8 @@ class ReportQC(PipelineTask):
         else:
             out_file = self.args.report_html
         if not os.path.isabs(out_file):
-            out_file = os.path.join(project.dirn,out_file)
+            out_file = os.path.join(os.path.dirname(self.args.qc_dir),
+                                    out_file)
         if project.info.run is None:
             title = "%s" % project.name
         else:


### PR DESCRIPTION
Fixes a bug with missing MultiQC reports when running the QC pipeline via the standalone `run_qc.py` utility.

The bug manifested as an absence of the MultiQC report in both the expected location (next to the main `qc_report.html` file) and also from the main report itself, and the ZIP archive of outputs.

The fix is to update the default locations of the main `qc_report.html` and MultiQC output within the QC pipeline itself, and to update `run_qc.py` to allow the pipeline to set the main report location unless explicitly specified by the user on the command line.