### PR TITLE
Add '--no-undetermined-fastqs' option to the 'make_fastqs' command

### DIFF
--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -2623,6 +2623,7 @@ class RunBcl2Fastq(PipelineTask):
                 illumina_data = IlluminaData(os.path.dirname(self.tmp_out_dir),
                                              os.path.basename(self.tmp_out_dir))
                 if illumina_data.undetermined:
+                    print("Removing undetermined fastqs")
                     for undetermined_sample in illumina_data.undetermined.samples:
                         for fq in undetermined_sample.fastq:
                             fq = os.path.join(undetermined_sample.dirn, fq)
@@ -2904,6 +2905,7 @@ class RunBclConvert(PipelineTask):
                 illumina_data = IlluminaData(os.path.dirname(self.tmp_out_dir),
                                              os.path.basename(self.tmp_out_dir))
                 if illumina_data.undetermined:
+                    print("Removing undetermined fastqs")
                     for undetermined_sample in illumina_data.undetermined.samples:
                         for fq in undetermined_sample.fastq:
                             fq = os.path.join(undetermined_sample.dirn, fq)

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -355,6 +355,7 @@ class MakeFastqs(Pipeline):
         self.add_param('find_adapters_with_sliding_window',value=False,
                        type=bool)
         self.add_param('create_empty_fastqs',value=False,type=bool)
+        self.add_param('no_undetermined_fastqs',value=False,type=bool)
         self.add_param('ignore_missing_bcls',value=False,type=bool)
         self.add_param('name',type=str)
         self.add_param('stats_file',type=str)
@@ -1200,6 +1201,8 @@ class MakeFastqs(Pipeline):
                         no_lane_splitting=self.params.no_lane_splitting,
                         create_fastq_for_index_read=\
                         create_fastq_for_index_read,
+                        no_undetermined_fastqs=
+                        self.params.no_undetermined_fastqs,
                         find_adapters_with_sliding_window=\
                         find_adapters_with_sliding_window,
                         create_empty_fastqs=self.params.create_empty_fastqs,
@@ -1284,6 +1287,8 @@ class MakeFastqs(Pipeline):
                                 create_fastq_for_index_read=\
                                 create_fastq_for_index_read,
                                 create_empty_fastqs=False,
+                                no_undetermined_fastqs=
+                                self.params.no_undetermined_fastqs,
                                 ignore_missing_fastqs=True,
                                 platform=identify_platform.output.platform,
                                 bclconvert_exe=\
@@ -1342,6 +1347,8 @@ class MakeFastqs(Pipeline):
                             create_fastq_for_index_read,
                             create_empty_fastqs=\
                             self.params.create_empty_fastqs,
+                            no_undetermined_fastqs=\
+                            self.params.no_undetermined_fastqs,
                             platform=identify_platform.output.platform,
                             bclconvert_exe=\
                             get_bclconvert.output.bclconvert_exe,
@@ -1684,9 +1691,9 @@ class MakeFastqs(Pipeline):
             primary_data_dir=None,force_copy_of_primary_data=False,
             no_lane_splitting=None,create_fastq_for_index_read=None,
             find_adapters_with_sliding_window=None,
-            create_empty_fastqs=None,ignore_missing_bcls=None,
-            name=None,stats_file=None,stats_full=None,
-            per_lane_stats=None,per_lane_sample_stats=None,
+            create_empty_fastqs=None, no_undetermined_fastqs=None,
+            ignore_missing_bcls=None, name=None,stats_file=None,
+            stats_full=None, per_lane_stats=None,per_lane_sample_stats=None,
             nprocessors=None,cellranger_jobmode='local',
             cellranger_mempercore=None,cellranger_maxjobs=None,
             cellranger_jobinterval=None,cellranger_localcores=None,
@@ -1722,6 +1729,8 @@ class MakeFastqs(Pipeline):
             sequences (--find-adapters-with-sliding-window)
           create_empty_fastqs (bool): if True then create empty
             "placeholder" Fastqs if not created by bcl2fastq
+          no_undetermined_fastqs (bool): if True then don't keep
+            the "undetermined" Fastqs if created
           ignore_missing_bcls (bool): if True then ignore missing
             or corrupted BCL files
           name (str): optional identifier for output
