### PR TITLE
Update auditing of compute usage in pipelines

### DIFF
--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -39,6 +39,7 @@ internal use:
 - sanitize_name: clean up task and command names for use in pipeline
 - collect_files: collect files based on glob patterns
 - resolve_parameter: get the value of arbitrary parameter or object
+- format_compute_time: pretty-print times from compute auditing
 
 Overview
 --------
@@ -4633,6 +4634,35 @@ def report_text(s,head=None,tail=None,prefix=None,
             report_text('\n'.join(lines[-tail:]),
                         prefix=prefix,
                         reportf=reportf)
+
+def format_compute_time(secs):
+    """
+    Format compute time into days, hours, minutes & seconds
+
+    Arguments:
+      secs (float): time interval in seconds
+
+    Returns:
+      String: compute time expressed as days, hours, minutes
+        and seconds (e.g. "4d 12h 6m 14.0s")
+    """
+    if secs >= 60.0:
+        mins = int(secs/60)
+        secs = secs - float(mins)*60.0
+    else:
+        mins = 0
+    if mins >= 60.0:
+        hours = int(mins/60)
+        mins = mins - hours*60
+    else:
+        hours = 0
+    if hours >= 24.0:
+        days = int(hours/24)
+        hours = hours - days*24
+    else:
+        days = 0
+    return " ".join([f"{days}d", f"{hours}h",
+                     f"{mins}m", f"{float(secs):.1f}s"])
 
 def collect_files(dirn,pattern):
     """

--- a/auto_process_ngs/pipeliner.py
+++ b/auto_process_ngs/pipeliner.py
@@ -2038,10 +2038,13 @@ class Pipeline:
                 compute_time_by_nslots[nslots] += compute_time
         self.report(f"Compute summary: {ncompute_jobs} compute jobs")
         for nslots in sorted(list(compute_time_by_nslots.keys())):
-            self.report(f"- {nslots:2d}-core jobs: "
-                        f"{ncompute_jobs_by_nslots[nslots]} jobs taking "
-                        f"{compute_time_by_nslots[nslots]}s total")
-        self.report(f"Total compute time {compute_time_total}s")
+            self.report(
+                f"- {nslots:2d}-core jobs: "
+                f"{ncompute_jobs_by_nslots[nslots]} jobs taking "
+                f"{compute_time_by_nslots[nslots]}s total "
+                f"[{format_compute_time(compute_time_by_nslots[nslots])}]")
+        self.report(f"Total compute time {compute_time_total}s"
+                    f"[{format_compute_time(compute_time_total)}]")
         if njobs_missing_audit_info:
             self.report(f"WARNING unable to acquire audit information "
                         f"for {njobs_missing_audit_info} job(s)")

--- a/auto_process_ngs/test/test_pipeliner.py
+++ b/auto_process_ngs/test/test_pipeliner.py
@@ -32,6 +32,7 @@ from auto_process_ngs.pipeliner import PathExistsParam
 from auto_process_ngs.pipeliner import FunctionParam
 from auto_process_ngs.pipeliner import PipelineError
 from auto_process_ngs.pipeliner import report_text
+from auto_process_ngs.pipeliner import format_compute_time
 from auto_process_ngs.pipeliner import resolve_parameter
 from auto_process_ngs.pipeliner import make_conda_env
 from auto_process_ngs.pipeliner import check_conda_env
@@ -4152,6 +4153,23 @@ and blank lines
                     tail=3,
                     reportf=write_output)
         self.assertEqual(output.getvalue(),input_text)
+
+class TestFormatComputeTime(unittest.TestCase):
+
+    def test_format_compute_time(self):
+        """
+        format_compute_time: check time is correctly formatted
+        """
+        self.assertEqual(format_compute_time(32), "0d 0h 0m 32.0s")
+        self.assertEqual(format_compute_time(60), "0d 0h 1m 0.0s")
+        self.assertEqual(format_compute_time(92), "0d 0h 1m 32.0s")
+        self.assertEqual(format_compute_time(392), "0d 0h 6m 32.0s")
+        self.assertEqual(format_compute_time(3632), "0d 1h 0m 32.0s")
+        self.assertEqual(format_compute_time(54000), "0d 15h 0m 0.0s")
+        self.assertEqual(format_compute_time(54015), "0d 15h 0m 15.0s")
+        self.assertEqual(format_compute_time(55215), "0d 15h 20m 15.0s")
+        self.assertEqual(format_compute_time(86429), "1d 0h 0m 29.0s")
+        self.assertEqual(format_compute_time(141629), "1d 15h 20m 29.0s")
 
 class TestResolveParameter(unittest.TestCase):
 


### PR DESCRIPTION
Updates the `pipeliner` module so that `PipelineTask` instances also collect creation and modification times for stdout files when collecting auditing information. These are then used as fallbacks if the job start and/or end times are not available when reporting the compute auditing information on pipeline termination (addresses bug in issue #1027).

Additionally the compute times are now reported in "day/hour/min/secs" format, in addition to the total number of seconds - this uses a new helper function `format_compute_times`. The output now looks like e.g.:

    2025-08-12 12:40:57 [QC] Compute summary: 75 compute jobs
    2025-08-12 12:40:57 [QC] -  1-core jobs: 43 jobs taking 566.0s total [0d 0h 9m 26.0s]
    2025-08-12 12:40:57 [QC] -  8-core jobs: 23 jobs taking 519.0s total [0d 0h 8m 39.0s]
    2025-08-12 12:40:57 [QC] - 16-core jobs: 4 jobs taking 867.0s total [0d 0h 14m 27.0s]
    2025-08-12 12:40:57 [QC] - 18-core jobs: 5 jobs taking 255.0s total [0d 0h 4m 15.0s]
    2025-08-12 12:40:57 [QC] Total compute time 2207.0s [0d 0h 36m 47.0s]