### PR TITLE
Updating specifying 10x single nuclei data in QC pipeline

### DIFF
--- a/auto_process_ngs/qc/modules/cellranger_count.py
+++ b/auto_process_ngs/qc/modules/cellranger_count.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 #     cellranger_count: implements 'cellranger_count' QC module
-#     Copyright (C) University of Manchester 2024-2025 Peter Briggs
+#     Copyright (C) University of Manchester 2024-2026 Peter Briggs
 
 """
 Implements the 'cellranger_count' QC module:
@@ -614,7 +614,7 @@ class RunCellrangerCount(PipelineTask):
     Run 'cellranger* count'
     """
     def init(self,samples,fastq_dir,reference_data_path,library_type,
-             out_dir,qc_dir=None,cellranger_exe=None,
+             out_dir,single_nuclei=None,qc_dir=None,cellranger_exe=None,
              cellranger_version=None,chemistry='auto',fastq_dirs=None,
              force_cells=None,cellranger_jobmode='local',
              cellranger_maxjobs=None,cellranger_mempercore=None,
@@ -637,6 +637,8 @@ class RunCellrangerCount(PipelineTask):
           out_dir (str): top-level directory to copy all
             final 'count' outputs into. Outputs won't be
             copied if no value is supplied
+          single_nuclei (bool): explicitly indicate that
+            data are single nuclei rather than single cell
           qc_dir (str): top-level QC directory to put
             'count' QC outputs (e.g. metrics CSV and summary
             HTML files) into. Outputs won't be copied if
@@ -762,12 +764,15 @@ class RunCellrangerCount(PipelineTask):
                         # count with cellranger versions < v10
                         print("Hard-trimming input R1 sequence to 26bp")
                         cmd.add_args("--r1-length=26")
-                    if self.args.library_type in ("snGEX", "snRNA-seq"):
+                    if self.args.single_nuclei or self.args.library_type in ("snGEX", "snRNA-seq"):
                         # For single nuclei RNA-seq specify the
                         # --include-introns option
+                        print("-- including some form of intron inclusion...")
                         if cellranger_major_version >= 7:
                             # Syntax is --include-introns {true|false}
                             # for cellranger 7.0+
+                            # NB From Cellranger 7 onwards '--include-introns true' is the default
+                            # See https://www.10xgenomics.com/support/software/cell-ranger/latest/miscellaneous/cr-intron-mode-rec
                             cmd.add_args("--include-introns",
                                          "true")
                         else:
@@ -927,7 +932,8 @@ def add_cellranger_count(p,project_name,project,qc_dir,
                          library_type,chemistry,
                          transcriptome_references,premrna_references,
                          atac_references,multiome_references,
-                         force_cells,samples=None,fastq_dirs=None,
+                         force_cells,single_nuclei=None,
+                         samples=None,fastq_dirs=None,
                          cellranger_exe=None,reference_dataset=None,
                          extra_projects=None,cellranger_out_dir=None,
                          cellranger_jobmode=None,cellranger_maxjobs=None,
@@ -970,6 +976,8 @@ def add_cellranger_count(p,project_name,project,qc_dir,
         the cell detection algorithm in 'cellranger'
         and 'cellranger-atac' using the '--force-cells'
         option (does nothing for 'cellranger-arc')
+      single_nuclei (bool): if set then indicates data
+        are single nuclei rather than single cell
       samples (list): optional, list of samples to
         restrict single library analyses to (or None
         to use all samples in project)
@@ -1110,6 +1118,7 @@ def add_cellranger_count(p,project_name,project,qc_dir,
         chemistry=chemistry,
         fastq_dirs=fastq_dirs,
         force_cells=force_cells,
+        single_nuclei=single_nuclei,
         cellranger_jobmode=cellranger_jobmode,
         cellranger_maxjobs=cellranger_maxjobs,
         cellranger_mempercore=cellranger_mempercore,

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -639,6 +639,12 @@ class QCPipeline(Pipeline):
                 except KeyError:
                     library_type = project.info.library_type
 
+                # Single nuclei flag
+                try:
+                    single_nuclei = qc_module_params['single_nuclei']
+                except KeyError:
+                    single_nuclei = False
+
                 # Set chemistry
                 try:
                     chemistry = qc_module_params['chemistry']
@@ -693,6 +699,7 @@ class QCPipeline(Pipeline):
                     organism,
                     fastq_dir,
                     qc_module_name,
+                    single_nuclei=single_nuclei,
                     library_type=library_type,
                     transcriptome_references=\
                     self.params.cellranger_transcriptomes,

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -167,7 +167,7 @@ QC_PROTOCOLS = {
             'rseqc_genebody_coverage',
             'rseqc_infer_experiment',
             'qualimap_rnaseq',
-            'cellranger_count'
+            'cellranger_count(single_nuclei=true)'
         ]
     },
 
@@ -203,11 +203,11 @@ QC_PROTOCOLS = {
             'rseqc_infer_experiment',
             'qualimap_rnaseq',
             'cellranger-arc_count',
-            # Also run Cellranger
-            # Set the chemistry to 'ARC-v1' and library to 'snRNA-seq'
+            # Also run Cellranger on GEX data
+            # Set the chemistry to 'ARC-v1' and single nuclei mode to 'true'
             # See https://kb.10xgenomics.com/hc/en-us/articles/360059656912
             'cellranger_count(chemistry=ARC-v1;'
-                             'library=snRNA-seq;'
+                             'single_nuclei=true;'
                              'cellranger_version=*;'
                              'cellranger_refdata=*;'
                              'set_cell_count=false;'

--- a/auto_process_ngs/test/qc/modules/test_cellranger_count.py
+++ b/auto_process_ngs/test/qc/modules/test_cellranger_count.py
@@ -1306,6 +1306,98 @@ class TestQCPipelineCellrangerCount(BaseQCPipelineTestCase):
                                                         "PJB",f)),
                             "Missing %s" % f)
 
+    def test_qcpipeline_qc_modules_cellranger_count_single_nuclei_10_0_0(self):
+        """
+        QCPipeline: 'cellranger_count' QC module (single-nuclei, Cellranger v10.0.0)
+        """
+        # Make mock QC executables
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 version="10.0.0",
+                                 assert_include_introns=True)
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        # Set library to a non-canonical name
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10x Chromium 3\'',
+                                           'Library type': 'SN RNAseq' })
+        p.create(top_dir=self.wd)
+        # QC protocol with cellranger_count and 'single_nuclei' set
+        protocol = QCProtocol(name="cellranger_count",
+                              description="Cellranger_count test",
+                              seq_data_reads=['r2',],
+                              index_reads=['r1'],
+                              qc_modules=("cellranger_count(single_nuclei=true)",))
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          protocol)
+        status = runqc.run(cellranger_transcriptomes=
+                           { 'human':
+                             '/data/refdata-gex-GRCh38-2024-A' },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check outputs
+        project_dir = os.path.join(self.wd,"PJB")
+        for f in (
+                "qc/cellranger_count",
+                "qc/cellranger_count/10.0.0/refdata-gex-GRCh38-2024-A/PJB1/_cmdline",
+                "qc/cellranger_count/10.0.0/refdata-gex-GRCh38-2024-A/PJB1/outs/web_summary.html",
+                "qc/cellranger_count/10.0.0/refdata-gex-GRCh38-2024-A/PJB1/outs/metrics_summary.csv",
+                "qc/cellranger_count/10.0.0/refdata-gex-GRCh38-2024-A/PJB2/_cmdline",
+                "qc/cellranger_count/10.0.0/refdata-gex-GRCh38-2024-A/PJB2/outs/web_summary.html",
+                "qc/cellranger_count/10.0.0/refdata-gex-GRCh38-2024-A/PJB2/outs/metrics_summary.csv",
+                "cellranger_count",
+                "cellranger_count/10.0.0/refdata-gex-GRCh38-2024-A/PJB1/_cmdline",
+                "cellranger_count/10.0.0/refdata-gex-GRCh38-2024-A/PJB1/outs/web_summary.html",
+                "cellranger_count/10.0.0/refdata-gex-GRCh38-2024-A/PJB1/outs/metrics_summary.csv",
+                "cellranger_count/10.0.0/refdata-gex-GRCh38-2024-A/PJB2/_cmdline",
+                "cellranger_count/10.0.0/refdata-gex-GRCh38-2024-A/PJB2/outs/web_summary.html",
+                "cellranger_count/10.0.0/refdata-gex-GRCh38-2024-A/PJB2/outs/metrics_summary.csv"):
+            self.assertTrue(os.path.exists(os.path.join(project_dir,f)),
+                            "%s: missing" % f)
+        # Check number of cells
+        project_metadata = AnalysisProjectInfo(
+            os.path.join(self.wd,"PJB","README.info"))
+        self.assertEqual(project_metadata.number_of_cells,29360)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"cellranger_count")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(protocol))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,None)
+        self.assertEqual(qc_info.star_index,None)
+        self.assertEqual(qc_info.annotation_bed,None)
+        self.assertEqual(qc_info.annotation_gtf,None)
+        self.assertEqual(qc_info.cellranger_version,"10.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check reports
+        for f in ("qc_report.html",
+                  "qc_report.PJB.zip"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
     def test_qcpipeline_qc_modules_cellranger_count_extra_project(self):
         """
         QCPipeline: 'cellranger_count' QC module (scRNA-seq with extra project)

--- a/auto_process_ngs/test/qc/protocols/test_10x_snrnaseq.py
+++ b/auto_process_ngs/test/qc/protocols/test_10x_snrnaseq.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Unit tests for qc/pipeline.py (10x single cell RNA-seq data)
+# Unit tests for qc/pipeline.py (10x single nuclei RNA-seq data)
 #######################################################################
 
 # All imports declared in __init__.py file
@@ -7,19 +7,19 @@ from . import *
 
 class TestQCPipeline(BaseQCPipelineTestCase):
     """
-    Tests for 10xGenomics single cell RNA-seq data
+    Tests for 10xGenomics single nuclei RNA-seq data
     """
-    def test_qcpipeline_with_10x_sc_rnaseq_data(self):
+    def test_qcpipeline_with_10x_sn_rnaseq_data(self):
         """
-        QCPipeline: 10xGenomics scRNA-seq run (10x_scRNAseq)
+        QCPipeline: 10xGenomics snRNA-seq run (10x_snRNAseq)
         """
         # Make mock QC executables
         MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
         MockFastQC.create(os.path.join(self.bin,"fastqc"))
         MockStar.create(os.path.join(self.bin,"STAR"))
         MockSamtools.create(os.path.join(self.bin,"samtools"))
-        MockPicard.create(os.path.join(self.bin,"picard"))
         MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
         MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
         MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
         MockQualimap.create(os.path.join(self.bin,"qualimap"))
@@ -37,12 +37,12 @@ class TestQCPipeline(BaseQCPipelineTestCase):
                                 metadata={ 'Organism': 'Human',
                                            'Single cell platform':
                                            '10x Chromium 3\'',
-                                           'Library type': 'scRNA-seq' })
+                                           'Library type': 'snRNA-seq' })
         p.create(top_dir=self.wd)
         # Set up and run the QC
         runqc = QCPipeline()
         runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
-                          fetch_protocol_definition("10x_scRNAseq"),
+                          fetch_protocol_definition("10x_snRNAseq"),
                           multiqc=True)
         status = runqc.run(fastq_screens=self.fastq_screens,
                            star_indexes=
@@ -60,9 +60,9 @@ class TestQCPipeline(BaseQCPipelineTestCase):
         # Check QC metadata
         qc_info = AnalysisProjectQCDirInfo(
             os.path.join(self.wd,"PJB","qc","qc.info"))
-        self.assertEqual(qc_info.protocol,"10x_scRNAseq")
+        self.assertEqual(qc_info.protocol,"10x_snRNAseq")
         self.assertEqual(qc_info.protocol_specification,
-                         str(fetch_protocol_definition("10x_scRNAseq")))
+                         str(fetch_protocol_definition("10x_snRNAseq")))
         self.assertEqual(qc_info.organism,"Human")
         self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
         self.assertEqual(qc_info.fastq_dir,


### PR DESCRIPTION
Adds a new `single_nuclei` parameter to the `cellranger_count` QC module, which indicates that the data should be treated as single nuclei rather than single cell.

The effect of specifying

    cellranger_count(single_nuclei=true;...)

is that inclusion of introns are explicitly specified when the QC module is executed, by adding the appropriate `--include-introns` argument to the `cellranger count` command.

The `10x_snRNAseq` and `10x_Multiome_GEX` QC protocols have also been updated to use this new parameter.

Note that for CellRanger versions 7 and higher, `cellranger count` includes introns by default (as per the recommendations from 10x Genomics: https://www.10xgenomics.com/support/software/cell-ranger/latest/miscellaneous/cr-intron-mode-rec).