### PR TITLE
QC pipeline: bugfix when handling projects where organism name contains whitespace

### DIFF
--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -452,7 +452,7 @@ class QCPipeline(Pipeline):
             get_star_index = GetReferenceDataset(
                 "%s: get STAR index for '%s'" % (project.name,
                                                  organism),
-                organism,
+                organism_name,
                 self.params.star_indexes,
                 force_reference=self.params.force_star_index)
             self.add_task(get_star_index)
@@ -480,7 +480,7 @@ class QCPipeline(Pipeline):
                 "%s: get RSeQC reference gene model for '%s'" %
                 (project.name,
                  organism),
-                organism,
+                organism_name,
                 self.params.annotation_bed_files)
             self.add_task(get_reference_gene_model)
             qc_metadata['annotation_bed'] = \
@@ -490,7 +490,7 @@ class QCPipeline(Pipeline):
             get_annotation_gtf = GetReferenceDataset(
                 "%s: get GTF annotation for '%s'" % (project.name,
                                                      organism),
-                organism,
+                organism_name,
                 self.params.annotation_gtf_files,
                 force_reference=self.params.force_gtf_annotation)
             self.add_task(get_annotation_gtf)

--- a/auto_process_ngs/test/qc/protocols/__init__.py
+++ b/auto_process_ngs/test/qc/protocols/__init__.py
@@ -82,7 +82,7 @@ class BaseQCPipelineTestCase(unittest.TestCase):
             self.fastq_screens[screen] = conf_file
         # Add (empty) reference data files
         self.ref_data = dict()
-        for build in ('hg38','mm10',):
+        for build in ('hg38','mm10', 'chok1'):
             self.ref_data[build] = {}
             build_dir = os.path.join(self.data,build)
             os.mkdir(build_dir)

--- a/auto_process_ngs/test/qc/protocols/test_standard_qc.py
+++ b/auto_process_ngs/test/qc/protocols/test_standard_qc.py
@@ -318,3 +318,90 @@ PJB2_S2_001.bam	153.754829	69.675347	139	37
             self.assertTrue(os.path.exists(os.path.join(self.wd,
                                                         "PJB",f)),
                             "Missing %s" % f)
