### PR TITLE
Update 'requirements.txt' to specify 'genomics-bcftbx' version 0.14.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ matplotlib
 pandas
 pillow
 psutil
-git+https://github.com/fls-bioinformatics-core/genomics.git#egg=genomics-bcftbx
+git+https://github.com/fls-bioinformatics-core/genomics.git@1.14.0#egg=genomics-bcftbx


### PR DESCRIPTION
Updates the `requirements.txt` file to specify the `genomics-bcftbx` version from Github, and pin to 0.14.0.

This should prevent development changes being included which might break `auto-process-ngs` code.