### PR TITLE
Create conda environments under the analysis directory by default for 'make_fastqs' & 'run_qc'

### DIFF
--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 #     make_fastqs_cmd.py: implement auto process make_fastqs command
-#     Copyright (C) University of Manchester 2018-2025 Peter Briggs
+#     Copyright (C) University of Manchester 2018-2026 Peter Briggs
 #
 #########################################################################
 
@@ -392,7 +392,12 @@ def make_fastqs(ap,protocol='standard',platform=None,
     if enable_conda is None:
         enable_conda = ap.settings.conda.enable_conda
     if conda_env_dir is None:
-        conda_env_dir = ap.settings.conda.env_dir
+        if ap.settings.conda.env_dir is not None:
+            # Use value from configuration
+            conda_env_dir = ap.settings.conda.env_dir
+        else:
+            # Use subdirectory of analysis dir
+            conda_env_dir = os.path.join(ap.analysis_dir, "__conda", "envs")
 
     # Other pipeline settings
     poll_interval = ap.settings.general.poll_interval

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -244,10 +244,11 @@ def run_qc(ap,projects=None,protocols=None,
         enable_conda = ap.settings.conda.enable_conda
     if conda_env_dir is None:
         # Use value from configuration
-        conda_env_dir = ap.settings.conda.env_dir
-    else:
-        # Use subdirectory of analysis dir
-        conda_env_dir = os.path.join(ap.analysis_dir, "__conda", "envs")
+        if ap.settings.conda.env_dir is not None:
+            conda_env_dir = ap.settings.conda.env_dir
+        else:
+            # Use subdirectory of analysis dir
+            conda_env_dir = os.path.join(ap.analysis_dir, "__conda", "envs")
     # Set scheduler parameters
     if poll_interval is None:
         poll_interval = ap.settings.general.poll_interval

--- a/auto_process_ngs/commands/run_qc_cmd.py
+++ b/auto_process_ngs/commands/run_qc_cmd.py
@@ -243,7 +243,11 @@ def run_qc(ap,projects=None,protocols=None,
     if enable_conda is None:
         enable_conda = ap.settings.conda.enable_conda
     if conda_env_dir is None:
+        # Use value from configuration
         conda_env_dir = ap.settings.conda.env_dir
+    else:
+        # Use subdirectory of analysis dir
+        conda_env_dir = os.path.join(ap.analysis_dir, "__conda", "envs")
     # Set scheduler parameters
     if poll_interval is None:
         poll_interval = ap.settings.general.poll_interval


### PR DESCRIPTION
Updates the `make_fastqs` and `run_qc` commands so that by default create any conda environments are now created in a subdirectory of the current analysis directory (specifically `<ANALYSIS_DIR>/__conda/envs`).

This default will still be overridden by locations supplied either via the command line, or via the configuration settings. The change is intended to prevent old or unwanted environments being left lying around after analyses have completed.