@@ -1905,6 +1914,7 @@ class MakeFastqs(Pipeline):
             'find_adapters_with_sliding_window':
             find_adapters_with_sliding_window,
             'create_empty_fastqs': create_empty_fastqs,
+            'no_undetermined_fastqs': no_undetermined_fastqs,
             'ignore_missing_bcls': ignore_missing_bcls,
             'name': name,
             'stats_file': stats_file,
@@ -2391,7 +2401,7 @@ class RunBcl2Fastq(PipelineTask):
              mask_short_adapter_reads=None,
              create_fastq_for_index_read=False,
              find_adapters_with_sliding_window=False,nprocessors=None,
-             create_empty_fastqs=False,
+             create_empty_fastqs=False, no_undetermined_fastqs=False,
              platform=None,bcl2fastq_exe=None,bcl2fastq_version=None,
              skip_bcl2fastq=False,conda_pkgs=None):
         """
@@ -2414,6 +2424,9 @@ class RunBcl2Fastq(PipelineTask):
           create_fastq_for_index_read (boolean): if True then
             also create Fastq files for index reads (default,
             don't create index read Fastqs)
+          no_undetermined_fastqs (bool): if True then don't
+            keep any 'undetermined' Fastq files (default, do
+            keep the 'undetermined' Fastqs)
           find_adapters_with_sliding_window (bool): if True
             then use sliding window algorith for identifying
             adapter sequences (default is to use string
@@ -2600,6 +2613,16 @@ class RunBcl2Fastq(PipelineTask):
                     # Terminate with an exception
                     raise Exception("Failed to verify outputs against "
                                     "samplesheet")
+            # Remove undetermined Fastqs
+            if self.args.no_undetermined_fastqs:
+                illumina_data = IlluminaData(os.path.dirname(self.tmp_out_dir),
+                                             os.path.basename(self.tmp_out_dir))
+                if illumina_data.undetermined:
+                    for undetermined_sample in illumina_data.undetermined.samples:
+                        for fq in undetermined_sample.fastq:
+                            fq = os.path.join(undetermined_sample.dirn, fq)
+                            if os.path.exists(fq):
+                                os.remove(fq)
             # Move to final location
             print("Moving output to final location: %s" % self.args.out_dir)
             os.rename(self.tmp_out_dir,self.args.out_dir)
@@ -2613,9 +2636,9 @@ class RunBclConvert(PipelineTask):
              minimum_trimmed_read_length=None,
              mask_short_adapter_reads=None,
              create_fastq_for_index_read=False,nprocessors=None,
-             create_empty_fastqs=False,ignore_missing_fastqs=False,
-             platform=None,bclconvert_exe=None,bclconvert_version=None,
-             skip_bclconvert=False):
+             create_empty_fastqs=False, no_undetermined_fastqs=False,
+             ignore_missing_fastqs=False, platform=None, bclconvert_exe=None,
+             bclconvert_version=None, skip_bclconvert=False):
         """
         Initialise the RunBclConvert task
 
