### PR TITLE
Force index sequence bases mask to correct length for 10xGenomics applications

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -3433,15 +3433,14 @@ class Run10xMkfastq(PipelineTask):
         if self.pkg in ('cellranger',
                         'spaceranger'):
             # scRNA-seq and Visium
+            # Update indexes to 10bp as well as applying user-defined
+            # read lengths
             if self.args.bases_mask == "auto":
-                if self.args.r1_length or self.args.r2_length:
-                    # Get explicit bases mask including truncation
-                    bases_mask = get_bases_mask(illumina_run.runinfo_xml,
-                                                r1=self.args.r1_length,
-                                                r2=self.args.r2_length)
-                else:
-                    # Leave external pipeline to set bases mask
-                    bases_mask = None
+                bases_mask = get_bases_mask(illumina_run.runinfo_xml,
+                                            r1=self.args.r1_length,
+                                            r2=self.args.r2_length,
+                                            i1=10,
+                                            i2=10)
             else:
                 bases_mask = self.args.bases_mask
         elif self.pkg == "cellranger-atac":

--- a/auto_process_ngs/bcl2fastq/utils.py
+++ b/auto_process_ngs/bcl2fastq/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     bcl2fastq/utils.py: utility functions for bcl2fastq conversion
-#     Copyright (C) University of Manchester 2013-2024 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2025 Peter Briggs
 #
 ########################################################################
 #
@@ -437,7 +437,8 @@ def get_required_samplesheet_format(bcl2fastq_version):
         raise NotImplementedError('unknown version: %s' %
                                   bcl2fastq_version)
 
-def get_bases_mask(run_info_xml,sample_sheet_file=None,r1=None,r2=None):
+def get_bases_mask(run_info_xml,sample_sheet_file=None,r1=None,r2=None,
+                   i1=None,i2=None):
     """
     Get bases mask string
 
@@ -452,6 +453,8 @@ def get_bases_mask(run_info_xml,sample_sheet_file=None,r1=None,r2=None):
       sample_sheet_file: (optional) path to sample sheet file
       r1 (int): length to truncate R1 reads to
       r2 (int): length to truncate R2 reads to
+      i1 (int): length to truncate I1 index sequences to
+      i2 (int): length to truncate I2 index sequences to
 
     Returns:
       Bases mask string e.g. 'y101,I6'.
@@ -460,27 +463,42 @@ def get_bases_mask(run_info_xml,sample_sheet_file=None,r1=None,r2=None):
     bases_mask = IlluminaData.IlluminaRunInfo(run_info_xml).bases_mask
     print("Bases mask: %s (from RunInfo.xml)" % bases_mask)
     # Truncate reads if specified
-    if not (r1 is None and r2 is None):
+    if not (r1 is None and r2 is None and i1 is None and i2 is None) :
         lengths = (r1,r2)
         reads = []
         read_number = 0
+        index_lengths = (i1,i2)
+        indices = []
+        index_number = 0
         for read in bases_mask.split(','):
             if read.upper().startswith('I'):
-                # Ignore index reads
-                reads.append(read)
-                continue
-            read_number += 1
-            rlen = lengths[read_number-1]
-            if rlen is not None:
-                # Truncated length specified
-                read_length = int(read[1:])
-                if rlen < read_length:
-                    new_read = "y%dn%d" % (rlen,read_length-rlen)
+                # Handle index read
+                index_number += 1
+                ilen = index_lengths[index_number-1]
+                if ilen is not None:
+                    # Truncated length specified
+                    read_length = int(read[1:])
+                    if ilen < read_length:
+                        new_read = "I%dn%d" % (ilen,read_length-ilen)
+                    else:
+                        new_read = read
+                    reads.append(new_read)
                 else:
-                    new_read = read
-                reads.append(new_read)
+                    reads.append(read)
             else:
-                reads.append(read)
+                # Handle non-index read
+                read_number += 1
+                rlen = lengths[read_number-1]
+                if rlen is not None:
+                    # Truncated length specified
+                    read_length = int(read[1:])
+                    if rlen < read_length:
+                        new_read = "y%dn%d" % (rlen,read_length-rlen)
+                    else:
+                        new_read = read
+                    reads.append(new_read)
+                else:
+                    reads.append(read)
         bases_mask = ','.join(reads)
         print("Bases mask: %s (updated to truncate reads)" % bases_mask)
     # Update bases mask from sample sheet if supplied
@@ -491,11 +509,12 @@ def get_bases_mask(run_info_xml,sample_sheet_file=None,r1=None,r2=None):
             example_barcode = ""
         if barcode_is_10xgenomics(example_barcode):
             print("Bases mask: barcode is 10xGenomics sample set ID")
-        else:
+        elif (i1 is None and i2 is None):
+            # Update the index masking from the sample sheet
             bases_mask = IlluminaData.fix_bases_mask(bases_mask,
                                                      example_barcode)
-        print("Bases mask: %s (updated for barcode sequence '%s')" %
-              (bases_mask,example_barcode))
+            print("Bases mask: %s (updated for barcode sequence '%s')" %
+                  (bases_mask,example_barcode))
     return bases_mask
 
 def bases_mask_is_valid(bases_mask):

--- a/auto_process_ngs/bcl2fastq/utils.py
+++ b/auto_process_ngs/bcl2fastq/utils.py
@@ -447,6 +447,12 @@ def get_bases_mask(run_info_xml,sample_sheet_file=None,r1=None,r2=None,
     which are index reads), and optionally updates this using the
     barcode information in the sample sheet file.
 
+    The lengths of the read and index sequences can also be set
+    explicitly via the appropriate options. (If the index sequence
+    length is explicitly set then they will not be modified from
+    the indexes which appear in the sample sheet, even if one was
+    supplied.)
+
     Arguments:
       run_info_xml: name and path of RunInfo.xml file from the
         sequencing run


### PR DESCRIPTION
Explicitly set the index sequence length in bases mask to 10 x 10bp for some 10x Genomics applications (specifically those using `cellranger` and `spaceranger`) in the Fastq generation pipeline, to fix a bug encountered when the number of cycles assigned to index reads is longer than 10bp.

Without this fix, in those situtations the default bases mask would assign all the cycles to the index reads which would then exceed the length of the indexes in the sample sheet generated by `cellranger` or `spaceranger`. This would then result in the following error from `bcl2fastq`:

    std::exception::what: Barcode lengths in the sample sheet do not match those in --use-bases-mask