### PR TITLE
Update 10x Chromium 3' OCM application support and add new QC protocol

### DIFF
--- a/auto_process_ngs/applications.py
+++ b/auto_process_ngs/applications.py
@@ -136,22 +136,23 @@ APPLICATIONS = [
         "assays": ["10x Chromium 3' (v4 GEM-X) sc GEX",],
         "tags": ["10x", "single_cell"]
     },
-    # 10x Chromium 3' OCM single-cell
+    # 10x Chromium 3' OCM single-cell & single-nuclei
     {
         "platforms": ["10x Chromium 3' OCM"],
-        "libraries": ["scRNA-seq"],
+        "libraries": ["scRNA-seq", "snRNA-seq"],
         "extensions": ["CSP", "CRISPR"],
         "alternative_extensions": {
             "Antibody Capture": "CSP",
             "Feature Barcode": "CSP",
         },
         "fastq_generation": "10x_chromium_sc",
-        "qc_protocol": "10x_scRNAseq",
+        "qc_protocol": "10x_OCM",
         "setup": {
             "templates": ["10x_multi_config(multiplexing=ocm)"],
             "directories": [],
         },
-        "assays": ["10x Chromium 3' (v4 GEM-X) OCM sc GEX",],
+        "assays": ["10x Chromium 3' (v4 GEM-X) OCM sc GEX",
+                   "10x Chromium 3' (v4 GEM-X) OCM sn GEX",],
         "tags": ["10x", "single_cell", "multiplex"]
     },
     # 10x Chromium 3' single-nuclei
@@ -166,19 +167,6 @@ APPLICATIONS = [
         },
         "assays": ["10x Chromium 3' (v4 GEM-X) sn GEX",],
         "tags": ["10x", "single_cell"]
-    },
-    # 10x Chromium 3' OCM single-nuclei
-    {
-        "platforms": ["10x Chromium 3' OCM"],
-        "libraries": ["snRNA-seq"],
-        "fastq_generation": "10x_chromium_sc",
-        "qc_protocol": "10x_snRNAseq",
-        "setup": {
-            "templates": ["10x_multi_config(multiplexing=ocm)"],
-            "directories": [],
-        },
-        "assays": ["10x Chromium 3' (v4 GEM-X) OCM sn GEX",],
-        "tags": ["10x", "single_cell", "multiplex"]
     },
     # 10x Chromium 5'
     {

--- a/auto_process_ngs/mock.py
+++ b/auto_process_ngs/mock.py
@@ -1877,7 +1877,7 @@ class Mock10xPackageExe:
             'ATAC' (when mocking 'cellranger-arc')
           multi_outputs (str): set type of
             outputs for 'cellranger multi' (either
-            'cellplex' or 'flex')
+            'ocm', 'flex' or 'cellplex')
           version (str): version of package to
             report
         """
@@ -2491,14 +2491,16 @@ Copyright (c) 2018 10x Genomics, Inc.  All rights reserved.
                 with open(web_summary_file,'wt') as fp:
                     fp.write("PLACEHOLDER FOR WEB_SUMMARY.HTML")
             # Multiplexing outs
-            if self._multi_outputs == 'cellplex':
+            if self._multi_outputs == 'ocm':
+                multi_outputs = ("cells_per_tag.json",)
+            elif self._multi_outputs == 'flex':
+                multi_outputs = ("cells_per_tag.json",
+                                 "frp_gem_barcode_overlap.csv")
+            elif self._multi_outputs == 'cellplex':
                 multi_outputs = ("assignment_confidence_table.csv",
                                  "cells_per_tag.json",
                                  "tag_calls_per_cell.csv",
                                  "tag_calls_summary.csv")
-            elif self._multi_outputs == 'flex':
-                multi_outputs = ("cells_per_tag.json",
-                                 "frp_gem_barcode_overlap.csv")
             else:
                 multi_outputs = ()
             for f in multi_outputs:

--- a/auto_process_ngs/qc/modules/cellranger_multi.py
+++ b/auto_process_ngs/qc/modules/cellranger_multi.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 #     cellranger_multi: implements 'cellranger_multi' QC module
-#     Copyright (C) University of Manchester 2024-2025 Peter Briggs
+#     Copyright (C) University of Manchester 2024-2026 Peter Briggs
 
 """
 Implements the 'cellranger_multi' QC module:
