### PR TITLE
'cellranger_count' QC module: don't hard trim R1 for CellRanger version 10 and higher

### DIFF
--- a/auto_process_ngs/qc/modules/cellranger_count.py
+++ b/auto_process_ngs/qc/modules/cellranger_count.py
@@ -744,8 +744,12 @@ class RunCellrangerCount(PipelineTask):
                                  self.args.force_cells)
                 # Additional options for cellranger 5.0+
                 if cellranger_major_version >= 5:
-                    # Hard-trim the input R1 sequence to 26bp
-                    cmd.add_args("--r1-length=26")
+                    if cellranger_major_version < 10:
+                        # Hard-trim the input R1 sequence to 26bp
+                        # Retained for reproducibility when running
+                        # count with cellranger versions < v10
+                        print("Hard-trimming input R1 sequence to 26bp")
+                        cmd.add_args("--r1-length=26")
                     if self.args.library_type == "snRNA-seq":
                         # For single nuclei RNA-seq specify the
                         if cellranger_major_version >= 7:


### PR DESCRIPTION
Updates the `RunCellrangerCount` task in the `cellranger_count` QC module (in `qc/modules/cellranger_count`), to no longer automatically hard trim R1 reads to 26 bp when running the `cellranger count` command.

The hard trimming appears to have been introduced when the code was updated for CellRanger version 5 (PR #640) and has been retained since then, however now that the Fastq generation protocols explicitly trim the reads (PR #1104) this should not be necessary (and it's unclear now why this was introduced in the first place).