### PR TITLE
Refactor how command functionality is attached to 'AutoProcess' class

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -29,11 +29,9 @@ import bcftbx.utils as bcf_utils
 import bcftbx.htmlpagewriter as htmlpagewriter
 from bcftbx.JobRunner import fetch_runner
 from bcftbx.FASTQFile import FastqIterator
-from . import commands
 from .analysis import AnalysisProject
 from .analysis import run_id
 from .analysis import run_reference_id
-from .decorators import add_command
 from .metadata import AnalysisDirParameters
 from .metadata import AnalysisDirMetadata
 from .metadata import ProjectMetadataFile
@@ -51,20 +49,7 @@ from . import get_version
 # Classes
 #######################################################################
 
-@add_command("setup",commands.setup)
-@add_command("make_fastqs",commands.make_fastqs)
-@add_command("analyse_barcodes",commands.analyse_barcodes)
-@add_command("merge_fastq_dirs",commands.merge_fastq_dirs)
-@add_command("setup_analysis_dirs",commands.setup_analysis_dirs)
-@add_command("run_qc",commands.run_qc)
-@add_command("publish_qc",commands.publish_qc)
-@add_command("archive",commands.archive)
-@add_command("update",commands.update)
-@add_command("report",commands.report)
-@add_command("update_fastq_stats",commands.update_fastq_stats)
-@add_command("import_project",commands.import_project)
-@add_command("clone",commands.clone)
-@add_command("samplesheet",commands.samplesheet)
+
 class AutoProcess:
     """
     Class implementing an automatic fastq generation and QC

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -3,11 +3,6 @@
 #     auto_processor.py: automated processing of Illumina sequence data
 #     Copyright (C) University of Manchester 2013-2026 Peter Briggs
 #
-#########################################################################
-#
-# auto_processor.py
-#
-#########################################################################
 
 #######################################################################
 # Imports
@@ -24,11 +19,7 @@ import ast
 import gzip
 import atexit
 import bcftbx.IlluminaData as IlluminaData
-import bcftbx.TabFile as TabFile
 import bcftbx.utils as bcf_utils
-import bcftbx.htmlpagewriter as htmlpagewriter
-from bcftbx.JobRunner import fetch_runner
-from bcftbx.FASTQFile import FastqIterator
 from .analysis import AnalysisProject
 from .analysis import run_id
 from .analysis import run_reference_id
@@ -39,11 +30,9 @@ from .utils import edit_file
 from .utils import get_numbered_subdir
 from .utils import sort_sample_names
 from .bcl2fastq.utils import get_sequencer_platform
-from .samplesheet_utils import check_and_warn
 from .settings import Settings
 from .exceptions import MissingParameterFileException
 from functools import reduce
-from . import get_version
 
 #######################################################################
 # Classes
@@ -55,24 +44,28 @@ class AutoProcess:
     Class implementing an automatic fastq generation and QC
     processing procedure for Illumina sequencing data
 
+    The 'AutoProcess' class provides an interface to a directory
+    being used for processing Illumina sequencing data, including
+    Fastq generation and QC operations.
+
+    The auto_process data processing and QC pipelines are
+    constructed around this class, which allows the current state
+    of the processing directory (and associated metadata) to be
+    accessed and modified.
+
+    Arguments:
+      analysis_dir (str): name/path for existing analysis
+        directory
+      settings (Settings): optional, if supplied then should
+        be a Settings instance; otherwise use a default
+        instance populated from the installation-specific
+        'auto_process.ini' file
+      allow_save_params (bool): if True then allow updates
+        to parameters to be saved back to the parameter file
+        (this is the default)
     """
     def __init__(self,analysis_dir=None,settings=None,
                  allow_save_params=True):
