### PR TITLE
Add support for 'cellranger multi' in standalone QC utility 'run_qc.py'

### DIFF
--- a/auto_process_ngs/cli/run_qc.py
+++ b/auto_process_ngs/cli/run_qc.py
@@ -655,13 +655,14 @@ def build_10x_multi_config(multi_config_file, fastq_dir, libraries,
                      f"reference,{vdj_reference}\n\n")
         # Libraries section
         fp.write(f"[libraries]\n"
-                 f"fastq_id,fastqs,lanes,physical_library_id,feature_types\n")
+                 f"fastq_id,fastqs,lanes,physical_library_id,"
+                 f"feature_types,subsample_rate\n")
         for fastq_id in sorted(libraries.keys()):
             fp.write(f"{fastq_id},"
                      f"{fastq_dir},"
                      f"any,"
                      f"{fastq_id},"
-                     f"{libraries[fastq_id]}\n")
+                     f"{libraries[fastq_id]},\n")
 
 def announce(title):
     """


### PR DESCRIPTION
Updates the standalone QC utility `run_qc.py` to implement basic support for running `cellranger multi`, by allowing the user to specify libraries (optionally also associated with physical samples) via the command line, using the new `--10x_library` option.

Each library must be specified using the syntax `--10x_library [SAMPLE:]FASTQ_ID:FEATURE_TYPE` (where `SAMPLE` is an optional physical sample name, `FASTQ_ID` is the essentially the "sample name" part of the Fastq name, and `FEATURE_TYPE` is the associated feature type, e.g. "Gene expression").

For example:

    --10x_library "PB01:PB01_GEX:GeneExpression" --10x_library PB01:PB01_TCR:VDJ-T ...

`run_qc.py` then uses the supplied information to build `cellranger multi` configuration files for example physical sample, with the feature types assigned within the `libraries` section.

A new option `--cellranger-vdj-reference` is also required to set the path to the VDJ reference dataset (needed if VDJ data is included), as this is not currently part of the `auto-process` configuration settings.