### PR TITLE
Automatically use "minimal" QC protocol for WGS, DNA-seq and CRISPR data

### DIFF
--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -767,6 +767,9 @@ def determine_qc_protocol_from_metadata(library_type,
     # Standard protocols
     if library_type is None or not library_type:
         protocol = "minimal"
+    elif library_type in ("DNA-seq", "WGS") or \
+         library_type.startswith("CRISPR"):
+        protocol = "minimal"
     elif paired_end:
         protocol = "standardPE"
     else:

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -390,6 +390,41 @@ class TestDetermineQCProtocolFromMetadataFunction(unittest.TestCase):
             paired_end=False),
                          "standardSE")
 
+    def test_determine_qc_protocol_from_metadata_wgs(self):
+        """
+        determine_qc_protocol_from_metadata: WGS data
+        """
+        self.assertEqual(determine_qc_protocol_from_metadata(
+            library_type="WGS",
+            single_cell_platform=None,
+            paired_end=False),
+                         "minimal")
+
+    def test_determine_qc_protocol_from_metadata_dna_seq(self):
+        """
+        determine_qc_protocol_from_metadata: DNA-seq data
+        """
+        self.assertEqual(determine_qc_protocol_from_metadata(
+            library_type="DNA-seq",
+            single_cell_platform=None,
+            paired_end=False),
+                         "minimal")
+
+    def test_determine_qc_protocol_from_metadata_crispr(self):
+        """
+        determine_qc_protocol_from_metadata: CRISPR data
+        """
+        self.assertEqual(determine_qc_protocol_from_metadata(
+            library_type="CRISPR",
+            single_cell_platform=None,
+            paired_end=False),
+                         "minimal")
+        self.assertEqual(determine_qc_protocol_from_metadata(
+            library_type="CRISPR-Cas9",
+            single_cell_platform=None,
+            paired_end=False),
+                         "minimal")
+
     def test_determine_qc_protocol_from_metadata_icell8(self):
         """
         determine_qc_protocol_from_metadata: ICELL8 data


### PR DESCRIPTION
Updates the automatic QC protocol determination (`determine_qc_protocol_from_metadata` function in `qc/protocols`) so that WGS, DNA-seq and CRISPR libraries are assigned the `minimal` QC protocol by default.