### PR TITLE
Consolidate path updating functionality in 'archive', 'clone' and 'update' commands

### DIFF
--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -140,39 +140,60 @@ class AutoProcess:
                     print("Making %s" % dir_path)
                     bcf_utils.mkdir(dir_path)
 
-    def update_paths(self):
+    def update_paths(self, base_path=None, new_path=None):
         """
         Update the paths stored in the analysis directory
 
         Checks the paths stored in the analysis directory
         metadata and parameter files, and updates them if
         they're inconsistent with the current location.
+
+        By default the original 'base' path is taken from
+        the path stored in the analysis directory parameters,
+        and the new 'base' path is assumed to be the current
+        path for the analysis directory (these settings
+        are sensible if the directory has been relocated or
+        copied).
+
+        Arguments:
+            base_path (str): current 'base' directory path
+            (defaults to path stored in analysis directory
+            parameters)
+            new_path (str): new 'base' directory path
+            (defaults to the current path of the analysis
+            directory)
         """
         # Update paths in the top-level parameter file
         # (if analysis dir has been moved or copied)
-        if self.params.analysis_dir != self.analysis_dir:
+        if base_path is None:
+            # Use stored path as original base path
+            base_path = self.params.analysis_dir
+        if new_path is None:
+            # Use current path as new base path
+            new_path = self.analysis_dir
+        if base_path != new_path:
             print("Updating analysis directory paths in parameter file")
-            old_dir = self.params.analysis_dir
+            print(f"-- old base path: {base_path}")
+            print(f"-- new base path: {new_path}")
             for p in ('analysis_dir',
                       'primary_data_dir',
                       'sample_sheet'):
                 if not self.params[p]:
                     continue
-                print("...updating '%s'" % p)
                 self.params[p] = os.path.normpath(
-                    os.path.join(self.analysis_dir,
-                                 os.path.relpath(self.params[p], old_dir)))
+                    os.path.join(new_path,
+                                 os.path.relpath(self.params[p], base_path)))
+                print(f"...updated '{p}' (set to '{self.params[p]}'")
             # Update paths in QC metadata in projects
             for project in self.get_analysis_projects_from_dirs():
                 # Iterate through all project directories
                 for qc_dir in project.qc_dirs:
                     qc_info = project.qc_info(qc_dir)
-                    print("...updating QC info for %s/%s" % (project.name,
-                                                             qc_dir))
                     qc_info['fastq_dir'] = os.path.normpath(
-                        os.path.join(self.analysis_dir,
+                        os.path.join(new_path,
                                      os.path.relpath(qc_info.fastq_dir,
-                                                     old_dir)))
+                                                     base_path)))
+                    print(f"...updated QC info for {project.name}/{qc_dir}")
                     qc_info.save()
             # Save the updated parameter data
             self.save_parameters(force=True)

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -25,7 +25,6 @@ from .analysis import run_id
 from .analysis import run_reference_id
 from .metadata import AnalysisDirParameters
 from .metadata import AnalysisDirMetadata
-from .metadata import AnalysisProjectQCDirInfo
 from .metadata import ProjectMetadataFile
 from .utils import edit_file
 from .utils import get_numbered_subdir
@@ -167,8 +166,7 @@ class AutoProcess:
             for project in self.get_analysis_projects_from_dirs():
                 # Iterate through all project directories
                 for qc_dir in project.qc_dirs:
