### PR TITLE
Update 'InferExperiment' class in 'qc/apps/rseqc' to handle unknown data type

### DIFF
--- a/auto_process_ngs/qc/apps/rseqc.py
+++ b/auto_process_ngs/qc/apps/rseqc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     qc/rseqc: utilities for handling RSeQC outputs
-#     Copyright (C) University of Manchester 2024 Peter Briggs
+#     Copyright (C) University of Manchester 2024-2025 Peter Briggs
 #
 """
 Provides utility classes and functions for handling RSeQC outputs.
@@ -32,10 +32,14 @@ logger = logging.getLogger(__name__)
 """
 Example output from infer_experiment.py:
 
-This is PairEnd Data
-Fraction of reads failed to determine: 0.0172
-Fraction of reads explained by "1++,1--,2+-,2-+": 0.4903
-Fraction of reads explained by "1+-,1-+,2++,2--": 0.4925
+> This is PairEnd Data
+> Fraction of reads failed to determine: 0.0172
+> Fraction of reads explained by "1++,1--,2+-,2-+": 0.4903
+> Fraction of reads explained by "1+-,1-+,2++,2--": 0.4925
+
+Example output for poor data:
+
+> Unknown Data type
 """
 
 class InferExperiment(object):
@@ -50,12 +54,13 @@ class InferExperiment(object):
 
     - log_file (str): path to the source log file
     - paired_end (bool): True if data are paired, False
-      if data are single end
+      if data are single end, None for unknown data type
     - forward (float): fraction of 'forward' aligned reads
     - reverse (float): fraction of 'reverse' aligned reads
     - unstranded (float): fraction of aligned reads neither
       'forward' nor 'reverse'
-
+    - known_data_type (bool): True if data type could be
+      identified, False if not
     """
     def __init__(self,infer_experiment_log):
         """
@@ -71,6 +76,7 @@ class InferExperiment(object):
         self._unstranded = None
         self._forward = None
         self._reverse = None
+        self._unknown = False
         # Process the log contents
         with open(self._infer_experiment_log,'rt') as fp:
             for line in fp:
@@ -87,6 +93,9 @@ class InferExperiment(object):
                 elif line.startswith("Fraction of reads explained by \"1+-,1-+,2++,2--\":") or \
                      line.startswith("Fraction of reads explained by \"+-,-+\":"):
                     self._reverse = float(line.split()[-1])
+                elif line == "Unknown Data type":
+                    self._unknown = True
+                    break
                 else:
                     pass
 
@@ -124,6 +133,13 @@ class InferExperiment(object):
         Fraction of aligned reads neither 'forward' nor 'reverse'
         """
         return self._unstranded
+
+    @property
+    def unknown(self):
+        """
+        True if data type could be identified, False if not
+        """
+        return self._unknown
 
 #######################################################################
 # Functions

--- a/auto_process_ngs/test/qc/apps/test_rseqc.py
+++ b/auto_process_ngs/test/qc/apps/test_rseqc.py
@@ -41,6 +41,7 @@ Fraction of reads explained by "1+-,1-+,2++,2--": 0.4925
         self.assertEqual(infer_expt.forward,0.4903)
         self.assertEqual(infer_expt.reverse,0.4925)
         self.assertEqual(infer_expt.unstranded,0.0172)
+        self.assertFalse(infer_expt.unknown)
 
     def test_infer_experiment_single_end(self):
         """
@@ -58,6 +59,22 @@ Fraction of reads explained by "+-,-+": 0.0161
         self.assertEqual(infer_expt.forward,0.9669)
         self.assertEqual(infer_expt.reverse,0.0161)
         self.assertEqual(infer_expt.unstranded,0.0170)
+        self.assertFalse(infer_expt.unknown)
+
+    def test_infer_experiment_unknown(self):
+        """
+        InferExperiment: unknown data type
+        """
+        log = self._make_file("infer_experiment.log",
+                              """Unknown Data type
+""")
+        infer_expt = InferExperiment(log)
+        self.assertEqual(infer_expt.log_file,log)
+        self.assertEqual(infer_expt.paired_end, None)
+        self.assertEqual(infer_expt.forward, None)
+        self.assertEqual(infer_expt.reverse, None)
+        self.assertEqual(infer_expt.unstranded, None)
+        self.assertTrue(infer_expt.unknown)
 
 class TestRseqcGeneBodyCoverageOutputFunction(unittest.TestCase):
 


### PR DESCRIPTION
Updates the `InferExperiment` class in `qc/apps/rseqc` to explicitly handle `Unknown Data type` from RSeQC's `infer_experiment.py` program.

Part of updates to address issue #1052.