@@ -2636,6 +2659,8 @@ class RunBclConvert(PipelineTask):
           create_fastq_for_index_read (boolean): if True then
             also create Fastq files for index reads (default,
             don't create index read Fastqs)
+          no_undetermined_fastqs (bool): if True then don't
+            create 'undetermined' Fastq files
           nprocessors (int): number of processors to use
             (taken from job runner by default)
           create_empty_fastqs (bool): if True then create empty
@@ -2869,6 +2894,16 @@ class RunBclConvert(PipelineTask):
                     # Terminate with an exception
                     raise Exception("Failed to verify outputs against "
                                     "samplesheet")
+            # Remove undetermined Fastqs
+            if self.args.no_undetermined_fastqs:
+                illumina_data = IlluminaData(os.path.dirname(self.tmp_out_dir),
+                                             os.path.basename(self.tmp_out_dir))
+                if illumina_data.undetermined:
+                    for undetermined_sample in illumina_data.undetermined.samples:
+                        for fq in undetermined_sample.fastq:
+                            fq = os.path.join(undetermined_sample.dirn, fq)
+                            if os.path.exists(fq):
+                                os.remove(fq)
             # Move to final location
             print("Moving output to final location: %s" % self.args.out_dir)
             os.rename(self.tmp_out_dir,self.args.out_dir)

--- a/auto_process_ngs/bcl2fastq/pipeline.py
+++ b/auto_process_ngs/bcl2fastq/pipeline.py
@@ -124,6 +124,7 @@ LANE_SUBSET_ATTRS = (
     'i2_length',
     'override_template',
     'no_lane_splitting',
+    'no_undetermined_fastqs',
     'tenx_filter_single_index',
     'tenx_filter_dual_index',
     'spaceranger_rc_i2_override',
@@ -485,6 +486,7 @@ class MakeFastqs(Pipeline):
                 adapter_sequence=self._adapter_sequence,
                 adapter_sequence2=self._adapter_sequence_read2,
                 no_lane_splitting=self.params.no_lane_splitting,
+                no_undetermined_fastqs=self.params.no_undetermined_fastqs,
                 create_fastq_for_index_read=\
                 self.params.create_fastq_for_index_read,
                 find_adapters_with_sliding_window=\
@@ -1087,6 +1089,11 @@ class MakeFastqs(Pipeline):
             create_fastq_for_index_read = \
                 subset['create_fastq_for_index_read']
 
+            #########################
+            # No undetermined Fastqs
+            #########################
+            no_undetermined_fastqs = subset['no_undetermined_fastqs']
+
             # Use sliding window for adapter trimming
             find_adapters_with_sliding_window = \
                 subset['find_adapters_with_sliding_window']
@@ -1201,8 +1208,7 @@ class MakeFastqs(Pipeline):
                         no_lane_splitting=self.params.no_lane_splitting,
                         create_fastq_for_index_read=\
                         create_fastq_for_index_read,
-                        no_undetermined_fastqs=
-                        self.params.no_undetermined_fastqs,
+                        no_undetermined_fastqs=no_undetermined_fastqs,
                         find_adapters_with_sliding_window=\
                         find_adapters_with_sliding_window,
                         create_empty_fastqs=self.params.create_empty_fastqs,
@@ -1287,8 +1293,7 @@ class MakeFastqs(Pipeline):
                                 create_fastq_for_index_read=\
                                 create_fastq_for_index_read,
                                 create_empty_fastqs=False,
-                                no_undetermined_fastqs=
-                                self.params.no_undetermined_fastqs,
+                                no_undetermined_fastqs=no_undetermined_fastqs,
                                 ignore_missing_fastqs=True,
                                 platform=identify_platform.output.platform,
                                 bclconvert_exe=\

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -453,6 +453,13 @@ def add_make_fastqs_command(cmdparser):
                               dest='create_fastq_for_index_read',
                               default=False,
                               help="also create FASTQs for index reads")
+    # Don't include 'undetermined' Fastqs
+    bcl_to_fastq.add_argument('--no-undetermined-fastqs',
+                              action='store_true',
+                              dest='no_undetermined_fastqs',
+                              default=False,
+                              help="don't create or keept the 'undetermined' FASTQs "
+                              "with unassigned reads from demultiplexing")
     # Ignore missing or corrupted BCL files
     bcl_to_fastq.add_argument("--ignore-missing-bcls", action="store_true",
                               dest="ignore_missing_bcls", default=False,
@@ -1639,6 +1646,7 @@ def make_fastqs(args):
         adapter_sequence=args.adapter_sequence,
         adapter_sequence_read2=args.adapter_sequence_read2,
         create_fastq_for_index_read=args.create_fastq_for_index_read,
+        no_undetermined_reads=args.no_undetermined_reads,
         ignore_missing_bcls=args.ignore_missing_bcls,
         find_adapters_with_sliding_window=\
         args.find_adapters_with_sliding_window,

--- a/auto_process_ngs/cli/auto_process.py
+++ b/auto_process_ngs/cli/auto_process.py
@@ -1646,7 +1646,7 @@ def make_fastqs(args):
         adapter_sequence=args.adapter_sequence,
         adapter_sequence_read2=args.adapter_sequence_read2,
         create_fastq_for_index_read=args.create_fastq_for_index_read,
-        no_undetermined_reads=args.no_undetermined_reads,
+        no_undetermined_fastqs=args.no_undetermined_fastqs,
         ignore_missing_bcls=args.ignore_missing_bcls,
         find_adapters_with_sliding_window=\
         args.find_adapters_with_sliding_window,

--- a/auto_process_ngs/commands/make_fastqs_cmd.py
+++ b/auto_process_ngs/commands/make_fastqs_cmd.py
@@ -53,6 +53,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
                 analyse_barcodes=True,barcode_analysis_dir=None,
                 force_copy_of_primary_data=False,
                 create_empty_fastqs=False,
+                no_undetermined_fastqs=False,
                 ignore_missing_bcls=False,runner=None,
                 cellranger_jobmode=None,
                 cellranger_mempercore=None,
@@ -165,6 +166,8 @@ def make_fastqs(ap,protocol='standard',platform=None,
       create_empty_fastqs (bool): if True then create empty 'placeholder'
         fastq files for any missing fastqs after bcl2fastq
         (must have completed with zero exit status)
+      no_undetermined_fastqs (bool): if True then don't keep the
+        "undetermined" fastq files
       runner (JobRunner): (optional) specify a non-default job runner
         to use for fastq generation
       cellranger_jobmode (str): (optional) job mode to run cellranger in
@@ -440,6 +443,7 @@ def make_fastqs(ap,protocol='standard',platform=None,
                              find_adapters_with_sliding_window,
                              create_empty_fastqs=create_empty_fastqs,
                              ignore_missing_bcls=ignore_missing_bcls,
+                             no_undetermined_fastqs=no_undetermined_fastqs,
                              stats_file=stats_file,
                              per_lane_stats=per_lane_stats_file,
                              nprocessors=nprocessors,

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_standard_bcl2fastq.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_standard_bcl2fastq.py
@@ -1033,6 +1033,86 @@ class TestMakeFastqs(BaseMakeFastqsTestCase):
                             "Missing file: %s" % filen)
 
     #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_no_undetermined_fastqs(self):
+        """
+        MakeFastqs: standard protocol/bcl2fastq: no 'undetermined' Fastqs
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl2fastq
+        # Check that --create-fastq-for-index-read is set
+        MockBcl2fastq2Exe.create(os.path.join(self.bin, "bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet)
+        status = p.run(analysis_dir,
+                       no_undetermined_fastqs=True,
+                       poll_interval=POLL_INTERVAL)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bcl2fastq_info,
+                         (os.path.join(self.bin,"bcl2fastq"),
+                          "bcl2fastq",
+                          "2.20.0.422"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+        for fq in ["Undetermined_S0_L001_R2_001.fastq.gz"]:
+            self.assertFalse(os.path.exists(os.path.join(analysis_dir, "bcl2fastq", fq)),
+                             f"'{fq}' is present (should be absent)")
+
+    #@unittest.skip("Skipped")
     def test_makefastqs_standard_protocol_rerun_completed_pipeline(self):
         """
         MakeFastqs: standard protocol/bcl2fastq: rerun completed pipeline

--- a/auto_process_ngs/test/bcl2fastq/pipeline/test_standard_bclconvert.py
+++ b/auto_process_ngs/test/bcl2fastq/pipeline/test_standard_bclconvert.py
@@ -839,6 +839,97 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,""")
             self.assertFastqStats(stats,fq,1,L1=1)
 
     #@unittest.skip("Skipped")
+    def test_makefastqs_standard_protocol_bclconvert_no_undetermined_fastqs(self):
+        """
+        MakeFastqs: standard protocol/bcl-convert: no 'undetermined' Fastqs
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        run_dir = illumina_run.dirn
+        # Sample sheet
+        sample_sheet = os.path.join(self.wd,"SampleSheet.csv")
+        with open(sample_sheet,'wt') as fp:
+            fp.write(SampleSheets.miseq)
+        # Create mock bcl-convert
+        MockBclConvertExe.create(os.path.join(self.bin, "bcl-convert"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Make an (empty) analysis directory
+        analysis_dir = os.path.join(self.wd,"analysis")
+        os.mkdir(analysis_dir)
+        # Do the test
+        p = MakeFastqs(run_dir,sample_sheet,
+                       bcl_converter="bcl-convert")
+        status = p.run(analysis_dir,
+                       no_undetermined_fastqs=True,
+                       poll_interval=POLL_INTERVAL)
+        self.assertEqual(status,0)
+        # Check outputs
+        self.assertEqual(p.output.platform,"miseq")
+        self.assertEqual(p.output.flow_cell_mode,None)
+        self.assertEqual(p.output.primary_data_dir,
+                         os.path.join(analysis_dir,
+                                      "primary_data"))
+        self.assertEqual(p.output.bclconvert_info,
+                         (os.path.join(self.bin,"bcl-convert"),
+                          "BCL Convert",
+                          "3.7.5"))
+        self.assertEqual(p.output.cellranger_info,None)
+        self.assertTrue(p.output.acquired_primary_data)
+        self.assertEqual(p.output.stats_file,
+                         os.path.join(analysis_dir,"statistics.info"))
+        self.assertEqual(p.output.stats_full,
+                         os.path.join(analysis_dir,"statistics_full.info"))
+        self.assertEqual(p.output.per_lane_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_statistics.info"))
+        self.assertEqual(p.output.per_lane_sample_stats,
+                         os.path.join(analysis_dir,
+                                      "per_lane_sample_stats.info"))
+        self.assertEqual(p.output.seq_len_stats,
+                         os.path.join(analysis_dir,
+                                      "seq_len_statistics.info"))
+        self.assertEqual(p.output.missing_fastqs,[])
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        self.assertEqual(IlluminaData(analysis_dir,"bcl2fastq").lanes,
+                         [1,])
+        self.assertTrue(os.path.islink(
+            os.path.join(analysis_dir,
+                         "primary_data",
+                         "171020_M00879_00002_AHGXXXX")))
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "seq_len_statistics.info",
+                      "processing_qc.html"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+        # Check Fastqs
+        stats = FastqStatistics(IlluminaData(analysis_dir,"bcl2fastq"))
+        self.assertEqual(stats.lane_names,['L1'])
+        for fq in ("Sample1_S1_L001_R1_001.fastq.gz",
+                   "Sample1_S1_L001_R2_001.fastq.gz",
+                   "Sample2_S2_L001_R1_001.fastq.gz",
+                   "Sample2_S2_L001_R2_001.fastq.gz",):
+            self.assertFastqStats(stats,fq,1,L1=1)
+        for fq in ["Undetermined_S0_L001_R1_001.fastq.gz",
+                   "Undetermined_S0_L001_R2_001.fastq.gz",]:
+            self.assertFalse(os.path.exists(os.path.join(analysis_dir, "bcl2fastq", fq)),
+                             f"'{fq}' is present (should be absent)")
+
+    #@unittest.skip("Skipped")
     def test_makefastqs_require_bclconvert_version(self):
         """
         MakeFastqs: standard protocol/bcl-convert: specify version

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -1358,12 +1358,6 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
             self.assertTrue(os.path.exists(
                 os.path.join(analysis_dir,filen)),
                             "Missing file: %s" % filen)
-        self.assertTrue(
-            os.path.exists(
-                os.path.join(analysis_dir,
-                             "logs",
-                             "002_make_fastqs",
-                             "missing_fastqs.log")))
 
     #@unittest.skip("Skipped")
     def test_make_fastqs_handle_bcl2fastq2_failure(self):

--- a/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
+++ b/auto_process_ngs/test/commands/test_make_fastqs_cmd.py
@@ -1301,6 +1301,71 @@ Sample2,Sample2,,,D702,CGTGTAGG,D501,ATGTAACT,,
                              "missing_fastqs.log")))
 
     #@unittest.skip("Skipped")
+    def test_make_fastqs_no_undetermined_fastqs(self):
+        """make_fastqs: no 'undetermined' fastqs
+        """
+        # Create mock source data
+        illumina_run = MockIlluminaRun(
+            "171020_M00879_00002_AHGXXXX",
+            "miseq",
+            top_dir=self.wd)
+        illumina_run.create()
+        # Create mock bcl2fastq
+        MockBcl2fastq2Exe.create(os.path.join(self.bin, "bcl2fastq"))
+        os.environ['PATH'] = "%s:%s" % (self.bin,
+                                        os.environ['PATH'])
+        # Do the test
+        ap = AutoProcess(settings=self.settings)
+        setup(ap, os.path.join(self.wd, "171020_M00879_00002_AHGXXXX"))
+        self.assertTrue(ap.params.sample_sheet is not None)
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertTrue(ap.params.primary_data_dir is None)
+        self.assertFalse(ap.params.acquired_primary_data)
+        make_fastqs(ap,
+                    protocol="standard",
+                    no_undetermined_fastqs=True)
+        # Check parameters
+        self.assertEqual(ap.params.bases_mask,"auto")
+        self.assertEqual(ap.params.primary_data_dir,
+                         os.path.join(self.wd,
+                                      "171020_M00879_00002_AHGXXXX_analysis",
+                                      "primary_data"))
+        self.assertTrue(ap.params.acquired_primary_data)
+        self.assertEqual(ap.params.unaligned_dir,"bcl2fastq")
+        self.assertEqual(ap.params.barcode_analysis_dir,"barcode_analysis")
+        self.assertEqual(ap.params.stats_file,"statistics.info")
+        # Check outputs
+        analysis_dir = os.path.join(
+            self.wd,
+            "171020_M00879_00002_AHGXXXX_analysis")
+        for subdir in (os.path.join("primary_data",
+                                    "171020_M00879_00002_AHGXXXX"),
+                       os.path.join("logs",
+                                    "002_make_fastqs"),
+                       "bcl2fastq",
+                       "barcode_analysis",):
+            self.assertTrue(os.path.isdir(
+                os.path.join(analysis_dir,subdir)),
+                            "Missing subdir: %s" % subdir)
+        for fq in ["Undetermined_S0_L001_R1_001.fastq.gz",]:
+            self.assertFalse(os.path.exists(os.path.join(analysis_dir, "bcl2fastq", fq)),
+                             f"'{fq}' is present (should be absent)")
+        for filen in ("statistics.info",
+                      "statistics_full.info",
+                      "per_lane_statistics.info",
+                      "per_lane_sample_stats.info",
+                      "projects.info"):
+            self.assertTrue(os.path.exists(
+                os.path.join(analysis_dir,filen)),
+                            "Missing file: %s" % filen)
+        self.assertTrue(
+            os.path.exists(
+                os.path.join(analysis_dir,
+                             "logs",
+                             "002_make_fastqs",
+                             "missing_fastqs.log")))
+
+    #@unittest.skip("Skipped")
     def test_make_fastqs_handle_bcl2fastq2_failure(self):
         """make_fastqs: handle bcl2fastq2 failure
         """

--- a/docs/source/using/make_fastqs.rst
+++ b/docs/source/using/make_fastqs.rst
@@ -275,8 +275,8 @@ be used with the other lanes:
 
    auto_process.py make_fastqs \
             --lanes=1-4,7-8:standard \
-	    --lanes=5,6:10x_chromium_sc \
-	    --sample-sheet=SampleSheet.updated.csv
+            --lanes=5,6:10x_chromium_sc \
+            --sample-sheet=SampleSheet.updated.csv
 
 
 .. note::
@@ -294,8 +294,8 @@ specify the adapter sequences for lane 8:
 
    auto_process.py make_fastqs \
             --lanes=1-7 \
-	    --lanes=8:adapter=CTGTCTCTTATACACATCT \
-	    --sample-sheet=SampleSheet.updated.csv
+            --lanes=8:adapter=CTGTCTCTTATACACATCT \
+            --sample-sheet=SampleSheet.updated.csv
 
 The general form of the ``--lanes`` option is:
 
@@ -328,6 +328,8 @@ Option                                Description
                                       for ``spaceranger`` (can be
                                       either ``true`` or ``false``)
 ``analyse_barcodes=yes|no``           Turn barcode analysis on or off
+``no_undetermined_fastqs=yes|no``     Turn undetermined Fastqs generation
+                                      on or off
 ===================================== ==================================
 
 These options will override the defaults and any global values


### PR DESCRIPTION
Adds a new option `--no-undetermined-fastqs` to the `make_fastqs` command.

When this option is specified, the "undetermined" Fastqs (i.e. Fastqs with any unassigned reads from demultiplexing) are not copied or otherwise generated during the Fastq generation process.

This option is intended to be useful in special cases (e.g. diagnostic situations, or cases where the unassigned reads are not useful) when it is helpful not to include the undetermined Fastqs in downstream processing (such as statistics generation). 