### PR TITLE
'transfer_data.py': fix web URL and 'keyboard interrupt' handling

### DIFF
--- a/auto_process_ngs/cli/transfer_data.py
+++ b/auto_process_ngs/cli/transfer_data.py
@@ -603,7 +603,7 @@ def main(argv=None):
     if weburl:
         url = weburl
         if subdir is not None:
-            weburl = os.path.join(url, subdir)
+            url = os.path.join(url, subdir)
         print(f"URL: %s" % url)
     else:
         url = None


### PR DESCRIPTION
Two fixes to the `transfer_data.py` utility:

* Corrects the URL printed at the end of transferring data when the ``--subdir`` option was specified (was missing the subdirectory)
* Updates the handling of `KeyboardInterrupt` exceptions within the scheduler (see #1087) by adding a flag to indicate if the handler is active or not, so keyboard interrupts shoud now force the utility to run to the end without executing further operations.