### PR TITLE
'add_command' decorator handle 'None' from wrapped command function

### DIFF
--- a/auto_process_ngs/decorators.py
+++ b/auto_process_ngs/decorators.py
@@ -85,6 +85,9 @@ def add_command(name,f):
             ret = 1
         else:
             print("[%s] %s: finished" % (timestamp(),name))
+        if ret is None:
+            # Assume success
+            ret = 0
         return ret
     def timestamp():
         # Return the current time


### PR DESCRIPTION
Updates the `add_command` decorator (in the `decorators` module) to explicitly return a value of `0` when the wrapped command function returns `None` (which usually happens because no explicit return value was set). This essentially assumes that the wrapped function has completed without a problem/error.