### PR TITLE
Add support for Bio-Rad ddSEQ Single Cell 3' RNA-Seq

### DIFF
--- a/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
+++ b/auto_process_ngs/commands/setup_analysis_dirs_cmd.py
@@ -112,7 +112,8 @@ def setup_analysis_dirs(ap,
             if not sc_platform in tenx.PLATFORMS and \
                not sc_platform in icell8.PLATFORMS and \
                not sc_platform in ('Parse Evercode',) and \
-               not sc_platform in ('Bio-Rad ddSEQ Single Cell ATAC',):
+               not sc_platform in ('Bio-Rad ddSEQ Single Cell ATAC',) and \
+               not sc_platform in ('Bio-Rad ddSEQ Single Cell 3\' RNA-Seq',):
                 logger.error("Unknown single cell platform for '%s': "
                              "'%s'" % (line['Project'],sc_platform))
                 raise Exception("Unknown single cell platform")

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -824,11 +824,17 @@ def determine_qc_protocol_from_metadata(library_type,
                                 "WT scRNA-seq"):
                 # Parse Evercode snRNAseq
                 protocol = "ParseEvercode"
+        # Bio-Rad RNA-Seq
+        elif single_cell_platform == "Bio-Rad ddSEQ Single Cell 3' RNA-Seq":
+            if library_type in ("scRNA-seq",
+                                "snRNA-seq",):
+                # Bio-Rad ddSeq RNA-Seq
+                protocol = "minimal"
         # Bio-Rad ATAC
         elif single_cell_platform == "Bio-Rad ddSEQ Single Cell ATAC":
             if library_type in ("scATAC-seq",
                                 "snATAC-seq",):
-                # 10xGenomics scATAC-seq
+                # Bio-Rad ddSeq ATAC
                 protocol = "BioRad_ddSEQ_ATAC"
         # ICELL8
         elif single_cell_platform == "ICELL8":

--- a/auto_process_ngs/test/qc/test_protocols.py
+++ b/auto_process_ngs/test/qc/test_protocols.py
@@ -781,6 +781,23 @@ class TestDetermineQCProtocolFromMetadataFunction(unittest.TestCase):
             paired_end=True),
                          "ParseEvercode")
 
+    def test_determine_qc_protocol_from_metadata_biorad_ddseq_rnaseq(self):
+        """
+        determine_qc_protocol_from_metadata: Bio-Rad ddSEQ Single Cell 3' RNA-Seq data
+        """
+        # scRNA-seq
+        self.assertEqual(determine_qc_protocol_from_metadata(
+            library_type="scRNA-seq",
+            single_cell_platform="Bio-Rad ddSEQ Single Cell 3' RNA-Seq",
+            paired_end=True),
+                         "minimal")
+        # snRNA-seq
+        self.assertEqual(determine_qc_protocol_from_metadata(
+            library_type="snRNA-seq",
+            single_cell_platform="Bio-Rad ddSEQ Single Cell 3' RNA-Seq",
+            paired_end=True),
+                         "minimal")
+
     def test_determine_qc_protocol_from_metadata_biorad_ddseq_atac(self):
         """
         determine_qc_protocol_from_metadata: Bio-Rad ddSEQ Single Cell ATAC data

--- a/docs/source/single_cell/bio_rad.rst
+++ b/docs/source/single_cell/bio_rad.rst
@@ -4,11 +4,9 @@ Processing Bio-Rad ddSEQ single cell data
 Background
 ----------
 
-Bio-Rad provides ddSEQ Single-Cell ATAC-seq and ddSEQ Single-Cell 3'
-RNA-seq kits. This document outlines using the ``auto-process-ngs``
-pipeline to perform Fastq generation and QC for ddSEQ Single-Cell
-ATAC-seq data (there is no support currently for ddSEQ single cell
-RNA-seq data).
+Bio-Rad provides ddSEQ Single-Cell 3' RNA-seq and ddSEQ Single-Cell
+ATAC-seq kits. This document outlines using the ``auto-process-ngs``
+pipeline to perform Fastq generation and QC for these data.
 
 Requirements
 ------------
@@ -20,8 +18,8 @@ Fastq generation
 ----------------
 
 The ``biorad_ddseq`` Fastq generation protocol should be used for
-Bio-Rad's ddSEQ Single-Cell ATAC-seq data when running the
-:doc:`make_fastqs <../using/make_fastqs>` command.
+Bio-Rad's ddSEQ Single-Cell RNA-Seq and ATAC-seq data when running
+the :doc:`make_fastqs <../using/make_fastqs>` command.
 
 
 Analysis project setup and QC
@@ -33,11 +31,12 @@ for the Parse Evercode project(s) in the ``projects.info`` control file.
 
 The following values are valid options:
 
-===================================== =================================
-Single cell platform                  Library types
-===================================== =================================
-``Bio-Rad ddSEQ Single Cell ATAC``    ``scATAC-seq``, ``snATAC-seq``
-===================================== =================================
+========================================  ==============================
+Single cell platform                      Library types
+========================================  ==============================
+``Bio-Rad ddSEQ Single Cell 3' RNA-Seq``  ``scRNA-seq``, ``snRNA-seq``
+``Bio-Rad ddSEQ Single Cell ATAC``        ``scATAC-seq``, ``snATAC-seq``
+========================================= ==============================
 
 Running the :doc:`setup_analysis_dirs <../using/setup_analysis_dirs>`
 command will automatically transfer these values into the project


### PR DESCRIPTION
Updates to support Bio-Rad ddSEQ Single Cell 3' RNA-Seq:

* Add `Bio-Rad ddSEQ Single Cell 3' RNA-Seq` as a recognised single cell platform in `setup_analysis_dirs`
* Use the `minimal` QC protocol for these data