### PR TITLE
Update organism name normalisation function and apply more consistently

### DIFF
--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -61,6 +61,7 @@ from ..tenx.cellplex import CellrangerMultiConfigCsv
 from ..tenx.multiome import MultiomeLibraries
 from ..tenx.utils import add_cellranger_args
 from ..utils import get_organism_list
+from ..utils import normalise_organism_name
 from .modules.cellranger_atac_count import CellrangerAtacCount
 from .modules.cellranger_arc_count import CellrangerArcCount
 from .modules.cellranger_count import CellrangerCount
@@ -80,7 +81,6 @@ from .protocols import parse_qc_module_spec
 from .reporting import report as reportqc
 from .utils import get_bam_basename
 from .utils import get_seq_data_samples
-from .utils import normalise_organism_name
 from .utils import set_cell_count_for_project
 from .verification import verify_project
 

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -80,6 +80,7 @@ from .protocols import parse_qc_module_spec
 from .reporting import report as reportqc
 from .utils import get_bam_basename
 from .utils import get_seq_data_samples
+from .utils import normalise_organism_name
 from .utils import set_cell_count_for_project
 from .verification import verify_project
 
@@ -286,10 +287,7 @@ class QCPipeline(Pipeline):
             organism = project.info.organism
 
         # Sanitised organism name
-        organism_name = str(organism).\
-                        strip().\
-                        lower().\
-                        replace(' ','_')
+        organism_name = normalise_organism_name(organism)
 
         # Report details
         self.report("-- Protocol   : %s" % protocol.name)

--- a/auto_process_ngs/qc/pipeline.py
+++ b/auto_process_ngs/qc/pipeline.py
@@ -36,12 +36,8 @@ import logging
 import tempfile
 import shutil
 import random
-from bcftbx.JobRunner import SimpleJobRunner
 from bcftbx.FASTQFile import FastqIterator
-from bcftbx.TabFile import TabFile
 from bcftbx.utils import mkdir
-from bcftbx.utils import mkdirs
-from bcftbx.utils import find_program
 from bcftbx.ngsutils import getreads
 from bcftbx.ngsutils import getreads_subset
 from ..analysis import AnalysisFastq
@@ -57,10 +53,7 @@ from ..pipeliner import PipelineCommandWrapper
 from ..pipeliner import PipelineParam as Param
 from ..pipeliner import ListParam
 from ..pipeliner import PipelineFailure
-from ..tenx.cellplex import CellrangerMultiConfigCsv
 from ..tenx.multiome import MultiomeLibraries
-from ..tenx.utils import add_cellranger_args
-from ..utils import get_organism_list
 from ..utils import normalise_organism_name
 from .modules.cellranger_atac_count import CellrangerAtacCount
 from .modules.cellranger_arc_count import CellrangerArcCount
@@ -75,8 +68,6 @@ from .modules.rseqc_genebody_coverage import RseqcGenebodyCoverage
 from .modules.rseqc_infer_experiment import RseqcInferExperiment
 from .modules.sequence_lengths import SequenceLengths
 from .modules.strandedness import Strandedness
-from .protocols import determine_qc_protocol
-from .protocols import fetch_protocol_definition
 from .protocols import parse_qc_module_spec
 from .reporting import report as reportqc
 from .utils import get_bam_basename

--- a/auto_process_ngs/test/test_utils.py
+++ b/auto_process_ngs/test/test_utils.py
@@ -1386,6 +1386,7 @@ class TestNormaliseOrganismName(unittest.TestCase):
                          "mus_musculus")
         self.assertEqual(normalise_organism_name(" Mus  musculus "),
                          "mus_musculus")
+        self.assertEqual(normalise_organism_name("C. elegans"), "c_elegans")
 
 class TestSplitUserHostDir(unittest.TestCase):
     """Tests for the split_user_host_dir function

--- a/auto_process_ngs/utils.py
+++ b/auto_process_ngs/utils.py
@@ -1100,9 +1100,9 @@ def normalise_organism_name(name):
       String: normalised organism name
     """
     # Make lowercase, split on commas and replace whitespace
-    # with single underscore, then strip leading/trailing
-    # underscores
-    return re.sub(r'\s+','_',str(name).lower()).strip('_')
+    # and other non-alphanumeric characters with single underscore,
+    # finally strip leading/trailing underscores
+    return re.sub(r'\W+','_',str(name).lower()).strip('_')
 
 def split_user_host_dir(location):
     # Split a location of the form [[user@]host:]dir into its


### PR DESCRIPTION
Two updates:

1. Updates the organism name normalisation function `normalise_organism_name` in the `utils` module, to also remove non-alphanumeric characters (so e.g. `C. elegans` -> `c_elegans`)
2. Use the `normalise_organism_name` function in the QC pipeline so that normalisation is applied more consistently within the `auto-process` package.