-                    qc_info = AnalysisProjectQCDirInfo(
-                        os.path.join(project.dirn,qc_dir,"qc.info"))
+                    qc_info = project.qc_info(qc_dir)
                     print("...updating QC info for %s/%s" % (project.name,
                                                              qc_dir))
                     qc_info['fastq_dir'] = os.path.normpath(

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -531,6 +531,58 @@ class AutoProcess:
         print("Updated project metadata file '%s'" %
               self.params.project_metadata)
 
+    def sync_project_metadata_file(self):
+        """
+        Synchronise 'projects.info' file with directory contents
+        """
+        # Load information from 'projects.info'
+        project_metadata = self.load_project_metadata()
+        # Comment out projects which don't exist on filesystem
+        save_required = False
+        for line in project_metadata:
+            # Iterate through the named projects
+            name = line['Project']
+            if name.startswith('#'):
+                # Commented out, ignore
+                continue
+            # Look for a matching project directory
+            project_dir = os.path.join(self.analysis_dir, name)
+            if not os.path.exists(project_dir):
+                print(f"Commenting out missing project '{name}'")
+                line['Project'] = f"#{name}"
+                save_required = True
+        if save_required:
+            project_metadata.save()
+        # Add any project directories without entries
+        save_required = False
+        projects = [line['Project'] for line in project_metadata]
+        for project in self.get_analysis_projects_from_dirs():
+            if project.name.endswith(".bak") \
+                    or project.name.endswith(".orig") \
+                    or project.name.endswith(".tmp"):
+                # Skip directories with extensions indicating they
+                # should be ignored
+                print(f"Not adding entry for unlisted project '{project.name}'")
+                continue
+            elif project.name == "undetermined":
+                # Skip undetermined
+                continue
+            elif project.name not in projects and f"#{project.name}" not in projects:
+                # Add new entry
+                print(f"Adding entry for unlisted project '{project.name}'")
+                project_metadata.add_project(project.name,
+                                             [s.name for s in project.samples],
+                                             user=project.info.user,
+                                             PI=project.info.PI,
+                                             organism=project.info.organism,
+                                             library_type=project.info.library_type,
+                                             sc_platform=project.info.single_cell_platform,
+                                             comments=project.info.comments)
+                save_required = True
+        # Save the updated project metadata if required
+        if save_required:
+            project_metadata.save()
+
     def detect_unaligned_dir(self):
         # Attempt to detect an existing 'bcl2fastq' or 'Unaligned' directory
         # containing data from bcl2fastq

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -10,13 +10,9 @@
 
 import sys
 import os
-import subprocess
 import logging
 import shutil
-import uuid
 import time
-import ast
-import gzip
 import atexit
 import bcftbx.IlluminaData as IlluminaData
 import bcftbx.utils as bcf_utils

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -25,6 +25,7 @@ from .analysis import run_id
 from .analysis import run_reference_id
 from .metadata import AnalysisDirParameters
 from .metadata import AnalysisDirMetadata
+from .metadata import AnalysisProjectQCDirInfo
 from .metadata import ProjectMetadataFile
 from .utils import edit_file
 from .utils import get_numbered_subdir
@@ -139,6 +140,44 @@ class AutoProcess:
                 if not os.path.exists(dir_path):
                     print("Making %s" % dir_path)
                     bcf_utils.mkdir(dir_path)
+
+    def update_paths(self):
+        """
+        Update the paths stored in the analysis directory
+
+        Checks the paths stored in the analysis directory
+        metadata and parameter files, and updates them if
+        they're inconsistent with the current location.
+        """
+        # Update paths in the top-level parameter file
+        # (if analysis dir has been moved or copied)
+        if self.params.analysis_dir != self.analysis_dir:
+            print("Updating analysis directory paths in parameter file")
+            old_dir = self.params.analysis_dir
+            for p in ('analysis_dir',
+                      'primary_data_dir',
+                      'sample_sheet'):
+                if not self.params[p]:
+                    continue
+                print("...updating '%s'" % p)
+                self.params[p] = os.path.normpath(
+                    os.path.join(self.analysis_dir,
+                                 os.path.relpath(self.params[p], old_dir)))
+            # Update paths in QC metadata in projects
+            for project in self.get_analysis_projects_from_dirs():
+                # Iterate through all project directories
+                for qc_dir in project.qc_dirs:
+                    qc_info = AnalysisProjectQCDirInfo(
+                        os.path.join(project.dirn,qc_dir,"qc.info"))
+                    print("...updating QC info for %s/%s" % (project.name,
+                                                             qc_dir))
+                    qc_info['fastq_dir'] = os.path.normpath(
+                        os.path.join(self.analysis_dir,
+                                     os.path.relpath(qc_info.fastq_dir,
+                                                     old_dir)))
+                    qc_info.save()
+            # Save the updated parameter data
+            self.save_parameters(force=True)
 
     def load_parameters(self,allow_save=True):
         """

--- a/auto_process_ngs/auto_processor.py
+++ b/auto_process_ngs/auto_processor.py
@@ -21,6 +21,7 @@ from .analysis import run_id
 from .analysis import run_reference_id
 from .metadata import AnalysisDirParameters
 from .metadata import AnalysisDirMetadata
+from .metadata import AnalysisProjectInfo
 from .metadata import ProjectMetadataFile
 from .utils import edit_file
 from .utils import get_numbered_subdir
@@ -1025,6 +1026,65 @@ class AutoProcess:
                                       pattern):
                 projects.append(test_project)
         return projects
+
+    def sync_project_metadata(self):
+        """
+        Update metadata stored in project dirs with 'projects.info'
+        """
+        # Load information from 'projects.info'
+        project_metadata = self.load_project_metadata()
+        save_required = False
+        for line in project_metadata:
+            # Iterate through the named projects
+            name = line['Project']
+            if name.startswith('#'):
+                # Commented out, ignore
+                continue
+            # Look for a matching project directory
+            project_dir = os.path.join(self.analysis_dir, name)
+            if os.path.exists(project_dir):
+                project = AnalysisProject(project_dir)
+                print(f"Checking metadata for project '{name}'")
+                # Synchronise metadata in projects with projects.info
+                metadata_items = dict(
+                    name=name,
+                    user=line['User'],
+                    PI=line['PI'],
+                    organism=line['Organism'],
+                    library_type=line['Library'],
+                    single_cell_platform=line['SC_Platform'],
+                    comments=line['Comments'],
+                    samples=project.sample_summary()
+                )
+                # Only update items where values differ
+                project_metadata_updated = False
+                for item in metadata_items:
+                    new_value = (metadata_items[item]
+                                 if metadata_items[item] != '.' else None)
+                    if project.info[item] != new_value:
+                        print("...updating '%s' => %r" % (item, new_value))
+                        project.info[item] = new_value
+                        project_metadata_updated = True
+                # Check paired-end info
+                project_info = AnalysisProjectInfo(project.info_file)
+                if project_info.paired_end != project.info.paired_end:
+                    print("...updating paired-end info")
+                    project_metadata_updated = True
+                # Save the updated project metadata if required
+                if project_metadata_updated:
+                    print(f"...saving project metadata for {project.name}")
+                    project.info.save()
+                # Update list of sample names in projects.info
+                sample_list = ','.join(sort_sample_names(
+                    [s.name for s in project.samples]))
+                if line['Samples'] != sample_list:
+                    print("...updating sample list in projects.info")
+                    line['Samples'] = sample_list
+                    save_required = True
+        # Save master project metadata
+        if save_required:
+            print("Saving projects.info")
+            project_metadata.save()
 
     def undetermined(self):
         # Return analysis project directory for undetermined indices

--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -13,8 +13,8 @@ import os
 import time
 import logging
 from ..analysis import AnalysisDir
+from ..auto_processor import AutoProcess
 from ..metadata import AnalysisDirMetadata
-from ..metadata import AnalysisDirParameters
 from ..command import Command
 from ..commands.report_cmd import report_concise
 from .. import apps
@@ -413,36 +413,12 @@ def archive(ap,archive_dir=None,platform=None,year=None,
     # Perform final archiving operations
     if final:
         # Update the final stored Fastq paths and metadata
-        # FIXME this is essentially duplicating functionality
-        # FIXME in the 'update' command
-        # FIXME (Also probably shouldn't update metadata for
-        # FIXME 'dry_run' mode?)
-        print("Updating stored paths and metadata")
+        # FIXME Probably shouldn't update metadata in 'dry_run' mode?
         staged_analysis_dir = os.path.join(archive_dir,staging)
         archived_analysis_dir = os.path.join(archive_dir,final_dest)
-        parameter_file = os.path.join(staged_analysis_dir,
-                                      "auto_process.info")
-        if os.path.exists(parameter_file):
-            params = AnalysisDirParameters()
-            params.load(parameter_file,strict=False)
-            base_path = params.analysis_dir
-            print("Stored base path: %s" % base_path)
-            for p in ('analysis_dir',
-                      'primary_data_dir',
-                      'sample_sheet'):
-                if not params[p]:
-                    continue
-                params[p] = os.path.normpath(
-                    os.path.join(archived_analysis_dir,
-                                 os.path.relpath(params[p],
-                                                 base_path)))
-                print("...updated '%s' (set to '%s')" % (p,params[p]))
-            params.save()
-        else:
-            base_path = ap.analysis_dir
-            logger.warning("Unable to get old base path from parameters")
-            logger.warning("Using base path: %s (may be incorrect)" %
-                           base_path)
+        AutoProcess(staged_analysis_dir).update_paths(
+            base_path=ap.params.analysis_dir,
+            new_path=archived_analysis_dir)
         # Run ID and reference
         metadata_file = os.path.join(staged_analysis_dir,
                                      "metadata.info")
@@ -490,21 +466,6 @@ def archive(ap,archive_dir=None,platform=None,year=None,
             # Save the updated information
             if project_info_updated:
                 project.info.save()
-            # QC metadata
-            # FIXME should do all QC dirs (not just the primary one)
-            qc_info = project.qc_info(project.qc_dir)
-            if qc_info.fastq_dir:
-                print("Project '%s': updating stored Fastq directory for QC" %
-                      project.name)
-                # FIXME could we just set it to the current Fastq path?
-                new_fastq_dir = os.path.normpath(
-                    os.path.join(archived_analysis_dir,
-                                 os.path.relpath(qc_info.fastq_dir,
-                                                 base_path)))
-                print("...updated Fastq directory: %s" % new_fastq_dir)
-                qc_info['fastq_dir'] = new_fastq_dir
-                if not dry_run:
-                    qc_info.save()
                 # Bail out if there was a problem
                 if retval != 0:
                     if not force:

--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -412,13 +412,16 @@ def archive(ap,archive_dir=None,platform=None,year=None,
             sched.stop()
     # Perform final archiving operations
     if final:
-        # Update the final stored Fastq paths and metadata
-        # FIXME Probably shouldn't update metadata in 'dry_run' mode?
+        # Paths to staging and final directories
         staged_analysis_dir = os.path.join(archive_dir,staging)
         archived_analysis_dir = os.path.join(archive_dir,final_dest)
-        AutoProcess(staged_analysis_dir).update_paths(
-            base_path=ap.params.analysis_dir,
-            new_path=archived_analysis_dir)
+        # Update the final stored Fastq paths and metadata
+        if not dry_run:
+            AutoProcess(staged_analysis_dir).update_paths(
+                base_path=ap.params.analysis_dir,
+                new_path=archived_analysis_dir)
+        else:
+            print("Updating paths skipped for dry run")
         # Run ID and reference
         metadata_file = os.path.join(staged_analysis_dir,
                                      "metadata.info")
@@ -432,7 +435,10 @@ def archive(ap,archive_dir=None,platform=None,year=None,
                 metadata['run_reference_id'] = ap.run_reference_id
                 print("...storing run reference ID ('%s')" %
                       metadata.run_reference_id)
-            metadata.save()
+            if not dry_run:
+                metadata.save()
+            else:
+                print("Run ID/reference ID not updated for dry run")
         # Project metadata and QC info
         analysis_dir =  AnalysisDir(staged_analysis_dir)
         # FIXME AnalysisDir.get_projects method might not get all
@@ -465,13 +471,16 @@ def archive(ap,archive_dir=None,platform=None,year=None,
                           project.name)
             # Save the updated information
             if project_info_updated:
-                project.info.save()
-                # Bail out if there was a problem
-                if retval != 0:
-                    if not force:
-                        raise Exception("Finalising archive failed")
-                    else:
-                        logger.warning("Finalising archive failed (ignored)")
+                if not dry_run:
+                    project.info.save()
+                else:
+                    print("Project metadata not updated for dry run")
+        # Bail out if there was a problem
+        if retval != 0:
+            if not force:
+                raise Exception("Finalising archive failed")
+            else:
+                logger.warning("Finalising archive failed (ignored)")
         # Complete archiving
         print("Moving to final location: %s" % final_dest)
         if not dry_run:

--- a/auto_process_ngs/commands/archive_cmd.py
+++ b/auto_process_ngs/commands/archive_cmd.py
@@ -10,7 +10,6 @@
 #######################################################################
 
 import os
-import time
 import logging
 from ..analysis import AnalysisDir
 from ..auto_processor import AutoProcess

--- a/auto_process_ngs/commands/clone_cmd.py
+++ b/auto_process_ngs/commands/clone_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     clone_cmd.py: implement auto process clone command
-#     Copyright (C) University of Manchester 2019 Peter Briggs
+#     Copyright (C) University of Manchester 2019-2026 Peter Briggs
 #
 #########################################################################
 
@@ -13,7 +13,7 @@ import os
 import logging
 import shutil
 from ..analysis import AnalysisProject
-from ..metadata import AnalysisDirParameters
+from ..auto_processor import AutoProcess
 import bcftbx.utils as bcf_utils
 
 # Module specific logger
@@ -141,17 +141,5 @@ def clone(ap,clone_dir,copy_fastqs=False,exclude_projects=False):
     for subdir in ('logs','ScriptCode',):
         print("[Subdirectories] making %s" % subdir)
         bcf_utils.mkdir(os.path.join(clone_dir,subdir))
-    # Update the settings
-    parameter_file = os.path.join(clone_dir,
-                                  os.path.basename(ap.parameter_file))
-    params = AnalysisDirParameters(filen=os.path.join(
-        clone_dir,
-        os.path.basename(ap.parameter_file)))
-    for p in ("sample_sheet","primary_data_dir"):
-        if not params[p]:
-            continue
-        print("[Parameters] updating '%s'" % p)
-        params[p] = os.path.join(clone_dir,
-                                 os.path.relpath(params[p],
-                                                 ap.analysis_dir))
-    params.save()
+    # Update the paths
+    AutoProcess(clone_dir).update_paths()

--- a/auto_process_ngs/commands/update_cmd.py
+++ b/auto_process_ngs/commands/update_cmd.py
@@ -11,11 +11,7 @@
 
 import os
 import logging
-from ..analysis import AnalysisProject
-from ..metadata import AnalysisProjectInfo
-from ..metadata import AnalysisProjectQCDirInfo
 from ..qc.utils import report_qc
-from ..utils import sort_sample_names
 
 # Module specific logger
 logger = logging.getLogger(__name__)
@@ -61,61 +57,9 @@ def update(ap, update_paths=True, update_project_metadata=True,
         ap.sync_project_metadata_file()
 
     if update_project_metadata:
-        # Update project metadata
-        project_metadata = ap.load_project_metadata(
-            ap.params.project_metadata)
-        save_required = False
-        for line in project_metadata:
-            # Iterate through the named projects
-            name = line['Project']
-            if name.startswith('#'):
-                # Commented out, ignore
-                continue
-            # Look for a matching project directory
-            project_dir = os.path.join(ap.analysis_dir,name)
-            if os.path.exists(project_dir):
-                project = AnalysisProject(project_dir)
-                print("Checking metadata for project '%s'" % name)
-                # Synchronise metadata in projects with projects.info
-                metadata_items = dict(
-                    name=name,
-                    user=line['User'],
-                    PI=line['PI'],
-                    organism=line['Organism'],
-                    library_type=line['Library'],
-                    single_cell_platform=line['SC_Platform'],
-                    comments=line['Comments'],
-                    samples=project.sample_summary()
-                )
-                # Only update items where values differ
-                project_metadata_updated = False
-                for item in metadata_items:
-                    new_value = (metadata_items[item]
-                                 if metadata_items[item] != '.' else None)
-                    if project.info[item] != new_value:
-                        print("...updating '%s' => %r" % (item,new_value))
-                        project.info[item] = new_value
-                        project_metadata_updated = True
-                # Check paired-end info
-                project_info = AnalysisProjectInfo(project.info_file)
-                if project_info.paired_end != project.info.paired_end:
-                    print("...updating paired-end info")
-                    project_metadata_updated = True
-                # Save the updated project metadata if required
-                if project_metadata_updated:
-                    print("...saving project metadata")
-                    project.info.save()
-                # Update list of sample names in projects.info
-                sample_list = ','.join(sort_sample_names(
-                    [s.name for s in project.samples]))
-                if line['Samples'] != sample_list:
-                    print("...updating sample list in projects.info")
-                    line['Samples'] = sample_list
-                    save_required = True
-        # Save master project metadata
-        if save_required:
-            print("Saving projects.info")
-            project_metadata.save()
+        # Synchronise metadata in each project with the
+        # contents of 'projects.info'
+        ap.sync_project_metadata()
 
     if update_qc_reports:
         # Update QC reports that are older than project metadata

--- a/auto_process_ngs/commands/update_cmd.py
+++ b/auto_process_ngs/commands/update_cmd.py
@@ -52,35 +52,8 @@ def update(ap, update_paths=True, update_project_metadata=True,
         logger.warning("No updates requested")
 
     if update_paths:
-        # Update paths in the top-level parameter file
-        # (if analysis dir has been moved or copied)
-        if ap.params.analysis_dir != ap.analysis_dir:
-            print("Updating analysis directory paths in parameter file")
-            old_dir = ap.params.analysis_dir
-            for p in ('analysis_dir',
-                      'primary_data_dir',
-                      'sample_sheet'):
-                if not ap.params[p]:
-                    continue
-                print("...updating '%s'" % p)
-                ap.params[p] = os.path.normpath(
-                    os.path.join(ap.analysis_dir,
-                                 os.path.relpath(ap.params[p],old_dir)))
-            # Update paths in QC metadata in projects
-            for project in ap.get_analysis_projects_from_dirs():
-                # Iterate through all project directories
-                for qc_dir in project.qc_dirs:
-                    qc_info = AnalysisProjectQCDirInfo(
-                        os.path.join(project.dirn,qc_dir,"qc.info"))
-                    print("...updating QC info for %s/%s" % (project.name,
-                                                             qc_dir))
-                    qc_info['fastq_dir'] = os.path.normpath(
-                        os.path.join(ap.analysis_dir,
-                                     os.path.relpath(qc_info.fastq_dir,
-                                                     old_dir)))
-                    qc_info.save()
-            # Save the updated parameter data
-            ap.save_parameters(force=True)
+        # Update paths if analysis dir has been moved or copied
+        ap.update_paths()
 
     if update_sync_projects:
         # Load information from 'projects.info'

--- a/auto_process_ngs/commands/update_cmd.py
+++ b/auto_process_ngs/commands/update_cmd.py
@@ -56,54 +56,9 @@ def update(ap, update_paths=True, update_project_metadata=True,
         ap.update_paths()
 
     if update_sync_projects:
-        # Load information from 'projects.info'
-        project_metadata = ap.load_project_metadata(
-            ap.params.project_metadata)
-        # Comment out projects which don't exist on filesystem
-        save_required = False
-        for line in project_metadata:
-            # Iterate through the named projects
-            name = line['Project']
-            if name.startswith('#'):
-                # Commented out, ignore
-                continue
-            # Look for a matching project directory
-            project_dir = os.path.join(ap.analysis_dir, name)
-            if not os.path.exists(project_dir):
-                print(f"Commenting out missing project '{name}'")
-                line['Project'] = f"#{name}"
-                save_required = True
-        if save_required:
-            project_metadata.save()
-        # Add any project directories without entries
-        save_required = False
-        projects = [line['Project'] for line in project_metadata]
-        for project in ap.get_analysis_projects_from_dirs():
-            if project.name.endswith(".bak") \
-                    or project.name.endswith(".orig") \
-                    or project.name.endswith(".tmp"):
-                # Skip directories with extensions indicating they
-                # should be ignored
-                print(f"Not adding entry for unlisted project '{project.name}'")
-                continue
-            elif project.name == "undetermined":
-                # Skip undetermined
-                continue
-            elif project.name not in projects and f"#{project.name}" not in projects:
-                # Add new entry
-                print(f"Adding entry for unlisted project '{project.name}'")
-                project_metadata.add_project(project.name,
-                                             [s.name for s in project.samples],
-                                             user=project.info.user,
-                                             PI=project.info.PI,
-                                             organism=project.info.organism,
-                                             library_type=project.info.library_type,
-                                             sc_platform=project.info.single_cell_platform,
-                                             comments=project.info.comments)
-                save_required = True
-        # Save the updated project metadata if required
-        if save_required:
-            project_metadata.save()
+        # Synchronise projects listed in 'projects.info'
+        # with contents of analysis directory
+        ap.sync_project_metadata_file()
 
     if update_project_metadata:
         # Update project metadata

--- a/auto_process_ngs/test/test_auto_processor.py
+++ b/auto_process_ngs/test/test_auto_processor.py
@@ -1167,3 +1167,189 @@ class TestAutoProcessUpdatePaths(unittest.TestCase):
                              os.path.join(new_path,
                                           proj.name,
                                           "fastqs"))
+
+
+class TestAutoProcessSyncProjectMetadataFile(unittest.TestCase):
+    """
+    Tests for the 'sync_project_metadata_file' method
+    """
+    def setUp(self):
+        # Project metadata items mapping
+        self.metadata_map = {
+            "User": "user",
+            "PI": "PI",
+            "Library": "library_type",
+            "SC_Platform": "single_cell_platform",
+            "Organism": "organism",
+            "Comments": "comments"
+        }
+        # Create a temp working dir
+        self.dirn = tempfile.mkdtemp(suffix='TestAutoProcess')
+        # Store original location
+        self.pwd = os.getcwd()
+        # Move to working directory
+        os.chdir(self.dirn)
+
+    def tearDown(self):
+        # Return to original dir
+        os.chdir(self.pwd)
+        # Remove the temporary test directory
+        shutil.rmtree(self.dirn)
+
+    def test_sync_project_metadata_file_project_no_longer_exists(self):
+        """
+        AutoProcess.sync_project_metadata_file: remove non-existent project
+        """
+        # Metadata for projects
+        project_metadata = {
+            "AB": {
+                "User": "Alan Bailey",
+                "PI": "Archie Ballard",
+                "Library": "RNA-seq",
+                "Organism": "Human"
+            }
+        }
+        # Make an auto-process directory with projects
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '231021_A00879_0087_000000000-AGEW9',
+            'novaseq',
+            project_metadata=project_metadata,
+            metadata={ "run_number": 87,
+                       "source": "local" },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Remove CDE project
+        shutil.rmtree(os.path.join(mockdir.dirn, "CDE"))
+        # Remove initial entry for CDE in projects.info
+        projects_info_contents = []
+        with open(os.path.join(mockdir.dirn,"projects.info"),'rt') as fp:
+            for line in fp:
+                if not line.startswith("CDE"):
+                    projects_info_contents.append(line)
+        with open(os.path.join(mockdir.dirn,"projects.info"),'wt') as fp:
+            fp.write("".join(projects_info_contents))
+        # Set up AutoProcess instance
+        ap = AutoProcess(mockdir.dirn)
+        # Check metadata items in projects.info pre-update
+        ap_project_metadata = ap.load_project_metadata()
+        for pname in project_metadata:
+            for item in project_metadata[pname]:
+                self.assertEqual(ap_project_metadata.lookup(pname)[item],
+                                 project_metadata[pname][item])
+        # Check metadata items in projects pre-update
+        for pname in project_metadata:
+            p = ap.get_analysis_projects(pname)[0]
+            for item in project_metadata[pname]:
+                project_item = self.metadata_map[item]
+                expected_value = project_metadata[pname][item]
+                self.assertEqual(p.info[project_item],
+                                 expected_value)
+        # Append info for missing project 'CDE' to projects.info
+        with open(os.path.join(mockdir.dirn,"projects.info"),'at') as fp:
+            fp.write("""CDE\tCDE3,CDE4\tCharles Edwards\tChIP-seq\t.\tMouse\tChristian Eggars\t1% PhiX spiked in
+""")
+        # Do the update
+        ap.sync_project_metadata_file()
+        # Reload and confirm the updates in projects.info
+        ap = AutoProcess(mockdir.dirn)
+        ap_project_metadata = ap.load_project_metadata()
+        for pname in ["AB", "#CDE"]:
+            self.assertTrue(pname in [p["Project"] for p in ap_project_metadata],
+                            f"'{pname}' not in project metadata")
+
+    def test_sync_project_metadata_file_add_unlisted_projects(self):
+        """
+        AutoProcess.sync_project_metadata_file: add unlisted projects
+        """
+        # Metadata for projects
+        project_metadata = {
+            "AB": {
+                "User": "Alan Bailey",
+                "PI": "Archie Ballard",
+                "Library": "RNA-seq",
+                "Organism": "Human"
+            },
+            "CDE": {
+                "User": "Charles Edwards",
+                "PI": "Christian Eggars",
+                "Library": "ChIP-seq",
+                "Organism": "Mouse"
+            }
+        }
+        # Make an auto-process directory with projects
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '231021_A00879_0087_000000000-AGEW9',
+            'novaseq',
+            project_metadata=project_metadata,
+            metadata={ "run_number": 87,
+                       "source": "local" },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Remove initial entry for CDE in projects.info
+        projects_info_contents = []
+        with open(os.path.join(mockdir.dirn,"projects.info"),'rt') as fp:
+            for line in fp:
+                if not line.startswith("CDE"):
+                    projects_info_contents.append(line)
+        with open(os.path.join(mockdir.dirn,"projects.info"),'wt') as fp:
+            fp.write("".join(projects_info_contents))
+        # Set up AutoProcess instance and do the update
+        ap = AutoProcess(mockdir.dirn)
+        ap.sync_project_metadata_file()
+        # Check contents of projects.info
+        with open(os.path.join(mockdir.dirn,"projects.info"),'rt') as fp:
+            expected_lines = [
+                "#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments",
+                "AB\tAB1,AB2\tAlan Bailey\tRNA-seq\t.\tHuman\tArchie Ballard\t.",
+                "CDE\tCDE3,CDE4\tCharles Edwards\tChIP-seq\t.\tMouse\tChristian Eggars\t."
+            ]
+            for expected, actual in zip(expected_lines, fp.read().split("\n")):
+                self.assertEqual(expected.strip(), actual.strip())
+
+    def test_sync_project_metadata_file_add_unlisted_projects_ignore_special_names(self):
+        """
+        AutoProcess.sync_project_metadata_file: ignore projects with "special" names
+        """
+        # Metadata for projects
+        project_metadata = {
+            "AB": {
+                "User": "Alan Bailey",
+                "PI": "Archie Ballard",
+                "Library": "RNA-seq",
+                "Organism": "Human"
+            },
+            "CDE.bak": {
+                "User": "Charles Edwards",
+                "PI": "Christian Eggars",
+                "Library": "ChIP-seq",
+                "Organism": "Mouse"
+            }
+        }
+        # Make an auto-process directory with projects
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '231021_A00879_0087_000000000-AGEW9',
+            'novaseq',
+            project_metadata=project_metadata,
+            metadata={ "run_number": 87,
+                       "source": "local" },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Remove entry for CDE.bak in projects.info
+        projects_info_contents = []
+        with open(os.path.join(mockdir.dirn,"projects.info"),'rt') as fp:
+            for line in fp:
+                if not line.startswith("CDE.bak"):
+                    projects_info_contents.append(line)
+        with open(os.path.join(mockdir.dirn,"projects.info"),'wt') as fp:
+            fp.write("".join(projects_info_contents))
+        # Set up AutoProcess instance and do the update
+        ap = AutoProcess(mockdir.dirn)
+        ap.sync_project_metadata_file()
+        # Check contents of projects.info
+        with open(os.path.join(mockdir.dirn,"projects.info"),'rt') as fp:
+            expected_lines = [
+                "#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments",
+                "AB\tAB1,AB2\tAlan Bailey\tRNA-seq\t.\tHuman\tArchie Ballard\t."
+            ]
+            for expected, actual in zip(expected_lines, fp.read().split("\n")):
+                self.assertEqual(expected.strip(), actual.strip())

--- a/auto_process_ngs/test/test_auto_processor.py
+++ b/auto_process_ngs/test/test_auto_processor.py
@@ -10,8 +10,10 @@ from textwrap import dedent
 from bcftbx.mock import MockIlluminaRun
 from auto_process_ngs.auto_processor import AutoProcess
 from auto_process_ngs.analysis import AnalysisProject
+from auto_process_ngs.metadata import AnalysisProjectQCDirInfo
 from auto_process_ngs.mock import MockAnalysisDirFactory
 from auto_process_ngs.mock import MockAnalysisProject
+from auto_process_ngs.mock import UpdateAnalysisProject
 from auto_process_ngs.settings import Settings
 
 # Unit tests
@@ -990,3 +992,135 @@ class TestAutoProcessCustomProjectMetadata(unittest.TestCase):
         self.assertEqual(ap.custom_project_metadata, ["order_numbers",
                                                       "sample_submission_date",
                                                       "assigned_to"])
+
+class TestAutoProcessUpdatePaths(unittest.TestCase):
+    """
+    Tests for the 'update_paths' property
+    """
+    def setUp(self):
+        # Create a temp working dir
+        self.dirn = tempfile.mkdtemp(suffix='TestAutoProcess')
+        # Store original location
+        self.pwd = os.getcwd()
+        # Move to working directory
+        os.chdir(self.dirn)
+
+    def tearDown(self):
+        # Return to original dir
+        os.chdir(self.pwd)
+        # Remove the temporary test directory
+        shutil.rmtree(self.dirn)
+
+    def test_update_paths_relocated_analysis_dir(self):
+        """
+        AutoProcess.update_paths: handle relocated analysis dir
+        """
+        # Make an auto-process directory
+        top_dir1 = os.path.join(self.dirn,"original")
+        os.mkdir(top_dir1)
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '231021_A00879_0087_000000000-AGEW9',
+            'novaseq',
+            metadata={ "run_number": 87,
+                       "source": "local" },
+            top_dir=top_dir1)
+        mockdir.create(no_project_dirs=True)
+        original_path = mockdir.dirn
+        # Relocate
+        top_dir2 = os.path.join(self.dirn,"new")
+        os.mkdir(top_dir2)
+        new_path = os.path.join(top_dir2,os.path.basename(mockdir.dirn))
+        os.rename(original_path,new_path)
+        # Set up AutoProcess instance
+        ap = AutoProcess(new_path)
+        # Check metadata items pre-update
+        self.assertEqual(ap.analysis_dir,new_path)
+        self.assertEqual(ap.params.analysis_dir,original_path)
+        self.assertEqual(ap.params.sample_sheet,
+                         os.path.join(original_path,
+                                      "custom_SampleSheet.csv"))
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(original_path,"primary_data"))
+        # Update the metadata
+        ap.update_paths()
+        # Reload and check metadata items post-update
+        ap = AutoProcess(new_path)
+        self.assertEqual(ap.analysis_dir,new_path)
+        self.assertEqual(ap.params.analysis_dir,new_path)
+        self.assertEqual(ap.params.sample_sheet,
+                         os.path.join(new_path,
+                                      "custom_SampleSheet.csv"))
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(new_path,"primary_data"))
+
+    def test_update_paths_relocated_analysis_dir_with_qc(self):
+        """
+        AutoProcess.update_paths: handle paths for QC in relocated analysis dir
+        """
+        # List of projects
+        project_list = ("AB","CDE","undetermined")
+        # Make an auto-process directory with projects
+        top_dir1 = os.path.join(self.dirn,"original")
+        os.mkdir(top_dir1)
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '231021_A00879_0087_000000000-AGEW9',
+            'novaseq',
+            metadata={ "run_number": 87,
+                       "source": "local" },
+            top_dir=top_dir1)
+        mockdir.create()
+        original_path = mockdir.dirn
+        # Add mock QC outputs to projects
+        for project_name in project_list:
+            p = AnalysisProject(os.path.join(mockdir.dirn,project_name))
+            UpdateAnalysisProject(p).add_qc_outputs()
+        # Relocate
+        top_dir2 = os.path.join(self.dirn,"new")
+        os.mkdir(top_dir2)
+        new_path = os.path.join(top_dir2,os.path.basename(mockdir.dirn))
+        os.rename(original_path,new_path)
+        # Set up AutoProcess instance
+        ap = AutoProcess(new_path)
+        # Check metadata items items pre-update
+        self.assertEqual(ap.analysis_dir,new_path)
+        self.assertEqual(ap.params.analysis_dir,original_path)
+        self.assertEqual(ap.params.sample_sheet,
+                         os.path.join(original_path,
+                                      "custom_SampleSheet.csv"))
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(original_path,"primary_data"))
+        # Check QC paths in projects pre-update
+        for proj in ap.get_analysis_projects():
+            qc_dirs = proj.qc_dirs
+            self.assertTrue(len(qc_dirs) == 1)
+            qc_info = AnalysisProjectQCDirInfo(os.path.join(new_path,
+                                                            proj.name,
+                                                            qc_dirs[0],
+                                                            "qc.info"))
+            self.assertEqual(qc_info.fastq_dir,
+                             os.path.join(original_path,
+                                          proj.name,
+                                          "fastqs"))
+        # Update the metadata
+        ap.update_paths()
+        # Reload and check metadata items post-update
+        ap = AutoProcess(new_path)
+        self.assertEqual(ap.analysis_dir,new_path)
+        self.assertEqual(ap.params.analysis_dir,new_path)
+        self.assertEqual(ap.params.sample_sheet,
+                         os.path.join(new_path,
+                                      "custom_SampleSheet.csv"))
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(new_path,"primary_data"))
+        # Check QC paths in projects post-update
+        for proj in ap.get_analysis_projects():
+            qc_dirs = proj.qc_dirs
+            self.assertTrue(len(qc_dirs) == 1)
+            qc_info = AnalysisProjectQCDirInfo(os.path.join(new_path,
+                                                            proj.name,
+                                                            qc_dirs[0],
+                                                            "qc.info"))
+            self.assertEqual(qc_info.fastq_dir,
+                             os.path.join(new_path,
+                                          proj.name,
+                                          "fastqs"))

--- a/auto_process_ngs/test/test_auto_processor.py
+++ b/auto_process_ngs/test/test_auto_processor.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 from bcftbx.mock import MockIlluminaRun
 from auto_process_ngs.auto_processor import AutoProcess
 from auto_process_ngs.analysis import AnalysisProject
+from auto_process_ngs.metadata import AnalysisProjectInfo
 from auto_process_ngs.metadata import AnalysisProjectQCDirInfo
 from auto_process_ngs.mock import MockAnalysisDirFactory
 from auto_process_ngs.mock import MockAnalysisProject
@@ -1353,3 +1354,220 @@ class TestAutoProcessSyncProjectMetadataFile(unittest.TestCase):
             ]
             for expected, actual in zip(expected_lines, fp.read().split("\n")):
                 self.assertEqual(expected.strip(), actual.strip())
+
+
+class TestAutoProcessSyncProjectMetadata(unittest.TestCase):
+    """
+    Tests for the 'sync_project_metadata' method
+    """
+    def setUp(self):
+        # Project metadata items mapping
+        self.metadata_map = {
+            "User": "user",
+            "PI": "PI",
+            "Library": "library_type",
+            "SC_Platform": "single_cell_platform",
+            "Organism": "organism",
+            "Comments": "comments"
+        }
+        # Create a temp working dir
+        self.dirn = tempfile.mkdtemp(suffix='TestAutoProcess')
+        # Store original location
+        self.pwd = os.getcwd()
+        # Move to working directory
+        os.chdir(self.dirn)
+
+    def tearDown(self):
+        # Return to original dir
+        os.chdir(self.pwd)
+        # Remove the temporary test directory
+        shutil.rmtree(self.dirn)
+
+    def test_sync_project_metadata_changed(self):
+        """
+        AutoProcess.sync_project_metadata: project metadata changed
+        """
+        # Metadata for projects
+        project_metadata = {
+            "AB": {
+                "User": "Alan Bailey",
+                "PI": "Archie Ballard",
+                "Library": "RNA-seq",
+                "Organism": "Human"
+            },
+            "CDE": {
+                "User": "Charles Edwards",
+                "PI": "Christian Eggars",
+                "Library": "ChIP-seq",
+                "Organism": "Mouse"
+            }
+        }
+        # Make an auto-process directory with projects
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '231021_A00879_0087_000000000-AGEW9',
+            'novaseq',
+            project_metadata=project_metadata,
+            metadata={ "run_number": 87,
+                       "source": "local" },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Set up AutoProcess instance
+        ap = AutoProcess(mockdir.dirn)
+        # Check metadata items in projects.info pre-update
+        ap_project_metadata = ap.load_project_metadata()
+        for pname in project_metadata:
+            for item in project_metadata[pname]:
+                self.assertEqual(ap_project_metadata.lookup(pname)[item],
+                                 project_metadata[pname][item])
+        # Check metadata items in projects pre-update
+        for pname in project_metadata:
+            p = ap.get_analysis_projects(pname)[0]
+            for item in project_metadata[pname]:
+                print(item)
+                project_item = self.metadata_map[item]
+                expected_value = project_metadata[pname][item]
+                self.assertEqual(p.info[project_item],
+                                 expected_value)
+        # Overwrite projects.info and update metadata
+        project_metadata["AB"]["Organism"] = "Mouse"
+        project_metadata["AB"]["Comments"] = "1% PhiX spiked in"
+        project_metadata["CDE"]["Comments"] = "1% PhiX spiked in"
+        with open(os.path.join(mockdir.dirn,"projects.info"),'wt') as fp:
+            fp.write("""#Project\tSamples\tUser\tLibrary\tSC_Platform\tOrganism\tPI\tComments
+AB\tAB1,AB2\tAlan Bailey\tRNA-seq\t.\tMouse\tArchie Ballard\t1% PhiX spiked in
+CDE\tCDE3,CDE4\tCharles Edwards\tChIP-seq\t.\tMouse\tChristian Eggars\t1% PhiX spiked in
+""")
+        ap.sync_project_metadata()
+        # Reload and confirm the updates in projects.info
+        ap = AutoProcess(mockdir.dirn)
+        ap_project_metadata = ap.load_project_metadata()
+        for pname in project_metadata:
+            for item in project_metadata[pname]:
+                self.assertEqual(ap_project_metadata.lookup(pname)[item],
+                                 project_metadata[pname][item])
+        # Confirm the updates in the projects
+        for pname in project_metadata:
+            p = ap.get_analysis_projects(pname)[0]
+            for item in project_metadata[pname]:
+                print(item)
+                project_item = self.metadata_map[item]
+                expected_value = project_metadata[pname][item]
+                self.assertEqual(p.info[project_item],
+                                 expected_value)
+
+    def test_sync_project_metadata_sample_list_changed(self):
+        """
+        AutoProcess.sync_project_metadata: synchronise sample list metadata
+        """
+        # Metadata for projects
+        project_metadata = {
+            "AB": {
+                "User": "Alan Bailey",
+                "PI": "Archie Ballard",
+                "Library": "RNA-seq",
+                "Organism": "Human"
+            },
+            "CDE": {
+                "User": "Charles Edwards",
+                "PI": "Christian Eggars",
+                "Library": "ChIP-seq",
+                "Organism": "Mouse"
+            }
+        }
+        # Make an auto-process directory with projects
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '231021_A00879_0087_000000000-AGEW9',
+            'novaseq',
+            project_metadata=project_metadata,
+            metadata={ "run_number": 87,
+                       "source": "local" },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Set up AutoProcess instance
+        ap = AutoProcess(mockdir.dirn)
+        # Check sample lists in projects.info
+        expected_samples = {
+            "AB": ["AB1","AB2"],
+            "CDE": ["CDE3","CDE4"]
+        }
+        ap_project_metadata = ap.load_project_metadata()
+        for pname in expected_samples:
+            self.assertEqual(ap_project_metadata.lookup(pname)["Samples"],
+                             ','.join(expected_samples[pname]))
+        # Check sample lists in project metadata
+        for pname in expected_samples:
+            p = ap.get_analysis_projects(pname)[0]
+            self.assertEqual(p.info.samples,
+                             "%s sample%s (%s)" %
+                             (len(expected_samples[pname]),
+                              's' if len(expected_samples[pname]) != 1 else '',
+                              ', '.join(expected_samples[pname])))
+        # Remove samples from projects
+        for fq in ("AB/fastqs/AB1_S1_R1_001.fastq.gz",
+                   "AB/fastqs/AB1_S1_R2_001.fastq.gz",
+                   "CDE/fastqs/CDE4_S4_R1_001.fastq.gz",
+                   "CDE/fastqs/CDE4_S4_R2_001.fastq.gz"):
+            os.remove(os.path.join(mockdir.dirn,fq))
+        expected_samples = {
+            "AB": ["AB2"],
+            "CDE": ["CDE3"]
+        }
+        # Update sample lists in metadata
+        ap.sync_project_metadata()
+        # Reload and check updated sample lists in projects.info
+        ap = AutoProcess(mockdir.dirn)
+        ap_project_metadata = ap.load_project_metadata()
+        for pname in expected_samples:
+            self.assertEqual(ap_project_metadata.lookup(pname)["Samples"],
+                             ','.join(expected_samples[pname]))
+        # Check updated sample lists in project metadata
+        for pname in expected_samples:
+            p = ap.get_analysis_projects(pname)[0]
+            self.assertEqual(p.info.samples,
+                             "%s sample%s (%s)" %
+                             (len(expected_samples[pname]),
+                              's' if len(expected_samples[pname]) != 1 else '',
+                              ', '.join(expected_samples[pname])))
+
+    def test_sync_project_metadata_paired_end_changed(self):
+        """
+        AutoProcess.sync_project_metadata: synchronise paired-end metadata
+        """
+        # Make an auto-process directory with projects
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '231021_A00879_0087_000000000-AGEW9',
+            'novaseq',
+            #project_metadata=project_metadata,
+            metadata={ "run_number": 87,
+                       "source": "local" },
+            top_dir=self.dirn)
+        mockdir.create()
+        # Check paired-end metadata in projects
+        # NB check the metadata directly (not via other objects)
+        expected_paired_end = {
+            "AB": True,
+            "CDE": True
+        }
+        for pname in expected_paired_end:
+            project_metadata = AnalysisProjectInfo(
+                os.path.join(mockdir.dirn,pname,"README.info"))
+            self.assertEqual(project_metadata.paired_end,
+                             expected_paired_end[pname])
+        # Remove R2 Fastqs from one of the projects
+        for fq in ("AB/fastqs/AB1_S1_R2_001.fastq.gz",
+                   "AB/fastqs/AB2_S2_R2_001.fastq.gz"):
+            os.remove(os.path.join(mockdir.dirn,fq))
+        # Set up AutoProcess instance and update metadata
+        ap = AutoProcess(mockdir.dirn)
+        ap.sync_project_metadata()
+        # Reload and check update paired-end metadata in projects
+        ap = AutoProcess(mockdir.dirn)
+        expected_paired_end = {
+            "AB": False,
+            "CDE": True
+        }
+        for pname in expected_paired_end:
+            project_metadata = AnalysisProjectInfo(
+                os.path.join(mockdir.dirn,pname,"README.info"))
+            self.assertEqual(project_metadata.paired_end,
+                             expected_paired_end[pname])

--- a/auto_process_ngs/test/test_auto_processor.py
+++ b/auto_process_ngs/test/test_auto_processor.py
@@ -1011,6 +1011,49 @@ class TestAutoProcessUpdatePaths(unittest.TestCase):
         # Remove the temporary test directory
         shutil.rmtree(self.dirn)
 
+    def test_update_paths_explicitly_supply_new_path(self):
+        """
+        AutoProcess.update_paths: explicitly supply new base path
+        """
+        # Make an auto-process directory
+        top_dir1 = os.path.join(self.dirn,"original")
+        os.mkdir(top_dir1)
+        mockdir = MockAnalysisDirFactory.bcl2fastq2(
+            '231021_A00879_0087_000000000-AGEW9',
+            'novaseq',
+            metadata={ "run_number": 87,
+                       "source": "local" },
+            top_dir=top_dir1)
+        mockdir.create(no_project_dirs=True)
+        original_path = mockdir.dirn
+        # Relocate to intermediate "staging" location
+        top_dir2 = os.path.join(self.dirn, "intermediate")
+        os.mkdir(top_dir2)
+        intermediate_path = os.path.join(top_dir2,
+                                         f"__{os.path.basename(mockdir.dirn)}.staged")
+        os.rename(original_path, intermediate_path)
+        # Set up AutoProcess instance
+        ap = AutoProcess(intermediate_path)
+        # Check metadata items pre-update
+        self.assertEqual(ap.analysis_dir, intermediate_path)
+        self.assertEqual(ap.params.analysis_dir, original_path)
+        self.assertEqual(ap.params.sample_sheet,
+                         os.path.join(original_path,
+                                      "custom_SampleSheet.csv"))
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(original_path,"primary_data"))
+        # Update the metadata
+        final_path = os.path.join(self.dirn, "final", os.path.basename(mockdir.dirn))
+        ap.update_paths(new_path=final_path)
+        # Reload and check metadata items post-update
+        ap = AutoProcess(intermediate_path)
+        self.assertEqual(ap.analysis_dir, intermediate_path)
+        self.assertEqual(ap.params.analysis_dir, final_path)
+        self.assertEqual(ap.params.sample_sheet,
+                         os.path.join(final_path, "custom_SampleSheet.csv"))
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(final_path, "primary_data"))
+
     def test_update_paths_relocated_analysis_dir(self):
         """
         AutoProcess.update_paths: handle relocated analysis dir


### PR DESCRIPTION
Consolidates the path updating functionality from the `update` command into a new `update_paths` method in the `AutoProcess` class (in the `auto_processor` module), then extends this to replace similar code in the `archive` and `clone` methods.

Closes #909.