### PR TITLE
transfer_data.py: fix errors tarring 10x Genomics outputs for transfer

### DIFF
--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -637,7 +637,7 @@ def main():
                                      project_name,
                                      project.info.run))
             targz_cmd = Command("tar",
-                                "czvhf",
+                                "czvf",
                                 targz,
                                 "-C",
                                 os.path.dirname(cellranger_dir),


### PR DESCRIPTION
Attempts to address bug reported in issue #1021, where tar gzipping the outputs from the 10x Genomics analysis pipelines (e.g. `cellranger count`) would report failures for multiple files ("file moved before we could read it").

These failures appear to be associated with broken symlinks in the 10x output directories, and are triggered by the use of `tar`s `-h` option (which attempts to replace symbolic links in the source with the link targets in the archive).

Attempting to use `--ignore-failed-read` and suppressing warnings didn't address the problem, so the fix implemented here is simply to drop the `-h` option from the `tar` operation.