-        """
-        Create a new AutoProcess instance
-
-        Arguments:
-          analysis_dir (str): name/path for existing analysis
-            directory
-          settings (Settings): optional, if supplied then should
-            be a Settings instance; otherwise use a default
-            instance populated from the installation-specific
-            'auto_process.ini' file
-          allow_save_params (bool): if True then allow updates
-            to parameters to be saved back to the parameter file
-            (this is the default)
-
-        """
         # Initialise
         self._master_log_dir = "logs"
         self._log_dir = self._master_log_dir

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -75,12 +75,14 @@ from bcftbx.cmdparse import add_runner_option
 from bcftbx.cmdparse import add_arg
 from bcftbx.JobRunner import fetch_runner
 from .. import get_version
-from ..auto_processor import AutoProcess
+from .. import auto_processor
+from .. import commands
 from ..bcl2fastq.pipeline import PROTOCOLS
 from ..bcl2fastq.pipeline import subset
 from ..commands.make_fastqs_cmd import BCL2FASTQ_DEFAULTS
 from ..commands.report_cmd import ReportingMode
 from ..commands.samplesheet_cmd import SampleSheetOperation
+from ..decorators import add_command
 from ..samplesheet_utils import predict_outputs
 from ..settings import Settings
 from ..settings import locate_auto_process_settings_file
@@ -94,6 +96,29 @@ logger = logging.getLogger(__name__)
 # Version and configuration
 __version__ = get_version()
 __settings = Settings()
+
+#######################################################################
+# Classes
+#######################################################################
+
+@add_command("setup", commands.setup)
+@add_command("make_fastqs", commands.make_fastqs)
+@add_command("analyse_barcodes", commands.analyse_barcodes)
+@add_command("merge_fastq_dirs", commands.merge_fastq_dirs)
+@add_command("setup_analysis_dirs", commands.setup_analysis_dirs)
+@add_command("run_qc", commands.run_qc)
+@add_command("publish_qc", commands.publish_qc)
+@add_command("archive", commands.archive)
+@add_command("update", commands.update)
+@add_command("report", commands.report)
+@add_command("update_fastq_stats", commands.update_fastq_stats)
+@add_command("import_project", commands.import_project)
+@add_command("clone", commands.clone)
+@add_command("samplesheet", commands.samplesheet)
+class AutoProcess(auto_processor.AutoProcess):
+    """
+    Augmented AutoProcess class with commands
+    """
 
 #######################################################################
 # Functions

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -3,11 +3,6 @@
 #     cli/auto_process.py: command line interface for auto_process_ngs
 #     Copyright (C) University of Manchester 2013-2026 Peter Briggs
 #
-#########################################################################
-#
-# auto_process.py
-#
-#########################################################################
 
 """
 Automated data processing & QC pipeline for Illumina sequence data
@@ -60,19 +55,16 @@ special cases and testing.
 
 import sys
 import os
-import subprocess
 import argparse
 import time
 import logging
 import bcftbx.utils as bcf_utils
-import bcftbx.platforms
 from bcftbx.cmdparse import CommandParser
 from bcftbx.cmdparse import add_debug_option
 from bcftbx.cmdparse import add_no_save_option
 from bcftbx.cmdparse import add_dry_run_option
 from bcftbx.cmdparse import add_nprocessors_option
 from bcftbx.cmdparse import add_runner_option
-from bcftbx.cmdparse import add_arg
 from bcftbx.JobRunner import fetch_runner
 from .. import get_version
 from .. import auto_processor
@@ -83,7 +75,6 @@ from ..commands.make_fastqs_cmd import BCL2FASTQ_DEFAULTS
 from ..commands.report_cmd import ReportingMode
 from ..commands.samplesheet_cmd import SampleSheetOperation
 from ..decorators import add_command
-from ..samplesheet_utils import predict_outputs
 from ..settings import Settings
 from ..settings import locate_auto_process_settings_file
 from ..tenx import CELLRANGER_ASSAY_CONFIGS
@@ -117,7 +108,7 @@ __settings = Settings()
 @add_command("samplesheet", commands.samplesheet)
 class AutoProcess(auto_processor.AutoProcess):
     """