@@ -737,10 +737,11 @@ class RunCellrangerMulti(PipelineTask):
                 qc_files = [f for f in expected_outputs(config_csv, multi_id)]
                 qc_files.append(os.path.join("outs",
                                              "config.csv"))
-                qc_files.append(os.path.join("outs",
-                                             "multi",
-                                             "multiplexing_analysis",
-                                             "tag_calls_summary.csv"))
+                for f in ("tag_calls_summary.csv",
+                          "cells_per_tag.json",):
+                    qc_files.append(os.path.join("outs",
+                                                 "multi",
+                                                 "multiplexing_analysis", f))
                 # Prefix dirs
                 prefix = multi_dir
                 if config.physical_sample:

--- a/auto_process_ngs/qc/protocols.py
+++ b/auto_process_ngs/qc/protocols.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     protocols: define and handle QC protocols
-#     Copyright (C) University of Manchester 2022-2025 Peter Briggs
+#     Copyright (C) University of Manchester 2022-2026 Peter Briggs
 #
 
 """
@@ -239,6 +239,26 @@ QC_PROTOCOLS = {
                                   'cellranger_refdata=*;'
                                   'set_cell_count=false;'
                                   'set_metadata=False)'
+        ]
+    },
+
+    "10x_OCM": {
+        "description": "10xGenomics OCM (on-chip multiplexing) data",
+        "reads": {
+            "seq_data": ('r2',),
+            "index": ('r1',)
+        },
+        "qc_modules": [
+            'fastqc',
+            'fastq_screen',
+            'sequence_lengths',
+            'rseqc_genebody_coverage',
+            'rseqc_infer_experiment',
+            'qualimap_rnaseq',
+            'cellranger_count(cellranger_use_multi_config=True;'
+                             'set_cell_count=false;'
+                             'set_metadata=False)',
+            'cellranger_multi'
         ]
     },
 

--- a/auto_process_ngs/tenx/cellplex.py
+++ b/auto_process_ngs/tenx/cellplex.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     tenx/cellplex.py: utilities for handling 10xGenomics Cellplex data
-#     Copyright (C) University of Manchester 2023-2025 Peter Briggs
+#     Copyright (C) University of Manchester 2023-2026 Peter Briggs
 #
 
 """
@@ -145,7 +145,8 @@ class CellrangerMultiConfigCsv:
                     continue
                 if current_section == "samples":
                     if line.startswith('sample_id,cmo_ids') or \
-                       line.startswith('sample_id,probe_barcode_ids'):
+                       line.startswith('sample_id,probe_barcode_ids') or \
+                       line.startswith('sample_id,ocm_barcode_ids'):
                         # Header line, skip
                         continue
                     else:

