### PR TITLE
Enable unit tests to work from within PyCharm

### DIFF
--- a/auto_process_ngs/test/__init__.py
+++ b/auto_process_ngs/test/__init__.py
@@ -1,0 +1,6 @@
+# In order to run tests without installing the auto_process_ngs package
+# we need to add the package "bin" directory
+
+import os
+__AUTO_PROCESS_BIN__ = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", "bin"))
+os.environ["PATH"] = f"{__AUTO_PROCESS_BIN__}{os.pathsep}{os.environ['PATH']}"


### PR DESCRIPTION
Adds the package `bin` directory to the `PATH` environment variable with the top-level `__init__.py` file of the unit tests, to enable the tests which use scripts from that directory (e.g. the Fastq generation or QC pipeline) to work within PyCharm (where the package isn't installed, so the scripts are not available in the virtual environment).