### PR TITLE
Update strand-specificity determination for 'qualimap rna-seq' in QC pipeline

### DIFF
--- a/auto_process_ngs/qc/modules/qualimap_rnaseq.py
+++ b/auto_process_ngs/qc/modules/qualimap_rnaseq.py
@@ -282,12 +282,18 @@ class RunQualimapRnaseq(PipelineTask):
             # Qualimap sequencing protocol can be
             # 'strand-specific-forward', 'strand-specific-reverse',
             # or 'non-strand-specific'
-            if reverse > forward and reverse > unstranded:
-                seq_protocol = "strand-specific-reverse"
-            elif forward > reverse and forward > unstranded:
-                seq_protocol = "strand-specific-forward"
-            else:
+            if unstranded > forward and unstranded > reverse:
                 seq_protocol = "non-strand-specific"
+            else:
+                ratio = forward/(reverse + 0.001)
+                if ratio < 0.2:
+                    seq_protocol = "strand-specific-reverse"
+                elif ratio > 5:
+                    seq_protocol = "strand-specific-forward"
+                else:
+                    seq_protocol = "non-strand-specific"
+            print(f"-- {bam_name}: {seq_protocol} "
+                  f"(F{forward:.1f}|R{reverse:.1f}|U{unstranded:.1f})")
             # Run Qualimap
             self.add_cmd("Run qualimap rnaseq on %s" %
                          os.path.basename(bam),


### PR DESCRIPTION
Attempts to fix a bug with the strand-specificity determination for running `qualimap rna-seq` in the QC pipeline (`qc/modules/qualimap`).

Prior to the fix the strand-specificity would only be set as `non-strand-specific` in cases when the proportion of "unstranded" reads  exceeded the "forward" and "reverse" proportions (as determined by `RSeQC` `infer_experiment.py`). In cases where roughly equal proportions are assigned to forward and reverse, this would be erroneously assigned as `strand-specific-forward`.

The fix examines the ratio of forward and reverse reads and only assigns `strand-specific-forward` or `strand-specific-reverse` in cases where one is roughly 5 times the size of the other (and both are greater than unstranded). Otherwise it is assigned as `non-strand-specific`.

The fix also explicitly prints the assignment and the raw numbers, to help with checking in future.