### PR TITLE
Fix reporting of '#reads/cell' (average reads per cell) in QC reports for multiplexes 10x Genomics data

### DIFF
--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -2433,13 +2433,18 @@ class SampleQCReporter:
                     # Not sure if this fallback is redundant?
                     value = metrics.median_reads_per_cell
             elif cellranger_data.mode == "multi":
-                # Default is median for Cellranger>=7
+                # Calculate from number of reads/number of cells
                 try:
-                    value = metrics.median_reads_per_cell
-                except (AttributeError,MissingMetricError):
-                    # Cellranger 8.0.0 doesn't output median
-                    # reads so fall back to mean
-                    value = metrics.mean_reads_per_cell
+                    value = int(metrics.reads_in_cells)/int(metrics.cells)
+                except (AttributeError, MissingMetricError):
+                    # Fallbacks
+                    # Default is median for Cellranger<=7
+                    try:
+                        value = metrics.median_reads_per_cell
+                    except (AttributeError, MissingMetricError):
+                        # Cellranger 8.0.0 doesn't output median
+                        # reads so fall back to mean
+                        value = metrics.mean_reads_per_cell
             try:
                 # Assume that reads per cell is an
                 # integer and trap if it isn't (e.g.

--- a/auto_process_ngs/qc/reporting.py
+++ b/auto_process_ngs/qc/reporting.py
@@ -2436,6 +2436,9 @@ class SampleQCReporter:
                 # Calculate from number of reads/number of cells
                 try:
                     value = int(metrics.reads_in_cells)/int(metrics.cells)
+                except (ZeroDivisionError, ValueError):
+                    # No cells, or number of cells is not a number?
+                    value = "N/A"
                 except (AttributeError, MissingMetricError):
                     # Fallbacks
                     # Default is median for Cellranger<=7

--- a/auto_process_ngs/tenx/metrics.py
+++ b/auto_process_ngs/tenx/metrics.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     tenx/metrics.py: classes for handling 10xGenomics metric summaries
-#     Copyright (C) University of Manchester 2023 Peter Briggs
+#     Copyright (C) University of Manchester 2023-2026 Peter Briggs
 #
 
 """
@@ -365,6 +365,7 @@ class MultiplexSummary(MetricsSummary):
 
     The following properties are available:
 
+    - reads_in_cells
     - cells
     - mean_reads_per_cell
     - median_reads_per_cell
@@ -419,6 +420,23 @@ class MultiplexSummary(MetricsSummary):
         # No matching library
         raise KeyError("No value for metric '%s' associated with "
                        "library type '%s'" % (name,library_type))
+    @property
+    def reads_in_cells(self):
+        """
+        Returns the number of reads in cells
+        """
+        try:
+            # Cellranger 10
+            return self.fetch('Number of reads in cells')
+        except MissingMetricError:
+            pass
+        try:
+            # Cellranger <= 9
+            return self.fetch('Number of reads from cells called from this sample')
+        except MissingMetricError:
+            pass
+        # Legacy (pre-7)
+        return self.fetch('Number of reads assigned to the sample')
     @property
     def cells(self):
         """

--- a/auto_process_ngs/test/tenx/test_metrics.py
+++ b/auto_process_ngs/test/tenx/test_metrics.py
@@ -201,6 +201,7 @@ class TestMultiplexSummary(unittest.TestCase):
         with open(summary_csv,'w') as fp:
             fp.write(CELLPLEX_METRICS_SUMMARY)
         m = MultiplexSummary(summary_csv)
+        self.assertEqual(m.reads_in_cells, 114898392)
         self.assertEqual(m.cells,5175)
         self.assertEqual(m.mean_reads_per_cell,28322)
         self.assertEqual(m.median_reads_per_cell,20052)
@@ -215,6 +216,7 @@ class TestMultiplexSummary(unittest.TestCase):
         with open(summary_csv,'w') as fp:
             fp.write(CELLPLEX_METRICS_SUMMARY_7_1_0)
         m = MultiplexSummary(summary_csv)
+        self.assertEqual(m.reads_in_cells, 61845367)
         self.assertEqual(m.cells,1569)
         self.assertEqual(m.mean_reads_per_cell,52483)
         self.assertEqual(m.median_reads_per_cell,26198)
@@ -229,6 +231,7 @@ class TestMultiplexSummary(unittest.TestCase):
         with open(summary_csv,'w') as fp:
             fp.write(CELLPLEX_METRICS_SUMMARY_CSP_7_1_0)
         m = MultiplexSummary(summary_csv)
