### PR TITLE
'archive': exclude temporary job runner directories from archiving

### DIFF
--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     archive_cmd.py: implement auto process archive command
-#     Copyright (C) University of Manchester 2017-2025 Peter Briggs
+#     Copyright (C) University of Manchester 2017-2026 Peter Briggs
 #
 #########################################################################
 
@@ -258,7 +258,8 @@ def archive(ap,archive_dir=None,platform=None,year=None,
                     '--exclude=*.bak',
                     '--exclude=*.tmp',
                     '--exclude=tmp.*',
-                    '--exclude=__*',]
+                    '--exclude=__*',
+                    '--exclude=.*runner*']
         if not include_bcl2fastq:
             # Determine whether bcl2fastq dir should be included implicitly
             # because there are links from the analysis directories

--- a/auto_process_ngs/test/commands/test_archive_cmd.py
+++ b/auto_process_ngs/test/commands/test_archive_cmd.py
@@ -1644,7 +1644,9 @@ ABM4,CMO304,ABM4
                         "save.bcl2fastqL1234",
                         "save.bcl2fastqL5678",
                         "tmp.illumina_qc.XYZ",
-                        "__qc.XYZ123.tmp",)
+                        "__qc.XYZ123.tmp",
+                        ".gejobrunner",
+                        ".slurmrunner.iupao01a")
         exclude_files = ("custom_SampleSheet.csv.bak",)
         for d in exclude_dirs:
             os.makedirs(os.path.join(mockdir.dirn,d))
@@ -1681,9 +1683,11 @@ ABM4,CMO304,ABM4
         self.assertTrue(os.path.exists(staging_dir))
         # Check unwanted content not copied across
         for d in exclude_dirs:
-            self.assertFalse(os.path.exists(os.path.join(staging_dir,d)))
+            self.assertFalse(os.path.exists(os.path.join(staging_dir,d)),
+                             f"{d}: is present but should be excluded")
         for f in exclude_files:
-            self.assertFalse(os.path.exists(os.path.join(staging_dir,f)))
+            self.assertFalse(os.path.exists(os.path.join(staging_dir,f)),
+                             f"{f}: is present but should be excluded")
         # Do second archive operation to final
         status = archive(ap,
                          archive_dir=archive_dir,


### PR DESCRIPTION
Updates the archiving command so that temporary job runner directories (e.g. `.gerunner`, `.slurmrunner.u33efg` etc) are excluded from the archiving.