--- a/auto_process_ngs/tenx/utils.py
+++ b/auto_process_ngs/tenx/utils.py
@@ -543,7 +543,8 @@ def make_multi_config_template(f, reference=None, fastq_dir=None,
             MULTIPLEXED_SAMPLE,BC001|BC002|...,DESCRIPTION
             """))
         elif multiplexing == "ocm":
-            fp.write(dedent("""[samples]
+            fp.write(dedent("""
+            [samples]
             sample_id,ocm_barcode_ids,description
             MULTIPLEXED_SAMPLE,OB1|OB2|...,DESCRIPTION
             """))

--- a/auto_process_ngs/test/qc/protocols/test_10x_ocm.py
+++ b/auto_process_ngs/test/qc/protocols/test_10x_ocm.py
@@ -1,0 +1,380 @@
+#######################################################################
+# Unit tests for qc/pipeline.py (10x OCM data)
+#######################################################################
+
+# All imports declared in __init__.py file
+from . import *
+
+class TestQCPipeline(BaseQCPipelineTestCase):
+    """
+    Tests for 10xGenomics OCM data
+    """
+    #@unittest.skip("Skipped")
+    def test_qcpipeline_with_10x_ocm_data(self):
+        """
+        QCPipeline: 10x Genomics 3' OCM data (10x_OCM)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 multi_outputs="ocm",
+                                 version="10.0.0")
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x Cellplex analysis project
+        p = MockAnalysisProject("PJB",("PJB1_OCM_S1_R1_001.fastq.gz",
+                                       "PJB1_OCM_S1_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10x Chromium 3\' OCM',
+                                           'Library type': 'scRNA-seq' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv file
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+create-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_OCM,%s,any,PJB1,gene expression,
+
+[samples]
+sample_id,ocm_barcode_ids,description
+PBA,OB1,PBA
+PBB,OB2,PBB
+""" % fastq_dir)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_OCM"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           cellranger_transcriptomes=
+                           { 'human':
+                             '/data/refdata-cellranger-gex-GRCh38-2024-A' },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"10x_OCM")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_OCM")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_OCM")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_OCM_S1_R1_001.fastq.gz,"
+                         "PJB1_OCM_S1_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,"10.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-cellranger-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_multi",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/_cmdline",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBA/web_summary.html",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBA/metrics_summary.csv",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBB/web_summary.html",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBB/metrics_summary.csv",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/multi/multiplexing_analysis/cells_per_tag.json",
+                  "cellranger_multi",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/_cmdline",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBA/web_summary.html",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBA/metrics_summary.csv",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBB/web_summary.html",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/per_sample_outs/PBB/metrics_summary.csv",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/outs/multi/multiplexing_analysis/cells_per_tag.json",
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_OCM/_cmdline",
+                  "qc/cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_OCM/outs/web_summary.html",
+                  "qc/cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_OCM/outs/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_OCM/_cmdline",
+                  "cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_OCM/outs/web_summary.html",
+                  "cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_OCM/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    #@unittest.skip("Skipped")
+    def test_qcpipeline_with_10x_ocm_data_multiple_physical_samples(self):
+        """
+        QCPipeline: 10x Genomics 3' OCM data (10x_OCM, multiple physical samples)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 multi_outputs="ocm",
+                                 version="10.0.0")
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x OCM analysis project
+        p = MockAnalysisProject("PJB",("PJB1_OCM_S1_R1_001.fastq.gz",
+                                       "PJB1_OCM_S1_R2_001.fastq.gz",
+                                       "PJB2_OCM_S2_R1_001.fastq.gz",
+                                       "PJB2_OCM_S2_R2_001.fastq.gz",),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10x Chromium 3\' OCM',
+                                           'Library type': 'scRNA-seq' })
+        p.create(top_dir=self.wd)
+        # Add the cellranger multi config.csv files
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB1.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+create-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB1_OCM,%s,any,PJB1,gene expression,
+
+[samples]
+sample_id,ocm_barcode_ids,description
+PBA,OB1,PBA
+PBB,OB2,PBB
+""" % fastq_dir)
+        with open(os.path.join(self.wd,
+                               "PJB",
+                               "10x_multi_config.PJB2.csv"),'wt') as fp:
+            fastq_dir = os.path.join(self.wd,
+                                     "PJB",
+                                     "fastqs")
+            fp.write("""[gene-expression]
+reference,/data/refdata-cellranger-gex-GRCh38-2024-A
+create-bam,true
+
+[libraries]
+fastq_id,fastqs,lanes,physical_library_id,feature_types,subsample_rate
+PJB2_OCM,%s,any,PJB2,gene expression,
+
+[samples]
+sample_id,ocm_barcode_ids,description
+PBC,OB3,PBC
+PBD,OB4,PBD
+""" % fastq_dir)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_OCM"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           cellranger_transcriptomes=
+                           { 'human':
+                             '/data/refdata-cellranger-gex-GRCh38-2024-A' },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"10x_OCM")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_OCM")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_OCM,PJB2_OCM")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_OCM_S1_R1_001.fastq.gz,"
+                         "PJB1_OCM_S1_R2_001.fastq.gz,"
+                         "PJB2_OCM_S2_R1_001.fastq.gz,"
+                         "PJB2_OCM_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,"10.0.0")
+        self.assertEqual(qc_info.cellranger_refdata,
+                         "/data/refdata-cellranger-gex-GRCh38-2024-A")
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "qc/cellranger_multi",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/_cmdline",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBA/web_summary.html",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBA/metrics_summary.csv",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBB/web_summary.html",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBB/metrics_summary.csv",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/multi/multiplexing_analysis/cells_per_tag.json",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/_cmdline",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBC/web_summary.html",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBC/metrics_summary.csv",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBD/web_summary.html",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBD/metrics_summary.csv",
+                  "qc/cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/multi/multiplexing_analysis/cells_per_tag.json",
+                  "cellranger_multi",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/_cmdline",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBA/web_summary.html",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBA/metrics_summary.csv",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBB/web_summary.html",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/per_sample_outs/PBB/metrics_summary.csv",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1/outs/multi/multiplexing_analysis/cells_per_tag.json",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/_cmdline",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBC/web_summary.html",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBC/metrics_summary.csv",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBD/web_summary.html",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/per_sample_outs/PBD/metrics_summary.csv",
+                  "cellranger_multi/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2/outs/multi/multiplexing_analysis/cells_per_tag.json",
+                  "qc/cellranger_count",
+                  "qc/cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_OCM/_cmdline",
+                  "qc/cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_OCM/outs/web_summary.html",
+                  "qc/cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_OCM/outs/metrics_summary.csv",
+                  "qc/cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_OCM/_cmdline",
+                  "qc/cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_OCM/outs/web_summary.html",
+                  "qc/cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_OCM/outs/metrics_summary.csv",
+                  "cellranger_count",
+                  "cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_OCM/_cmdline",
+                  "cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_OCM/outs/web_summary.html",
+                  "cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB1_OCM/outs/metrics_summary.csv",
+                  "cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_OCM/_cmdline",
+                  "cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_OCM/outs/web_summary.html",
+                  "cellranger_count/10.0.0/refdata-cellranger-gex-GRCh38-2024-A/PJB2_OCM/outs/metrics_summary.csv",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+
+    #@unittest.skip("Skipped")
+    def test_qcpipeline_with_ocm_data_no_multi_config_file(self):
+        """
+        QCPipeline: 10x Genomics 3' OCM data (10x_OCM, no multi config)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockCellrangerExe.create(os.path.join(self.bin,"cellranger"),
+                                 multi_outputs="ocm",
+                                 version="10.0.0")
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock 10x Cellplex analysis project
+        p = MockAnalysisProject("PJB",("PJB1_OCM_S1_R1_001.fastq.gz",
+                                       "PJB1_OCM_S1_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Human',
+                                           'Single cell platform':
+                                           '10x Chromium 3\' OCM',
+                                           'Library type': 'scRNA-seq' })
+        p.create(top_dir=self.wd)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("10x_OCM"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'human': '/data/hg38/star_index' },
+                           annotation_bed_files=
+                           { 'human': self.ref_data['hg38']['bed'] },
+                           annotation_gtf_files=
+                           { 'human': self.ref_data['hg38']['gtf'] },
+                           cellranger_transcriptomes=
+                           { 'human':
+                             '/data/refdata-cellranger-gex-GRCh38-2020-A' },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"10x_OCM")
+        self.assertEqual(qc_info.protocol_specification,
+                         str(fetch_protocol_definition("10x_OCM")))
+        self.assertEqual(qc_info.organism,"Human")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1_OCM")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_OCM_S1_R1_001.fastq.gz,"
+                         "PJB1_OCM_S1_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/hg38/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['hg38']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['hg38']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+        # Check that unexpected outputs are not present
+        for f in ("qc/cellranger_multi",
+                  "qc/cellranger_count",):
+            self.assertFalse(os.path.exists(os.path.join(self.wd,
+                                                         "PJB",f)),
+                            "Found %s (shouldn't be present)" % f)

--- a/auto_process_ngs/test/test_applications.py
+++ b/auto_process_ngs/test/test_applications.py
@@ -67,7 +67,7 @@ class TestIdentifyApplication(TestCase):
                              "scRNA-seq+CRISPR"]:
             application = identify_application(platform, library_type)
             self.assertEqual(application["fastq_generation"], "10x_chromium_sc")
-            self.assertEqual(application["qc_protocol"], "10x_scRNAseq")
+            self.assertEqual(application["qc_protocol"], "10x_OCM")
 
     def test_identify_application_10x_chromium_3prime_snrnaseq(self):
         """
@@ -95,7 +95,7 @@ class TestIdentifyApplication(TestCase):
                              "snRNA-seq+CRISPR"]:
             application = identify_application(platform, library_type)
             self.assertEqual(application["fastq_generation"], "10x_chromium_sc")
-            self.assertEqual(application["qc_protocol"], "10x_snRNAseq")
+            self.assertEqual(application["qc_protocol"], "10x_OCM")
 
     def test_identify_application_10x_chromium_5prime_immune_profiling(self):
         """


### PR DESCRIPTION
Updates the application definition for 10x Chromium 3' OCM data (to combine the two existing defintions into a single definition).

Also implements a new QC protocol `10x_OCM` for these type of data which includes the `cellranger_multi` QC module, and makes this the default for the updated application.

Includes updates to the `Mock10xPackageExe` class (in the `mock` module) to mimick outputs for OCM data (in order to implement tests for the new protocol), and other minor updates to the `cellranger multi` config file handling to deal with the templates for OCM data.

Closes #1156.