+        self.assertEqual(m.reads_in_cells, 32611101)
         self.assertEqual(m.cells,1582)
         self.assertEqual(m.mean_reads_per_cell,24975)
         self.assertEqual(m.median_reads_per_cell,18376)
@@ -245,6 +248,7 @@ class TestMultiplexSummary(unittest.TestCase):
         with open(summary_csv,'w') as fp:
             fp.write(CELLPLEX_METRICS_SUMMARY_8_0_0)
         m = MultiplexSummary(summary_csv)
+        self.assertEqual(m.reads_in_cells, 32611101)
         self.assertEqual(m.cells,1582)
         self.assertEqual(m.mean_reads_per_cell,20614)
         self.assertEqual(m.median_genes_per_cell,2042)
@@ -261,6 +265,7 @@ class TestMultiplexSummary(unittest.TestCase):
         with open(summary_csv, "wt") as fp:
             fp.write(CELLPLEX_METRICS_SUMMARY_9_0_0)
         m = MultiplexSummary(summary_csv)
+        self.assertEqual(m.reads_in_cells, 61968623)
         self.assertEqual(m.cells, 1571)
         self.assertEqual(m.mean_reads_per_cell, 39445)
         self.assertEqual(m.median_genes_per_cell, 2472)
@@ -277,6 +282,7 @@ class TestMultiplexSummary(unittest.TestCase):
         with open(summary_csv, "wt") as fp:
             fp.write(CELLPLEX_METRICS_SUMMARY_10_0_0)
         m = MultiplexSummary(summary_csv)
+        self.assertEqual(m.reads_in_cells, 61968623)
         self.assertEqual(m.cells, 1571)
         self.assertEqual(m.mean_reads_per_cell, 52565)
         self.assertEqual(m.median_genes_per_cell, 2472)
@@ -292,6 +298,7 @@ class TestMultiplexSummary(unittest.TestCase):
         with open(summary_csv,'w') as fp:
             fp.write(FLEX_METRICS_SUMMARY_8_0_0)
         m = MultiplexSummary(summary_csv)
+        self.assertEqual(m.reads_in_cells, 63271140)
         self.assertEqual(m.cells,2302)
         self.assertEqual(m.mean_reads_per_cell,27485)
         self.assertEqual(m.median_genes_per_cell,2465)
@@ -307,6 +314,7 @@ class TestMultiplexSummary(unittest.TestCase):
         with open(summary_csv,'w') as fp:
             fp.write(FLEX_METRICS_SUMMARY_9_0_0)
         m = MultiplexSummary(summary_csv)
+        self.assertEqual(m.reads_in_cells, 215425674)
         self.assertEqual(m.cells, 13958)
         self.assertEqual(m.mean_reads_per_cell, 15434)
         self.assertEqual(m.median_genes_per_cell, 1956)
@@ -322,6 +330,7 @@ class TestMultiplexSummary(unittest.TestCase):
         with open(summary_csv,'w') as fp:
             fp.write(FLEX_METRICS_SUMMARY_10_0_0)
         m = MultiplexSummary(summary_csv)
+        self.assertEqual(m.reads_in_cells, 217870314)
         self.assertEqual(m.cells, 14160)
         self.assertEqual(m.mean_reads_per_cell, 19731)
         self.assertEqual(m.median_genes_per_cell, 1953)


### PR DESCRIPTION
Addresses an issue with the `#reads/cell` values reported in the "Multiplexing analysis" summary table in the QC report for multiplexed 10x Genomics data (e.g. Flex).

Essentially:

* The `#reads/cell` value reported in the table for each multiplexed sample appears to be calculated by CellRanger across all multiplexed samples (so the same value appears in each row of the table)
* Although this is not strictly a bug in the QC pipeline or reporting, a user might reasonably expect that the reported value would actually just be the reads per cell for the specific multiplexed sample
* As Cellranger doesn't appear to calculate that directly, instead the PR updates the reporting code to calculate and report an appropriate reads per cells value for each multiplexed sample instead; this done by dividing the number of reads in cells by the number of cells for each multiplexed sample.

The following changes are required:

* Extending the multiplexing metrics extraction code for per-sample Cellranger `multi` outputs (the `MultiplexSummary` class in the `tenx/metrics.py` module) to add a new propery `reads_in_cells`;
* Updating the reporting of `#reads/cell` (in the `qc/reporting.py` module) to calculate the value from the number of reads in cells and the number of cells.