### PR TITLE
Fix missing cell count for '10xGenomics Chromium GEM-X' single cell platform

### DIFF
--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -494,7 +494,7 @@ def set_cell_count_for_project(project_dir,qc_dir=None,
     single_cell_platform = project.info.single_cell_platform
     if single_cell_platform:
         if single_cell_platform.startswith("10xGenomics Chromium 3'") or \
-           single_cell_platform.startswith("10xGenomics Chromium GEM-X 3'") or \
+           single_cell_platform.startswith("10xGenomics Chromium GEM-X") or \
            single_cell_platform.startswith("10xGenomics Chromium Next GEM") or \
            single_cell_platform.startswith("10xGenomics Chromium 5'"):
             pipeline = "cellranger"

--- a/auto_process_ngs/test/qc/test_utils.py
+++ b/auto_process_ngs/test/qc/test_utils.py
@@ -691,6 +691,45 @@ Cellranger version\t8.0.0
                                          project_dir).info.number_of_cells,
                          2272)
 
+    def test_set_cell_count_for_project_chromium_gem_x(self):
+        """
+        set_cell_count_for_project: test for scRNA-seq (10x Chromium GEM-X)
+        """
+        # Set up mock project
+        project_dir = self._make_mock_analysis_project(
+            "10xGenomics Chromium GEM-X",
+            "scRNA-seq")
+        # Add metrics_summary.csv
+        counts_dir = os.path.join(project_dir,
+                                  "qc",
+                                  "cellranger_count",
+                                  "8.0.0",
+                                  "refdata-gex-GRCh38-2020-A",
+                                  "PJB1",
+                                  "outs")
+        mkdirs(counts_dir)
+        metrics_summary_file = os.path.join(counts_dir,
+                                            "metrics_summary.csv")
+        with open(metrics_summary_file,'wt') as fp:
+            fp.write(METRICS_SUMMARY)
+        # Add QC info file
+        with open(os.path.join(project_dir,"qc","qc.info"),'wt') as fp:
+            fp.write("""Cellranger reference datasets\t/data/refdata-gex-GRCh38-2020-A
+Cellranger version\t8.0.0
+""")
+        # Check initial cell count
+        print("Checking number of cells")
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         None)
+        # Update the cell counts
+        print("Updating number of cells")
+        set_cell_count_for_project(project_dir)
+        # Check updated cell count
+        self.assertEqual(AnalysisProject("PJB1",
+                                         project_dir).info.number_of_cells,
+                         2272)
+
     def test_set_cell_count_for_project_chromium_next_gem(self):
         """
         set_cell_count_for_project: test for scRNA-seq (10x Chromium Next GEM)


### PR DESCRIPTION
Fixes the `set_cell_count_for_project` function (in `qc/utils`) to recognise the general single cell platform `10xGenomics Chromium GEM-X*` when determining how to set total cells for a project (previously only the more specific `10xGenomics Chromium GEM-X 3'*` platform was recognised).