### PR TITLE
'run_qc.py': create conda environments under working directory by default

### DIFF
--- a/auto_process_ngs/cli/run_qc.py
+++ b/auto_process_ngs/cli/run_qc.py
@@ -1350,6 +1350,12 @@ def main(argv=None):
     if not working_dir:
         working_dir = os.path.join(project_dir,'__run_qc')
 
+    # Location for conda environments
+    conda_env_dir = args.conda_env_dir
+    if conda_env_dir is None:
+        # Explicitly set to a subdirectory of the working directory
+        conda_env_dir = os.path.join(working_dir, "__conda", "envs")
+
     # Set up and run the QC pipeline
     announce("Running QC pipeline")
     runqc = QCPipeline()
@@ -1394,7 +1400,7 @@ def main(argv=None):
                        default_runner=default_runner,
                        envmodules=envmodules,
                        enable_conda=enable_conda,
-                       conda_env_dir=args.conda_env_dir,
+                       conda_env_dir=conda_env_dir,
                        working_dir=working_dir,
                        force_star_index=force_star_index,
                        force_gtf_annotation=force_gtf_annotation,
@@ -1413,6 +1419,7 @@ def main(argv=None):
                   out_dir=out_dir,
                   zip_outputs=True,
                   multiqc=(not args.no_multiqc),
+                  conda_env_dir=conda_env_dir,
                   force=True,
                   runner=runners['report_runner'])
 

--- a/auto_process_ngs/qc/utils.py
+++ b/auto_process_ngs/qc/utils.py
@@ -103,7 +103,7 @@ def verify_qc(project,qc_dir=None,fastq_dir=None,qc_protocol=None,
 def report_qc(project,qc_dir=None,fastq_dir=None,qc_protocol=None,
               report_html=None,zip_outputs=True,multiqc=False,
               out_dir=None,force=False,runner=None,log_dir=None,
-              suppress_warning=False):
+              conda_env_dir=None,suppress_warning=False):
     """
     Generate report for the QC run for a project
 
@@ -132,6 +132,9 @@ def report_qc(project,qc_dir=None,fastq_dir=None,qc_protocol=None,
         for running the reporting
       log_dir (str): optional, specify a directory to
         write logs to
+      conda_env_dir (str): optional, specify the directory
+        to create conda environments under (default: use
+        value supplied in settings)
       suppress_warning (bool): if True then don't show the
         warning message even when there are missing metrics
         (default: show the warning if there are missing
@@ -183,7 +186,8 @@ def report_qc(project,qc_dir=None,fastq_dir=None,qc_protocol=None,
     if Settings().conda.enable_conda:
         print("Attempting to acquire conda environment for reporting")
         # Get location for conda environments
-        conda_env_dir = Settings().conda.env_dir
+        if conda_env_dir is None:
+            conda_env_dir = Settings().conda.env_dir
         # Set up conda wrapper
         conda = CondaWrapper(env_dir=conda_env_dir)
         # Get environment for MultiQC reporting


### PR DESCRIPTION
Updates the standalone QC runner utility `run_qc.py` to create conda environments under the temporary working directory by default.

The default is still overridden by locations set on the command line or within the configuration file. The purpose of this change is to stop old or unwanted conda environments to be left once the QC pipeline has been run.