### PR TITLE
'transfer_data.py': add option to include 10xGenomics '.cloupe' files

### DIFF
--- a/docs/source/using/managing_data.rst
+++ b/docs/source/using/managing_data.rst
@@ -223,6 +223,9 @@ is possible to include additional files:
  * Outputs from 10xGenomics pipelines (e.g. ``cellranger count``)
    packaged into a ``tgz`` archive (specify the
    ``--include_10x_outputs`` option)
+ * ``.cloupe`` files from 10xGenomics pipeline outputs collected
+   into a ``.zip`` archive (specify the ``--include_cloupe_files``
+   option)
  * Image files in the ``Visium_images`` subdirectory of 10xGenomics
    Visium datasets packaged into a ``tgz`` archive (specify the
    ``--include_visium_images`` option)


### PR DESCRIPTION
Address request in issue #1022 to include `.cloupe` files from 10xGenomics pipeline outputs when copying data for sharing using the `transfer_data.py` utility.

PR adds a new `--include_cloupe_files` which searches for these files and bundles them into a `.zip` archive which is then copied to the final location.

If the option is specified but no `.cloupe` files are found then the utility will stop with an error.