### PR TITLE
Update 'report_qc' function to handle custom output directory

### DIFF
--- a/auto_process_ngs/cli/run_qc.py
+++ b/auto_process_ngs/cli/run_qc.py
@@ -1164,6 +1164,7 @@ def main():
                   qc_dir=qc_dir,
                   qc_protocol=args.qc_protocol,
                   report_html=out_file,
+                  out_dir=out_dir,
                   zip_outputs=True,
                   multiqc=(not args.no_multiqc),
                   force=True,

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -101,7 +101,7 @@ def verify_qc(project,qc_dir=None,fastq_dir=None,qc_protocol=None,
 
 def report_qc(project,qc_dir=None,fastq_dir=None,qc_protocol=None,
               report_html=None,zip_outputs=True,multiqc=False,
-              force=False,runner=None,log_dir=None,
+              out_dir=None,force=False,runner=None,log_dir=None,
               suppress_warning=False):
     """
     Generate report for the QC run for a project
@@ -121,6 +121,10 @@ def report_qc(project,qc_dir=None,fastq_dir=None,qc_protocol=None,
         archive with the report and QC outputs
       multiqc (bool): if True then also generate MultiQC
         report
+      out_dir (str): optional, path to the output
+        directory to write the reports to (defaults
+        to the project directory, ignored if report
+        HTML file name is explicitly provided)
       force (bool): if True then force generation of
         QC report even if verification fails
       runner (JobRunner): optional, job runner to use
@@ -147,6 +151,11 @@ def report_qc(project,qc_dir=None,fastq_dir=None,qc_protocol=None,
         log_dir = os.path.join(project.dirn,"logs")
         if not os.path.isdir(log_dir):
             log_dir = None
+    # Output directory for reports
+    if out_dir is None:
+        out_dir = project.dirn
+    else:
+        out_dir = os.path.abspath(out_dir)
     # Sort out runners
     if runner is None:
         runner = Settings().general.default_runner
@@ -211,7 +220,7 @@ def report_qc(project,qc_dir=None,fastq_dir=None,qc_protocol=None,
             multiqc_report = os.path.join(os.path.dirname(report_html),
                                           multiqc_report)
         else:
-            multiqc_report = os.path.join(project.dirn, multiqc_report)
+            multiqc_report = os.path.join(out_dir, multiqc_report)
         # Build MultiQC command
         multiqc_cmd = Command(
             "multiqc",
@@ -257,7 +266,7 @@ def report_qc(project,qc_dir=None,fastq_dir=None,qc_protocol=None,
     else:
         out_file = report_html
     if not os.path.isabs(out_file):
-        out_file = os.path.join(project.dirn,out_file)
+        out_file = os.path.join(out_dir, out_file)
     report_cmd = Command(
         "reportqc.py",
         "--filename",out_file,

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -226,6 +226,68 @@ class TestReportQCFunction(unittest.TestCase):
                                                         "PJB",f)),
                             "Found %s (should be missing)" % f)
 
+    def test_report_qc_specify_output_dir_qc_dir_outside_project_dir(self):
+        """
+        report_qc: specify output directory (QC dir outside project)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"))
+        p.create(top_dir=self.wd)
+        # Add QC outputs
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        UpdateAnalysisProject(project).add_qc_outputs(
+            include_multiqc=False)
+        # Make an alternative output directory
+        out_dir = os.path.join(self.wd, "outs")
+        os.mkdir(out_dir)
+        # Move the QC directory into the output directory
+        os.rename(os.path.join(self.wd, "PJB", "qc"),
+                  os.path.join(out_dir, "qc"))
+        # Do reporting
+        self.assertEqual(report_qc(project,
+                                   qc_dir=os.path.join(out_dir, "qc"),
+                                   out_dir=out_dir,
+                                   multiqc=True), 0)
+        # Check output and reports
+        for f in ("qc_report.html",
+                  "multiqc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(out_dir, f)),
+                            "Missing %s" % f)
+
+    def test_report_qc_specify_output_directory_no_zip(self):
+        """
+        report_qc: specify the output directory (no ZIP)
+        """
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"))
+        p.create(top_dir=self.wd)
+        # Add QC outputs
+        project = AnalysisProject("PJB",
+                                  os.path.join(self.wd,"PJB"))
+        UpdateAnalysisProject(project).add_qc_outputs(
+            include_multiqc=False)
+        # Make an alternative output directory
+        out_dir = os.path.join(self.wd, "outs")
+        os.mkdir(out_dir)
+        # Do reporting
+        self.assertEqual(report_qc(project,
+                                   zip_outputs=False,
+                                   out_dir=out_dir,
+                                   multiqc=True), 0)
+        # Check output and reports
+        for f in ("qc_report.html",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(out_dir, f)),
+                            "Missing %s" % f)
+
 class TestGetBamBasename(unittest.TestCase):
     """
     Tests for the 'get_bam_basename' function

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -164,9 +164,10 @@ class TestReportQCFunction(unittest.TestCase):
         # Add QC outputs
         project = AnalysisProject("PJB",
                                   os.path.join(self.wd,"PJB"))
-        UpdateAnalysisProject(project).add_qc_outputs()
+        UpdateAnalysisProject(project).add_qc_outputs(
+            include_multiqc=False)
         # Do reporting
-        self.assertEqual(report_qc(project),0)
+        self.assertEqual(report_qc(project, multiqc=True), 0)
         # Check output and reports
         for f in ("qc_report.html",
                   "qc_report.PJB.zip",
@@ -187,14 +188,15 @@ class TestReportQCFunction(unittest.TestCase):
         # Add QC outputs
         project = AnalysisProject("PJB",
                                   os.path.join(self.wd,"PJB"))
-        UpdateAnalysisProject(project).add_qc_outputs()
+        UpdateAnalysisProject(project).add_qc_outputs(
+            include_multiqc=False)
         # Remove an output
         os.remove(os.path.join(self.wd,
                                "PJB",
                                "qc",
                                "PJB1_S1_R1_001_fastqc.html"))
         # Do reporting
-        self.assertEqual(report_qc(project),1)
+        self.assertEqual(report_qc(project, multiqc=True), 1)
         # Check output and reports
         for f in ("qc_report.html",
                   "qc_report.PJB.zip",
@@ -215,7 +217,7 @@ class TestReportQCFunction(unittest.TestCase):
         project = AnalysisProject("PJB",
                                   os.path.join(self.wd,"PJB"))
         # Do reporting
-        self.assertEqual(report_qc(project),1)
+        self.assertEqual(report_qc(project, multiqc=True), 1)
         # Check output and reports
         for f in ("qc_report.html",
                   "qc_report.PJB.zip",


### PR DESCRIPTION
Updates the `report_qc` function in `qc/utils` so that it can take a custom output directory for the reports (previously always used the project directory; this is still the default).

Also updates the `run_qc.py` utility to set the correct directory for reports that are generated when the pipeline itself has failed.

Finally, fixes a minor issue in the implementation of the unit tests for `report_qc` (the MultiQC reports were always present in the input data, rendering the check on their presence at the end of the test pointless).