### PR TITLE
simple_scheduler: update how "daemonic" thread is created in 'SimpleScheduler'

### DIFF
--- a/auto_process_ngs/simple_scheduler.py
+++ b/auto_process_ngs/simple_scheduler.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     simple_scheduler.py: provide basic scheduler capability
-#     Copyright (C) University of Manchester 2013-2024 Peter Briggs
+#     Copyright (C) University of Manchester 2013-2025 Peter Briggs
 #
 ########################################################################
 #
@@ -107,8 +107,7 @@ class SimpleScheduler(threading.Thread):
 
         """
 
-        threading.Thread.__init__(self)
-        self.setDaemon(1)
+        threading.Thread.__init__(self, daemon=True)
         # Default job runner
         if runner is None:
             runner = JobRunner.SimpleJobRunner()


### PR DESCRIPTION
Updates the creation of "daemonic" `Thread` instances in the `SimpleScheduler` class in the `simple_scheduler` module, by setting the `daemon` parameter when a new `Thread` is instantiated (rather than calling the deprecated `setDaemon()` method once the `Thread` instance has been created).