+
+    def test_qcpipeline_standard_paired_end_organism_with_whitespace(self):
+        """QCPipeline: standard QC run (paired-end data, organism name contains whitespace)
+        """
+        # Make mock QC executables
+        MockFastqScreen.create(os.path.join(self.bin,"fastq_screen"))
+        MockFastQC.create(os.path.join(self.bin,"fastqc"))
+        MockStar.create(os.path.join(self.bin,"STAR"))
+        MockSamtools.create(os.path.join(self.bin,"samtools"))
+        MockPicard.create(os.path.join(self.bin,"picard"))
+        MockGtf2bed.create(os.path.join(self.bin,"gtf2bed"))
+        MockRSeQC.create(os.path.join(self.bin,"infer_experiment.py"))
+        MockRSeQC.create(os.path.join(self.bin,"geneBody_coverage.py"))
+        MockQualimap.create(os.path.join(self.bin,"qualimap"))
+        MockMultiQC.create(os.path.join(self.bin,"multiqc"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make mock analysis project
+        p = MockAnalysisProject("PJB",("PJB1_S1_R1_001.fastq.gz",
+                                       "PJB1_S1_R2_001.fastq.gz",
+                                       "PJB2_S2_R1_001.fastq.gz",
+                                       "PJB2_S2_R2_001.fastq.gz"),
+                                metadata={ 'Organism': 'Chinese hamster' })
+        p.create(top_dir=self.wd)
+        # Set up and run the QC
+        runqc = QCPipeline()
+        runqc.add_project(AnalysisProject(os.path.join(self.wd,"PJB")),
+                          fetch_protocol_definition("standard"),
+                          multiqc=True)
+        status = runqc.run(fastq_screens=self.fastq_screens,
+                           star_indexes=
+                           { 'chinese_hamster': '/data/chok1/star_index' },
+                           annotation_bed_files=
+                           { 'chinese_hamster': self.ref_data['chok1']['bed'] },
+                           annotation_gtf_files=
+                           { 'chinese_hamster': self.ref_data['chok1']['gtf'] },
+                           poll_interval=POLL_INTERVAL,
+                           max_jobs=1,
+                           runners={ 'default': SimpleJobRunner(), })
+        self.assertEqual(status,0)
+        # Check QC metadata
+        qc_info = AnalysisProjectQCDirInfo(
+            os.path.join(self.wd,"PJB","qc","qc.info"))
+        self.assertEqual(qc_info.protocol,"standard")
+        self.assertEqual(qc_info.protocol_specification,
+                         "standard:'Standard QC for single and paired-end data':"
+                         "seq_reads=[r1,r2]:index_reads=[]:qc_modules=[fastq_screen,fastqc,picard_insert_size_metrics,"
+                         "qualimap_rnaseq,rseqc_genebody_coverage,rseqc_infer_experiment,sequence_lengths]")
+        self.assertEqual(qc_info.organism,"Chinese hamster")
+        self.assertEqual(qc_info.seq_data_samples,"PJB1,PJB2")
+        self.assertEqual(qc_info.fastq_dir,
+                         os.path.join(self.wd,"PJB","fastqs"))
+        self.assertEqual(qc_info.fastqs,
+                         "PJB1_S1_R1_001.fastq.gz,"
+                         "PJB1_S1_R2_001.fastq.gz,"
+                         "PJB2_S2_R1_001.fastq.gz,"
+                         "PJB2_S2_R2_001.fastq.gz")
+        self.assertEqual(qc_info.fastqs_split_by_lane,False)
+        self.assertEqual(qc_info.fastq_screens,
+                         "model_organisms,other_organisms,rRNA")
+        self.assertEqual(qc_info.star_index,"/data/chok1/star_index")
+        self.assertEqual(qc_info.annotation_bed,self.ref_data['chok1']['bed'])
+        self.assertEqual(qc_info.annotation_gtf,self.ref_data['chok1']['gtf'])
+        self.assertEqual(qc_info.cellranger_version,None)
+        self.assertEqual(qc_info.cellranger_refdata,None)
+        self.assertEqual(qc_info.cellranger_probeset,None)
+        # Check output and reports
+        for f in ("qc",
+                  "qc_report.html",
+                  "qc_report.PJB.zip",
+                  "multiqc_report.html"):
+            self.assertTrue(os.path.exists(os.path.join(self.wd,
+                                                        "PJB",f)),
+                            "Missing %s" % f)
+        # Check collated Picard insert sizes
+        collated_insert_sizes = os.path.join(self.wd,
+                                             "PJB",
+                                             "qc",
+                                             "insert_sizes.chinese_hamster.tsv")
+        self.assertTrue(os.path.exists(collated_insert_sizes),
+                        "Missing collated insert sizes TSV")
+        with open(collated_insert_sizes,'rt') as fp:
+            self.assertEqual(fp.read(),
+                             """#Bam file	Mean insert size	Standard deviation	Median insert size	Median absolute deviation
+PJB1_S1_001.bam	153.754829	69.675347	139	37
+PJB2_S2_001.bam	153.754829	69.675347	139	37
+""")


### PR DESCRIPTION
Fixes a bug in the QC pipeline (`qc/pipeline.py`) when the supplied organism name contains whitespace (e.g. `Chinese hamster`) and the configuration includes matching reference data (e.g. an organism section called `[organism:chinese_hamster]`).

In this case the normalised organism name would be `chinese_hamster`, but this was not being used consistently in the pipeline and for some tasks a "partially normalised" name (`chinese hamster`) was being used instead. As a result some reference data (e.g. STAR indexes and annotation files) were not being picked up.

This PR aims to fix the bug by using the normalised name more consistently within the pipeline code.