-    Augmented AutoProcess class with commands
+    Augmented AutoProcess class with commands attached
     """
 
 #######################################################################

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -15,6 +15,7 @@ from auto_process_ngs.mock import MockBclConvertExe
 from auto_process_ngs.mock import MockCellrangerExe
 from auto_process_ngs.mock import Mock10xPackageExe
 from auto_process_ngs.commands.make_fastqs_cmd import make_fastqs
+from auto_process_ngs.commands.setup_cmd import setup
 from auto_process_ngs.bcl2fastq.pipeline import subset
 
 # Set to False to keep test output dirs
@@ -76,8 +77,7 @@ poll_interval = 0.01
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_M00879_00002_AHGXXXX"))
+        setup(ap, os.path.join(self.wd, "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -133,8 +133,7 @@ poll_interval = 0.01
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_M00879_00002_AHGXXXX"))
+        setup(ap, os.path.join(self.wd, "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -190,8 +189,7 @@ poll_interval = 0.01
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_M00879_00002_AHGXXXX"))
+        setup(ap, os.path.join(self.wd, "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -249,8 +247,7 @@ poll_interval = 0.01
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_M00879_00002_AHGXXXX"))
+        setup(ap, os.path.join(self.wd, "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -306,8 +303,7 @@ poll_interval = 0.01
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_M00879_00002_AHGXXXX"))
+        setup(ap, os.path.join(self.wd, "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -373,8 +369,7 @@ smpl2,smpl2,,,A005,SI-GA-B1,10xGenomics,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_NB500968_00002_AHGXXXX"),
+        setup(ap, os.path.join(self.wd, "171020_NB500968_00002_AHGXXXX"),
                  sample_sheet=sample_sheet)
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
@@ -440,9 +435,8 @@ smpl2,smpl2,,,A005,CTTAGGAC,10xGenomics,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_NB500968_00002_AHGXXXX"),
-                 sample_sheet=sample_sheet)
+        setup(ap, os.path.join(self.wd, "171020_NB500968_00002_AHGXXXX"),
+              sample_sheet=sample_sheet)
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -510,9 +504,8 @@ smpl2,smpl2,,,A005,SI-NA-B1,10xGenomics,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_NB500968_00002_AHGXXXX"),
-                 sample_sheet=sample_sheet)
+        setup(ap, os.path.join(self.wd, "171020_NB500968_00002_AHGXXXX"),
+              sample_sheet=sample_sheet)
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -577,9 +570,8 @@ smpl2,smpl2,,,SI-NA-B1,AGTCCCATCA,10xGenomics,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_NB500968_00002_AHGXXXX"),
-                 sample_sheet=sample_sheet)
+        setup(ap, os.path.join(self.wd, "171020_NB500968_00002_AHGXXXX"),
+              sample_sheet=sample_sheet)
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -646,9 +638,8 @@ smpl2,smpl2,,,A005,SI-TT-B1,10xGenomics,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_NB500968_00002_AHGXXXX"),
-                 sample_sheet=sample_sheet)
+        setup(ap, os.path.join(self.wd, "171020_NB500968_00002_AHGXXXX"),
+              sample_sheet=sample_sheet)
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -716,9 +707,8 @@ smpl2,smpl2,,,A005,SI-TT-B1,10xGenomics,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_NB500968_00002_AHGXXXX"),
-                 sample_sheet=sample_sheet)
+        setup(ap, os.path.join(self.wd, "171020_NB500968_00002_AHGXXXX"),
+              sample_sheet=sample_sheet)
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -788,9 +778,8 @@ smpl2,smpl2,,,A005,SI-TT-B1,10xGenomics,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_NB500968_00002_AHGXXXX"),
-                 sample_sheet=sample_sheet)
+        setup(ap, os.path.join(self.wd, "171020_NB500968_00002_AHGXXXX"),
+              sample_sheet=sample_sheet)
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -860,9 +849,8 @@ smpl2,smpl2,,,A005,SI-TT-B1,10xGenomics,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_NB500968_00002_AHGXXXX"),
-                 sample_sheet=sample_sheet)
+        setup(ap, os.path.join(self.wd, "171020_NB500968_00002_AHGXXXX"),
+              sample_sheet=sample_sheet)
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -927,9 +915,8 @@ smpl2,smpl2,,,SI-TT-B1,AGTCCCATCA,10xGenomics,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_NB500968_00002_AHGXXXX"),
-                 sample_sheet=sample_sheet)
+        setup(ap, os.path.join(self.wd, "171020_NB500968_00002_AHGXXXX"),
+              sample_sheet=sample_sheet)
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -997,9 +984,8 @@ smpl2,smpl2,,,A005,SI-TT-B1,10xGenomics,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_NB500968_00002_AHGXXXX"),
-                 sample_sheet=sample_sheet)
+        setup(ap, os.path.join(self.wd, "171020_NB500968_00002_AHGXXXX"),
+              sample_sheet=sample_sheet)
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -1064,9 +1050,8 @@ smpl2,smpl2,,,SI-TT-B1,AGTCCCATCA,10xGenomics,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_NB500968_00002_AHGXXXX"),
-                 sample_sheet=sample_sheet)
+        setup(ap, os.path.join(self.wd, "171020_NB500968_00002_AHGXXXX"),
+              sample_sheet=sample_sheet)
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -1139,9 +1124,8 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_NB500968_00002_AHGXXXX"),
-                 sample_sheet=sample_sheet)
+        setup(ap, os.path.join(self.wd, "171020_NB500968_00002_AHGXXXX"),
+              sample_sheet=sample_sheet)
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -1199,8 +1183,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_M00879_00002_AHGXXXX"))
+        setup(ap, os.path.join(self.wd, "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -1271,8 +1254,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_M00879_00002_AHGXXXX"))
+        setup(ap, os.path.join(self.wd, "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -1337,8 +1319,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_M00879_00002_AHGXXXX"))
+        setup(ap, os.path.join(self.wd, "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -1400,8 +1381,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_UNKNOWN_00002_AHGXXXX"))
+        setup(ap, os.path.join(self.wd, "171020_UNKNOWN_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -1463,8 +1443,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_UNKNOWN_00002_AHGXXXX"))
+        setup(ap, os.path.join(self.wd, "171020_UNKNOWN_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertTrue(ap.metadata.platform is None)
         ap.metadata["platform"] = "miseq"
@@ -1526,8 +1505,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_M00879_00002_AHGXXXX"))
+        setup(ap, os.path.join(self.wd, "171020_M00879_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -1559,8 +1537,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
                                         os.environ['PATH'])
         # Do the test
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_SN7001250_00002_AHGXXXX"))
+        setup(ap, os.path.join(self.wd, "171020_SN7001250_00002_AHGXXXX"))
         self.assertTrue(ap.params.sample_sheet is not None)
         self.assertEqual(ap.params.bases_mask,"auto")
         self.assertTrue(ap.params.primary_data_dir is None)
@@ -1624,8 +1601,7 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
         os.environ['PATH'] = "%s:%s" % (self.bin,
                                         os.environ['PATH'])
         ap = AutoProcess(settings=self.settings)
-        ap.setup(os.path.join(self.wd,
-                              "171020_M00879_00002_AHGXXXX"))
+        setup(ap, os.path.join(self.wd, "171020_M00879_00002_AHGXXXX"))
         # Make a projects.info file
         with open(os.path.join(ap.analysis_dir,'projects.info'),"wt") as fp:
             fp.write(

--- a/auto_process_ngs/test/commands/test_samplesheet_cmd.py
+++ b/auto_process_ngs/test/commands/test_samplesheet_cmd.py
@@ -10,7 +10,7 @@ from bcftbx.IlluminaData import SampleSheet
 from auto_process_ngs.auto_processor import AutoProcess
 from auto_process_ngs.mock import MockAnalysisDir
 from auto_process_ngs.commands.samplesheet_cmd import SampleSheetOperation
-from auto_process_ngs.commands.samplesheet_cmd import samplesheet
+from auto_process_ngs.commands.samplesheet_cmd import samplesheet as samplesheet_cmd
 from auto_process_ngs.commands.samplesheet_cmd import import_samplesheet
 
 # Unit tests
@@ -65,17 +65,16 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Update sample sheet project for lane 3
-        ap.samplesheet(SampleSheetOperation.SET_PROJECT,
-                       "CarlDewey",
-                       lanes=[3])
+        samplesheet_cmd(ap, SampleSheetOperation.SET_PROJECT,
+                        "CarlDewey",
+                        lanes=[3])
         for line in SampleSheet(sample_sheet_file):
             if line['Lane'] == 3:
                 self.assertEqual(line["Sample_Project"],"CarlDewey")
         # Update sample sheet project matching on sample ID
-        ap.samplesheet(SampleSheetOperation.SET_PROJECT,
-                       "AndrewBloggs",
-                       where=("SAMPLE_ID",
-                              "AB*"))
+        samplesheet_cmd(ap, SampleSheetOperation.SET_PROJECT,
+                        "AndrewBloggs",
+                        where=("SAMPLE_ID", "AB*"))
         for line in SampleSheet(sample_sheet_file):
             if line['Lane'] in (1,2):
                 self.assertEqual(line["Sample_Project"],"AndrewBloggs")
@@ -130,17 +129,16 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Update sample sheet name for lane 3
-        ap.samplesheet(SampleSheetOperation.SET_SAMPLE_NAME,
-                       "SAMPLE_ID",
-                       lanes=[3])
+        samplesheet_cmd(ap, SampleSheetOperation.SET_SAMPLE_NAME,
+                        "SAMPLE_ID",
+                        lanes=[3])
         for line in SampleSheet(sample_sheet_file):
             if line['Lane'] == 3:
                 self.assertEqual(line["Sample_Name"],"CD1")
         # Update sample sheet name matching on project name
-        ap.samplesheet(SampleSheetOperation.SET_SAMPLE_NAME,
-                       "SAMPLE_ID",
-                       where=("SAMPLE_PROJECT",
-                              "AndrewBloggs"))
+        samplesheet_cmd(ap,SampleSheetOperation.SET_SAMPLE_NAME,
+                        "SAMPLE_ID",
+                        where=("SAMPLE_PROJECT", "AndrewBloggs"))
         for line in SampleSheet(sample_sheet_file):
             if line['Lane'] in (1,2):
                 self.assertEqual(line["Sample_Name"],
@@ -196,17 +194,16 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_I
         # Make autoprocess instance
         ap = AutoProcess(analysis_dir=mockdir.dirn)
         # Update sample sheet name for lane 3
-        ap.samplesheet(SampleSheetOperation.SET_SAMPLE_ID,
-                       "SAMPLE_NAME",
-                       lanes=[3])
+        samplesheet_cmd(ap, SampleSheetOperation.SET_SAMPLE_ID,
+                        "SAMPLE_NAME",
+                        lanes=[3])
         for line in SampleSheet(sample_sheet_file):
             if line['Lane'] == 3:
                 self.assertEqual(line["Sample_ID"],"CD1")
         # Update sample sheet name matching on project name
-        ap.samplesheet(SampleSheetOperation.SET_SAMPLE_ID,
-                       "SAMPLE_NAME",
-                       where=("SAMPLE_PROJECT",
-                              "AndrewBloggs"))
+        samplesheet_cmd(ap,SampleSheetOperation.SET_SAMPLE_ID,
+                        "SAMPLE_NAME",
+                        where=("SAMPLE_PROJECT", "AndrewBloggs"))
         for line in SampleSheet(sample_sheet_file):
             if line['Lane'] in (1,2):
                 self.assertEqual(line["Sample_Name"],


### PR DESCRIPTION
Refactors the how attaching of command funcationality to `AutoProcess` class is performed; now instead of this happening as part of the class definition in the `auto_processor` module,  it is done as part of creating a subclass of `AutoProcess` in the `cli/auto_process` module.

Since the commands are accessed within the CLI this is a more appropriate location for attaching them; also by removing them from the `AutoProcess` class definition it makes it safe to reuse within individual command functions, by preventing circular imports.