### PR TITLE
Remove stdout messaging from 'fetch_reference_data' function

### DIFF
--- a/auto_process_ngs/settings.py
+++ b/auto_process_ngs/settings.py
@@ -1428,8 +1428,6 @@ def fetch_reference_data(s,name):
     refdata = dict()
     for organism in s.organisms:
         data_item = s.organisms[organism][name]
-        print(f"fetch_reference_data: {organism}/{name} = {data_item}")
-        print("%r" % data_item)
         if data_item:
             refdata[organism] = data_item
     return refdata


### PR DESCRIPTION
Removes the stdout messaging output from the `fetch_reference_data` function (in the `settings` module), which appears to have been left over from recent updates to the implementation of the `Settings` class (PR #1044).