### PR TITLE
Fixes to standalone 'run_qc.py' QC utility 'local' mode on compute clusters

### DIFF
--- a/auto_process_ngs/cli/run_qc.py
+++ b/auto_process_ngs/cli/run_qc.py
@@ -848,9 +848,9 @@ def main():
         # Set the default threads for different jobs
         nthreads = min(max_cores,8)
         nthreads_star = min(max_cores,
-                                int(math.ceil(32.0/mempercore)))
+                            int(math.ceil(32.0/mempercore)))
         ncores_picard = min(max_cores,
-                              int(math.ceil(4.0/mempercore)*2))
+                            int(math.ceil(4.0/mempercore)*2))
         ncores_qualimap = min(max_cores,
                               int(math.ceil(4.0/mempercore)*2))
         print("-- Threads for QC: %s" % nthreads)

--- a/auto_process_ngs/cli/run_qc.py
+++ b/auto_process_ngs/cli/run_qc.py
@@ -169,10 +169,11 @@ def add_pipeline_options(p,fastq_subset_size,default_nthreads):
                             "to 0 to use all reads)" % fastq_subset_size)
     qc_options.add_argument('-t','--threads',action='store',
                             dest="nthreads",type=int,default=None,
-                            help="number of threads to use for QC script "
-                            "(default: %s)" % ('taken from job runner'
-                                               if not default_nthreads
-                                               else default_nthreads,))
+                            help="number of threads to use for multicore "
+                            "jobs (default: %s; ignored when using "
+                            "--local)" % ('taken from job runners'
+                                          if not default_nthreads
+                                          else default_nthreads,))
 
 def add_reference_data_options(p):
     """
@@ -830,6 +831,9 @@ def main():
         # Used local runners and set defaults according to
         # resources available on local system
         print("Running locally: overriding settings in configuration")
+        if args.nthreads:
+            # Warn if nthreads was set on command line
+            print("Number of threads set but is ignored in 'local' mode")
         local_env = get_execution_environment()
         if not max_cores:
             max_cores = local_env.max_cores
@@ -849,13 +853,6 @@ def main():
                               int(math.ceil(4.0/mempercore)*2))
         ncores_qualimap = min(max_cores,
                               int(math.ceil(4.0/mempercore)*2))
-        # Override if nthreads was explicitly set
-        # on the command line
-        if args.nthreads:
-            nthreads = args.nthreads
-            nthreads_star = args.nthreads
-            ncores_picard = args.nthreads
-            ncores_qualimap = args.nthreads
         print("-- Threads for QC: %s" % nthreads)
         print("-- Threads for STAR: %s" % nthreads_star)
         if nthreads_star*mempercore < 32.0:

--- a/auto_process_ngs/cli/run_qc.py
+++ b/auto_process_ngs/cli/run_qc.py
@@ -869,7 +869,7 @@ def main():
         cellranger_mempercore = None
         cellranger_jobinterval = None
         cellranger_localcores = min(max_cores,16)
-        cellranger_localmem = max_mem
+        cellranger_localmem = cellranger_localcores*mempercore
         print("-- Cellranger localcores: %d" % cellranger_localcores)
         print("-- Cellranger localmem  : %.1f Gbs" % cellranger_localmem)
         # Set up local runners

--- a/auto_process_ngs/cli/run_qc.py
+++ b/auto_process_ngs/cli/run_qc.py
@@ -855,11 +855,7 @@ def main():
                               int(math.ceil(4.0/mempercore)*2))
         print("-- Threads for QC: %s" % nthreads)
         print("-- Threads for STAR: %s" % nthreads_star)
-        if nthreads_star*mempercore < 32.0:
-            logger.warning("Insufficient memory for STAR?")
         print("-- Cores for Qualimap: %s" % ncores_qualimap)
-        if ncores_qualimap*mempercore < 8.0:
-            logger.warning("Insufficient memory for Qualimap?")
         # Remove limit on number of jobs
         print("-- Set maximum no of jobs to 'unlimited'")
         max_jobs = None
@@ -872,6 +868,17 @@ def main():
         cellranger_localmem = cellranger_localcores*mempercore
         print("-- Cellranger localcores: %d" % cellranger_localcores)
         print("-- Cellranger localmem  : %.1f Gbs" % cellranger_localmem)
+        # Warn if resources seem to be insufficient for
+        # specific programs
+        if nthreads_star*mempercore < 32.0:
+            print(f"Warning: insufficient memory for STAR? "
+                  f" ({nthreads_star*mempercore:.1f} < 32G)")
+        if ncores_qualimap*mempercore < 8.0:
+            print("Warning: insufficient memory for Qualimap?"
+                  f" ({ncores_qualimap*mempercore:.1f} < 8G)")
+        if cellranger_localmem < 64.0:
+            print("Warning: insufficient memory for Cellranger?"
+                  f" ({cellranger_localmem:.1f} < 64G)")
         # Set up local runners
         default_runner = SimpleJobRunner()
         runners = {


### PR DESCRIPTION
Implements a fix to the `run_qc.py` standalone QC pipeline utility when running in 'local' mode (`--local`) on Slurm compute clusters; also updates how resources are allocated for specific programs (STAR, Qualimap, Cellranger etc) in this mode.